### PR TITLE
clarify-zeebe-version

### DIFF
--- a/docs/components/modeler/web-modeler/play-your-process.md
+++ b/docs/components/modeler/web-modeler/play-your-process.md
@@ -61,7 +61,7 @@ Incidents are raised as they would be in Zeebe. Here are some common incidents a
 
 ### Limitations and availability
 
-Play uses the most recent alpha version of Zeebe available. Any BPMN elements unavailable in the most recent alpha release will not be available in Play.
+Play uses Zeebe 8.2. Any BPMN elements unavailable in Zeebe 8.2, such as signal events, will not be available in Play.
 :::note
 [Inbound Connectors](/docs/components/connectors/connector-types.md#inbound-connectors) do not connect to external systems and must be completed manually. [Start events with forms](/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md#embed-form-in-start-event) will be completed without the form being shown.
 :::

--- a/versioned_docs/version-8.2/components/modeler/web-modeler/play-your-process.md
+++ b/versioned_docs/version-8.2/components/modeler/web-modeler/play-your-process.md
@@ -61,12 +61,12 @@ Incidents are raised as they would be in Zeebe. Here are some common incidents a
 
 ### Limitations and availability
 
-Play uses the most recent alpha version of Zeebe available. Any BPMN elements unavailable in the most recent alpha release will not be available in Play.
+Play uses Zeebe 8.2. Any BPMN elements unavailable in Zeebe 8.2, such as signal events, will not be available in Play.
 :::note
 [Inbound Connectors](/docs/components/connectors/connector-types.md#inbound-connectors) do not connect to external systems and must be completed manually. [Start events with forms](/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md#embed-form-in-start-event) will be completed without the form being shown.
 :::
 
-For Camuynda 8 SaaS, Play is available to all Web Modeler users with editor or admin permissions within a project. It is not available to users with an Enterprise plan, which includes some consultants and [Camunda for Common Good](https://camunda.com/common-good/). Play will be available to Enterprise users after Camunda launches the early access program in Q4 2023.
+For Camunda 8 SaaS, Play is available to all Web Modeler users with editor or admin permissions within a project. It is not available to users with an Enterprise plan, which includes some consultants and [Camunda for Common Good](https://camunda.com/common-good/). Play will be available to Enterprise users after Camunda launches the early access program in Q4 2023.
 
 For Self-Managed, Play is controlled by the **PLAY_ENABLED** flag. It is `true` by default for the Docker distribution for development use, and `false` by default on the Kubernetes distribution for production use.
 

--- a/versioned_docs/version-8.3/components/modeler/web-modeler/play-your-process.md
+++ b/versioned_docs/version-8.3/components/modeler/web-modeler/play-your-process.md
@@ -61,7 +61,7 @@ Incidents are raised as they would be in Zeebe. Here are some common incidents a
 
 ### Limitations and availability
 
-Play uses the most recent alpha version of Zeebe available. Any BPMN elements unavailable in the most recent alpha release will not be available in Play.
+Play uses Zeebe 8.2. Any BPMN elements unavailable in Zeebe 8.2, such as signal events, will not be available in Play.
 :::note
 [Inbound Connectors](/docs/components/connectors/connector-types.md#inbound-connectors) do not connect to external systems and must be completed manually. [Start events with forms](/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md#embed-form-in-start-event) will be completed without the form being shown.
 :::


### PR DESCRIPTION
## Description

Zeebe Play has not updated its version to support 8.3. Therefore, Signal events are not supported. However, our docs suggest that they are supported. This is inaccurate.

## When should this change go live?

With the next release

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
