### PR TITLE
docs(zeebe): add docs for dynamic scaling api

### DIFF
--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -1,0 +1,182 @@
+---
+id: cluster-scaling
+title: "Cluster Scaling"
+description: "How to scale a Zeebe cluster"
+---
+
+:::note
+This is an experimental feature.
+:::
+
+Zeebe allows scaling an existing cluster. When new brokers are added, the partitions will be redistributed to the new brokers thus distributing some load. The cluster can also be scaled down to remove extra brokers.
+
+Zeebe provides a REST API to manage the cluster scaling. The cluster management API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#actuator.endpoints). This is accessible via the management port of the gateway.
+
+## Configuration
+
+- This is an experimental feature. To use the feature set `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEDYNAMICCLUSTERTOPOLOGY` to `true`.
+
+## Scaling API
+
+To scale up, start new brokers and use the scaling api to add the new brokers to the cluster and distribute data to them.
+
+### Request
+
+```
+POST actuator/cluster/brokers/
+[
+  <brokerId1>, <brokerId2>,..
+]
+```
+
+The input is a list of broker Ids that will be in the final cluster after scaling.
+
+<details>
+  <summary>Example request</summary>
+
+```
+curl --request POST 'http://localhost:9600/actuator/cluster/brokers' \
+-H 'Content-Type: application/json' \
+-d '["0", "1", "2", "3"]'
+```
+
+</details>
+
+### Response
+
+The response is a json object
+
+```
+{
+  changeId: <changeId>
+  currentTopology: [...]
+  plannedChanges: [...]
+  expectedTopology: [...]
+}
+```
+
+- `changeId`: Id of the changes initiated to scale the cluster. This can be used to monitor the progress of scaling operation.
+- `currentTopology`: A list of current brokers and the partition distribution.
+- `plannedChanges`: A sequence of operations that has to be executed to achieve scaling.
+- `expectedToplogy`: The expected list of brokers and the partition distribution once the scaling is completed.
+
+The scaling is executed asynchronously. Use the Query API to monitor the progress.
+
+## Query API
+
+The current cluster topology and any ongoing scaling operations can be monitored via the query endpoint.
+
+### Request
+
+```
+GET actuator/cluster
+```
+
+### Response
+
+```
+{
+  version: <version>
+  brokers: [...]
+  change:  {}
+}
+```
+
+- `version` The version of current cluster topology. The version is updated when ever the cluster is scaled up or down.
+- `brokers`: A list of current brokers and the partition distribution.
+- `change`: The details about any ongoing scaling operations or the last completed scaling operation.
+
+<details>
+  <summary>Example response</summary>
+
+```
+{
+  "version": 2,
+  "brokers": [
+    {
+      "id": 1,
+      "state": "ACTIVE",
+      "version": 4,
+      "lastUpdatedAt": "2023-11-03T16:57:16.479167471Z",
+      "partitions": [
+        {
+          "id": 1,
+          "state": "ACTIVE",
+          "priority": 2
+        },
+        ...
+      ]
+    },
+    ...
+  ],
+  "change": {
+    "id": 2,
+    "status": "IN_PROGRESS",
+    "completed": [
+         {
+        "operation": "BROKER_ADD",
+        "brokerId": 4,
+        "completedAt": "2023-11-03T16:53:09Z"
+      },
+      {
+        "operation": "PARTITION_JOIN",
+        "brokerId": 4,
+        "partitionId": 5,
+        "priority": 3,
+        "completedAt": "2023-11-03T16:53:41Z"
+      },
+      ...
+    ],
+    "pending": [
+      {
+        "operation": "PARTITION_JOIN",
+        "brokerId": 3,
+        "partitionId": 3,
+        "priority": 2
+      },
+      ...
+    ]
+  }
+}
+
+```
+
+</details>
+
+## Examples
+
+### Scale up
+
+To scale a cluster of size 3 to cluster of size 6, first start new brokers. If you have deployed Zeebe in k8s you can run use `kubctl scale statefulset` command to start new brokers.
+
+```
+kubectl scale statefuleset <zeebe-statefulset> --replicas=6
+```
+
+The above command starts new brokers, but the new brokers are not part of the cluster yet. To actually scale the cluster, send the following request to Zeebe cluster.
+
+```
+curl --request POST 'http://zeebe-gateway:9600/actuator/cluster/brokers' \
+-H 'Content-Type: application/json' \
+-d '["0", "1", "2", "3", "4", "5"]'
+```
+
+Here 0,1,2 are the existing brokers and 3,4 and 5 are the newly added brokers.
+
+You can then use the Query API to monitor the progress of scaling.
+
+### Scale down
+
+To scale down the cluster back to size 3, first move all data from the to-be removed brokers.
+
+```
+curl --request POST 'http://zeebe-gateway:9600/actuator/cluster/brokers' \
+-H 'Content-Type: application/json' \
+-d '["0", "1", "2"]'
+```
+
+The above commands move all data to the given the brokers 0,1 and 2. Use the Query API to monitor the progress. Once the change is marked as COMPLETED, shutdown the brokers. If you have deployed Zeebe in k8s you can can run the following command to shutdown brokers 3,4 and 5.
+
+```
+kubectl scale statefuleset <zeebe-statefulset> --replicas=3
+```

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -4,7 +4,7 @@ title: "Cluster Scaling"
 description: "How to scale a Zeebe cluster"
 ---
 
-:::note
+:::warning
 This is an experimental feature.
 :::
 

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -1,7 +1,7 @@
 ---
 id: cluster-scaling
-title: "Cluster Scaling"
-description: "How to scale a Zeebe cluster"
+title: "Cluster scaling"
+description: "Scale an existing cluster by adding or removing brokers."
 ---
 
 :::warning
@@ -14,18 +14,18 @@ Zeebe provides a REST API to manage the cluster scaling. The cluster management 
 
 ## Configuration
 
-- This is an experimental feature. To use the feature set `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEDYNAMICCLUSTERTOPOLOGY` to `true`.
+- This is an experimental feature. To use the feature, set `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEDYNAMICCLUSTERTOPOLOGY` to `true`.
 
 :::warning
-Do not turn of this feature after the cluster is scaled atleast once. If you turn of the feature and restart the cluster without updated the configuration, the cluster uses the original configuration and can result in data loss.
+Do not turn off this feature after the cluster is scaled. If you turn off the feature and restart the cluster without updating the configuration, the cluster will use the original configuration and this can result in data loss.
 :::
 
 ## Scaling API
 
-To scale up, start new brokers and use the scaling api to add the new brokers to the cluster and distribute data to them.
+To scale up, start new brokers and use the scaling API below to add the new brokers to the cluster and distribute data to them.
 
 :::warning
-This endpoint does not respect FIXED partitioning scheme configured via `zeebe.broker.experimental.partitioning`. When this endpoint is used the partitions will be redistributed using ROUND_ROBIN strategy.
+This endpoint does not respect the **fixed** partitioning scheme configured via `zeebe.broker.experimental.partitioning`. When this endpoint is used, the partitions are redistributed using ROUND_ROBIN strategy.
 :::
 
 ### Request
@@ -37,7 +37,7 @@ POST actuator/cluster/brokers/
 ]
 ```
 
-The input is a list of _all_ broker ids that will be in the final cluster after scaling.
+The input is a list of _all_ broker ids that will be in the final cluster after scaling:
 
 <details>
   <summary>Example request</summary>
@@ -52,7 +52,7 @@ curl --request POST 'http://localhost:9600/actuator/cluster/brokers' \
 
 ### Response
 
-The response is a json object
+The response is a JSON object:
 
 ```
 {
@@ -63,12 +63,12 @@ The response is a json object
 }
 ```
 
-- `changeId`: Id of the changes initiated to scale the cluster. This can be used to monitor the progress of scaling operation. The id is typically increasing so that new requests get a higher id than the previous one.
+- `changeId`: Id of the changes initiated to scale the cluster. This can be used to monitor the progress of the scaling operation. The id typically increases so new requests get a higher id than the previous one.
 - `currentTopology`: A list of current brokers and the partition distribution.
 - `plannedChanges`: A sequence of operations that has to be executed to achieve scaling.
 - `expectedToplogy`: The expected list of brokers and the partition distribution once the scaling is completed.
 
-The scaling is executed asynchronously. Use the Query API to monitor the progress.
+The scaling is executed asynchronously. Use the Query API below to monitor the progress.
 
 ## Query API
 
@@ -90,7 +90,7 @@ GET actuator/cluster
 }
 ```
 
-- `version` The version of current cluster topology. The version is updated when ever the cluster is scaled up or down.
+- `version`: The version of current cluster topology. The version is updated when the cluster is scaled up or down.
 - `brokers`: A list of current brokers and the partition distribution.
 - `change`: The details about any ongoing scaling operations or the last completed scaling operation.
 
@@ -155,13 +155,13 @@ GET actuator/cluster
 
 ### Scale up
 
-To scale a cluster of size 3 to cluster of size 6, first start new brokers. If you have deployed Zeebe in k8s you can run use `kubectl scale statefulset` command to start new brokers.
+To scale a cluster of size 3 to cluster of size 6, first start the new brokers. If you have deployed Zeebe in Kubernetes, you can use the command `kubectl scale statefulset` to start new brokers:
 
 ```
 kubectl scale statefuleset <zeebe-statefulset> --replicas=6
 ```
 
-The above command starts new brokers, but the new brokers are not part of the cluster yet. To actually scale the cluster, send the following request to Zeebe cluster.
+The command above starts new brokers, but the new brokers are not part of the cluster yet. To actually scale the cluster, send the following request to the Zeebe cluster:
 
 ```
 curl --request POST 'http://zeebe-gateway:9600/actuator/cluster/brokers' \
@@ -169,13 +169,13 @@ curl --request POST 'http://zeebe-gateway:9600/actuator/cluster/brokers' \
 -d '["0", "1", "2", "3", "4", "5"]'
 ```
 
-Here 0,1,2 are the existing brokers and 3,4 and 5 are the newly added brokers.
+Here, `0`, `1`, and `2` are the existing brokers, and `3`, `4`, and `5` are the newly-added brokers.
 
 You can then use the Query API to monitor the progress of scaling.
 
 ### Scale down
 
-To scale down the cluster back to size 3, first move all data from the to-be removed brokers.
+To scale down the cluster back to size `3`, first move all data from the to-be removed brokers:
 
 ```
 curl --request POST 'http://zeebe-gateway:9600/actuator/cluster/brokers' \
@@ -183,7 +183,7 @@ curl --request POST 'http://zeebe-gateway:9600/actuator/cluster/brokers' \
 -d '["0", "1", "2"]'
 ```
 
-The above commands move all data to the given the brokers 0,1 and 2. Use the Query API to monitor the progress. Once the change is marked as COMPLETED, shutdown the brokers. If you have deployed Zeebe in k8s you can can run the following command to shutdown brokers 3,4 and 5.
+The above command moves all data to the given the brokers `0`, `1`, and `2`. Use the Query API to monitor the progress. Once the change is marked as COMPLETED, shut down the brokers. If you have deployed Zeebe in Kubernetes, you can run the following command to shut down brokers `3`, `4`, and `5`:
 
 ```
 kubectl scale statefuleset <zeebe-statefulset> --replicas=3

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -29,7 +29,7 @@ POST actuator/cluster/brokers/
 ]
 ```
 
-The input is a list of broker Ids that will be in the final cluster after scaling.
+The input is a list of *all* broker ids that will be in the final cluster after scaling.
 
 <details>
   <summary>Example request</summary>

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -8,7 +8,7 @@ description: "How to scale a Zeebe cluster"
 This is an experimental feature.
 :::
 
-Zeebe allows scaling an existing cluster. When new brokers are added, the partitions will be redistributed to the new brokers thus distributing some load. The cluster can also be scaled down to remove extra brokers.
+Zeebe allows scaling an existing cluster by adding or removing brokers. Partitions are automatically redistributed over the new set of brokers to spread the load evenly.
 
 Zeebe provides a REST API to manage the cluster scaling. The cluster management API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#actuator.endpoints). This is accessible via the management port of the gateway.
 

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -16,9 +16,17 @@ Zeebe provides a REST API to manage the cluster scaling. The cluster management 
 
 - This is an experimental feature. To use the feature set `ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEDYNAMICCLUSTERTOPOLOGY` to `true`.
 
+:::warning
+Do not turn of this feature after the cluster is scaled atleast once. If you turn of the feature and restart the cluster without updated the configuration, the cluster uses the original configuration and can result in data loss.
+:::
+
 ## Scaling API
 
 To scale up, start new brokers and use the scaling api to add the new brokers to the cluster and distribute data to them.
+
+:::warning
+This endpoint does not respect FIXED partitioning scheme configured via `zeebe.broker.experimental.partitioning`. When this endpoint is used the partitions will be redistributed using ROUND_ROBIN strategy.
+:::
 
 ### Request
 
@@ -29,7 +37,7 @@ POST actuator/cluster/brokers/
 ]
 ```
 
-The input is a list of *all* broker ids that will be in the final cluster after scaling.
+The input is a list of _all_ broker ids that will be in the final cluster after scaling.
 
 <details>
   <summary>Example request</summary>
@@ -55,7 +63,7 @@ The response is a json object
 }
 ```
 
-- `changeId`: Id of the changes initiated to scale the cluster. This can be used to monitor the progress of scaling operation.
+- `changeId`: Id of the changes initiated to scale the cluster. This can be used to monitor the progress of scaling operation. The id is typically increasing so that new requests get a higher id than the previous one.
 - `currentTopology`: A list of current brokers and the partition distribution.
 - `plannedChanges`: A sequence of operations that has to be executed to achieve scaling.
 - `expectedToplogy`: The expected list of brokers and the partition distribution once the scaling is completed.

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -147,7 +147,7 @@ GET actuator/cluster
 
 ### Scale up
 
-To scale a cluster of size 3 to cluster of size 6, first start new brokers. If you have deployed Zeebe in k8s you can run use `kubctl scale statefulset` command to start new brokers.
+To scale a cluster of size 3 to cluster of size 6, first start new brokers. If you have deployed Zeebe in k8s you can run use `kubectl scale statefulset` command to start new brokers.
 
 ```
 kubectl scale statefuleset <zeebe-statefulset> --replicas=6

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -5,7 +5,7 @@ description: "Scale an existing cluster by adding or removing brokers."
 ---
 
 :::warning
-This is an experimental feature.
+This is an experimental feature, and therefore we do not recommend using it in production.
 :::
 
 Zeebe allows scaling an existing cluster by adding or removing brokers. Partitions are automatically redistributed over the new set of brokers to spread the load evenly.

--- a/sidebars.js
+++ b/sidebars.js
@@ -918,6 +918,7 @@ module.exports = {
             "self-managed/zeebe-deployment/operations/rebalancing",
             "self-managed/zeebe-deployment/operations/management-api",
             "self-managed/zeebe-deployment/operations/backups",
+            "self-managed/zeebe-deployment/operations/cluster-scaling",
           ],
         },
         {


### PR DESCRIPTION
## Description

related to #2855 

This PR adds a minimal documentation for Cluster scaling api of Zeebe. 

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

Release with `8.4.0-alpha1`

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
