### PR TITLE
fix(reference): added 8.3 version matrix for dependency components

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -47,6 +47,7 @@ The core Camunda components have a unified fixed release schedule following the 
 
 | Helm chart | Zeebe, Operate, Tasklist | Optimize | Web Modeler | Connectors |
 | ---------- | ------------------------ | -------- | ----------- | ---------- |
+| 8.3.x      | 8.3.x                    | 3.11.x   | 8.3.x       | >= 8.3.0   |
 | 8.2.x      | 8.2.x                    | 3.10.x   | 8.2.x       | >= 0.18.0  |
 | 8.1.x      | 8.1.x                    | 3.9.x    | N/A         | N/A        |
 | 8.0.x      | 8.0.x                    | 3.9.x    | N/A         | N/A        |

--- a/versioned_docs/version-8.3/reference/supported-environments.md
+++ b/versioned_docs/version-8.3/reference/supported-environments.md
@@ -47,6 +47,7 @@ The core Camunda components have a unified fixed release schedule following the 
 
 | Helm chart | Zeebe, Operate, Tasklist | Optimize | Web Modeler | Connectors |
 | ---------- | ------------------------ | -------- | ----------- | ---------- |
+| 8.3.x      | 8.3.x                    | 3.11.x   | 8.3.x       | >= 8.3.0   |
 | 8.2.x      | 8.2.x                    | 3.10.x   | 8.2.x       | >= 0.18.0  |
 | 8.1.x      | 8.1.x                    | 3.9.x    | N/A         | N/A        |
 | 8.0.x      | 8.0.x                    | 3.9.x    | N/A         | N/A        |


### PR DESCRIPTION
## Description

This change will let customers know which component versions are officially supported on version 8.3.


<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

Soon, but there's no urgency. I think this PR should have been created before 8.3 but our team got busy with other things, so we forgot to add it.

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
