### PR TITLE
Document message templates and generated value

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -331,6 +331,26 @@ Configures the [task type](../../../bpmn/service-tasks/#task-definition) for a s
 
 The `zeebe:property` binding allows you to set any arbitrary property for an outside system. It does not impact execution of the Zeebe engine.
 
+#### `bpmn:Message#property`
+
+| **Binding `type`**          | `bpmn:Message#property`                            |
+| --------------------------- | -------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown` |
+| **Binding parameters**      | `name`: The name of the property                   |
+| **Mapping result**          | `<bpmn:message [name]="[userInput]" />`            |
+
+The `bpmn:Message#property` binding allows you to set properties of a `bpmn:Message` referred to by the templated element. This binding is only valid for templates of events with `bpmn:MessageEventDefinition`.
+
+#### `bpmn:Message#zeebe:subscription#property`
+
+| **Binding `type`**          | `bpmn:Message#property`                            |
+| --------------------------- | -------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown` |
+| **Binding parameters**      | `name`: The name of the property                   |
+| **Mapping result**          | `<zeebe:subscription [name]="[userInput]" />`      |
+
+The `bpmn:Message#zeebe:subscription#property` binding allows you to set properties of a `zeebe:subscription` set within `bpmn:Message` referred to by the templated element. This binding is only valid for templates of events with `bpmn:MessageEventDefinition`.
+
 ### Optional bindings
 
 We support optional bindings that do not persist empty values in the underlying BPMN 2.0 XML.

--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -182,6 +182,23 @@ In addition, fields can be activated conditionally via these properties:
 - `id`: An identifier that can be used to reference the property in conditional properties
 - `condition`: A condition that determines when [the property is active](#defining-conditional-properties)
 
+### Generated value
+
+As an alternative to static `value`, you can use a generated value. The value is generated when a property is applied to an element. Currently, the generated value can be a UUID:
+
+```json
+{
+  "type": "Hidden",
+  "generatedValue": {
+    "type": "uuid"
+  },
+  "binding": {
+    "type": "zeebe:property",
+    "name": "id"
+  }
+}
+```
+
 ### Types
 
 The input types `String`, `Text`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.

--- a/versioned_docs/version-8.3/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.3/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -316,6 +316,26 @@ Configures the [task type](../../../bpmn/service-tasks/#task-definition) for a s
 
 The `zeebe:property` binding allows you to set any arbitrary property for an outside system. It does not impact execution of the Zeebe engine.
 
+#### `bpmn:Message#property`
+
+| **Binding `type`**          | `bpmn:Message#property`                            |
+| --------------------------- | -------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown` |
+| **Binding parameters**      | `name`: The name of the property                   |
+| **Mapping result**          | `<bpmn:message [name]="[userInput]" />`            |
+
+The `bpmn:Message#property` binding allows you to set properties of a `bpmn:Message` referred to by the templated element. This binding is only valid for templates of events with `bpmn:MessageEventDefinition`.
+
+#### `bpmn:Message#zeebe:subscription#property`
+
+| **Binding `type`**          | `bpmn:Message#property`                            |
+| --------------------------- | -------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown` |
+| **Binding parameters**      | `name`: The name of the property                   |
+| **Mapping result**          | `<zeebe:subscription [name]="[userInput]" />`      |
+
+The `bpmn:Message#zeebe:subscription#property` binding allows you to set properties of a `zeebe:subscription` set within `bpmn:Message` referred to by the templated element. This binding is only valid for templates of events with `bpmn:MessageEventDefinition`.
+
 ### Optional bindings
 
 We support optional bindings that do not persist empty values in the underlying BPMN 2.0 XML.

--- a/versioned_docs/version-8.3/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.3/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -181,6 +181,23 @@ In addition, fields can be activated conditionally via these properties:
 - `id`: An identifier that can be used to reference the property in conditional properties
 - `condition`: A condition that determines when [the property is active](#defining-conditional-properties)
 
+### Generated value
+
+As an alternative to static `value`, you can use a generated value. The value is generated when a property is applied to an element. Currently, the generated value can be a UUID:
+
+```json
+{
+  "type": "Hidden",
+  "generatedValue": {
+    "type": "uuid"
+  },
+  "binding": {
+    "type": "zeebe:property",
+    "name": "id"
+  }
+}
+```
+
 ### Types
 
 The input types `String`, `Text`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.


### PR DESCRIPTION
## Description

This pull request documents the message templates and generated values which were added in 8.3 as part of https://github.com/camunda/product-hub/issues/817

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

Closes https://github.com/bpmn-io/internal-docs/issues/797