### PR TITLE
Improve documentation for SearchAfter field

### DIFF
--- a/docs/apis-tools/tasklist-api-rest/schemas/requests/task-search-request.mdx
+++ b/docs/apis-tools/tasklist-api-rest/schemas/requests/task-search-request.mdx
@@ -178,19 +178,23 @@ TaskSearchRequest - query object to search tasks by provided params.
 
 #### [<code style={{ fontWeight: 'normal' }}>TaskSearchRequest.<b>searchAfter</b></code>](#)<Bullet />`string` <Badge class="secondary" text="list"/>
 
-> Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly after this values plus same sort values.
+> Array of values that should be copied from `sortValues` of one of the tasks from the current search results page. 
+> It enables the API to return a page of tasks that directly follow the provided values in terms of sorting order.
 
 #### [<code style={{ fontWeight: 'normal' }}>TaskSearchRequest.<b>searchAfterOrEqual</b></code>](#)<Bullet />`string` <Badge class="secondary" text="list"/>
 
-> Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly after this values.
+> Array of values that should be copied from `sortValues` of one of the tasks from the current search results page. 
+> It enables the API to return a page of tasks that directly follow or are equal to the provided values in terms of sorting order.
 
 #### [<code style={{ fontWeight: 'normal' }}>TaskSearchRequest.<b>searchBefore</b></code>](#)<Bullet />`string` <Badge class="secondary" text="list"/>
 
-> Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly before this values plus same sort values.
+> Array of values that should be copied from `sortValues` of one of the tasks from the current search results page. 
+> It enables the API to return a page of tasks that directly precede the provided values in terms of sorting order.
 
 #### [<code style={{ fontWeight: 'normal' }}>TaskSearchRequest.<b>searchBeforeOrEqual</b></code>](#)<Bullet />`string` <Badge class="secondary" text="list"/>
 
-> Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly before this values.
+> Array of values that should be copied from `sortValues` of one of the tasks from the current search results page. 
+> It enables the API to return a page of tasks that directly precede or are equal to the provided values in terms of sorting order.
 
 ### Consumed by
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->
https://github.com/camunda/tasklist/issues/3259

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
