### PR TITLE
Fix admonition closing on job workers concept page

### DIFF
--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -78,11 +78,13 @@ When `Completing or failing jobs` with [variables](components/concepts/variables
 - When `Failing a job` the variables are only created in the local scope of the task.
 
 :::tip Failing a job with variables
+
 There are several advantages when failing a job with variables. Consider the following use cases:
 
 - You can fail a job and raise an incident by setting the job `retries` to zero. In this case, it would be useful to provide some additional details through a variable when the incident is analyzed.
 - If your job worker can split the job into smaller pieces and finish some but not all of these, it can fail the job with variables indicating which parts of the job were successfully finished and which weren't. Such a job should be failed with a positive number of retries so another job worker can pick it up again and continue where the other job worker left off. The job can be completed when all parts are finished by a job worker successfully.
-  :::
+
+:::
 
 ## Timeouts
 

--- a/versioned_docs/version-8.2/components/concepts/job-workers.md
+++ b/versioned_docs/version-8.2/components/concepts/job-workers.md
@@ -78,11 +78,13 @@ When `Completing or failing jobs` with [variables](components/concepts/variables
 - When `Failing a job` the variables are only created in the local scope of the task.
 
 :::tip Failing a job with variables
+
 There are several advantages when failing a job with variables. Consider the following use cases:
 
 - You can fail a job and raise an incident by setting the job `retries` to zero. In this case, it would be useful to provide some additional details through a variable when the incident is analyzed.
 - If your job worker can split the job into smaller pieces and finish some but not all of these, it can fail the job with variables indicating which parts of the job were successfully finished and which weren't. Such a job should be failed with a positive number of retries so another job worker can pick it up again and continue where the other job worker left off. The job can be completed when all parts are finished by a job worker successfully.
-  :::
+
+:::
 
 ## Timeouts
 


### PR DESCRIPTION
## Description

Closes #2364.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
