### PR TITLE
archive(8.0) isolation: port recent changes in main

### DIFF
--- a/versioned_docs/version-8.0/components/best-practices/development/service-integration-patterns.md
+++ b/versioned_docs/version-8.0/components/best-practices/development/service-integration-patterns.md
@@ -120,7 +120,7 @@ You can leverage [message buffering](/docs/components/concepts/messages#message-
 
 Retries are not built-in, so if you need to model a loop to retry the initial service call if no response is received. And (at least in the current Zeebe version), there is no possibility to trigger error events for a receive task, which means you need to model error messages as response payload or separate message types — both are discussed later in this post.
 
-A final note for high-performance environments: These powerful messaging capabilities do not come for free and require some overhead within the engine. For pure request/response calls that return within milliseconds, none of the features are truly required. If you are looking to build a high-performance scenario, using service tasks instead of message correlation for request/response calls, you can tune your overall performance or throughput. However, as with everything performance related, the devil is in the detail, so [reach out to us](https://forum.camunda.io/) to discuss such a scenario in more depth.
+A final note for high-performance environments: These powerful messaging capabilities do not come for free and require some overhead within the engine. For pure request/response calls that return within milliseconds, none of the features are truly required. If you are looking to build a high-performance scenario, using service tasks instead of message correlation for request/response calls, you can tune your overall performance or throughput. However, as with everything performance related, the devil is in the detail, so [contact us](/contact) to discuss such a scenario in more depth.
 
 **Summary And recommendations**
 

--- a/versioned_docs/version-8.0/components/console/console-troubleshooting/feedback-and-support.md
+++ b/versioned_docs/version-8.0/components/console/console-troubleshooting/feedback-and-support.md
@@ -3,8 +3,8 @@ id: feedback-and-support
 title: Feedback and support
 ---
 
-If you have any problems, questions, or suggestions, contact us via the [Camunda Platform Forum](https://forum.camunda.io/).
+If you have any problems, questions, or suggestions, [contact us](/contact).
 
-**Feedback and support** can be submitted or requested via the corresponding entry in the navigation menu. If you have a **license agreement** with us, you will be redirected to the [support queue](https://jira.camunda.com/projects/SUPPORT/) at Camunda. In our Trial phase, contact can be made using the internal form:
+**Feedback and support** can be submitted or requested in the forum (outlined on our contact page above) via the corresponding entry in the navigation menu. If you have a **license agreement** with us, you will be redirected to the [support queue](https://jira.camunda.com/projects/SUPPORT/) at Camunda. In our Trial phase, contact can be made using the internal form:
 
 ![feedback-dialog](./img/contact-feedback-and-support.png)

--- a/versioned_docs/version-8.0/components/modeler/bpmn/exclusive-gateways/exclusive-gateways.md
+++ b/versioned_docs/version-8.0/components/modeler/bpmn/exclusive-gateways/exclusive-gateways.md
@@ -20,7 +20,7 @@ An exclusive gateway can also be used to join multiple incoming flows together a
 
 A `conditionExpression` defines when a flow is taken. It is a [boolean expression](/components/concepts/expressions.md#boolean-expressions) that can access the process instance variables and compare them with literals or other variables. The condition is fulfilled when the expression returns `true`.
 
-Multiple boolean values or comparisons can be combined as disjunction (`and`) or conjunction (`or`).
+Multiple boolean values or comparisons can be combined as disjunction (`or`) or conjunction (`and`).
 
 For example:
 

--- a/versioned_docs/version-8.0/components/zeebe/open-source/get-help-get-involved.md
+++ b/versioned_docs/version-8.0/components/zeebe/open-source/get-help-get-involved.md
@@ -4,13 +4,7 @@ title: "Get help and get involved"
 description: "Ask questions, report problems, and make contributions."
 ---
 
-We provide a few different public-facing Zeebe support and feedback channels where users can ask questions, report problems, and make contributions.
-
-### Camunda Platform 8 user forum
-
-The best place to ask questions about Zeebe and troubleshoot issues is the [forum](https://forum.camunda.io).
-
-The Zeebe team monitors the forum closely, and we do our best to respond to all questions in a timely manner.
+We provide a few different public-facing Zeebe support and feedback channels where users can ask questions, report problems, and make contributions. Ask questions about Zeebe and troubleshoot issues by [contacting us](/contact).
 
 ### Create an issue in GitHub
 

--- a/versioned_docs/version-8.0/reference/status.md
+++ b/versioned_docs/version-8.0/reference/status.md
@@ -21,4 +21,4 @@ To receive service status updates:
 
 ## Support
 
-Support can be requested by subscription or enterprise customers via [JIRA](https://jira.camunda.com/projects/SUPPORT/). Otherwise, use the [Camunda Platform 8 community forum](https://forum.camunda.io/). For more information about Enterprise support and additional support resources, see [Enterprise Support](https://camunda.com/support/).
+Support can be requested by subscription or enterprise customers via [JIRA](https://jira.camunda.com/projects/SUPPORT/). Otherwise, [contact us](/contact). For more information about Enterprise support and additional support resources, see [Enterprise Support](https://camunda.com/support/).

--- a/versioned_docs/version-8.0/self-managed/platform-deployment/platform-8-deployment.md
+++ b/versioned_docs/version-8.0/self-managed/platform-deployment/platform-8-deployment.md
@@ -60,4 +60,4 @@ We support the following deployment options (the sequence expresses preference) 
 
 ## Getting help
 
-If you have questions or feedback about deployment with Zeebe, we encourage you to visit the [user forum](https://forum.camunda.io/).
+If you have questions or feedback about deployment with Zeebe, we encourage you to [contact us](/contact).

--- a/versioned_docs/version-8.0/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.0/self-managed/zeebe-deployment/zeebe-installation.md
@@ -18,4 +18,4 @@ New to BPMN and want to learn more before moving forward? [Visit our Get Started
 
 ## Additional resources
 
-If you have questions or feedback, we encourage you to visit the [user forum](https://forum.camunda.io/) or [GitHub issue tracker](https://github.com/camunda/zeebe/issues).
+If you have questions or feedback, we encourage you to [contact us](/contact) or visit the [GitHub issue tracker](https://github.com/camunda/zeebe/issues).


### PR DESCRIPTION
## Description

Note: this targets the `unsupported/8.0` branch and will never make it to main.

Incorporates two recent PRs that merged into main after I branched `unsupported/8.0`:

- #2835
- #2834


<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
