### PR TITLE
feat: detect crossover links as a PR check

### DIFF
--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -11,14 +11,14 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
+      - name: Verify format with Vale
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          filter_mode: added
+          reporter: github-pr-review
       - name: Verify format with Prettier
         uses: EPMatt/reviewdog-action-prettier@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           fail_on_error: true
-      - name: Verify format with Vale
-        uses: errata-ai/vale-action@reviewdog
-        with:
-          filter_mode: added
-          reporter: github-pr-review

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -16,9 +16,3 @@ jobs:
         with:
           filter_mode: added
           reporter: github-pr-review
-      - name: Verify format with Prettier
-        uses: EPMatt/reviewdog-action-prettier@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          fail_on_error: true

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -1,0 +1,24 @@
+name: check-format
+on: [pull_request]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Install Dependencies
+        run: npm ci
+      - name: Verify format with Prettier
+        uses: EPMatt/reviewdog-action-prettier@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          fail_on_error: true
+      - name: Verify format with Vale
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          filter_mode: added
+          reporter: github-pr-review

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = "styles/camunda"
 
 [{docs,versioned_docs}/**/*.{md,mdx}]
-BasedOnStyles = docsInstance
+BasedOnStyles = all, docsInstance
 
 [{optimize,optimize_versioned_docs}/**/*.{md,mdx}]
-BasedOnStyles = optimizeInstance
+BasedOnStyles = all, optimizeInstance

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = "styles/camunda"
+
+[{docs,versioned_docs}/**/*.{md,mdx}]
+BasedOnStyles = docsInstance
+
+[{optimize,optimize_versioned_docs}/**/*.{md,mdx}]
+BasedOnStyles = optimizeInstance

--- a/styles/camunda/all/hrefProduction.yml
+++ b/styles/camunda/all/hrefProduction.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please use relative URLs."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\(https://docs.camunda.io/(optimize|docs)/[^\\)]*\\)"

--- a/styles/camunda/all/hrefProduction.yml
+++ b/styles/camunda/all/hrefProduction.yml
@@ -4,4 +4,5 @@ level: warning
 nonword: true
 scope: raw
 tokens:
+  # Captures anything that is hardcoded to our production URL.
   - "\\[[^\\]]*\\]\\(https://docs.camunda.io/(optimize|docs)/[^\\)]*\\)"

--- a/styles/camunda/docsInstance/hrefDocsToDocs.yml
+++ b/styles/camunda/docsInstance/hrefDocsToDocs.yml
@@ -4,4 +4,5 @@ level: warning
 nonword: true
 scope: raw
 tokens:
+  # Captures any markdown link that directs to a URL starting with `docs` and not ending with `.md` or `.mdx`.
   - "\\[[^\\]]*\\]\\((\\.)?(\\/)?docs(?!.*(\\.md|\\.mdx))[^\\)]*\\)"

--- a/styles/camunda/docsInstance/hrefDocsToDocs.yml
+++ b/styles/camunda/docsInstance/hrefDocsToDocs.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please specify the file extension."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\((\\.)?(\\/)?docs(?!.*(\\.md|\\.mdx))[^\\)]*\\)"

--- a/styles/camunda/docsInstance/hrefDocsToOptimize.yml
+++ b/styles/camunda/docsInstance/hrefDocsToOptimize.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please use the `$optimize$` token when crossing doc instances."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\(\\/optimize[^\\)]*\\)"

--- a/styles/camunda/docsInstance/hrefDocsToOptimize.yml
+++ b/styles/camunda/docsInstance/hrefDocsToOptimize.yml
@@ -4,4 +4,5 @@ level: warning
 nonword: true
 scope: raw
 tokens:
+  # Captures any markdown link that crosses over to the `optimize` instance without using `$optimize$`.
   - "\\[[^\\]]*\\]\\(\\/optimize[^\\)]*\\)"

--- a/styles/camunda/optimizeInstance/hrefOptimizeToDocs.yml
+++ b/styles/camunda/optimizeInstance/hrefOptimizeToDocs.yml
@@ -4,4 +4,5 @@ level: warning
 nonword: true
 scope: raw
 tokens:
+  # Captures any markdown link that crosses over to the `docs` instance without using `$docs$`.
   - "\\[[^\\]]*\\]\\(\\/docs[^\\)]*\\)"

--- a/styles/camunda/optimizeInstance/hrefOptimizeToDocs.yml
+++ b/styles/camunda/optimizeInstance/hrefOptimizeToDocs.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please use the `$docs$` token when crossing doc instances."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\(\\/docs[^\\)]*\\)"

--- a/styles/camunda/optimizeInstance/hrefOptimizeToOptimize.yml
+++ b/styles/camunda/optimizeInstance/hrefOptimizeToOptimize.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Improper link format: '%s'. Please specify the file extension."
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - "\\[[^\\]]*\\]\\((\\.)?(\\/)?optimize(?!.*(\\.md|\\.mdx))[^\\)]*\\)"

--- a/styles/camunda/optimizeInstance/hrefOptimizeToOptimize.yml
+++ b/styles/camunda/optimizeInstance/hrefOptimizeToOptimize.yml
@@ -4,4 +4,5 @@ level: warning
 nonword: true
 scope: raw
 tokens:
+  # Captures any markdown link that directs to a URL starting with `optimize` and not ending with `.md` or `.mdx`.
   - "\\[[^\\]]*\\]\\((\\.)?(\\/)?optimize(?!.*(\\.md|\\.mdx))[^\\)]*\\)"


### PR DESCRIPTION
## Description

Addresses #1876.

See #2664 for more details and context about how this PR came about. 

This PR introduces [vale](https://vale.sh/) as a markdown linter. It introduces 4 linting rules that detect links that cross over instances or versions of the docs, and runs them as a pull request check.

- The 4 rules are run against only the changes included in the PR.
- If a rule is violated in a PR, a comment is added at the point of violation, as an FYI.
- If a rule is violated in a PR, the check **does not** fail.

An example of a violation can be found [in this prototype PR](https://github.com/camunda/camunda-docs/pull/2664#discussion_r1340415150). It looks like this: 

<img width="963" alt="image" src="https://github.com/camunda/camunda-docs/assets/1627089/c5a6a1cf-74fb-4287-8440-0333efbf8f90">

## The crossover validation rules

The rules in this PR are inspired by [our guidance on preferred link format](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/documentation-guidelines.md#internal-links). There are five of them: 

1. Within the main docs instance, any link that starts with `docs/` but doesn't end with `.md` or `.mdx` triggers a warning (navigating by source file path is preferred).
2. Within the main docs instance, any link that starts with `/optimize/` triggers a warning (using `$optimize$` is preferred).
3. Within the optimize docs instance, any link that starts with `optimize/` but doesn't end with `.md` or `.mdx` triggers a warning (navigating by source file path is preferred).
4. Within the optimize docs instance, any link that starts with `/docs/` triggers a warning (using `$docs$` is preferred).
5. Any link that starts with "https://docs.camunda.io/docs" or "https://docs.camunda.io/optimize" triggers a warning (prefer relative URLs).

This doesn't cover _all_ possible links that could cause cross-version linking, but it covers the large majority of issues we currently have.

## Running the validation locally

This PR **does not** include a command within the package.json to run vale locally. This is because vale is not distributed via npm. It can be installed on a computer via other means (e.g. homebrew) and run in this project directory to validate locally, like this: 

```
vale .
```

Though keep in mind, that runs against _all files_ and currently returns 436 warnings. It requires care and effort to isolate the exact problem when running locally.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
