### PR TITLE
Small improvements to configuring multi-tenancy in zeebe gateway

### DIFF
--- a/docs/self-managed/concepts/multi-tenancy.md
+++ b/docs/self-managed/concepts/multi-tenancy.md
@@ -6,6 +6,7 @@ description: "Multi-tenancy allows you to re-use your Camunda installation."
 ---
 
 :::caution
+
 Multi-tenancy is disabled by default and can be enabled by the use of environment variables. This feature should be
 enabled in all required components, see:
 
@@ -15,7 +16,8 @@ enabled in all required components, see:
 - [Tasklist multi-tenancy](../../../self-managed/tasklist-deployment/tasklist-configuration/#multi-tenancy)
 - [Optimize multi-tenancy]($optimize$/self-managed/optimize-deployment/configuration/multi-tenancy/)
 - [Connectors multi-tenancy](../../../self-managed/connectors-deployment/connectors-configuration/#multi-tenancy)
-  :::
+
+:::
 
 ## Multi-tenancy in Camunda 8
 

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -7,6 +7,10 @@ description: "Analyze how to configure the Zeebe gateway, including byte sizes, 
 
 The Zeebe Gateway can be configured similarly to the broker via the `application.yaml` file or environment variables. A complete gateway configuration template is available in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/dist/src/main/config/gateway.yaml.template).
 
+:::info Configure an embedded gateway
+If you're configuring a gateway that is embedded inside of a broker (i.e. you've set [`zeebe.broker.gateway.enable`](./broker.md#zeebebrokergateway)), then you must use `zeebe.broker.gateway.*` instead of `zeebe.gateway.*` for any of the configuration options below. For environment variables this means you must use `ZEEBE_BROKER_GATEWAY_*` instead of `ZEEBE_GATEWAY_*`.
+:::
+
 ## Conventions
 
 Take the following conventions into consideration when working with the gateway configuration.
@@ -171,7 +175,7 @@ security:
 | issuerBackendUrl | The URL to the auth provider backend, used to validate tokens. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL`. | http://keycloak:8080/auth/realms/camunda-platform |
 | audience         | The required audience of the auth token. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE`.                               | zeebe-api                                         |
 | type             | The identity auth type to apply, one of `keycloak` or `auth0`. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE`.             | keycloak                                          |
-| baseUrl          | The URL to the Identity instance. This setting can also be overridden using the environment variable `ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL`.                                | http://identity:8084                              |
+| baseUrl          | The URL to the Identity instance. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL`.                                       | http://identity:8084                              |
 
 #### YAML snippet
 
@@ -321,9 +325,9 @@ interceptors:
 Multi-tenancy in Zeebe can be configured with the following configuration properties; set the
 [`identity.baseUrl` property](#zeebegatewayclustersecurityauthenticationidentity) as well. Read more [in the multi-tenancy documentation](../../../self-managed/concepts/multi-tenancy.md).
 
-| Field   | Description                                                                                                                                            | Example value |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| enabled | Enables multi-tenancy for the cluster. This setting can also be overridden using the environment variable `ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED`. | True          |
+| Field   | Description                                                                                                                                     | Example value |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled | Enables multi-tenancy for the cluster. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_MULTITENANCY_ENABLED`. | True          |
 
 #### YAML snippet
 

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -322,8 +322,14 @@ interceptors:
 
 ### zeebe.gateway.multiTenancy
 
-Multi-tenancy in Zeebe can be configured with the following configuration properties; set the
-[`identity.baseUrl` property](#zeebegatewayclustersecurityauthenticationidentity) as well. Read more [in the multi-tenancy documentation](../../../self-managed/concepts/multi-tenancy.md).
+Multi-tenancy in Zeebe can be configured with the following configuration properties.
+Read more [in the multi-tenancy documentation](../../../self-managed/concepts/multi-tenancy.md).
+
+:::note
+For now, multi-tenancy is only supported in combination with Identity.
+To use multi-tenancy, you must set [`authentication.mode`](#zeebegatewayclustersecurityauthentication) to `'identity'` and specify the
+[`identity.baseUrl`](#zeebegatewayclustersecurityauthenticationidentity) as well.
+:::
 
 | Field   | Description                                                                                                                                     | Example value |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/configuration/gateway.md
@@ -7,6 +7,10 @@ description: "Analyze how to configure the Zeebe gateway, including byte sizes, 
 
 The Zeebe Gateway can be configured similarly to the broker via the `application.yaml` file or environment variables. A complete gateway configuration template is available in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/dist/src/main/config/gateway.yaml.template).
 
+:::info Configure an embedded gateway
+If you're configuring a gateway that is embedded inside of a broker (i.e. you've set [`zeebe.broker.gateway.enable`](./broker.md#zeebebrokergateway)), then you must use `zeebe.broker.gateway.*` instead of `zeebe.gateway.*` for any of the configuration options below. For environment variables this means you must use `ZEEBE_BROKER_GATEWAY_*` instead of `ZEEBE_GATEWAY_*`.
+:::
+
 ## Conventions
 
 Take the following conventions into consideration when working with the gateway configuration.

--- a/versioned_docs/version-8.3/self-managed/concepts/multi-tenancy.md
+++ b/versioned_docs/version-8.3/self-managed/concepts/multi-tenancy.md
@@ -6,6 +6,7 @@ description: "Multi-tenancy allows you to re-use your Camunda installation."
 ---
 
 :::caution
+
 Multi-tenancy is disabled by default and can be enabled by the use of environment variables. This feature should be
 enabled in all required components, see:
 
@@ -15,7 +16,8 @@ enabled in all required components, see:
 - [Tasklist multi-tenancy](../../../self-managed/tasklist-deployment/tasklist-configuration/#multi-tenancy)
 - [Optimize multi-tenancy]($optimize$/self-managed/optimize-deployment/configuration/multi-tenancy/)
 - [Connectors multi-tenancy](../../../self-managed/connectors-deployment/connectors-configuration/#multi-tenancy)
-  :::
+
+:::
 
 ## Multi-tenancy in Camunda 8
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/gateway.md
@@ -7,6 +7,10 @@ description: "Analyze how to configure the Zeebe gateway, including byte sizes, 
 
 The Zeebe Gateway can be configured similarly to the broker via the `application.yaml` file or environment variables. A complete gateway configuration template is available in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/dist/src/main/config/gateway.yaml.template).
 
+:::info Configure an embedded gateway
+If you're configuring a gateway that is embedded inside of a broker (i.e. you've set [`zeebe.broker.gateway.enable`](./broker.md#zeebebrokergateway)), then you must use `zeebe.broker.gateway.*` instead of `zeebe.gateway.*` for any of the configuration options below. For environment variables this means you must use `ZEEBE_BROKER_GATEWAY_*` instead of `ZEEBE_GATEWAY_*`.
+:::
+
 ## Conventions
 
 Take the following conventions into consideration when working with the gateway configuration.
@@ -171,7 +175,7 @@ security:
 | issuerBackendUrl | The URL to the auth provider backend, used to validate tokens. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL`. | http://keycloak:8080/auth/realms/camunda-platform |
 | audience         | The required audience of the auth token. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE`.                               | zeebe-api                                         |
 | type             | The identity auth type to apply, one of `keycloak` or `auth0`. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE`.             | keycloak                                          |
-| baseUrl          | The URL to the Identity instance. This setting can also be overridden using the environment variable `ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL`.                                | http://identity:8084                              |
+| baseUrl          | The URL to the Identity instance. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL`.                                       | http://identity:8084                              |
 
 #### YAML snippet
 
@@ -321,9 +325,9 @@ interceptors:
 Multi-tenancy in Zeebe can be configured with the following configuration properties; set the
 [`identity.baseUrl` property](#zeebegatewayclustersecurityauthenticationidentity) as well. Read more [in the multi-tenancy documentation](../../../self-managed/concepts/multi-tenancy.md).
 
-| Field   | Description                                                                                                                                            | Example value |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| enabled | Enables multi-tenancy for the cluster. This setting can also be overridden using the environment variable `ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED`. | True          |
+| Field   | Description                                                                                                                                     | Example value |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled | Enables multi-tenancy for the cluster. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_MULTITENANCY_ENABLED`. | True          |
 
 #### YAML snippet
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/gateway.md
@@ -322,8 +322,14 @@ interceptors:
 
 ### zeebe.gateway.multiTenancy
 
-Multi-tenancy in Zeebe can be configured with the following configuration properties; set the
-[`identity.baseUrl` property](#zeebegatewayclustersecurityauthenticationidentity) as well. Read more [in the multi-tenancy documentation](../../../self-managed/concepts/multi-tenancy.md).
+Multi-tenancy in Zeebe can be configured with the following configuration properties.
+Read more [in the multi-tenancy documentation](../../../self-managed/concepts/multi-tenancy.md).
+
+:::note
+For now, multi-tenancy is only supported in combination with Identity.
+To use multi-tenancy, you must set [`authentication.mode`](#zeebegatewayclustersecurityauthentication) to `'identity'` and specify the
+[`identity.baseUrl`](#zeebegatewayclustersecurityauthenticationidentity) as well.
+:::
 
 | Field   | Description                                                                                                                                     | Example value |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

This resolves multiple small problems with the documentation on configuring the Zeebe Gateway for multi-tenancy.

1. While the gateway configuration page discusses how to configure the gateway, it can be used to configure both a standalone gateway (`zeebe.gateway.*`) and an embedded gateway (`zeebe.broker.gateway.*`). However, the page focuses on documenting the standalone gateway. I've corrected all references to configuring an embedded gateway to a standalone gateway. I've also added an admonition to clarify how users can use the information on the page to configure an embedded gateway.
2. I also discovered that the caution admonition for the multi-tenancy concept was formatted wrongly, and fixed it.
3. Lastly, it wasn't documented that users must use Identity when they want to use multi-tenancy. This means they must set the authentication mode to identity. For an example where this was confusing, see [this thread](https://camunda.slack.com/archives/C02UMKN3DTL/p1697477187503239).

## Screenshots
1. New admonition to clarity how to configure an embedded gateway using the info on the page.
<img width="1007" alt="Screenshot 2023-10-17 at 14 35 00" src="https://github.com/camunda/camunda-docs/assets/3511026/2f14facd-ef59-4518-a2d7-a73343b5213a">

2. Broken caution admonition fixed
- Before <img width="1008" alt="Screenshot 2023-10-17 at 14 36 54" src="https://github.com/camunda/camunda-docs/assets/3511026/ec714f27-0531-4f4f-bc47-33bcab376f89">
- After <img width="1017" alt="Screenshot 2023-10-17 at 14 37 25" src="https://github.com/camunda/camunda-docs/assets/3511026/96916088-5f4e-4d1f-ba7c-e66041d1b796">

3. Documented how to configure multi-tenancy with Identity.
- Before <img width="1007" alt="Screenshot 2023-10-17 at 14 34 21" src="https://github.com/camunda/camunda-docs/assets/3511026/f6556da1-88ea-4d95-b54c-65dd68ca7153">

- After <img width="1007" alt="Screenshot 2023-10-17 at 14 34 39" src="https://github.com/camunda/camunda-docs/assets/3511026/ad90d066-04a7-4a04-b9dd-235f19981b4d">

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
