### PR TITLE
chore(connectors): updated runtime execution information

### DIFF
--- a/docs/self-managed/connectors-deployment/connectors-configuration.md
+++ b/docs/self-managed/connectors-deployment/connectors-configuration.md
@@ -168,7 +168,7 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```
 

--- a/docs/self-managed/platform-deployment/manual.md
+++ b/docs/self-managed/platform-deployment/manual.md
@@ -170,7 +170,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official Connectors.
+Bundle includes runtime with all available Camunda Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.

--- a/docs/self-managed/platform-deployment/manual.md
+++ b/docs/self-managed/platform-deployment/manual.md
@@ -170,13 +170,13 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official connectors.
+Bundle includes runtime with all Camunda official Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/bundle-with-connector $
@@ -184,7 +184,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors bundle with all custom connectors locally, run:
+To start Connectors bundle with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -200,7 +200,7 @@ The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connect
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/runtime-only-with-connector $
@@ -208,7 +208,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors runtime with all custom connectors locally, run:
+To start Connectors runtime with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -218,7 +218,7 @@ This starts a Zeebe client, registering the defined Connector as a job worker. B
 
 ### Configuring runtime
 
-Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+Visit the [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
 to find up-to-date runtime configuration options.
 
 ## Run Identity

--- a/docs/self-managed/platform-deployment/manual.md
+++ b/docs/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
@@ -149,18 +149,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
@@ -151,7 +151,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official Connectors.
+Bundle includes runtime with all available Camunda Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/local.md
@@ -151,13 +151,13 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official connectors.
+Bundle includes runtime with all Camunda official Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/bundle-with-connector $
@@ -165,7 +165,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors bundle with all custom connectors locally, run:
+To start Connectors bundle with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -179,9 +179,9 @@ Runtime-only variant is useful when you wish to run only specific Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
 outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/runtime-only-with-connector $
@@ -189,7 +189,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors runtime with all custom connectors locally, run:
+To start Connectors runtime with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -199,7 +199,7 @@ This starts a Zeebe client, registering the defined Connector as a job worker. B
 
 ### Configuring runtime
 
-Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+Visit the [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
 to find up-to-date runtime configuration options.
 
 ## Run Identity

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
@@ -148,6 +148,6 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
@@ -170,7 +170,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official Connectors.
+Bundle includes runtime with all available Camunda Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
@@ -170,13 +170,13 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official connectors.
+Bundle includes runtime with all Camunda official Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/bundle-with-connector $
@@ -184,7 +184,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors bundle with all custom connectors locally, run:
+To start Connectors bundle with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -200,7 +200,7 @@ The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connect
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/runtime-only-with-connector $
@@ -208,7 +208,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors runtime with all custom connectors locally, run:
+To start Connectors runtime with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -218,7 +218,7 @@ This starts a Zeebe client, registering the defined Connector as a job worker. B
 
 ### Configuring runtime
 
-Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+Visit the [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
 to find up-to-date runtime configuration options.
 
 ## Run Identity

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
@@ -148,6 +148,6 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
@@ -170,7 +170,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official Connectors.
+Bundle includes runtime with all available Camunda Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
@@ -170,13 +170,13 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official connectors.
+Bundle includes runtime with all Camunda official Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/bundle-with-connector $
@@ -184,7 +184,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors bundle with all custom connectors locally, run:
+To start Connectors bundle with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -200,7 +200,7 @@ The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connect
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/runtime-only-with-connector $
@@ -208,7 +208,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors runtime with all custom connectors locally, run:
+To start Connectors runtime with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -218,7 +218,7 @@ This starts a Zeebe client, registering the defined Connector as a job worker. B
 
 ### Configuring runtime
 
-Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+Visit the [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
 to find up-to-date runtime configuration options.
 
 ## Run Identity

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 

--- a/versioned_docs/version-8.3/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/connectors-deployment/connectors-configuration.md
@@ -168,7 +168,7 @@ docker run --rm --name=connectors -d \
 In manual installations, add the JAR to the `-cp` argument of the Java call:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
+java -cp 'connector-runtime-application-VERSION-with-dependencies.jar:...:my-secret-provider-with-dependencies.jar' \
     io.camunda.connector.runtime.ConnectorRuntimeApplication
 ```
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
@@ -170,7 +170,7 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official Connectors.
+Bundle includes runtime with all available Camunda Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
@@ -170,13 +170,13 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ### Bundle
 
-Bundle includes runtime with all Camunda official connectors.
+Bundle includes runtime with all Camunda official Connectors.
 
 The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/bundle-with-connector $
@@ -184,7 +184,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors bundle with all custom connectors locally, run:
+To start Connectors bundle with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -200,7 +200,7 @@ The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connect
 outbound Connectors available on the `classpath` automatically.
 It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
 
-Consider, you have the following file structure:
+Consider the following file structure:
 
 ```shell
 /home/user/runtime-only-with-connector $
@@ -208,7 +208,7 @@ Consider, you have the following file structure:
 └── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
 ```
 
-To start Connectors runtime with all custom connectors locally, run:
+To start Connectors runtime with all custom Connectors locally, run:
 
 ```bash
 java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
@@ -218,7 +218,7 @@ This starts a Zeebe client, registering the defined Connector as a job worker. B
 
 ### Configuring runtime
 
-Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+Visit the [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
 to find up-to-date runtime configuration options.
 
 ## Run Identity

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/manual.md
@@ -168,18 +168,58 @@ To update Tasklist versions, visit the [guide to update Tasklist](../../componen
 
 ## Run Connectors
 
-The [Connector runtime environment](https://repo1.maven.org/maven2/io/camunda/spring-zeebe-connector-runtime) picks up outbound Connectors available on the `classpath` automatically.
-It uses the default configuration specified by a Connector through its `@OutboundConnector` annotation.
+### Bundle
 
-To run the [REST Connector](https://search.maven.org/artifact/io.camunda.connector/connector-http-json) with the runtime environment, execute the following command:
+Bundle includes runtime with all Camunda official connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/bundle-with-connector $
+├── connector-runtime-bundle-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors bundle with all custom connectors locally, run:
 
 ```bash
-java -cp 'spring-zeebe-connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+java -cp "/home/user/bundle-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 ```
 
 This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
-You can configure the Zeebe client using the options provided by [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#configuration-options).
+
+### Runtime-only
+
+Runtime-only variant is useful when you wish to run only specific Connectors.
+
+The [Connector runtime bundle](https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-application/) picks up
+outbound Connectors available on the `classpath` automatically.
+It uses the default configuration specified by a Connector through its `@OutboundConnector` and `@InboundConnector` annotations.
+
+Consider, you have the following file structure:
+
+```shell
+/home/user/runtime-only-with-connector $
+├── connector-runtime-application-VERSION-with-dependencies.jar
+└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+```
+
+To start Connectors runtime with all custom connectors locally, run:
+
+```bash
+java -cp "/home/user/runtime-only-with-connector/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+```
+
+This starts a Zeebe client, registering the defined Connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.
+
+### Configuring runtime
+
+Checkout a [Camunda Connector Runtime GitHub page](https://github.com/camunda/connectors/tree/main/connector-runtime#configuration-options)
+to find up-to-date runtime configuration options.
 
 ## Run Identity
 


### PR DESCRIPTION
## Description

chore(connectors): updated runtime execution information

## When should this change go live?

Anytime

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
