### PR TITLE
docs(ootbc): Add headers property to kafka connector

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/kafka.md
+++ b/docs/components/connectors/out-of-the-box-connectors/kafka.md
@@ -34,8 +34,9 @@ To make your **Kafka Producer Connector** for publishing messages executable, ta
 1. (Optional) Set the relevant credentials in the **Authentication** section. For example, `{{secrets.MY_KAFKA_USERNAME}}`. See the relevant [appendix section](#what-mechanism-is-used-to-authenticate-against-kafka) to find more about Kafka secure authentication.
 2. In the **Kafka** section, set the URL of bootstrap server(s); comma-separated if more than one server required.
 3. In the **Kafka** section, set the topic name.
-4. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
-5. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
+4. (Optional) In the **Kafka** section, fill out the field **Headers** to set producer configuration values. Only `UTF-8` strings are supported as header values.
+5. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
+6. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
 
 ## Kafka Producer Connector response
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/kafka.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/kafka.md
@@ -34,8 +34,9 @@ To make your **Kafka Producer Connector** for publishing messages executable, ta
 1. (Optional) Set the relevant credentials in the **Authentication** section. For example, `{{secrets.MY_KAFKA_USERNAME}}`. See the relevant [appendix section](#what-mechanism-is-used-to-authenticate-against-kafka) to find more about Kafka secure authentication.
 2. In the **Kafka** section, set the URL of bootstrap server(s); comma-separated if more than one server required.
 3. In the **Kafka** section, set the topic name.
-4. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
-5. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
+4. (Optional) In the **Kafka** section, fill out the field **Headers** to set producer configuration values. Only `UTF-8` strings are supported as header values.
+5. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
+6. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
 
 ## Kafka Producer Connector response
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/kafka.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/kafka.md
@@ -34,8 +34,9 @@ To make your **Kafka Producer Connector** for publishing messages executable, ta
 1. (Optional) Set the relevant credentials in the **Authentication** section. For example, `{{secrets.MY_KAFKA_USERNAME}}`. See the relevant [appendix section](#what-mechanism-is-used-to-authenticate-against-kafka) to find more about Kafka secure authentication.
 2. In the **Kafka** section, set the URL of bootstrap server(s); comma-separated if more than one server required.
 3. In the **Kafka** section, set the topic name.
-4. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
-5. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
+4. (Optional) In the **Kafka** section, fill out the field **Headers** to set producer configuration values. Only `UTF-8` strings are supported as header values.
+5. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
+6. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
 
 ## Kafka Producer Connector response
 

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/kafka.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/kafka.md
@@ -34,8 +34,9 @@ To make your **Kafka Producer Connector** for publishing messages executable, ta
 1. (Optional) Set the relevant credentials in the **Authentication** section. For example, `{{secrets.MY_KAFKA_USERNAME}}`. See the relevant [appendix section](#what-mechanism-is-used-to-authenticate-against-kafka) to find more about Kafka secure authentication.
 2. In the **Kafka** section, set the URL of bootstrap server(s); comma-separated if more than one server required.
 3. In the **Kafka** section, set the topic name.
-4. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
-5. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
+4. (Optional) In the **Kafka** section, fill out the field **Headers** to set producer configuration values. Only `UTF-8` strings are supported as header values.
+5. (Optional) In the **Kafka** section, fill out the field **Additional properties** to set producer configuration values. See the list of supported configurations at the [official Kafka documentation page](https://kafka.apache.org/documentation/#producerconfigs). Also check preconfigured values for the **Kafka Producer Connector** in the relevant [appendix section](#what-are-default-kafka-producer-client-properties).
+6. In the **Message** section, set the **Key** and the **Value** that will be sent to Kafka topic.
 
 ## Kafka Producer Connector response
 


### PR DESCRIPTION
## Description

Add headers property to kafka connector

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->
Related : 
 - [ ] https://github.com/camunda/connectors/issues/1016
 - [ ] https://github.com/camunda/web-modeler/pull/6498

## When should this change go live?
14, November, 2023
<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until 14, November, 2023 (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory
- [ ] I have added changes to the main `/docs` directory (aka `/next/`)
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
