### PR TITLE
chore(reference): clarify alpha features vs alpha releases

### DIFF
--- a/docs/reference/release-policy.md
+++ b/docs/reference/release-policy.md
@@ -30,10 +30,12 @@ These components include:
 - Connectors
 - Console
 
+Admins can [enable alpha features](/docs/components/console/manage-organization/enable-alpha-features.md) for components outside of the cluster in the organization settings screen.
+
 For components inside a **cluster**, Camunda provides two channels for provisioning and follows the [Camunda release policy](https://camunda.com/release-policy/):
 
-- **Stable**: Provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
-- **Alpha**: Provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
+- **Stable**: General availability features for cluster components are available through the stable channel. This channel provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
+- **Alpha**: Alpha features for cluster components are available through the alpha channel. This channel provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
 
 On the stable channel, the last three supported minor versions are made available for provisioning.
 

--- a/versioned_docs/version-8.1/reference/release-policy.md
+++ b/versioned_docs/version-8.1/reference/release-policy.md
@@ -30,10 +30,12 @@ These components include:
 - Connectors
 - Console
 
+Admins can [enable alpha features](/docs/components/console/manage-organization/enable-alpha-features.md) for components outside of the cluster in the organization settings screen.
+
 For components inside a **cluster**, Camunda provides two channels for provisioning and follows the [Camunda release policy](https://camunda.com/release-policy/):
 
-- **Stable**: Provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
-- **Alpha**: Provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
+- **Stable**: General availability features for cluster components are available through the stable channel. This channel provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
+- **Alpha**: Alpha features for cluster components are available through the alpha channel. This channel provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
 
 On the stable channel, the last three supported minor versions are made available for provisioning.
 
@@ -55,4 +57,4 @@ If you are not an enterprise customer, you can stay up to date via [release blog
 
 ### New versions
 
-If you are running Camunda 8 Self-Managed, follow our [update guide](/guides/update-guide/introduction.md).
+If you are running Camunda 8 Self-Managed, follow our [update guide](/self-managed/operational-guides/update-guide/introduction.md).

--- a/versioned_docs/version-8.1/reference/release-policy.md
+++ b/versioned_docs/version-8.1/reference/release-policy.md
@@ -57,4 +57,4 @@ If you are not an enterprise customer, you can stay up to date via [release blog
 
 ### New versions
 
-If you are running Camunda 8 Self-Managed, follow our [update guide](/self-managed/operational-guides/update-guide/introduction.md).
+If you are running Camunda 8 Self-Managed, follow our [update guide](/guides/update-guide/introduction.md).

--- a/versioned_docs/version-8.2/reference/release-policy.md
+++ b/versioned_docs/version-8.2/reference/release-policy.md
@@ -30,10 +30,12 @@ These components include:
 - Connectors
 - Console
 
+Admins can [enable alpha features](/docs/components/console/manage-organization/enable-alpha-features.md) for components outside of the cluster in the organization settings screen.
+
 For components inside a **cluster**, Camunda provides two channels for provisioning and follows the [Camunda release policy](https://camunda.com/release-policy/):
 
-- **Stable**: Provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
-- **Alpha**: Provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
+- **Stable**: General availability features for cluster components are available through the stable channel. This channel provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
+- **Alpha**: Alpha features for cluster components are available through the alpha channel. This channel provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
 
 On the stable channel, the last three supported minor versions are made available for provisioning.
 
@@ -55,4 +57,4 @@ If you are not an enterprise customer, you can stay up to date via [release blog
 
 ### New versions
 
-If you are running Camunda 8 Self-Managed, follow our [update guide](/guides/update-guide/introduction.md).
+If you are running Camunda 8 Self-Managed, follow our [update guide](/self-managed/operational-guides/update-guide/introduction.md).

--- a/versioned_docs/version-8.2/reference/release-policy.md
+++ b/versioned_docs/version-8.2/reference/release-policy.md
@@ -57,4 +57,4 @@ If you are not an enterprise customer, you can stay up to date via [release blog
 
 ### New versions
 
-If you are running Camunda 8 Self-Managed, follow our [update guide](/self-managed/operational-guides/update-guide/introduction.md).
+If you are running Camunda 8 Self-Managed, follow our [update guide](/guides/update-guide/introduction.md).

--- a/versioned_docs/version-8.3/reference/release-policy.md
+++ b/versioned_docs/version-8.3/reference/release-policy.md
@@ -30,10 +30,12 @@ These components include:
 - Connectors
 - Console
 
+Admins can [enable alpha features](/docs/components/console/manage-organization/enable-alpha-features.md) for components outside of the cluster in the organization settings screen.
+
 For components inside a **cluster**, Camunda provides two channels for provisioning and follows the [Camunda release policy](https://camunda.com/release-policy/):
 
-- **Stable**: Provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
-- **Alpha**: Provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
+- **Stable**: General availability features for cluster components are available through the stable channel. This channel provides the latest feature and patch releases ready for most users at minimal risk. The releases follow semantic versioning and can be updated to the next minor or patch release without data loss.
+- **Alpha**: Alpha features for cluster components are available through the alpha channel. This channel provides preview releases in preparation for the next stable release. They provide a short-term stability point to test new features and give feedback before they are released to the stable channel. Try these to ensure the upcoming release works with your infrastructure. These releases cannot be updated to a newer release, and therefore are not meant to be used in production.
 
 On the stable channel, the last three supported minor versions are made available for provisioning.
 


### PR DESCRIPTION
## Description

We have alpha features and alpha releases? How does the user know the difference?

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
