### PR TITLE
update camunda platform docs references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,5 +20,5 @@
 
 - [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
 - [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
-- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
-- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
+- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
+- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -126,9 +126,9 @@ the Apache Spark contributor guidelines, and the Kubernetes contributor guide.
 [mdx]: https://mdxjs.com/
 [markdown]: https://www.markdownguide.org/
 [markdown and mdx features]: ./howtos/markdown-and-mdx-features.md
-[open a pull request]: https://github.com/camunda/camunda-platform-docs/compare
+[open a pull request]: https://github.com/camunda/camunda-docs/compare
 [documentation guidelines]: ./howtos/documentation-guidelines.md
-[opening an issue]: https://github.com/camunda/camunda-platform-docs/issues
+[opening an issue]: https://github.com/camunda/camunda-docs/issues
 [docusaurus 2]: https://v2.docusaurus.io/
 [github web-based editor]: https://docs.github.com/en/codespaces/the-githubdev-web-based-editor
 [git]: https://git-scm.com/

--- a/docs/reference/licenses.md
+++ b/docs/reference/licenses.md
@@ -30,7 +30,7 @@ The source code of Desktop Modeler is licensed under the MIT license as stated i
 
 ### Camunda 8 documentation
 
-License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-platform-docs/blob/main/LICENSE.txt) of the Camunda 8 documentation repository.
+License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-docs/blob/main/LICENSE.txt) of the Camunda 8 documentation repository.
 
 ## Terms & conditions
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ module.exports = {
   onBrokenMarkdownLinks: "throw",
   favicon: "img/favicon.ico",
   organizationName: "camunda", // Usually your GitHub org/user name.
-  projectName: "camunda-platform-docs", // Usually your repo name.
+  projectName: "camunda-docs", // Usually your repo name.
   trailingSlash: true,
   // do not delete the following 'noIndex' line as it is modified for staging
   noIndex: false,
@@ -45,7 +45,7 @@ module.exports = {
         routeBasePath: "optimize",
         beforeDefaultRemarkPlugins: [versionedLinks],
         sidebarPath: require.resolve("./optimize_sidebars.js"),
-        editUrl: "https://github.com/camunda/camunda-platform-docs/edit/main/",
+        editUrl: "https://github.com/camunda/camunda-docs/edit/main/",
         versions: {
           "3.9.0": {
             banner: "none",
@@ -235,8 +235,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl:
-            "https://github.com/camunda/camunda-platform-docs/edit/main/",
+          editUrl: "https://github.com/camunda/camunda-docs/edit/main/",
           beforeDefaultRemarkPlugins: [versionedLinks],
           // 👋 When cutting a new version, remove the banner for maintained versions by adding an entry. Remove the entry to versions >18 months old.
           versions: {

--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -63,11 +63,11 @@ Specific Optimize versions are aligned with Camunda versions as follows:
 
 The large object in each sidebars file contains two different types of items:
 
-- Items within the same [documentation instance](#instances-docs-vs-optimize) are [linked by the path to the target .md file](https://github.com/camunda/camunda-platform-docs/blob/89993fbc1446c203324f38139ae7eb40e19b14ac/versioned_sidebars/version-8.1-sidebars.json#L5):
+- Items within the same [documentation instance](#instances-docs-vs-optimize) are [linked by the path to the target .md file](https://github.com/camunda/camunda-docs/blob/89993fbc1446c203324f38139ae7eb40e19b14ac/versioned_sidebars/version-8.1-sidebars.json#L5):
   ```json
   "guides/introduction-to-camunda",
   ```
-- Items in the opposite [documentation instance](#instances-docs-vs-optimize) are [linked by an object containing the title and URL of the target document](https://github.com/camunda/camunda-platform-docs/blob/89993fbc1446c203324f38139ae7eb40e19b14ac/versioned_sidebars/version-8.1-sidebars.json#L331-L335):
+- Items in the opposite [documentation instance](#instances-docs-vs-optimize) are [linked by an object containing the title and URL of the target document](https://github.com/camunda/camunda-docs/blob/89993fbc1446c203324f38139ae7eb40e19b14ac/versioned_sidebars/version-8.1-sidebars.json#L331-L335):
   ```json
   {
     "type": "link",
@@ -77,7 +77,7 @@ The large object in each sidebars file contains two different types of items:
   ```
 
 > **Note**
-> The "next" versions of the docs are JavaScript rather than JSON. As such, [cross-instance sidebar items in these files](https://github.com/camunda/camunda-platform-docs/blob/main/sidebars.js#L266) call a helper function instead of emitting the entire cross-instance object for each item.
+> The "next" versions of the docs are JavaScript rather than JSON. As such, [cross-instance sidebar items in these files](https://github.com/camunda/camunda-docs/blob/main/sidebars.js#L266) call a helper function instead of emitting the entire cross-instance object for each item.
 
 ### Synchronization of sidebars
 
@@ -93,23 +93,23 @@ Any PRs that make a structural change to one of the instance's sidebars file in 
 When linking internally from one document to another, follow these guidelines:
 
 - if the source and target document are within the same instance (i.e. both are in `docs` or both are in `optimize`):
-  - Use a relative path to the target markdown file if it is in the same subtree as the source file. [See example](https://github.com/camunda/camunda-platform-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/components/console/introduction-to-console.md?plain=1#L10).
-  - Use an absolute path to the target markdown file if it is in a different subtree than the source file. [See example](https://github.com/camunda/camunda-platform-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/apis-tools/community-clients/spring.md?plain=1#L8).
+  - Use a relative path to the target markdown file if it is in the same subtree as the source file. [See example](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/components/console/introduction-to-console.md?plain=1#L10).
+  - Use an absolute path to the target markdown file if it is in a different subtree than the source file. [See example](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/apis-tools/community-clients/spring.md?plain=1#L8).
   - Always include the `.md` extension in the path.
 - if the source and target document are in different instances (i.e. one is in `docs` and the other is in `optimize`):
-  - If the source is in `docs` and the target is in `optimize`, use the `$optimize$` token to prefix the URL. [See example](https://github.com/camunda/camunda-platform-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/guides/setting-up-development-project.md?plain=1#L17).
-  - If the source is in `optimize` and the target is in `docs`, use the `$docs$` token to prefix the URL. [See example](https://github.com/camunda/camunda-platform-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/optimize/components/what-is-optimize.md?plain=1#L8).
+  - If the source is in `docs` and the target is in `optimize`, use the `$optimize$` token to prefix the URL. [See example](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/guides/setting-up-development-project.md?plain=1#L17).
+  - If the source is in `optimize` and the target is in `docs`, use the `$docs$` token to prefix the URL. [See example](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/optimize/components/what-is-optimize.md?plain=1#L8).
   - Use the browser-facing _URL_ to the target document, instead of the path to the target's `.md` file.
   - Do not include the `.md` extension on the target path.
 
 ## Adding a new documentation page
 
 1. Select the corresponding directory.
-2. Add the document id to [the corresponding sidebars file](#sidebar-navigation). [Example](https://github.com/camunda/camunda-platform-docs/blob/main/versioned_sidebars/version-8.1-sidebars.json#L47):
+2. Add the document id to [the corresponding sidebars file](#sidebar-navigation). [Example](https://github.com/camunda/camunda-docs/blob/main/versioned_sidebars/version-8.1-sidebars.json#L47):
    ```json
    " components/components-overview",
    ```
-3. If the doc is [in one of the shared sections](#synchronization-of-sidebars), add a parallel change to [the other instance's corresponding sidebars file](#sidebar-navigation). [Example](https://github.com/camunda/camunda-platform-docs/blob/main/optimize_versioned_sidebars/version-3.9.0-sidebars.json#L3-L7):
+3. If the doc is [in one of the shared sections](#synchronization-of-sidebars), add a parallel change to [the other instance's corresponding sidebars file](#sidebar-navigation). [Example](https://github.com/camunda/camunda-docs/blob/main/optimize_versioned_sidebars/version-3.9.0-sidebars.json#L3-L7):
    ```json
    {
      "type": "link",
@@ -152,7 +152,7 @@ Given the following procedures, teams will respond to screenshot updates and sug
 Visit the [Modeler screenshot automation repo](https://github.com/camunda/camunda-docs-modeler-screenshots/blob/main/README.md) for details on updating screenshots and scripting new screenshots.
 
 **Zeebe**
-Currently, Zeebe diagrams are stored as BPMN in a [repository](https://github.com/camunda/camunda-platform-docs/tree/main/media-src/product-manuals/zeebe), and as diagrams within Google Drive. This Google Drive is organized according to the structure of documentation in `camunda-platform-docs`.
+Currently, Zeebe diagrams are stored as BPMN in a [repository](https://github.com/camunda/camunda-docs/tree/main/media-src/product-manuals/zeebe), and as diagrams within Google Drive. This Google Drive is organized according to the structure of documentation in `camunda-docs`.
 
 :::note
 When saving diagrams, we should not take manual screenshots. Rather, authors should incorporate diagrams directly via **Download > PNG image (.png)**.
@@ -196,7 +196,7 @@ After the proposed change is finished open a GitHub PR and assign at least one r
 
 As a reviewer feel free to merge any PR which you feel comfortable with after your review. If you have questions, concerns, or feel that you are not the right person to review the PR please make this transparent to the PR author so they can clarify this.
 
-[versioned-source]: https://github.com/camunda/camunda-platform-docs/tree/main/versioned_docs
-[next-source]: https://github.com/camunda/camunda-platform-docs/tree/main/docs
-[versioned-sidebars]: https://github.com/camunda/camunda-platform-docs/tree/main/versioned_sidebars
-[next-sidebars]: https://github.com/camunda/camunda-platform-docs/blob/main/sidebars.js
+[versioned-source]: https://github.com/camunda/camunda-docs/tree/main/versioned_docs
+[next-source]: https://github.com/camunda/camunda-docs/tree/main/docs
+[versioned-sidebars]: https://github.com/camunda/camunda-docs/tree/main/versioned_sidebars
+[next-sidebars]: https://github.com/camunda/camunda-docs/blob/main/sidebars.js

--- a/howtos/markdown-and-mdx-features.md
+++ b/howtos/markdown-and-mdx-features.md
@@ -4,11 +4,11 @@ The Docusaurus documentation provides a detailed explanation of the Markdown fea
 
 ## Versioned links
 
-The custom [versionedLinks](https://github.com/camunda/camunda-platform-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/src/mdx/versionedLinks.js) MDX plugin allows us to link documentation [across instances](./documentation-guidelines.md#docs-vs-optimize) without having to declare version numbers in every link.
+The custom [versionedLinks](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/src/mdx/versionedLinks.js) MDX plugin allows us to link documentation [across instances](./documentation-guidelines.md#docs-vs-optimize) without having to declare version numbers in every link.
 
 The plugin will expand tokens (e.g. `$optimize$`) into a prefix for the correct version, based on the location of the source file. For example, if a file in `versioned_docs/version-8.0` links to `$optimize$/some-path`, it will expand to the correct URL for Optimize version 3.8.0.
 
-See [the expandVersionedUrl source](https://github.com/camunda/camunda-platform-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/src/mdx/expandVersionedUrl.js#L1-L23) for mappings of versions across instances.
+See [the expandVersionedUrl source](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/src/mdx/expandVersionedUrl.js#L1-L23) for mappings of versions across instances.
 
 ## Images
 

--- a/howtos/release-procedure.md
+++ b/howtos/release-procedure.md
@@ -12,12 +12,12 @@ To perform a patch release, confirm what is on `main` via staging at [stage.docs
 
 Then use the GitHub UI and follow the instructions below:
 
-1. Navigate to https://github.com/camunda/camunda-platform-docs/releases and click **Draft a new release**
+1. Navigate to https://github.com/camunda/camunda-docs/releases and click **Draft a new release**
 2. Click **Choose a tag** and create a new tag representing the next patch release. The title with autopopulate.
 3. Click **Autogenerate release notes**. The **Describe this release** field will fill with PRs included in this release.
 4. Click **Publish release**.
 
-The build process for [publish-prod](https://github.com/camunda/camunda-platform-docs/actions/workflows/publish-prod.yaml) will kick off which could take around 30 min to finish. If publish-prod is successful, the updates will appear on [docs.camunda.io](https://docs.camunda.io).
+The build process for [publish-prod](https://github.com/camunda/camunda-docs/actions/workflows/publish-prod.yaml) will kick off which could take around 30 min to finish. If publish-prod is successful, the updates will appear on [docs.camunda.io](https://docs.camunda.io).
 
 ## Perform a minor release
 
@@ -96,12 +96,12 @@ sitemap: {
 
 Use the GitHub UI and follow the instructions below:
 
-1. Navigate to https://github.com/camunda/camunda-platform-docs/releases and click **Draft a new release**
+1. Navigate to https://github.com/camunda/camunda-docs/releases and click **Draft a new release**
 2. Click **Choose a tag** and create a new tag representing the minor release. The title with autopopulate.
 3. Click **Autogenerate release notes**. The **Describe this release** field will fill with PRs included in this release.
 4. Click **Publish release**.
 
-The build process for [publish-prod](https://github.com/camunda/camunda-platform-docs/actions/workflows/publish-prod.yaml) will kick off which could take around 30 min to finish. If publish-prod is successful, the updates will appear on [docs.camunda.io](https://docs.camunda.io).
+The build process for [publish-prod](https://github.com/camunda/camunda-docs/actions/workflows/publish-prod.yaml) will kick off which could take around 30 min to finish. If publish-prod is successful, the updates will appear on [docs.camunda.io](https://docs.camunda.io).
 
 ## Manually Trigger the Algolia crawler (DocSearch)
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -39,13 +39,13 @@ When a version is archived, it is removed from the main docs, isolated on a bran
 
 1. Create a new branch named `unsupported/x.xx` where `x.xx` is the version to be archived. The branch should be created from the latest commit on the `main` branch.
 2. On the `main` branch:
-   1. Configure the `publish-prod` workflow to ignore tags for the archived version. See [this PR](https://github.com/camunda/camunda-platform-docs/pull/2172) as an example.
+   1. Configure the `publish-prod` workflow to ignore tags for the archived version. See [this PR](https://github.com/camunda/camunda-docs/pull/2172) as an example.
       - It's important to do this before publishing a production release for the archived version, to avoid accidentally publishing the archived version as the main docs.
 3. On the `unsupported/x.xx` branch:
    1. Confirm the version number(s) to be archived at the top of the `./hacks/isolateVersion/allSteps.sh` script.
    2. Run the `./hacks/isolateVersion/allSteps.sh` script. This automates a handful of basic steps; see the script for more details.
-      - For the sake of review-ability, you might consider breaking these changes into multiple PRs. See [this very large PR](https://github.com/camunda/camunda-platform-docs/pull/2165) and [this much smaller PR](https://github.com/camunda/camunda-platform-docs/pull/2166) as examples.
-   3. Make the manual changes described by the output of the `allSteps.sh` script. See [this PR](https://github.com/camunda/camunda-platform-docs/pull/2167) as an example.
+      - For the sake of review-ability, you might consider breaking these changes into multiple PRs. See [this very large PR](https://github.com/camunda/camunda-docs/pull/2165) and [this much smaller PR](https://github.com/camunda/camunda-docs/pull/2166) as examples.
+   3. Make the manual changes described by the output of the `allSteps.sh` script. See [this PR](https://github.com/camunda/camunda-docs/pull/2167) as an example.
    4. After they're all merged, confirm that these changes publish to the associated staging location: `https://stage.unsupported.docs.camunda.io/x.xx/`.
    5. Publish the production release for the archived version, by adding a tag to the HEAD of the `unsupported/x.xx` branch.
       - Name the tag `x.xx.0` where `x.xx` is the version number.

--- a/src/mdx/expandVersionedUrl.spec.js
+++ b/src/mdx/expandVersionedUrl.spec.js
@@ -3,7 +3,7 @@ const expandVersionedUrl = require("./expandVersionedUrl");
 describe("expandVersionedUrl", () => {
   describe("unexpandable URLs", () => {
     const sourcePath =
-      "/Users/monkeypants/camunda-platform-docs/optimize/what-is-optimize.md";
+      "/Users/monkeypants/camunda-docs/optimize/what-is-optimize.md";
 
     it.each(["/a/path/without/tokens", "$a$/path/with/unknown/tokens"])(
       "does not expand the URL %s",
@@ -18,16 +18,16 @@ describe("expandVersionedUrl", () => {
 
     it.each([
       [
-        "/Users/monkeypants/camunda-platform-docs/optimize/what-is-optimize.md",
+        "/Users/monkeypants/camunda-docs/optimize/what-is-optimize.md",
         "/docs/next/some/thing",
       ],
 
       [
-        "/Users/monkeypants/camunda-platform-docs/optimize_versioned_docs/version-3.10.0/what-is-optimize.md",
+        "/Users/monkeypants/camunda-docs/optimize_versioned_docs/version-3.10.0/what-is-optimize.md",
         "/docs/some/thing",
       ],
       [
-        "/Users/monkeypants/camunda-platform-docs/optimize_versioned_docs/version-3.7.0/what-is-optimize.md",
+        "/Users/monkeypants/camunda-docs/optimize_versioned_docs/version-3.7.0/what-is-optimize.md",
         "/docs/1.3/some/thing",
       ],
     ])("when in %s it expands to %s", (sourcePath, expandedUrl) => {
@@ -40,15 +40,15 @@ describe("expandVersionedUrl", () => {
 
     it.each([
       [
-        "/Users/monkeypants/camunda-platform-docs/docs/what-is-optimize.md",
+        "/Users/monkeypants/camunda-docs/docs/what-is-optimize.md",
         "/optimize/next/some/thing",
       ],
       [
-        "/Users/monkeypants/camunda-platform-docs/versioned_docs/version-8.2/what-is-optimize.md",
+        "/Users/monkeypants/camunda-docs/versioned_docs/version-8.2/what-is-optimize.md",
         "/optimize/some/thing",
       ],
       [
-        "/Users/monkeypants/camunda-platform-docs/versioned_docs/version-1.3/what-is-optimize.md",
+        "/Users/monkeypants/camunda-docs/versioned_docs/version-1.3/what-is-optimize.md",
         "/optimize/3.7.0/some/thing",
       ],
     ])("when in %s it expands to %s", (sourcePath, expandedUrl) => {

--- a/versioned_docs/version-8.0/reference/licenses.md
+++ b/versioned_docs/version-8.0/reference/licenses.md
@@ -26,7 +26,7 @@ The source code of Desktop Modeler is licensed under the MIT license as stated i
 
 ### Camunda Platform 8 documentation
 
-License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-platform-docs/blob/main/LICENSE.txt) of the Camunda Platform 8 documentation repository.
+License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-docs/blob/main/LICENSE.txt) of the Camunda Platform 8 documentation repository.
 
 ## Terms & conditions
 

--- a/versioned_docs/version-8.1/reference/licenses.md
+++ b/versioned_docs/version-8.1/reference/licenses.md
@@ -30,7 +30,7 @@ The source code of Desktop Modeler is licensed under the MIT license as stated i
 
 ### Camunda 8 documentation
 
-License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-platform-docs/blob/main/LICENSE.txt) of the Camunda 8 documentation repository.
+License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-docs/blob/main/LICENSE.txt) of the Camunda 8 documentation repository.
 
 ## Terms & conditions
 

--- a/versioned_docs/version-8.2/reference/licenses.md
+++ b/versioned_docs/version-8.2/reference/licenses.md
@@ -30,7 +30,7 @@ The source code of Desktop Modeler is licensed under the MIT license as stated i
 
 ### Camunda 8 documentation
 
-License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-platform-docs/blob/main/LICENSE.txt) of the Camunda 8 documentation repository.
+License information for our documentation can be found in the [LICENSE.txt](https://github.com/camunda/camunda-docs/blob/main/LICENSE.txt) of the Camunda 8 documentation repository.
 
 ## Terms & conditions
 


### PR DESCRIPTION
## Description

THE FINAL RENAMING STEP 👺 

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
