### PR TITLE
Update create-decision-tables-using-dmn.md

### DIFF
--- a/versioned_docs/version-8.3/guides/create-decision-tables-using-dmn.md
+++ b/versioned_docs/version-8.3/guides/create-decision-tables-using-dmn.md
@@ -32,7 +32,7 @@ Once logged in to your Camunda 8 account, take the following steps:
 
 1. Navigate to Modeler by clicking the square-shaped icon in the top left corner of the page.
 2. Click **New project** and name your project. For this example, we'll name our project "Deciding what to wear".
-3. Click **Create new file > BPMN Diagram** and name your diagram. We'll name our diagram "Picking an outfit".
+3. Click **Create new file > DMN Diagram** and name your diagram. We'll name our diagram "Picking an outfit".
 
 ## DMN in action
 


### PR DESCRIPTION
"BPMN" should be "DMN" in create-decision-tables-using-dmn.md

## Description

"Getting started with DMN" paragraph contains false instruction, telling user to create "BPMN Diagram" instead "DMN Diagram"
