### PR TITLE
Update exclusive-gateways.md

### DIFF
--- a/versioned_docs/version-1.3/components/modeler/bpmn/exclusive-gateways/exclusive-gateways.md
+++ b/versioned_docs/version-1.3/components/modeler/bpmn/exclusive-gateways/exclusive-gateways.md
@@ -20,7 +20,7 @@ An exclusive gateway can also be used to join multiple incoming flows together a
 
 A `conditionExpression` defines when a flow is taken. It is a [boolean expression](/components/concepts/expressions.md#boolean-expressions) that can access the process instance variables and compare them with literals or other variables. The condition is fulfilled when the expression returns `true`.
 
-Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).
+Multiple Boolean values or comparisons can be combined as disjunction (`OR`) or conjunction (`AND`).
 
 For example:
 


### PR DESCRIPTION
There was a typo in the Camunda 8 documentation:

>Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).

But:
disjunction = OR,
conjunction = AND.

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
