### PR TITLE
chore: synchronize sidebars for v1.3/3.7.0

### DIFF
--- a/optimize_versioned_sidebars/version-3.7.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.7.0-sidebars.json
@@ -823,12 +823,12 @@
           "Camunda 7 specific": [
             {
               "type": "link",
-              "label": "Deciding about your Camunda 7 stack",
+              "label": "Deciding about your Camunda Platform 7 stack",
               "href": "/docs/1.3/components/best-practices/architecture/deciding-about-your-stack-c7/"
             },
             {
               "type": "link",
-              "label": "Sizing Your Camunda 7 Environment",
+              "label": "Sizing Your Camunda Platform 7 Environment",
               "href": "/docs/1.3/components/best-practices/architecture/sizing-your-environment-c7/"
             },
             {
@@ -858,7 +858,7 @@
             },
             {
               "type": "link",
-              "label": "Extending human task management in Camunda 7",
+              "label": "Extending human task management in Camunda Platform 7",
               "href": "/docs/1.3/components/best-practices/architecture/extending-human-task-management-c7/"
             }
           ]


### PR DESCRIPTION
## Description

Pre-work for #2432.

This PR synchronizes sidebars for the 1.3/3.7.0 version of the docs. 

## Not included

- Synchronization for <= 8.1. If that needs to happen, it will come in a separate PR.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule. Required prior to version release next week.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
