### PR TITLE
[DO NOT MERGE] prototype: Warn about changes in `current` but not `next`, and vice-versa.

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -7,28 +7,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout last two commits of the PR
+        # The last *two* commits are (1) everything in this branch, and (2) the parent of this branch.
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Identify files changed in next but not current, or vice versa
+
+      - name: Identify files changed in next but not current, or vice versa. Build a message for them.
         run: |
+          # find all files changed in this PR, search for only within a folder, and remove that folder from the matches.
           next_files=($( git diff --name-only HEAD^ | grep ^docs/ | sed 's/^docs\///')) 
           current_files=($( git diff --name-only HEAD^ | grep ^versioned_docs/version-8.3/ | sed 's/^versioned_docs\/version-8.3\///' )) 
 
+          # remove file names duplicated in the two sets, leaving only files that are unique to one set.
           missing_files=(`echo ${next_files[@]} ${current_files[@]} | tr ' ' '\n' | sort | uniq -u`)
 
-          echo $missing_files
-
+          # exit if there are no offenders.
           if [ ${#missing_files} -eq 0 ]; then
             echo "No obvious missing version updates." 
             exit 0
           fi
 
+          # identify which set each of the unique files came from, by finding the intersection of the offenders and each set.
           only_in_next=(`echo ${next_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
           only_in_current=(`echo ${current_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
 
           message=""
 
+          # Append a message for the files only changed in next.
+          #  I'm unsure why some of the markdown here (the emphasis) gets formatted by GitHub, but some doesn't (the unordered list).
           if [ ${#only_in_next[@]} -gt 0 ]; then
             message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/><ul>'
             for file in "${only_in_next[@]}"; do
@@ -37,6 +43,8 @@ jobs:
             message+="</ul>"
           fi
 
+          # Append a message for the files only changed in current.
+          #  I'm unsure why some of the markdown here (the emphasis) gets formatted by GitHub, but some doesn't (the unordered list).
           if [ ${#only_in_current[@]} -gt 0 ]; then
             message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/><ul>'
             for file in "${only_in_current[@]}"; do
@@ -45,8 +53,10 @@ jobs:
             message+="</ul>"
           fi
 
+          # For debug purposes.
           echo $message
 
+          # Pass the message to the next step.
           echo POTENTIAL_MISSING_VERSIONS_MESSAGE="$message" >> $GITHUB_ENV
       - name: Comment on PR if version updates are potentially missing
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -30,7 +30,7 @@ jobs:
           message=""
 
           if [ ${#only_in_next[@]} -gt 0 ]; then
-            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/>'
+            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/>%0A'
             for file in "${only_in_next[@]}"; do
               message+="  * docs/$file<br/>"
             done
@@ -38,7 +38,7 @@ jobs:
           fi
 
           if [ ${#only_in_current[@]} -gt 0 ]; then
-            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/>'
+            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/>%0A'
             for file in "${only_in_current[@]}"; do
               message+="  * versioned_docs/version-8.3/$file<br/>"
             done

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -32,7 +32,7 @@ jobs:
           if [ ${#only_in_next[@]} -gt 0 ]; then
             message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.\n'
             for file in "${only_in_next[@]}"; do
-              message+="  - docs/$file\n"
+              message+="  * docs/$file\n"
             done
             message+="\n"
           fi
@@ -40,14 +40,14 @@ jobs:
           if [ ${#only_in_current[@]} -gt 0 ]; then
             message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.\n'
             for file in "${only_in_current[@]}"; do
-              message+="  - versioned_docs/version-8.3/$file\n"
+              message+="  * versioned_docs/version-8.3/$file\n"
             done
             message+="\n"
           fi
 
           echo $message
 
-          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="${message/\\n/<br/>}" >> $GITHUB_ENV
+          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="${message//\\n/<br/>}" >> $GITHUB_ENV
       - name: Comment on PR if version updates are potentially missing
         uses: thollander/actions-comment-pull-request@v2
         if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE != '' }}

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -31,16 +31,16 @@ jobs:
           echo FILES_ONLY_IN_CURRENT="(${only_in_current[@]})" >> $GITHUB_ENV
       - name: Emit uncommon files
         run: |
-          if [ ${#only_in_next[@]} -eq 0 ] && [ ${#only_in_current[@]} -eq 0 ]; then
+          if [ ${#FILES_ONLY_IN_NEXT[@]} -eq 0 ] && [ ${#FILES_ONLY_IN_CURRENT[@]} -eq 0 ]; then
             exit 0
           fi 
 
-          if [ ${#only_in_next[@]} -gt 0 ]; then
+          if [ ${#FILES_ONLY_IN_NEXT[@]} -gt 0 ]; then
             echo "These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version."
-            echo ${only_in_next[@]} | tr ' ' '\n' | sed 's/^/  docs\//'
+            echo ${FILES_ONLY_IN_NEXT[@]} | tr ' ' '\n' | sed 's/^/  docs\//'
           fi
 
-          if [ ${#only_in_current[@]} -gt 0 ]; then
+          if [ ${#FILES_ONLY_IN_CURRENT[@]} -gt 0 ]; then
             echo "These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version."
-            echo ${only_in_current[@]} | tr ' ' '\n' | sed 's/^/  versioned_docs\/version-8.3\//'
+            echo ${FILES_ONLY_IN_CURRENT[@]} | tr ' ' '\n' | sed 's/^/  versioned_docs\/version-8.3\//'
           fi

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -30,19 +30,20 @@ jobs:
           message=""
 
           if [ ${#only_in_next[@]} -gt 0 ]; then
-            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/><ul>'
+            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/>'
+            message+=""
             for file in "${only_in_next[@]}"; do
-              message+="<li>docs/$file</li>"
+              message+="* docs/$file"
             done
-            message+="</ul>"
+            # message+=""
           fi
 
           if [ ${#only_in_current[@]} -gt 0 ]; then
-            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/><ul>'
+            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/>'
             for file in "${only_in_current[@]}"; do
-              message+="<li>versioned_docs/version-8.3/$file</li>"
+              message+="* versioned_docs/version-8.3/$file"
             done
-            message+="</ul>"
+            # message+=""
           fi
 
           echo $message

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -12,7 +12,23 @@ jobs:
           fetch-depth: 2
       - name: Process files changed in the current commit
         run: |
-          changedFiles=$(git diff --name-only HEAD^)
-          for file in $changedFiles; do
-            echo "Processing file: $file"
-          done
+          next_files=($( git diff --name-only HEAD^ | grep ^docs/ | sed 's/^docs\///')) 
+          current_files=($( git diff --name-only HEAD^ | grep ^versioned_docs/version-8.3/ | sed 's/^versioned_docs\/version-8.3\///' )) 
+
+          echo $next_files
+          echo "-------------"
+          echo $current_files
+          echo "-------------"
+
+          missing_files=(`echo ${next_files[@]} ${current_files[@]} | tr ' ' '\n' | sort | uniq -u`)
+
+          echo $missing_files
+
+          only_in_next=(`echo ${next_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
+          only_in_current=(`echo ${current_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
+
+          echo "only in next:"
+          echo $only_in_next
+
+          echo "only in current:"
+          echo $only_in_current

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -30,19 +30,19 @@ jobs:
           message=""
 
           if [ ${#only_in_next[@]} -gt 0 ]; then
-            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/>%0A'
+            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/><ul>'
             for file in "${only_in_next[@]}"; do
-              message+="  * docs/$file<br/>"
+              message+="<li>docs/$file</li>"
             done
-            message+="<br/>"
+            message+="</ul><br/>"
           fi
 
           if [ ${#only_in_current[@]} -gt 0 ]; then
-            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/>%0A'
+            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/><ul>'
             for file in "${only_in_current[@]}"; do
-              message+="  * versioned_docs/version-8.3/$file<br/>"
+              message+="<li>versioned_docs/version-8.3/$file</li>"
             done
-            message+="<br/>"
+            message+="</ul><br/>"
           fi
 
           echo $message

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -51,5 +51,5 @@ jobs:
         if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE == '' }}
         with:
           message: |
-            ${{ POTENTIAL_MISSING_VERSIONS_MESSAGE }}
+            ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE }}
           comment_tag: execution

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -30,24 +30,24 @@ jobs:
           message=""
 
           if [ ${#only_in_next[@]} -gt 0 ]; then
-            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.\n'
+            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/>'
             for file in "${only_in_next[@]}"; do
-              message+="  * docs/$file\n"
+              message+="  * docs/$file<br/>"
             done
-            message+="\n"
+            message+="<br/>"
           fi
 
           if [ ${#only_in_current[@]} -gt 0 ]; then
-            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.\n'
+            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/>'
             for file in "${only_in_current[@]}"; do
-              message+="  * versioned_docs/version-8.3/$file\n"
+              message+="  * versioned_docs/version-8.3/$file<br/>"
             done
-            message+="\n"
+            message+="<br/>"
           fi
 
           echo $message
 
-          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="${message//\\n/<br/>}" >> $GITHUB_ENV
+          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="$message" >> $GITHUB_ENV
       - name: Comment on PR if version updates are potentially missing
         uses: thollander/actions-comment-pull-request@v2
         if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE != '' }}

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -47,7 +47,7 @@ jobs:
 
           echo $message
 
-          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="$message" >> $GITHUB_ENV
+          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="${message/\\n/<br/>}" >> $GITHUB_ENV
       - name: Comment on PR if version updates are potentially missing
         uses: thollander/actions-comment-pull-request@v2
         if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE != '' }}

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -34,7 +34,7 @@ jobs:
             for file in "${only_in_next[@]}"; do
               message+="<li>docs/$file</li>"
             done
-            message+="</ul><br/>"
+            message+="</ul>"
           fi
 
           if [ ${#only_in_current[@]} -gt 0 ]; then
@@ -42,7 +42,7 @@ jobs:
             for file in "${only_in_current[@]}"; do
               message+="<li>versioned_docs/version-8.3/$file</li>"
             done
-            message+="</ul><br/>"
+            message+="</ul>"
           fi
 
           echo $message

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -57,7 +57,5 @@ jobs:
 
             ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE }}
 
-            You may have done this intentionally, but we wanted to point it out in case you didn't. 
-            You can read more about the versioning within our docs in our 
-            [documentation guidelines](https://github.com/camunda/camunda-docs/blob/c666b7e5e35bfe31468ce4ac679ea7b62ab86d73/howtos/documentation-guidelines.md#versions).
+            You may have done this intentionally, but we wanted to point it out in case you didn't. You can read more about the versioning within our docs in our [documentation guidelines](https://github.com/camunda/camunda-docs/blob/c666b7e5e35bfe31468ce4ac679ea7b62ab86d73/howtos/documentation-guidelines.md#versions).
           comment_tag: execution

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -31,7 +31,16 @@ jobs:
           echo FILES_ONLY_IN_CURRENT="(${only_in_current[@]})" >> $GITHUB_ENV
       - name: Emit uncommon files
         run: |
-          echo "only in next:"
-          echo ${FILES_ONLY_IN_NEXT[@]} | tr ' ' '\n'
-          echo "only in current:"
-          echo ${FILES_ONLY_IN_CURRENT[@]} | tr ' ' '\n'
+          if [ ${#only_in_next[@]} -eq 0 ] && [ ${#only_in_current[@]} -eq 0 ]; then
+            exit 0
+          fi 
+
+          if [ ${#only_in_next[@]} -gt 0 ]; then
+            echo "These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version."
+            echo ${only_in_next[@]} | tr ' ' '\n' | sed 's/^/  docs\//'
+          fi
+
+          if [ ${#only_in_current[@]} -gt 0 ]; then
+            echo "These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version."
+            echo ${only_in_current[@]} | tr ' ' '\n' | sed 's/^/  versioned_docs\/version-8.3\//'
+          fi

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -1,0 +1,16 @@
+on: pull_request
+jobs:
+  list-pr-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (fetch last two commits) of the PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+      - name: Process files changed in the current commit
+        run: |
+          changedFiles=$(git diff --name-only HEAD^)
+          for file in $changedFiles; do
+            echo "Processing file: $file"
+          done

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -53,5 +53,11 @@ jobs:
         if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE != '' }}
         with:
           message: |
+            :wave: :robot: Hello! Did you make your changes in all the right places? 
+
             ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE }}
+
+            You may have done this intentionally, but we wanted to point it out in case you didn't. 
+            You can read more about the versioning within our docs in our 
+            [documentation guidelines](https://github.com/camunda/camunda-docs/blob/c666b7e5e35bfe31468ce4ac679ea7b62ab86d73/howtos/documentation-guidelines.md#versions).
           comment_tag: execution

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -15,14 +15,14 @@ jobs:
           next_files=($( git diff --name-only HEAD^ | grep ^docs/ | sed 's/^docs\///')) 
           current_files=($( git diff --name-only HEAD^ | grep ^versioned_docs/version-8.3/ | sed 's/^versioned_docs\/version-8.3\///' )) 
 
-          echo $next_files
-          echo "-------------"
-          echo $current_files
-          echo "-------------"
-
           missing_files=(`echo ${next_files[@]} ${current_files[@]} | tr ' ' '\n' | sort | uniq -u`)
 
           echo $missing_files
+
+          if [ ${#missing_files} -eq 0 ]
+            echo "No obvious missing version updates." 
+            exit 0
+          fi
 
           only_in_next=(`echo ${next_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
           only_in_current=(`echo ${current_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
@@ -46,6 +46,10 @@ jobs:
           fi
 
           echo POTENTIAL_MISSING_VERSIONS_MESSAGE="$message" >> $GITHUB_ENV
-      - name: Emit message if it exists
-        run: |
-          echo $POTENTIAL_MISSING_VERSIONS_MESSAGE
+      - name: Comment on PR if version updates are potentially missing
+        uses: thollander/actions-comment-pull-request@v2
+        if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE == '' }}
+        with:
+          message: |
+            ${{ POTENTIAL_MISSING_VERSIONS_MESSAGE }}
+          comment_tag: execution

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -19,7 +19,7 @@ jobs:
 
           echo $missing_files
 
-          if [ ${#missing_files} -eq 0 ]
+          if [ ${#missing_files} -eq 0 ]; then
             echo "No obvious missing version updates." 
             exit 0
           fi

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Process files changed in the current commit
+      - name: Identify files changed in next but not current, or vice versa
         run: |
           next_files=($( git diff --name-only HEAD^ | grep ^docs/ | sed 's/^docs\///')) 
           current_files=($( git diff --name-only HEAD^ | grep ^versioned_docs/version-8.3/ | sed 's/^versioned_docs\/version-8.3\///' )) 
@@ -27,8 +27,11 @@ jobs:
           only_in_next=(`echo ${next_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
           only_in_current=(`echo ${current_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
 
+          echo FILES_ONLY_IN_NEXT="(${only_in_next[@]})" >> $GITHUB_ENV
+          echo FILES_ONLY_IN_CURRENT="(${only_in_current[@]})" >> $GITHUB_ENV
+      - name: Emit uncommon files
+        run: |
           echo "only in next:"
-          echo $only_in_next
-
+          echo ${FILES_ONLY_IN_NEXT[@]} | tr ' ' '\n'
           echo "only in current:"
-          echo $only_in_current
+          echo ${FILES_ONLY_IN_CURRENT[@]} | tr ' ' '\n'

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -30,20 +30,19 @@ jobs:
           message=""
 
           if [ ${#only_in_next[@]} -gt 0 ]; then
-            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/>'
-            message+=""
+            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.<br/><ul>'
             for file in "${only_in_next[@]}"; do
-              message+="* docs/$file"
+              message+="<li>docs/$file</li>"
             done
-            # message+=""
+            message+="</ul>"
           fi
 
           if [ ${#only_in_current[@]} -gt 0 ]; then
-            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/>'
+            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.<br/><ul>'
             for file in "${only_in_current[@]}"; do
-              message+="* versioned_docs/version-8.3/$file"
+              message+="<li>versioned_docs/version-8.3/$file</li>"
             done
-            # message+=""
+            message+="</ul>"
           fi
 
           echo $message

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -1,12 +1,14 @@
+name: Check versions
+
 on: pull_request
+
 jobs:
   list-pr-changes:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout (fetch last two commits) of the PR
+      - name: Checkout last two commits of the PR
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
       - name: Process files changed in the current commit
         run: |

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -45,10 +45,12 @@ jobs:
             message+="\n"
           fi
 
+          echo $message
+
           echo POTENTIAL_MISSING_VERSIONS_MESSAGE="$message" >> $GITHUB_ENV
       - name: Comment on PR if version updates are potentially missing
         uses: thollander/actions-comment-pull-request@v2
-        if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE == '' }}
+        if: ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE != '' }}
         with:
           message: |
             ${{ env.POTENTIAL_MISSING_VERSIONS_MESSAGE }}

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -27,20 +27,25 @@ jobs:
           only_in_next=(`echo ${next_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
           only_in_current=(`echo ${current_files[@]} ${missing_files[@]} | tr ' ' '\n' | sort | uniq -D | uniq`)
 
-          echo FILES_ONLY_IN_NEXT="(${only_in_next[@]})" >> $GITHUB_ENV
-          echo FILES_ONLY_IN_CURRENT="(${only_in_current[@]})" >> $GITHUB_ENV
-      - name: Emit uncommon files
+          message=""
+
+          if [ ${#only_in_next[@]} -gt 0 ]; then
+            message+='These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version.\n'
+            for file in "${only_in_next[@]}"; do
+              message+="  - docs/$file\n"
+            done
+            message+="\n"
+          fi
+
+          if [ ${#only_in_current[@]} -gt 0 ]; then
+            message+='These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version.\n'
+            for file in "${only_in_current[@]}"; do
+              message+="  - versioned_docs/version-8.3/$file\n"
+            done
+            message+="\n"
+          fi
+
+          echo POTENTIAL_MISSING_VERSIONS_MESSAGE="$message" >> $GITHUB_ENV
+      - name: Emit message if it exists
         run: |
-          if [ ${#FILES_ONLY_IN_NEXT[@]} -eq 0 ] && [ ${#FILES_ONLY_IN_CURRENT[@]} -eq 0 ]; then
-            exit 0
-          fi 
-
-          if [ ${#FILES_ONLY_IN_NEXT[@]} -gt 0 ]; then
-            echo "These files were changed only in the *next* version. You might want to duplicate these changes in the *current* version."
-            echo ${FILES_ONLY_IN_NEXT[@]} | tr ' ' '\n' | sed 's/^/  docs\//'
-          fi
-
-          if [ ${#FILES_ONLY_IN_CURRENT[@]} -gt 0 ]; then
-            echo "These files were changed only in the *current* version. You might want to duplicate these changes in the *next* version."
-            echo ${FILES_ONLY_IN_CURRENT[@]} | tr ' ' '\n' | sed 's/^/  versioned_docs\/version-8.3\//'
-          fi
+          echo $POTENTIAL_MISSING_VERSIONS_MESSAGE

--- a/docs/components/operate/userguide/delete-resources.md
+++ b/docs/components/operate/userguide/delete-resources.md
@@ -4,6 +4,8 @@ title: Delete resources
 description: "Let's delete process and decision definitions."
 ---
 
+Deelleeteeeee stuff
+
 A specific version of a resource, meaning a process or decision definition, can be deleted from the **Processes** and **Decisions** pages.
 
 ## Delete process definition from Processes page

--- a/versioned_docs/version-8.3/apis-tools/operate-api/tutorial.md
+++ b/versioned_docs/version-8.3/apis-tools/operate-api/tutorial.md
@@ -5,6 +5,8 @@ slug: /apis-tools/operate-api/tutorial
 description: "Step through examples to implement an application using the Operate API and render a BPMN diagram."
 ---
 
+Steve broke this
+
 In this tutorial, we'll step through examples to highlight the capabilities of the Operate API, such as rendering a BPMN diagram.
 
 ## Getting started

--- a/versioned_docs/version-8.3/components/operate/userguide/delete-resources.md
+++ b/versioned_docs/version-8.3/components/operate/userguide/delete-resources.md
@@ -4,6 +4,8 @@ title: Delete resources
 description: "Let's delete process and decision definitions."
 ---
 
+Deelleeteeeee stuff
+
 A specific version of a resource, meaning a process or decision definition, can be deleted from the **Processes** and **Decisions** pages.
 
 ## Delete process definition from Processes page


### PR DESCRIPTION
This PR should probably not be merged in its current state. There is a bit of cleanup to do, and I'm not 100% sure we want it implemented.

It is a prototype of #1778. 

## Description

This prototype is a job thief! It seeks to steal a non-trivial portion of Amara's PR review responsibilities. It adds a workflow that is triggered on `pull_request`, which automatically comments on a PR when there are changes in the `next` version but not `current`, or the `current` version but not `next`.

The comment looks like this (screenshotted from this PR itself, see below):

<img width="879" alt="image" src="https://github.com/camunda/camunda-docs/assets/1627089/81a87247-0a43-454f-b1cf-287bf6e90698">

## Summary of the logic to trigger a message

* If all the changed files in `next` are also changed in `current`, and vice-versa, no comment is added to the PR.
* If changed files exist in `next` that aren't also changed in `current`, a comment is added, and the message will list the files.
* If changed files exist in `current` that aren't also changed in `next`, a comment is added, and the message will list the files.
* The message, if it's presented, also includes some helpful context about why this message is appearing, and how to learn more about versioning in our docs.

## Some technical choices I made 

* It does **not** spam the PR with comments as commits are added. 
   If the missed version edits change throughout the life of the PR, the same comment will be updated with new information. We can change this behavior if we'd like, in two ways: (1) spam the PR every time a commit is pushed (🙅), or (2) delete & recreate the message each time a commit is pushed (🤷).
* The message is not "dismissable". It appears as an unresolvable comment on the PR.
   This is less about me "choosing" to do it this way, and more about me not knowing how to do it any other way. But we probably _could_....I'd just have to dig a lot more.
* The only version scenarios I implemented are: a file is edited in `next` but not `current`, or vice versa. 
   I don't think we should warn about older version changes, in either direction, because those are much more infrequent. I think the majority of times we make a change in `next` but not `current`, or `current` but not `next`, it is an accident, and we end up duplicating them. I might be wrong about this.

## Yet to do, but I will wait until I'm confident we want this

- [ ] Extend the check to include Optimize docs
- [ ] Finalize the messaging in the comments
- [ ] Probably trigger on `pull_request_target` instead of `pull_request`, to accommodate forked PRs. Regardless of whether it requires a change, that scenario should be tested.
- [ ] Update the message after all issues have been cleared up

## How this prototype moves forward

- If people think this is a good idea, I will re-implement it, including the "yet to do" list above. I will also add multiple "test" PRs _into_ the new PR, to confirm a variety of scenarios are covered as planned.
- If people think this is not a good idea, I will close this prototype and go back to the drawing board on #1778.