### PR TITLE
docs(tasklist): document Fetch variables in Task Search REST api

### DIFF
--- a/docs/apis-tools/tasklist-api-rest/schemas/models/include-variable.mdx
+++ b/docs/apis-tools/tasklist-api-rest/schemas/models/include-variable.mdx
@@ -1,0 +1,82 @@
+---
+id: include-variable
+title: IncludeVariable
+hide_table_of_contents: false
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+export const Bullet = () => (
+  <>
+    <span
+      style={{
+        fontWeight: "normal",
+        fontSize: ".5em",
+        color: "var(--ifm-color-secondary-darkest)",
+      }}
+    >
+      &nbsp;●&nbsp;
+    </span>
+  </>
+);
+
+export const SpecifiedBy = (props) => (
+  <>
+    Specification
+    <a
+      className="link"
+      style={{ fontSize: "1.5em", paddingLeft: "4px" }}
+      target="_blank"
+      href={props.url}
+      title={"Specified by " + props.url}
+    >
+      ⎘
+    </a>
+  </>
+);
+
+export const Badge = (props) => (
+  <>
+    <span class={"badge badge--" + props.class}>{props.text}</span>
+  </>
+);
+
+Include variables in tasks search response
+
+<Tabs groupId="schema" defaultValue="schema" values={
+[
+{label:'Schema',value: 'schema'},
+{label:'Example value',value: 'example'}
+]
+}>
+<TabItem value='schema'>
+
+```json
+{
+    "name": string,
+}
+```
+
+</TabItem>
+
+<TabItem value='example'>
+
+```json
+{
+  "name": "variableName"
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Fields
+
+#### [<code style={{ fontWeight: 'normal' }}>IncludeVariable.<b>name</b></code>](#)<Bullet />`string` <Badge class="secondary" text="non-null"/>
+
+> The name of the variable
+
+### Member of
+
+[`TaskSearchRequest`](../requests/task-search-request.mdx) <Badge class="secondary" text="object"/>

--- a/docs/apis-tools/tasklist-api-rest/schemas/requests/task-search-request.mdx
+++ b/docs/apis-tools/tasklist-api-rest/schemas/requests/task-search-request.mdx
@@ -71,7 +71,8 @@ TaskSearchRequest - query object to search tasks by provided params.
     "searchAfter": [string],
     "searchAfterOrEqual": [string],
     "searchBefore": [string],
-    "searchBeforeOrEqual": [string]
+    "searchBeforeOrEqual": [string],
+    "includeVariables": [IncludeVariable]
 }
 ```
 
@@ -115,7 +116,12 @@ TaskSearchRequest - query object to search tasks by provided params.
   "searchAfter": ["string"],
   "searchAfterOrEqual": ["string"],
   "searchBefore": ["string"],
-  "searchBeforeOrEqual": ["string"]
+  "searchBeforeOrEqual": ["string"],
+  "includeVariables": [
+    {
+      "name": "variable_name"
+    }
+  ]
 }
 ```
 
@@ -201,6 +207,10 @@ TaskSearchRequest - query object to search tasks by provided params.
 
 > Used to return a paginated result. Array of values that should be copied from `sortValues` of one of the tasks from the current search results page.
 > It enables the API to return a page of tasks that directly precede or are equal to the task identified by the provided values, with respect to the sorting order.
+
+#### [<code style={{ fontWeight: 'normal' }}>TaskSearchRequest.<b>includeVariables</b></code>](#)<Bullet />[`IncludeVariable`](../models/include-variable.mdx) <Badge class="secondary" text="list"/>
+
+> An array used to specify a list of variable names that should be included in the response when querying tasks. This field allows users to selectively retrieve specific variables associated with the tasks returned in the search results.
 
 ### Consumed by
 

--- a/docs/apis-tools/tasklist-api-rest/schemas/responses/task-search-response.mdx
+++ b/docs/apis-tools/tasklist-api-rest/schemas/responses/task-search-response.mdx
@@ -71,7 +71,8 @@ TaskSearchResponse - representing the searched task.
     "dueDate": string,
     "followUpDate": string,
     "candidateGroups": [string],
-    "candidateUsers": [string]
+    "candidateUsers": [string],
+    "variables": [VariableSearchResponse]
 }
 ```
 
@@ -98,7 +99,16 @@ TaskSearchResponse - representing the searched task.
   "dueDate": "2023-03-29T20:08:07.171Z",
   "followUpDate": "2023-03-29T20:08:07.171Z",
   "candidateGroups": ["string"],
-  "candidateUsers": ["string"]
+  "candidateUsers": ["string"],
+  "variables": [
+    {
+      "id": "<id>-<var_name>",
+      "name": "<var_name>",
+      "value": "\"stringVariableValue\"",
+      "isValueTruncated": false,
+      "previewValue": "\"stringVariableValue\""
+    }
+  ]
 }
 ```
 
@@ -182,6 +192,10 @@ TaskSearchResponse - representing the searched task.
 #### [<code style={{ fontWeight: 'normal' }}>TaskSearchResponse.<b>dueDate</b></code>](#)<Bullet />`string` <Badge class="secondary" text="list"/>
 
 > Due date for the task
+
+#### [<code style={{ fontWeight: 'normal' }}>TaskSearchResponse.<b>variables</b></code>](#)<Bullet />[`VariableSearchResponse`](./variable-search-response.mdx) <Badge class="secondary" text="list"/>
+
+> An array of task's variables. Only variables specified in [`TaskSearchReqeuest`](../requests/task-search-request.mdx#)`.includeVariables` are returned. Note that variable's draft value is not returned in TaskSearchResponse.
 
 ### Returned by
 

--- a/docs/apis-tools/tasklist-api-rest/schemas/responses/variable-search-response.mdx
+++ b/docs/apis-tools/tasklist-api-rest/schemas/responses/variable-search-response.mdx
@@ -118,3 +118,7 @@ VariableSearchResponse - represents a variable in a search response. It contains
 ### Returned by
 
 [`Search task variables`](../../controllers/tasklist-api-rest-task-controller.md#search-task-variables) <Badge class="secondary" text="POST"/> <Bullet />
+
+### Member of
+
+[`TaskSearchResponse`](../responses/task-search-response.mdx) <Badge class="secondary" text="object"/>


### PR DESCRIPTION
closes https://github.com/camunda/tasklist/issues/3774

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
