### PR TITLE
Add multi tenancy section to Job Worker

### DIFF
--- a/docs/apis-tools/java-client/job-worker.md
+++ b/docs/apis-tools/java-client/job-worker.md
@@ -199,19 +199,20 @@ We implemented a best-effort mechanism to detect such issues and make the job av
 
 To help ensure accurate detection of client shutdown, make sure to close your job workers gracefully when you're finished with them. This will in turn tell the gateway that the worker is gone, and will help prevent job loss.
 
-## Multi tenancy
+## Multi-tenancy
 
-You can configure a Job worker pick up jobs belonging to one, or more tenants. When using the builder you can configure
-the tenant(s) it works for. Alternatively, you can configure default tenant(s) on the client. If you configure a
-default, all Job workers you open will work on Jobs for the configured default tenants.
+You can configure a job worker to pick up jobs belonging to one or more tenants. When using the builder, you can configure
+the tenant(s) it works for.
+
+Alternatively, you can configure default tenant(s) on the client. If you configure a default, all job workers you open will work on jobs for the configured default tenants.
 
 :::note
-The client must be authorized for **all** the provided tenants. If it is not, the Job worker will not work on any Jobs.
+The client must be authorized for **all** the provided tenants. If it is not, the job worker will not work on any jobs.
 :::
 
 ### Job worker builder
 
-Opening a Job worker for a single tenant:
+Opening a job worker for a single tenant:
 
 ```java
 client.newWorker()
@@ -221,7 +222,7 @@ client.newWorker()
     .open();
 ```
 
-Opening a Job worker for multiple tenants:
+Opening a job worker for multiple tenants:
 
 ```java
 client.newWorker()

--- a/docs/apis-tools/java-client/job-worker.md
+++ b/docs/apis-tools/java-client/job-worker.md
@@ -198,3 +198,40 @@ Since an activated job must now cross two network boundaries - from broker to ga
 We implemented a best-effort mechanism to detect such issues and make the job available again, but this is never guaranteed, as it's not always possible to accurately detect in time that a job did not make it (e.g. network time out, where the job may or may not have made it to the recipient). When this happens, the job will remain in limbo until it times out, at which point it can be pushed out again.
 
 To help ensure accurate detection of client shutdown, make sure to close your job workers gracefully when you're finished with them. This will in turn tell the gateway that the worker is gone, and will help prevent job loss.
+
+## Multi tenancy
+
+You can configure a Job worker pick up jobs belonging to one, or more tenants. When using the builder you can configure
+the tenant(s) it works for. Alternatively, you can configure default tenant(s) on the client. If you configure a
+default, all Job workers you open will work on Jobs for the configured default tenants.
+
+:::note
+The client must be authorized for **all** the provided tenants. If it is not, the Job worker will not work on any Jobs.
+:::
+
+### Job worker builder
+
+Opening a Job worker for a single tenant:
+
+```java
+client.newWorker()
+    .jobType("myJobType")
+    .handler(new MyJobTypeHandler())
+    .tenantId("myTenant")
+    .open();
+```
+
+Opening a Job worker for multiple tenants:
+
+```java
+client.newWorker()
+    .jobType("myJobType")
+    .handler(new MyJobTypeHandler())
+    .tenantIds("myTenant", "myOtherTenant")
+    .open();
+```
+
+### Default tenant
+
+You can configure the default tenant(s) using environment variables or system properties. It's configured using
+`DEFAULT_JOB_WORKER_TENANT_IDS` or `zeebe.client.worker.tenantIds` respectively.

--- a/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
@@ -199,19 +199,20 @@ We implemented a best-effort mechanism to detect such issues and make the job av
 
 To help ensure accurate detection of client shutdown, make sure to close your job workers gracefully when you're finished with them. This will in turn tell the gateway that the worker is gone, and will help prevent job loss.
 
-## Multi tenancy
+## Multi-tenancy
 
-You can configure a Job worker pick up jobs belonging to one, or more tenants. When using the builder you can configure
-the tenant(s) it works for. Alternatively, you can configure default tenant(s) on the client. If you configure a
-default, all Job workers you open will work on Jobs for the configured default tenants.
+You can configure a job worker to pick up jobs belonging to one or more tenants. When using the builder, you can configure
+the tenant(s) it works for.
+
+Alternatively, you can configure default tenant(s) on the client. If you configure a default, all job workers you open will work on jobs for the configured default tenants.
 
 :::note
-The client must be authorized for **all** the provided tenants. If it is not, the Job worker will not work on any Jobs.
+The client must be authorized for **all** the provided tenants. If it is not, the job worker will not work on any jobs.
 :::
 
 ### Job worker builder
 
-Opening a Job worker for a single tenant:
+Opening a job worker for a single tenant:
 
 ```java
 client.newWorker()
@@ -221,7 +222,7 @@ client.newWorker()
     .open();
 ```
 
-Opening a Job worker for multiple tenants:
+Opening a job worker for multiple tenants:
 
 ```java
 client.newWorker()

--- a/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
@@ -198,3 +198,40 @@ Since an activated job must now cross two network boundaries - from broker to ga
 We implemented a best-effort mechanism to detect such issues and make the job available again, but this is never guaranteed, as it's not always possible to accurately detect in time that a job did not make it (e.g. network time out, where the job may or may not have made it to the recipient). When this happens, the job will remain in limbo until it times out, at which point it can be pushed out again.
 
 To help ensure accurate detection of client shutdown, make sure to close your job workers gracefully when you're finished with them. This will in turn tell the gateway that the worker is gone, and will help prevent job loss.
+
+## Multi tenancy
+
+You can configure a Job worker pick up jobs belonging to one, or more tenants. When using the builder you can configure
+the tenant(s) it works for. Alternatively, you can configure default tenant(s) on the client. If you configure a
+default, all Job workers you open will work on Jobs for the configured default tenants.
+
+:::note
+The client must be authorized for **all** the provided tenants. If it is not, the Job worker will not work on any Jobs.
+:::
+
+### Job worker builder
+
+Opening a Job worker for a single tenant:
+
+```java
+client.newWorker()
+    .jobType("myJobType")
+    .handler(new MyJobTypeHandler())
+    .tenantId("myTenant")
+    .open();
+```
+
+Opening a Job worker for multiple tenants:
+
+```java
+client.newWorker()
+    .jobType("myJobType")
+    .handler(new MyJobTypeHandler())
+    .tenantIds("myTenant", "myOtherTenant")
+    .open();
+```
+
+### Default tenant
+
+You can configure the default tenant(s) using environment variables or system properties. It's configured using
+`DEFAULT_JOB_WORKER_TENANT_IDS` or `zeebe.client.worker.tenantIds` respectively.


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

This commit adds a section about Multi tenancy in Job workers and how to configure them. It also includes some small code examples to guide users during implementation.

## When should this change go live?

Part of the 8.3 release

closes #2697

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
