### PR TITLE
feat(templates): document correlationKey changes

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -368,6 +368,11 @@ The `bpmn:Message#property` binding allows you to set properties of a `bpmn:Mess
 
 The `bpmn:Message#zeebe:subscription#property` binding allows you to set properties of a `zeebe:subscription` set within `bpmn:Message` referred to by the templated element. This binding is only valid for templates of events with `bpmn:MessageEventDefinition`.
 
+:::note
+
+The binding name of `correlationKey` is not applicable to Message Start Events on a Process. In such cases, the property will be automatically hidden.
+:::
+
 ### Optional bindings
 
 We support optional bindings that do not persist empty values in the underlying BPMN 2.0 XML.
@@ -569,10 +574,11 @@ For a property value to be used in a condition, the property needs to have an `i
 
 A property can depend on one or more conditions. If there are multiple conditions, they can be defined using `allMatch`. All of the conditions must be met for the property to be active.
 
-There are two possible comparison operators:
+There are three possible comparison operators:
 
 - `equals`: Checks if the value is equal to the value defined in the condition.
 - `oneOf`: Checks if the value is in the list of values defined in the condition.
+- `isActive`: Checks if the referenced property is currently active and not hidden by other conditions.
 
 ```json
 ...


### PR DESCRIPTION
## Description

This PR:
- documents changes in the display of templated correlationKey. It will be automatically hidden in Start Events on a Process, but will still be visible for start events in event based subprocesses (and boundary/intermediate events)
- adds a new condition

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until December release
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] ~~I have added changes to the relevant `/versioned_docs` directory, or~~ they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), ~~or they are not for **future versions**.~~
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
