### PR TITLE
[do not merge] prototype: detect cross-instance/cross-version links (and report them as comments; and report prettier issues as comments too.)

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -24,11 +24,6 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
-      - name: Verify format
-        run: npm run format:check
-      - uses: errata-ai/vale-action@reviewdog
-        with:
-          filter_mode: added
       - name: Build
         run: npm run build
         env:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -26,6 +26,9 @@ jobs:
         run: npm ci
       - name: Verify format
         run: npm run format:check
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          filter_mode: added
       - name: Build
         run: npm run build
         env:

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -1,0 +1,12 @@
+name: check-format
+on: [pull_request]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify format
+        run: npm run format:check
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          filter_mode: added

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
+          fail_on_error: true
       - name: Verify format with Vale
         uses: errata-ai/vale-action@reviewdog
         with:

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -16,3 +16,4 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           filter_mode: added
+          reporter: github-pr-review

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -11,14 +11,14 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
+      - name: Verify format with Vale
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          filter_mode: added
+          reporter: github-pr-review
       - name: Verify format with Prettier
         uses: EPMatt/reviewdog-action-prettier@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           fail_on_error: true
-      - name: Verify format with Vale
-        uses: errata-ai/vale-action@reviewdog
-        with:
-          filter_mode: added
-          reporter: github-pr-review

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
+      - name: Install Dependencies
+        run: npm ci
       - name: Verify format
         run: npm run format:check
       - uses: errata-ai/vale-action@reviewdog

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -5,6 +5,10 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
       - name: Verify format
         run: npm run format:check
       - uses: errata-ai/vale-action@reviewdog

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -11,9 +11,13 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
-      - name: Verify format
-        run: npm run format:check
-      - uses: errata-ai/vale-action@reviewdog
+      - name: Verify format with Prettier
+        uses: EPMatt/reviewdog-action-prettier@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+      - name: Verify format with Vale
+        uses: errata-ai/vale-action@reviewdog
         with:
           filter_mode: added
           reporter: github-pr-review

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = "styles/camunda"
+
+[{docs,versioned_docs}/**/*.{md,mdx}]
+BasedOnStyles = docsInstance
+
+[{optimize,optimize_versioned_docs}/**/*.{md,mdx}]
+BasedOnStyles = optimizeInstance

--- a/docs/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
+++ b/docs/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
@@ -20,6 +20,10 @@ Continuous integration and deployment are pivotal for rapid and reliable softwar
 
 Integrating Web Modeler into your CI/CD pipelines can significantly enhance process application development and deployment workflows. By automating process application deployment, changes can be promptly and accurately reflected in the production environment. This agility empowers teams to swiftly respond to evolving business needs, fostering a flexible and adaptable process orchestration approach.
 
+## Steve is cool
+
+This section is added to see how the vale github action handles changes in a file where there are previous violations.
+
 ## Prerequisites
 
 Each pipeline is unique. The Web Modeler API offers flexibility to tailor integrations according to your pipelines. To get started, there are a few prerequisites based on your setup:

--- a/docs/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
+++ b/docs/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
@@ -24,6 +24,8 @@ Integrating Web Modeler into your CI/CD pipelines can significantly enhance proc
 
 This section is added to see how the vale github action handles changes in a file where there are previous violations.
 
+Adding more changes to trigger a check of this file again.
+
 ## Prerequisites
 
 Each pipeline is unique. The Web Modeler API offers flexibility to tailor integrations according to your pipelines. To get started, there are a few prerequisites based on your setup:

--- a/docs/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
+++ b/docs/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
@@ -26,6 +26,8 @@ This section is added to see how the vale github action handles changes in a fil
 
 Adding more changes to trigger a check of this file again.
 
+And now adding [a violation](/docs/next/components/concepts/clusters/) to make sure I didn't totally break things.
+
 ## Prerequisites
 
 Each pipeline is unique. The Web Modeler API offers flexibility to tailor integrations according to your pipelines. To get started, there are a few prerequisites based on your setup:

--- a/styles/camunda/docsInstance/hrefDocsToDocs.yml
+++ b/styles/camunda/docsInstance/hrefDocsToDocs.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please specify the file extension."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\((\\.)?(\\/)?docs(?!.*(\\.md|\\.mdx))[^\\)]*\\)"

--- a/styles/camunda/docsInstance/hrefDocsToOptimize.yml
+++ b/styles/camunda/docsInstance/hrefDocsToOptimize.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please use the `$optimize$` token when crossing doc instances."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\(\\/optimize[^\\)]*\\)"

--- a/styles/camunda/optimizeInstance/hrefOptimizeToDocs.yml
+++ b/styles/camunda/optimizeInstance/hrefOptimizeToDocs.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please use the `$docs$` token when crossing doc instances."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\(\\/docs[^\\)]*\\)"

--- a/styles/camunda/optimizeInstance/hrefOptimizeToOptimize.yml
+++ b/styles/camunda/optimizeInstance/hrefOptimizeToOptimize.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please specify the file extension."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\((\\.)?(\\/)?optimize(?!.*(\\.md|\\.mdx))[^\\)]*\\)"

--- a/versioned_docs/version-8.1/apis-tools/operate-api/index.md
+++ b/versioned_docs/version-8.1/apis-tools/operate-api/index.md
@@ -36,7 +36,7 @@ The following settings are needed to request a token:
 | client id                | Name of your registered client                  | -                    |
 | client secret            | Password for your registered client             | -                    |
 | audience                 | Permission name; if not given use default value | `operate.camunda.io` |
-| authorization server url | Token issuer server                             | -                    |
+| authorization server url | Token issuer server                     | -                    |
 
 :::note
 For more information on how to get these values for Camunda 8, read [Manage API Clients](/docs/components/console/manage-clusters/manage-api-clients/).

--- a/versioned_docs/version-8.1/apis-tools/operate-api/index.md
+++ b/versioned_docs/version-8.1/apis-tools/operate-api/index.md
@@ -27,7 +27,7 @@ You need authentication to access the API endpoints.
 
 #### Authentication via JWT access token
 
-You must pass an access token as a header in each request to the SaaS Operate API. When you create an Operate [client](/guides/setup-client-connection-credentials.md), you get all the information needed to connect to Operate.
+You must pass an access token as a header in each request to the SaaS Operate API. When you create an Operate [client](/docs/guides/setup-client-connection-credentials/), you get all the information needed to connect to Operate.
 
 The following settings are needed to request a token:
 


### PR DESCRIPTION
DO NOT MERGE! This PR is experimental, to explore ideas and gather feedback.

## Description

Initially intended to resolve #1876, but through a small additional effort I was able to extend it to resolve #1104. It also opens up the door for a variety of other quality checks.

This PR introduces automated PR review comments for two types of formatting -- Prettier, and [Vale](https://vale.sh/). It also intentionally includes two formatting violations, to demonstrate what happens when format violations are included in a pull request.

There are many details described below. I'm looking for feedback of any kind, for any or all of it.

## Detecting cross-instance/cross-version links

This is done with custom Vale rules. The rules are inspired by [our guidance on preferred link format](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#internal-links). There are four of them: 

1. Within the main docs instance, any link that starts with `docs/` but doesn't end with `.md` or `.mdx` triggers a warning (navigating by source file path is preferred).
2. Within the main docs instance, any link that starts with `/optimize/` triggers a warning (using `$optimize$` is preferred).
3. Within the optimize docs instance, any link that starts with `optimize/` but doesn't end with `.md` or `.mdx` triggers a warning (navigating by source file path is preferred).
4. Within the optimize docs instance, any link that starts with `/docs/` triggers a warning (using `$docs$` is preferred).

This doesn't cover _all_ possible links that could cause cross-version linking, but it covers the large majority of issues we currently have.

## Reporting as comments

There are multiple options for reporting from the Vale GitHub action, but I chose reporting as comments because it's the most visible. I also set these rules to **not** fail the check. This is because I don't have 100% confidence that these rules will always prevent us from merging a PR.

## Vale

Vale was mentioned in #1904 as a possible tool for linting our docs for specific words/phrases. I looked at multiple tools for finding cross-instance/cross-version links, but this suggestion inspired me to use Vale. Configuring it here unlocks a massive opportunity to automate certain things that @christinaausley is watching for, enabling her to focus on less tedious work. One obvious current example -- we could add a rule to check for use of `Camunda Platform`. 

There are also a ton of language style rules (e.g. passive voice), spelling, ...so many options... that we can easily enable. See [Vale's built-in rules](https://vale.sh/explorer/), the [write-good rules](https://github.com/errata-ai/write-good), and [Microsoft's rules](https://github.com/errata-ai/Microsoft) -- all of these are easily enabled, with a line or two of configuration; we can also use any of them as inspiration to write our own.

## Format-checking as separate from the `build-docs` workflow

There is a technical reason that I chose to extract the format-checking steps from the `build-docs` workflow. The `build-docs` workflow can be triggered on `push` for Camunda-org members, which prevents the reporting aspects in this PR from identifying newly introduced changes. There are nearly 500 violations of the cross-linking rules already in the codebase -- so showing _all_ errors is not an option.

Having said that, I actually _prefer_ having these formatting checks separate from the build itself. It felt like build-docs was doing a lot of things, and having these things run in parallel should speed up the build-docs workflow a bit.

## Prettier reporting

This is completely separate from the Vale checking, and didn't need to be part of this experiment. But once I'd extracted a check-format workflow, it made sense to also move prettier in here....and once I'd done that, I really wanted to see what it'd be like to have comments on the PR, so that fly-by changes can be fixed when they include formatting issues. This is a long-standing pain point, described more in #1104. 

## When should this change go live?

It shouldn't. I'm going to break it into smaller pieces and open new PRs, after gathering feedback.

