### PR TITLE
docs(8.3-release): add release notes and blog link

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/introduction.md
+++ b/docs/self-managed/operational-guides/update-guide/introduction.md
@@ -20,10 +20,8 @@ There is a dedicated update guide for each version:
 
 Update from 8.2.x to 8.3.0
 
-<!-- ADD LINK WHEN AVAILABLE
-[Release notes](/)
-[Release blog](/)
--->
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.3.0)
+[Release blog](https://camunda.com/blog/2023/10/camunda-8-3-scaling-automation-maximize-value/)
 
 ### [Camunda 8.1 to Camunda 8.2](../810-to-820)
 

--- a/versioned_docs/version-8.3/self-managed/operational-guides/update-guide/introduction.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/update-guide/introduction.md
@@ -20,10 +20,8 @@ There is a dedicated update guide for each version:
 
 Update from 8.2.x to 8.3.0
 
-<!-- ADD LINK WHEN AVAILABLE
-[Release notes](/)
-[Release blog](/)
--->
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.3.0)
+[Release blog](https://camunda.com/blog/2023/10/camunda-8-3-scaling-automation-maximize-value/)
 
 ### [Camunda 8.1 to Camunda 8.2](../810-to-820)
 


### PR DESCRIPTION
## Description

Add release note and blog links to update guidelines

closes #2377 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
