### PR TITLE
docs(self-managed): add upgrade notes for Helm chart 8.3.1

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -93,6 +93,35 @@ For more details on the Keycloak upgrade path, you can also read the [Bitnami Ke
 
 ## Version update instructions
 
+### v8.3.1
+
+:::caution
+The following steps are applied when upgrading from any previous version not only 8.3.0.
+:::
+
+To fix a critical issue, the following components had labels changes: Operate, Optimize, Tasklist, Zeebe, and Zeebe Gateway.
+
+Hence, before the upgrading from any previous versions, the Deployment/StatefulSet should be deleted (there will be a downtime between the resource deletion and the actual upgrade).
+
+```shell
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-operate
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-tasklist
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-optimize
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-zeebe-gateway
+kubectl -n <RELEASE_NAMESPACE> delete statefulset <RELEASE_NAME>-zeebe
+```
+
+Then follow the upgrade process as normal.
+
+#### Zeebe Gateway
+
+This change has no effect in the normal upgrade using Helm CLI, however it could be important in case you are using Helm post-rendering via other tools like Kustomize.
+
+The following resources have been renamed:
+
+- **ConfigMap:** From `<RELEASE_NAME>-zeebe-gateway-gateway` to `<RELEASE_NAME>-zeebe-gateway`.
+- **ServiceAccount:** From `<RELEASE_NAME>-zeebe-gateway-gateway` to `<RELEASE_NAME>-zeebe-gateway`.
+
 ### v8.3.0 (minor)
 
 :::caution

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -93,6 +93,35 @@ For more details on the Keycloak upgrade path, you can also read the [Bitnami Ke
 
 ## Version update instructions
 
+### v8.3.1
+
+:::caution
+The following steps are applied when upgrading from any previous version not only 8.3.0.
+:::
+
+To fix a critical issue, the following components had labels changes: Operate, Optimize, Tasklist, Zeebe, and Zeebe Gateway.
+
+Hence, before the upgrading from any previous versions, the Deployment/StatefulSet should be deleted (there will be a downtime between the resource deletion and the actual upgrade).
+
+```shell
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-operate
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-tasklist
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-optimize
+kubectl -n <RELEASE_NAMESPACE> delete deployment <RELEASE_NAME>-zeebe-gateway
+kubectl -n <RELEASE_NAMESPACE> delete statefulset <RELEASE_NAME>-zeebe
+```
+
+Then follow the upgrade process as normal.
+
+#### Zeebe Gateway
+
+This change has no effect in the normal upgrade using Helm CLI, however it could be important in case you are using Helm post-rendering via other tools like Kustomize.
+
+The following resources have been renamed:
+
+- **ConfigMap:** From `<RELEASE_NAME>-zeebe-gateway-gateway` to `<RELEASE_NAME>-zeebe-gateway`.
+- **ServiceAccount:** From `<RELEASE_NAME>-zeebe-gateway-gateway` to `<RELEASE_NAME>-zeebe-gateway`.
+
 ### v8.3.0 (minor)
 
 :::caution


### PR DESCRIPTION
## Description

Upgrade notes for Helm chart 8.3.1
Related to: https://github.com/camunda/camunda-platform-helm/pull/962

## When should this change go live?

v8.3.1 release.

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
