### PR TITLE
Add `index.processInstanceMigration` flag to Elasticsearch and OpenSearch exporters

### DIFF
--- a/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
@@ -93,6 +93,7 @@ and process values).
 | processInstance               | If `true` records related to process instances will be exported                                         | `true`       |
 | processInstanceBatch          | If `true` records related to process instances batches will be exported                                 | `false`      |
 | processInstanceCreation       | If `true` records related to process instance creations will be exported                                | `true`       |
+| processInstanceMigration      | If `true` records related to process instance migrations will be exported                               | `true`       |
 | processInstanceModification   | If `true` records related to process instance modifications will be exported                            | `true`       |
 | processMessageSubscription    | If `true` records related to process message subscriptions will be exported                             | `true`       |
 | resourceDeletion              | If `true` records related to resource deletions will be exported                                        | `true`       |
@@ -207,6 +208,7 @@ exporters:
         processEvent: false
         processInstance: true
         processInstanceCreation: true
+        processInstanceMigration: true
         processInstanceModification: true
         processMessageSubscription: true
         resourceDeletion: true

--- a/docs/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
+++ b/docs/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
@@ -93,6 +93,7 @@ and process values).
 | processInstance               | If `true` records related to process instances will be exported                                         | `true`       |
 | processInstanceBatch          | If `true` records related to process instances batches will be exported                                 | `false`      |
 | processInstanceCreation       | If `true` records related to process instance creations will be exported                                | `true`       |
+| processInstanceMigration      | If `true` records related to process instance migrations will be exported                               | `true`       |
 | processInstanceModification   | If `true` records related to process instance modifications will be exported                            | `true`       |
 | processMessageSubscription    | If `true` records related to process message subscriptions will be exported                             | `true`       |
 | resourceDeletion              | If `true` records related to resource deletions will be exported                                        | `true`       |
@@ -231,6 +232,7 @@ exporters:
         processEvent: false
         processInstance: true
         processInstanceCreation: true
+        processInstanceMigration: true
         processInstanceModification: true
         processMessageSubscription: true
         resourceDeletion: true


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Both the Elasticsearch and OpenSearch exporters support a new configuration option with the upcoming 8.4 release:
- `index.processInstanceMigration`

This boolean flag (default true) allows to filter records related to the upcoming process instance migration feature.

closes #2910 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

>**Note**
> Question regarding: This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
>
> When should we merge something to the Next docs? [The related code is in review](https://github.com/camunda/zeebe/pull/15164). Once merged, it will be on Zeebe's `main`. The first release it will see is `8.4.0-alpha2`. Should we wait to merge this documentation, or should we add it already?

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
