### PR TITLE
Update supported versions of Openshift Zeebe Gateway Ingress

### DIFF
--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -265,7 +265,6 @@ helm install <RELEASE_NAME> camunda/camunda-platform --skip-crds \
 
 | OpenShift version | Supported          |
 | ----------------- | ------------------ |
-| 4.10.x            | limited            |
 | 4.11.x            | :white_check_mark: |
 
 The Ingress on OpenShift works slightly different from the Kubernetes default. The mechanism is called [routes](https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html).


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

As we did not explicitely support newer versions than 4.10 of Openshift before, the section had its own version table.

This table can be removed in newer versions of the docs.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
