### PR TITLE
chore(migration): add upgrade notice for issue OPT-7419

### DIFF
--- a/optimize/self-managed/optimize-deployment/migration-update/3.10-to-3.11_8.3.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/3.10-to-3.11_8.3.md
@@ -17,6 +17,12 @@ Here you will find information about:
 - Changes in behavior (for example, due to a new feature)
 - Changes in translation resources
 
+## Known Issues
+
+## Migration of Camunda Platform 7 data for 3.11.0, 3.11.1 and 3.11.2
+
+Under some circumstances, the migration of Camunda 7 data for versions 3.11.0, 3.11.1 and 3.11.2 can cause issues with the tenant selection of report definitions and collection scopes. This only occurs if data is present in Elasticsearch with the value "zeebe" in the datasource field, which can happen for example if the "onboarding" dataset set is used in Optimize. To avoid this issue we recommend that Camunda 7 users skip 3.11.0, 3.11.1 and 3.11.2 and instead migrate straight to Optimize version 3.11.3.
+
 ## Changes in supported environments
 
 ### Elasticsearch

--- a/optimize/self-managed/optimize-deployment/migration-update/3.10-to-3.11_8.3.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/3.10-to-3.11_8.3.md
@@ -17,11 +17,11 @@ Here you will find information about:
 - Changes in behavior (for example, due to a new feature)
 - Changes in translation resources
 
-## Known Issues
+## Known issues
 
-## Migration of Camunda Platform 7 data for 3.11.0, 3.11.1 and 3.11.2
+## Migration of Camunda 7 data for 3.11.0, 3.11.1, and 3.11.2
 
-Under some circumstances, the migration of Camunda 7 data for versions 3.11.0, 3.11.1 and 3.11.2 can cause issues with the tenant selection of report definitions and collection scopes. This only occurs if data is present in Elasticsearch with the value "zeebe" in the datasource field, which can happen for example if the "onboarding" dataset set is used in Optimize. To avoid this issue we recommend that Camunda 7 users skip 3.11.0, 3.11.1 and 3.11.2 and instead migrate straight to Optimize version 3.11.3.
+Under some circumstances, the migration of Camunda 7 data for versions 3.11.0, 3.11.1, and 3.11.2 can cause issues with the tenant selection of report definitions and collection scopes. This only occurs if data is present in Elasticsearch with the value `zeebe` in the datasource field, which can happen if the `onboarding` dataset set is used in Optimize, for example. To avoid this issue, we recommend Camunda 7 users skip 3.11.0, 3.11.1, and 3.11.2, and instead migrate straight to Optimize version 3.11.3.
 
 ## Changes in supported environments
 


### PR DESCRIPTION
related to OPT-7421

## Description

We encountered a potential migration issue for 3.11 and recommend C7 customers to skip straight to 3.11.3 for a safer migration path.

## When should this change go live?

These docs refer to the upcoming 3.11.3 patch which we are releasing asap, imo we can merge the docs even beforehand.

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
