### PR TITLE
Add link to request info for performance and benchmarking

### DIFF
--- a/docs/components/concepts/what-is-camunda-cloud.md
+++ b/docs/components/concepts/what-is-camunda-cloud.md
@@ -40,3 +40,7 @@ Camunda Cloud is designed to operate on a very large scale. To achieve this, it 
 Most existing workflow engines offer a vast amount of features. While having access to lots of features is generally a good thing, it can come at a cost of increased complexity and degraded performance.
 
 Camunda Cloud is entirely focused on providing a compact, robust, and scalable solution for process orchestration. Rather than supporting a broad spectrum of features, its goal is to excel within this scope.
+
+## Next steps
+
+* To request information about Camunda Cloud performance and benchmarking, see our [Contact](/contact/) page.

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -9,12 +9,12 @@ There are various channels where you can reach us.
 
 - We encourage everyone to participate in our **community** via the [Camunda Cloud community forum](https://forum.camunda.io/) or [Slack](https://camunda-cloud.slack.com/), where you can exchange ideas with other Zeebe and Camunda Cloud users, as well as the product developers. If you are joining our Slack for the first time, you will need to get an [invite](https://zeebe-slack-invite.herokuapp.com/) first.
 
-- If you find a **bug**, please open an issue in this [repository](https://github.com/camunda-cloud/issues). The bugs have a default template, so please describe what doesn't work in detail.
+- If you find a **bug**, open an issue in this [repository](https://github.com/camunda-cloud/issues). The bugs have a default template, so please describe what doesn't work in detail.
 
-- We also accept **feature requests** through a similar process. Please open an issue in this [repository](https://github.com/camunda-cloud/issues). The feature requests have a default template, so please describe what you'd like to see in detail.
+- We also accept **feature requests** through a similar process. Please open an issue in this [repository](https://github.com/camunda-cloud/issues). The feature requests have a default template, so describe what you'd like to see in detail.
 
-- For **security-related issues**, please review our [Security notices](../../docs/reference/notices) for the most up-to-date information on known issues and steps to report a vulnerability so we can solve the problem as quickly as possible. Do not use GitHub for security-related issues.
+- For **security-related issues**, review our [Security notices](../../docs/reference/notices) for the most up-to-date information on known issues and steps to report a vulnerability so we can solve the problem as quickly as possible. Do not use GitHub for security-related issues.
 
-- **Feedback and Support** can be submitted or requested via JIRA for subscription or enterprise customers in the Support project. Otherwise, please use the [Camunda Cloud community forum](https://forum.camunda.io/). For more information about Enterprise support and additional support resources please see [Enterprise Support](https://camunda.com/support/).
+- **Feedback and Support** can be submitted or requested via JIRA for subscription or enterprise customers in the Support project. Otherwise, use the [Camunda Cloud community forum](https://forum.camunda.io/). For more information about Enterprise support and additional support resources please see [Enterprise Support](https://camunda.com/support/).
 
-- For sales inquiries or anything not listed above, please use our [Contact Us](https://camunda.com/contact/) form. 
+- For sales inquiries, information about Camunda Cloud performance and benchmarking, or anything not listed above, use our [Contact Us](https://camunda.com/contact/) form. 


### PR DESCRIPTION
Since Camunda Cloud SaaS benchmarking and performance testing is currently documented for use by the internal team, I've updated the Contact page with directions to use the Contact Us form. I also updated the What is Camunda Cloud? concept and will work to add more links on this topic as we restructure the docs.