### PR TITLE
docs(modeler): link default execution platform version flag

### DIFF
--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -40,8 +40,8 @@ Flags passed as command line arguments take precedence over those configured via
 | "user-data-dir"                                    | [Electron default](../search-paths) |
 | ["display-version"](#custom-display-version-label) | `undefined`                         |
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
-| "c7-engine-version"                                | `undefined`                         |
-| "c8-engine-version"                                | `undefined`                         |
+| ["c7-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
+| ["c8-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
 
 ## Examples
 

--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -26,22 +26,22 @@ Flags passed as command line arguments take precedence over those configured via
 
 ## Available Flags
 
-| flag                                               | default value                       |
-| -------------------------------------------------- | ----------------------------------- |
-| ["disable-plugins"](#disable-plug-ins)             | false                               |
-| "disable-adjust-origin"                            | false                               |
-| "disable-cmmn"                                     | true                                |
-| "disable-dmn"                                      | false                               |
-| "disable-form"                                     | false                               |
-| "disable-platform"                                 | false                               |
-| "disable-zeebe"                                    | false                               |
-| "disable-remote-interaction"                       | false                               |
-| "single-instance"                                  | false                               |
-| "user-data-dir"                                    | [Electron default](../search-paths) |
-| ["display-version"](#custom-display-version-label) | `undefined`                         |
-| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
-| ["c7-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
-| ["c8-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
+| flag                                                       | default value                       |
+| ---------------------------------------------------------- | ----------------------------------- |
+| ["disable-plugins"](#disable-plug-ins)                     | false                               |
+| "disable-adjust-origin"                                    | false                               |
+| "disable-cmmn"                                             | true                                |
+| "disable-dmn"                                              | false                               |
+| "disable-form"                                             | false                               |
+| "disable-platform"                                         | false                               |
+| "disable-zeebe"                                            | false                               |
+| "disable-remote-interaction"                               | false                               |
+| "single-instance"                                          | false                               |
+| "user-data-dir"                                            | [Electron default](../search-paths) |
+| ["display-version"](#custom-display-version-label)         | `undefined`                         |
+| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)          | `undefined`                         |
+| ["c7-engine-version"](#default-execution-platform-version) | `undefined`                         |
+| ["c8-engine-version"](#default-execution-platform-version) | `undefined`                         |
 
 ## Examples
 

--- a/versioned_docs/version-8.3/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.3/components/modeler/desktop-modeler/flags/flags.md
@@ -40,8 +40,8 @@ Flags passed as command line arguments take precedence over those configured via
 | "user-data-dir"                                    | [Electron default](../search-paths) |
 | ["display-version"](#custom-display-version-label) | `undefined`                         |
 | ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
-| "c7-engine-version"                                | `undefined`                         |
-| "c8-engine-version"                                | `undefined`                         |
+| ["c7-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
+| ["c8-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
 
 ## Examples
 

--- a/versioned_docs/version-8.3/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.3/components/modeler/desktop-modeler/flags/flags.md
@@ -26,22 +26,22 @@ Flags passed as command line arguments take precedence over those configured via
 
 ## Available Flags
 
-| flag                                               | default value                       |
-| -------------------------------------------------- | ----------------------------------- |
-| ["disable-plugins"](#disable-plug-ins)             | false                               |
-| "disable-adjust-origin"                            | false                               |
-| "disable-cmmn"                                     | true                                |
-| "disable-dmn"                                      | false                               |
-| "disable-form"                                     | false                               |
-| "disable-platform"                                 | false                               |
-| "disable-zeebe"                                    | false                               |
-| "disable-remote-interaction"                       | false                               |
-| "single-instance"                                  | false                               |
-| "user-data-dir"                                    | [Electron default](../search-paths) |
-| ["display-version"](#custom-display-version-label) | `undefined`                         |
-| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)  | `undefined`                         |
-| ["c7-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
-| ["c8-engine-version"](#default-execution-platform-version)                                | `undefined`                         |
+| flag                                                       | default value                       |
+| ---------------------------------------------------------- | ----------------------------------- |
+| ["disable-plugins"](#disable-plug-ins)                     | false                               |
+| "disable-adjust-origin"                                    | false                               |
+| "disable-cmmn"                                             | true                                |
+| "disable-dmn"                                              | false                               |
+| "disable-form"                                             | false                               |
+| "disable-platform"                                         | false                               |
+| "disable-zeebe"                                            | false                               |
+| "disable-remote-interaction"                               | false                               |
+| "single-instance"                                          | false                               |
+| "user-data-dir"                                            | [Electron default](../search-paths) |
+| ["display-version"](#custom-display-version-label)         | `undefined`                         |
+| ["zeebe-ssl-certificate"](#zeebe-ssl-certificate)          | `undefined`                         |
+| ["c7-engine-version"](#default-execution-platform-version) | `undefined`                         |
+| ["c8-engine-version"](#default-execution-platform-version) | `undefined`                         |
 
 ## Examples
 


### PR DESCRIPTION
## Description

This adds an in-page link to make contents easier accessible.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
