### PR TITLE
chore(formsReference): remove outdated info

### DIFF
--- a/docs/components/modeler/forms/camunda-forms-reference.md
+++ b/docs/components/modeler/forms/camunda-forms-reference.md
@@ -11,7 +11,7 @@ The Camunda Forms feature was added with the 7.15.0 release of Camunda Platform 
 
 Camunda Forms allow you to easily design and configure forms, and then embed them in Camunda Tasklist.
 
-* Camunda Forms are created in Camunda Modeler. You can find out how in the [Camunda Modeler documentation](../about.md).
+* Camunda Forms are created in Camunda Modeler.
 * Camunda Forms can be embedded in Camunda Tasklist. You can find out how in the [user task forms guide](../../../guides/utilizing-forms.md).
 * Camunda Forms are powered by the open-source [bpmn-io form-js library](https://github.com/bpmn-io/form-js). Visit the [open source repository](https://github.com/bpmn-io/form-js) to find out how to render a form using plain JavaScript in a custom application (note that this also requires you to fetch the form from the respective BPMN 2.0 element and provide data as needed to the form.)
 


### PR DESCRIPTION
* We don't explain how to create forms in the about page. However, that
  is okay, since it is obvious. Just removing this to not have invalid
content in the docs.