### PR TITLE
feat: add AWS Aurora documentation for Identity

### DIFF
--- a/docs/self-managed/identity/deployment/configuration-variables.md
+++ b/docs/self-managed/identity/deployment/configuration-variables.md
@@ -61,6 +61,25 @@ There are no default values for the variables above. See
 supported databases.
 :::
 
+#### Running Identity on Amazon Aurora PostgreSQL
+
+Identity supports running on Amazon Aurora PostgreSQL.
+To connect Identity with your Amazon Aurora PostgreSQL instance, make the following configuration adjustments:
+
+1. Modify the `SPRING_DATASOURCE_URL` environment variable: `jdbc:aws-wrapper:postgresql://[DB_HOST]:[DB_PORT]/[DB_NAME]`.
+2. Add the environment variable `SPRING_DATASOURCE_DRIVER_CLASS_NAME` with the value `software.amazon.jdbc.Driver`.
+
+For a full list of available driver parameters visit the [AWS JDBC Driver documentation](https://github.com/awslabs/aws-advanced-jdbc-wrapper/wiki/UsingTheJdbcDriver#aws-advanced-jdbc-driver-parameters).
+
+##### AWS IAM authentication
+
+To use AWS Identity and Access Management (IAM) database authentication with your Amazon Aurora PostgreSQL
+instance, in addition to the adjustments described [above](#running-identity-on-amazon-aurora-postgresql), follow these steps:
+
+1. Modify the `SPRING_DATASOURCE_URL` environment variable as follows: `jdbc:aws-wrapper:postgresql://[DB_HOST]:[DB_PORT]/[DB_NAME]?wrapperPlugins=iam`.
+2. Modify the `SPRING_DATASOURCE_USERNAME` environment variable to match the database user you configured for AWS IAM authentication as described in the [Amazon Aurora documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html#UsingWithRDS.IAMDBAuth.DBAccounts.PostgreSQL).
+3. Remove the `SPRING_DATASOURCE_PASSWORD` environment variable.
+
 ### Feature flags
 
 Identity uses feature flag environment variables to enable and disable features; the supported flags are:

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
@@ -238,6 +238,11 @@ Don't forget to set the `serviceAccountName` of the deployment/statefulset to th
 Since Web Modeler RestAPI uses PostgreSQL, configure the `restapi` to use IRSA with Amazon Aurora PostgreSQL. Check the [Web Modeler database configuration](../../../../modeler/web-modeler/configuration/database.md#running-web-modeler-on-amazon-aurora-postgresql) for more details.
 Web Modeler already comes fitted with the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) within the Docker image.
 
+### Identity
+
+Since Identity uses PostgreSQL, configure `identity` to use IRSA with Amazon Aurora PostgreSQL. Check the [Identity database configuration](../../../../identity/deployment/configuration-variables.md#running-identity-on-amazon-aurora-postgresql) for more details.
+Identity already comes fitted with the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) within the Docker image.
+
 #### Kubernetes configuration
 
 As an example, configure the following environment variables


### PR DESCRIPTION
## Description

Fixes https://github.com/camunda-cloud/identity/issues/2267

Adds documentation on how to configure Identity to use a AWS Aurora database.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

The functionality will be released with Identity `8.4.0-alpha1` on 07. Nov 2023. The release announcement is normally made a week later, so these changes can be released from 2023-11-07 to 2023-11-14

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
