### PR TITLE
chore(connectors): updated references and run instructions

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/slack.md
+++ b/docs/components/connectors/out-of-the-box-connectors/slack.md
@@ -211,7 +211,16 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `"event": {"text": "12345"}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.body.event.text`
+- **Correlation key (payload)**: `=if request.body.event = null then "" else request.body.event.text`
+
+:::note
+Please, keep in mind that when you subscribe to the Slack Events API, Slack will send an URL verification message first.
+Since a verification message does not contain `event` object, you have to specify the correlation key as following:
+`=if request.body.event = null then "" else <your payload extraction>` otherwise Zeebe will reject Slack verification message
+with HTTP code 422 `Correlation key not resolved: =request.body.event.text`.
+
+See an example of an URL verification message in [appendix](#slack-url-verification-request-example)
+:::
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 
@@ -295,6 +304,16 @@ for every incoming request. Read more about signing secrets in the
 [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
 
 ## Appendix
+
+### Slack URL verification request example
+
+```json
+{
+  "token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+  "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+  "type": "url_verification"
+}
+```
 
 ### Slack `app_mention` event example
 

--- a/docs/self-managed/platform-deployment/manual.md
+++ b/docs/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.0/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.0/self-managed/connectors-deployment/connectors-configuration.md
@@ -148,6 +148,6 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
@@ -149,18 +149,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` annotations
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/slack.md
@@ -211,7 +211,16 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `"event": {"text": "12345"}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.body.event.text`
+- **Correlation key (payload)**: `=if request.body.event = null then "" else request.body.event.text`
+
+:::note
+Please, keep in mind that when you subscribe to the Slack Events API, Slack will send an URL verification message first.
+Since a verification message does not contain `event` object, you have to specify the correlation key as following:
+`=if request.body.event = null then "" else <your payload extraction>` otherwise Zeebe will reject Slack verification message
+with HTTP code 422 `Correlation key not resolved: =request.body.event.text`.
+
+See an example of an URL verification message in [appendix](#slack-url-verification-request-example)
+:::
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 
@@ -295,6 +304,16 @@ for every incoming request. Read more about signing secrets in the
 [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
 
 ## Appendix
+
+### Slack URL verification request example
+
+```json
+{
+  "token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+  "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+  "type": "url_verification"
+}
+```
 
 ### Slack `app_mention` event example
 

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
@@ -148,6 +148,6 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/slack.md
@@ -211,7 +211,16 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `"event": {"text": "12345"}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.body.event.text`
+- **Correlation key (payload)**: `=if request.body.event = null then "" else request.body.event.text`
+
+:::note
+Please, keep in mind that when you subscribe to the Slack Events API, Slack will send an URL verification message first.
+Since a verification message does not contain `event` object, you have to specify the correlation key as following:
+`=if request.body.event = null then "" else <your payload extraction>` otherwise Zeebe will reject Slack verification message
+with HTTP code 422 `Correlation key not resolved: =request.body.event.text`.
+
+See an example of an URL verification message in [appendix](#slack-url-verification-request-example)
+:::
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 
@@ -295,6 +304,16 @@ for every incoming request. Read more about signing secrets in the
 [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
 
 ## Appendix
+
+### Slack URL verification request example
+
+```json
+{
+  "token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+  "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+  "type": "url_verification"
+}
+```
 
 ### Slack `app_mention` event example
 

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
@@ -148,6 +148,6 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/slack.md
@@ -211,7 +211,16 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `"event": {"text": "12345"}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.body.event.text`
+- **Correlation key (payload)**: `=if request.body.event = null then "" else request.body.event.text`
+
+:::note
+Please, keep in mind that when you subscribe to the Slack Events API, Slack will send an URL verification message first.
+Since a verification message does not contain `event` object, you have to specify the correlation key as following:
+`=if request.body.event = null then "" else <your payload extraction>` otherwise Zeebe will reject Slack verification message
+with HTTP code 422 `Correlation key not resolved: =request.body.event.text`.
+
+See an example of an URL verification message in [appendix](#slack-url-verification-request-example)
+:::
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 
@@ -295,6 +304,16 @@ for every incoming request. Read more about signing secrets in the
 [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
 
 ## Appendix
+
+### Slack URL verification request example
+
+```json
+{
+  "token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+  "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+  "type": "url_verification"
+}
+```
 
 ### Slack `app_mention` event example
 

--- a/versioned_docs/version-8.3/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/connectors-deployment/connectors-configuration.md
@@ -148,7 +148,7 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 


### PR DESCRIPTION
## Description

chore(connectors): updated references and run instructions

## When should this change go live?

⚠️ we decided to hold it off for now.

- [x] This change is not yet live and should not be merged until `hold` label is removed
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
