### PR TITLE
docs(ootbc): add warning for deprecated secrets syntax

### DIFF
--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -14,6 +14,10 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
+:::warning
+`secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
+:::
+
 You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
 Use the Console component to [create and manage secrets](/components/console/manage-clusters/manage-secrets.md).
 

--- a/versioned_docs/version-8.0/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.0/components/connectors/use-connectors/index.md
@@ -14,6 +14,10 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
+:::warning
+`secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
+:::
+
 You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
 Use the Console component to [create and manage secrets](/components/console/manage-clusters/manage-secrets.md).
 

--- a/versioned_docs/version-8.1/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors/index.md
@@ -14,6 +14,10 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
+:::warning
+`secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
+:::
+
 You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
 Use the Console component to [create and manage secrets](/components/console/manage-clusters/manage-secrets.md).
 

--- a/versioned_docs/version-8.2/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.2/components/connectors/use-connectors/index.md
@@ -14,6 +14,10 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
+:::warning
+`secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
+:::
+
 You can use sensitive information in your Connectors without exposing it in your BPMN processes by referencing secrets.
 Use the Console component to [create and manage secrets](/components/console/manage-clusters/manage-secrets.md).
 


### PR DESCRIPTION
## Description
Added warning to` 8.0`, `8.1`, `8.2` and `next` versions : 
![Screenshot 2023-09-07 at 14 56 23](https://github.com/camunda/camunda-platform-docs/assets/108869886/efcf6c60-31aa-4223-bca8-dd6a51726512)


related : 
https://github.com/camunda/team-connectors/issues/448

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?
TBD
<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
