### PR TITLE
feat: document `zeebe:taskDefinition` binding

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -96,7 +96,8 @@ Let us consider the following example that defines a template for a mail sending
       "type": "Hidden",
       "value": "http",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {
@@ -159,7 +160,7 @@ Let us consider the following example that defines a template for a mail sending
 
 The example defines five custom fields, each mapped to different technical properties:
 
-- The task type `http` is mapped to the `zeebe:taskDefinition:type` property in BPMN 2.0 XML.
+- The task type `http` is mapped to the `type` property of a `zeebe:taskDefinition` element in BPMN 2.0 XML.
 - The `REST Endpoint URL` and `REST Method` are mapped to `task headers`.
 - The `Request Body` is mapped to a local variable via an `input parameter`.
 - The `Result Variable` is mapped into a process variable via an `output parameter`.
@@ -296,7 +297,21 @@ Configures an [output mapping](../../../../concepts/variables/#output-mappings).
 
 Configures a [task header](../../../bpmn/service-tasks/#task-headers).
 
+#### `zeebe:taskDefinition`
+
+| **Binding `type`**          | `zeebe:taskDefinition`                                                            |
+| --------------------------- | --------------------------------------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br /> `Text`<br />`Hidden`<br />`Dropdown`                               |
+| **Binding parameters**      | `property`: The name of the task definition property. Can be `type` or `retries`. |
+| **Mapping result**          | `<zeebe:taskDefinition [property]="[userInput]" />`                               |
+
+Configures the [task](../../../bpmn/service-tasks/#task-definition) for a service or user task.
+
 #### `zeebe:taskDefinition:type`
+
+:::warning
+`zeebe:taskDefinition:type` is a deprecated binding. Instead, use `zeebe:taskDefinition` with `property=type`.
+:::
 
 | **Binding `type`**          | `zeebe:taskDefinition:type`                         |
 | --------------------------- | --------------------------------------------------- |


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until 14.11.2023 (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
