### PR TITLE
docs(desktop-modeler): add `formFieldTypes` to closed forms

### DIFF
--- a/docs/components/modeler/desktop-modeler/telemetry/telemetry.md
+++ b/docs/components/modeler/desktop-modeler/telemetry/telemetry.md
@@ -57,7 +57,7 @@ These events include the following properties:
   - `executionPlatform`: <target platform\>
   - `executionPlatformVersion`: <target platform version\>
 
-In the case of a Form, the payload also includes the `formFieldTypes`:
+In the case of a form, the payload also includes the `formFieldTypes`:
 
 ```json
 "formFieldTypes": {

--- a/docs/components/modeler/desktop-modeler/telemetry/telemetry.md
+++ b/docs/components/modeler/desktop-modeler/telemetry/telemetry.md
@@ -57,6 +57,16 @@ These events include the following properties:
   - `executionPlatform`: <target platform\>
   - `executionPlatformVersion`: <target platform version\>
 
+In the case of a Form, the payload also includes the `formFieldTypes`:
+
+```json
+"formFieldTypes": {
+  "textfield": 6,
+  "group": 2,
+  "image": 4
+}
+```
+
 ### Deployment and start instance events
 
 The `Deployment Event` is sent in the following situations:


### PR DESCRIPTION
## Description

This adds the new `formFieldTypes` data we track with closed forms.

Related to https://github.com/camunda/camunda-modeler/pull/3954

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until 14th November 2023 (Desktop Modeler 5.17.0 Release) (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
