### PR TITLE
Connectors/OOTB/Salesforce: Added reference to examples

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/salesforce.md
+++ b/docs/components/connectors/out-of-the-box-connectors/salesforce.md
@@ -72,19 +72,23 @@ The response body looks like the following:
 
 **sObject records** support **Create record**, **Get record**, **Update record**, and **Delete record**.
 
+:::note
+Every operation explanation contains a link to the Salesforce API docs which will explain the request and provide an example.
+:::
+
 #### Create record
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Record fields:** Field values for the Salesforce object to create.
+- **Record fields:** Field values for the Salesforce object to create, e.g. `{ Name: "Express Logistics and Transport" }`.
 
-Review the response body format in the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm).
+Review an example including the response body format in the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm).
 
 #### Get record
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
-- **Relationship field name _(optional)_:** Name of the field that contains the relationship.
-- **Query Parameters _(optional)_:** Additional query parameters that can be provided along with the request.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
+- **Relationship field name _(optional)_:** Name of the field that contains the relationship, e.g. _Opportunities_.
+- **Query Parameters _(optional)_:** Additional query parameters that can be provided along with the request, e.g. `{ fields: "AccountNumber,BillingPostalCode" }`.
 
 When omitting the **Relationship field name**, a [get request for a record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_get.htm) is performed. Otherwise, a [get request for records using sObject relationships](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_relationships_get.htm) is performed. In the documentation linked above, you can find the possible use case for **Query parameters**; for example, [filtering fields](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm).
 
@@ -106,8 +110,8 @@ Find another example [here](https://developer.salesforce.com/docs/atlas.en-us.ap
 #### Update object
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
-- **Record fields:** Field values for the Salesforce object to update.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
+- **Record fields:** Field values for the Salesforce object to update, e.g. `{ BillingCity : "San Francisco" }`.
 
 [These update the record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_patch.htm) using the given fields.
 
@@ -116,7 +120,7 @@ As an update does not return a body, you will not be able to map any data from t
 #### Delete object
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
 
 [These delete the record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm).
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/salesforce.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/salesforce.md
@@ -72,19 +72,23 @@ The response body looks like the following:
 
 **sObject records** support **Create record**, **Get record**, **Update record**, and **Delete record**.
 
+:::note
+Every operation explanation contains a link to the Salesforce API docs which will explain the request and provide an example.
+:::
+
 #### Create record
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Record fields:** Field values for the Salesforce object to create.
+- **Record fields:** Field values for the Salesforce object to create, e.g. `{ Name: "Express Logistics and Transport" }`.
 
-Review the response body format in the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm).
+Review an example including the response body format in the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm).
 
 #### Get record
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
-- **Relationship field name _(optional)_:** Name of the field that contains the relationship.
-- **Query Parameters _(optional)_:** Additional query parameters that can be provided along with the request.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
+- **Relationship field name _(optional)_:** Name of the field that contains the relationship, e.g. _Opportunities_.
+- **Query Parameters _(optional)_:** Additional query parameters that can be provided along with the request, e.g. `{ fields: "AccountNumber,BillingPostalCode" }`.
 
 When omitting the **Relationship field name**, a [get request for a record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_get.htm) is performed. Otherwise, a [get request for records using sObject relationships](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_relationships_get.htm) is performed. In the documentation linked above, you can find the possible use case for **Query parameters**; for example, [filtering fields](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm).
 
@@ -106,8 +110,8 @@ Find another example [here](https://developer.salesforce.com/docs/atlas.en-us.ap
 #### Update object
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
-- **Record fields:** Field values for the Salesforce object to update.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
+- **Record fields:** Field values for the Salesforce object to update, e.g. `{ BillingCity : "San Francisco" }`.
 
 [These update the record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_patch.htm) using the given fields.
 
@@ -116,7 +120,7 @@ As an update does not return a body, you will not be able to map any data from t
 #### Delete object
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
 
 [These delete the record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm).
 

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/salesforce.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/salesforce.md
@@ -72,19 +72,23 @@ The response body looks like the following:
 
 **sObject records** support **Create record**, **Get record**, **Update record**, and **Delete record**.
 
+:::note
+Every operation explanation contains a link to the Salesforce API docs which will explain the request and provide an example.
+:::
+
 #### Create record
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Record fields:** Field values for the Salesforce object to create.
+- **Record fields:** Field values for the Salesforce object to create, e.g. `{ Name: "Express Logistics and Transport" }`.
 
-Review the response body format in the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm).
+Review an example including the response body format in the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm).
 
 #### Get record
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
-- **Relationship field name _(optional)_:** Name of the field that contains the relationship.
-- **Query Parameters _(optional)_:** Additional query parameters that can be provided along with the request.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
+- **Relationship field name _(optional)_:** Name of the field that contains the relationship, e.g. _Opportunities_.
+- **Query Parameters _(optional)_:** Additional query parameters that can be provided along with the request, e.g. `{ fields: "AccountNumber,BillingPostalCode" }`.
 
 When omitting the **Relationship field name**, a [get request for a record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_get.htm) is performed. Otherwise, a [get request for records using sObject relationships](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_relationships_get.htm) is performed. In the documentation linked above, you can find the possible use case for **Query parameters**; for example, [filtering fields](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm).
 
@@ -106,8 +110,8 @@ Find another example [here](https://developer.salesforce.com/docs/atlas.en-us.ap
 #### Update object
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
-- **Record fields:** Field values for the Salesforce object to update.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
+- **Record fields:** Field values for the Salesforce object to update, e.g. `{ BillingCity : "San Francisco" }`.
 
 [These update the record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_patch.htm) using the given fields.
 
@@ -116,7 +120,7 @@ As an update does not return a body, you will not be able to map any data from t
 #### Delete object
 
 - **Salesforce object:** The Salesforce object to create, e.g. _Account_.
-- **Salesforce object ID:** Identifier of the Salesforce object.
+- **Salesforce object ID:** Identifier of the Salesforce object, e.g. _001R0000005hDFYIA2_.
 
 [These delete the record](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm).
 


### PR DESCRIPTION
## Description

This PR will add a hint that each operation description contains a link to the Salesforce docs which contains useful examples.

Also, this PR adds examples to each parameter.

closes https://github.com/camunda/team-connectors/issues/495

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
