### PR TITLE
Add `userTask` flag to ES and OS exporters

### DIFF
--- a/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
@@ -99,6 +99,7 @@ and process values).
 | signal                        | If `true` records related to signals will be exported                                                   | `true`       |
 | signalSubscription            | If `true` records related to signal subscriptions will be exported                                      | `true`       |
 | timer                         | If `true` records related to timers will be exported                                                    | `true`       |
+| userTask                      | If `true` records related to user tasks will be exported                                                | `true`       |
 | variable                      | If `true` records related to variables will be exported                                                 | `true`       |
 | variableDocument              | If `true` records related to variable documents will be exported                                        | `true`       |
 
@@ -213,6 +214,7 @@ exporters:
         signal: true
         signalSubscription: true
         timer: true
+        userTask: true
         variable: true
         variableDocument: true
 ```

--- a/docs/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
+++ b/docs/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
@@ -99,6 +99,7 @@ and process values).
 | signal                        | If `true` records related to signals will be exported                                                   | `true`       |
 | signalSubscription            | If `true` records related to signal subscriptions will be exported                                      | `true`       |
 | timer                         | If `true` records related to timers will be exported                                                    | `true`       |
+| userTask                      | If `true` records related to user tasks will be exported                                                | `true`       |
 | variable                      | If `true` records related to variables will be exported                                                 | `true`       |
 | variableDocument              | If `true` records related to variable documents will be exported                                        | `true`       |
 
@@ -237,6 +238,7 @@ exporters:
         signal: true
         signalSubscription: true
         timer: true
+        userTask: true
         variable: true
         variableDocument: true
 ```


### PR DESCRIPTION
## Description

Both the Elasticsearch and OpenSearch exporters support a new configuration option with the upcoming 8.4 release:
- `index.userTask`

This boolean flag (default `true`) allows to filter records related to the upcoming Zeebe user tasks feature.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [X] This change is not yet live and should not be merged until https://github.com/camunda/zeebe/issues/14996 is merged (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
