### PR TITLE
docs(self-managed): add install zeebe exporters guide

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,0 +1,44 @@
+---
+id: install-zeebe-exporters
+title: "Install Zeebe exporters"
+description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+---
+
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+
+The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
+
+```yaml
+extraInitContainers:
+  - name: init-exporters-hazelcast
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+  - name: init-exporters-kafka
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+env:
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
+    value: /exporters/zeebe-hazelcast-exporter.jar
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
+    value: io.zeebe.hazelcast.exporter.HazelcastExporter
+  - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS
+    value: "{{ .Release.Name }}-hazelcast"
+```
+
+This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
+which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+you can configure the exporter parameters.

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,10 +1,10 @@
 ---
 id: install-zeebe-exporters
 title: "Install Zeebe exporters"
-description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+description: "Add dynamic exporters to Zeebe brokers in Camunda 8 Self-Managed deployment."
 ---
 
-Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe exporters by using `initContainer`.
 
 The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
 
@@ -39,6 +39,6 @@ env:
     value: "{{ .Release.Name }}-hazelcast"
 ```
 
-This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
-which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+This example is downloading the exporters' JAR from a URL and adding the JAR to the `exporters` directory,
+which will be scanned for JARs and added to the Zeebe broker classpath. Then, with `environment variables`,
 you can configure the exporter parameters.

--- a/sidebars.js
+++ b/sidebars.js
@@ -819,6 +819,7 @@ module.exports = {
                 "self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak",
                 "self-managed/platform-deployment/helm-kubernetes/guides/connecting-to-entra-id",
                 "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation",
+                "self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters",
               ],
             },
             "self-managed/platform-deployment/troubleshooting",

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,0 +1,44 @@
+---
+id: install-zeebe-exporters
+title: "Install Zeebe exporters"
+description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+---
+
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+
+The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
+
+```yaml
+extraInitContainers:
+  - name: init-exporters-hazelcast
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+  - name: init-exporters-kafka
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+env:
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
+    value: /exporters/zeebe-hazelcast-exporter.jar
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
+    value: io.zeebe.hazelcast.exporter.HazelcastExporter
+  - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS
+    value: "{{ .Release.Name }}-hazelcast"
+```
+
+This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
+which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+you can configure the exporter parameters.

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,10 +1,10 @@
 ---
 id: install-zeebe-exporters
 title: "Install Zeebe exporters"
-description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+description: "Add dynamic exporters to Zeebe brokers in Camunda 8 Self-Managed deployment."
 ---
 
-Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe exporters by using `initContainer`.
 
 The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
 
@@ -39,6 +39,6 @@ env:
     value: "{{ .Release.Name }}-hazelcast"
 ```
 
-This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
-which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+This example is downloading the exporters' JAR from a URL and adding the JAR to the `exporters` directory,
+which will be scanned for JARs and added to the Zeebe broker classpath. Then, with `environment variables`,
 you can configure the exporter parameters.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,0 +1,44 @@
+---
+id: install-zeebe-exporters
+title: "Install Zeebe exporters"
+description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+---
+
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+
+The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
+
+```yaml
+extraInitContainers:
+  - name: init-exporters-hazelcast
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+  - name: init-exporters-kafka
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+env:
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
+    value: /exporters/zeebe-hazelcast-exporter.jar
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
+    value: io.zeebe.hazelcast.exporter.HazelcastExporter
+  - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS
+    value: "{{ .Release.Name }}-hazelcast"
+```
+
+This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
+which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+you can configure the exporter parameters.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,10 +1,10 @@
 ---
 id: install-zeebe-exporters
 title: "Install Zeebe exporters"
-description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+description: "Add dynamic exporters to Zeebe brokers in Camunda 8 Self-Managed deployment."
 ---
 
-Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe exporters by using `initContainer`.
 
 The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
 
@@ -39,6 +39,6 @@ env:
     value: "{{ .Release.Name }}-hazelcast"
 ```
 
-This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
-which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+This example is downloading the exporters' JAR from a URL and adding the JAR to the `exporters` directory,
+which will be scanned for JARs and added to the Zeebe broker classpath. Then, with `environment variables`,
 you can configure the exporter parameters.

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,0 +1,44 @@
+---
+id: install-zeebe-exporters
+title: "Install Zeebe exporters"
+description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+---
+
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+
+The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
+
+```yaml
+extraInitContainers:
+  - name: init-exporters-hazelcast
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+  - name: init-exporters-kafka
+    image: busybox:1.35
+    command: ["/bin/sh", "-c"]
+    args:
+      [
+        "wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al /exporters",
+      ]
+    volumeMounts:
+      - name: exporters
+        mountPath: /exporters/
+env:
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
+    value: /exporters/zeebe-hazelcast-exporter.jar
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
+    value: io.zeebe.hazelcast.exporter.HazelcastExporter
+  - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS
+    value: "{{ .Release.Name }}-hazelcast"
+```
+
+This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
+which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+you can configure the exporter parameters.

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters.md
@@ -1,10 +1,10 @@
 ---
 id: install-zeebe-exporters
 title: "Install Zeebe exporters"
-description: "Adding dynamic exporters to Zeebe Brokers in Camunda 8 Self-Managed deployment."
+description: "Add dynamic exporters to Zeebe brokers in Camunda 8 Self-Managed deployment."
 ---
 
-Camunda 8 Self-Managed Helm chart supports the addition of Zeebe Exporters by using `initContainer`.
+Camunda 8 Self-Managed Helm chart supports the addition of Zeebe exporters by using `initContainer`.
 
 The following is an example to install Zeebe [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter) and [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter) exporters.
 
@@ -39,6 +39,6 @@ env:
     value: "{{ .Release.Name }}-hazelcast"
 ```
 
-This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
-which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
+This example is downloading the exporters' JAR from a URL and adding the JAR to the `exporters` directory,
+which will be scanned for JARs and added to the Zeebe broker classpath. Then, with `environment variables`,
 you can configure the exporter parameters.

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -881,7 +881,8 @@
                 "self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress",
                 "self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup",
                 "self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak",
-                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation"
+                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation",
+                "self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters"
               ]
             },
             "self-managed/platform-deployment/troubleshooting"

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -944,7 +944,8 @@
                 "self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress",
                 "self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup",
                 "self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak",
-                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation"
+                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation",
+                "self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters"
               ]
             },
             "self-managed/platform-deployment/troubleshooting"

--- a/versioned_sidebars/version-8.3-sidebars.json
+++ b/versioned_sidebars/version-8.3-sidebars.json
@@ -990,7 +990,8 @@
                 "self-managed/platform-deployment/helm-kubernetes/guides/accessing-components-without-ingress",
                 "self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup",
                 "self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak",
-                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation"
+                "self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation",
+                "self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters"
               ]
             },
             "self-managed/platform-deployment/troubleshooting"


### PR DESCRIPTION
## Description

This guide was in [camunda/camunda-platform-helm](https://github.com/camunda/camunda-platform-helm), and as we keep the repo for development, all guides should be in the official docs.

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.