### PR TITLE
make migration warning clearer

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -10,6 +10,10 @@ Release date: 10th of October 2023
 
 End of maintenance: 9th of April 2025
 
+:::caution
+We identified some bugs in 8.3.0 that could prevent the migration from succeeding. These are being addressed and will be available in an upcoming 8.3.1 patch. We suggest not updating until the patch is released.
+:::
+
 :::caution Breaking change
 
 ### Zeebe Docker image now runs with unprivileged user by default

--- a/docs/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/docs/self-managed/operational-guides/update-guide/820-to-830.md
@@ -9,8 +9,7 @@ description: "Review which adjustments must be made to migrate from Camunda 8.2.
 The following sections explain which adjustments must be made to migrate from Camunda 8.2.x to 8.3.0 for each component.
 
 :::caution
-Updating Operate, Tasklist, and Optimize from 8.2.x to 8.3.0 will potentially take longer than expected, depending on the data to be migrated.
-Additionally, we identified some bugs that could also prevent the migration from succeeding. These are being addressed and will be available in an upcoming 8.3.1 patch. We suggest not updating until the patch is released.
+Updating Operate, Tasklist, and Optimize from 8.2.x to 8.3.x will potentially take longer than expected, depending on the data to be migrated. We identified some bugs in the 8.3.0 release that could prevent migration from succeeding, which are fixed in 8.3.1. When updating, it is therefore recommended you skip version 8.3.0 and update directly to 8.3.1.
 :::
 
 ## Helm chart - Breaking Changes

--- a/docs/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/docs/self-managed/operational-guides/update-guide/820-to-830.md
@@ -9,7 +9,7 @@ description: "Review which adjustments must be made to migrate from Camunda 8.2.
 The following sections explain which adjustments must be made to migrate from Camunda 8.2.x to 8.3.0 for each component.
 
 :::caution
-Updating Operate, Tasklist, and Optimize from 8.2.x to 8.3.x will potentially take longer than expected, depending on the data to be migrated. We identified some bugs in the 8.3.0 release that could prevent migration from succeeding, which are fixed in 8.3.1. When updating, it is therefore recommended you skip version 8.3.0 and update directly to 8.3.1.
+We identified some bugs in 8.3.0 that could prevent the migration from succeeding. These are being addressed and will be available in an upcoming 8.3.1 patch. We suggest not updating until the patch is released.
 :::
 
 ## Helm chart - Breaking Changes

--- a/versioned_docs/version-8.3/reference/announcements.md
+++ b/versioned_docs/version-8.3/reference/announcements.md
@@ -10,6 +10,10 @@ Release date: 10th of October 2023
 
 End of maintenance: 9th of April 2025
 
+:::caution
+We identified some bugs in 8.3.0 that could prevent the migration from succeeding. These are being addressed and will be available in an upcoming 8.3.1 patch. We suggest not updating until the patch is released.
+:::
+
 :::caution Breaking change
 
 ### Zeebe Docker image now runs with unprivileged user by default

--- a/versioned_docs/version-8.3/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/update-guide/820-to-830.md
@@ -9,8 +9,7 @@ description: "Review which adjustments must be made to migrate from Camunda 8.2.
 The following sections explain which adjustments must be made to migrate from Camunda 8.2.x to 8.3.0 for each component.
 
 :::caution
-Updating Operate, Tasklist, and Optimize from 8.2.x to 8.3.0 will potentially take longer than expected, depending on the data to be migrated.
-Additionally, we identified some bugs that could also prevent the migration from succeeding. These are being addressed and will be available in an upcoming 8.3.1 patch. We suggest not updating until the patch is released.
+We identified some bugs in 8.3.0 that could prevent the migration from succeeding. These are being addressed and will be available in an upcoming 8.3.1 patch. We suggest not updating until the patch is released.
 :::
 
 ## Helm chart - Breaking Changes


### PR DESCRIPTION
## Description

Updating the migration warning we added based on suggestions from support to make less confusing for customers.
The /versioned file contains the text as we would like it to show prior to the upcoming 8.3.1 patch.
Once the patch it released, we will update the /versioned file to have the same text as the updated /next file

## When should this change go live?
asap please

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
