### PR TITLE
docs(collaboration): add documentation about necessary email address

### DIFF
--- a/docs/components/modeler/web-modeler/collaboration.md
+++ b/docs/components/modeler/web-modeler/collaboration.md
@@ -29,7 +29,7 @@ There are four roles with different levels of access rights that can be assigned
 ### Inviting users to projects
 
 :::note
-Web Modeler expects users to have email addresses to receive invitations correctly.
+Web Modeler expects users to have an email address associated with their account in the identity management system to receive invitations correctly.
 :::
 
 On the right side of a project, view a list of your collaborators and invite more by taking the steps below:


### PR DESCRIPTION
## What is the purpose of the change

Update the documentation on docs.camunda.io to reflect that the Web Modeler expects users to have email addresses assigned.

## PR Checklist

- [x] My changes apply to an already released version, and I have added them to the relevant `/versioned_docs` directory, or they are not for an already released version.
- [x] My changes apply to future versions, and I have added them to the main `/docs` directory, or they are not for future versions.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
