### PR TITLE
fix: unify paths

### DIFF
--- a/docs/components/modeler/forms/configuration/forms-config-data-binding.md
+++ b/docs/components/modeler/forms/configuration/forms-config-data-binding.md
@@ -39,7 +39,7 @@ Setting this field to value `21` would lead to the following output data:
 {
   "user": {
 	"info": {
-      "age": 21
+	  "age": 21
 	}
   }
 }
@@ -49,16 +49,16 @@ Setting this field to value `21` would lead to the following output data:
 
 In a form that utilizes **groups**, the group's **path** acts as a prefix to the key of each child field within that group. This effectively extends the key and allows for more intricate data mapping.
 
-For example, if the group's path is `user.data`, and a child field has a key of `age`, the complete key would become `user.info.age`. This is particularly useful to deal with nested data structure inputs and outputs.
+For example, if the group's path is `user.info`, and a child field has a key of `age`, the complete key would become `user.info.age`. This is particularly useful to deal with nested data structure inputs and outputs.
 
 ![Group Example Image](../assets/group-mapping-example.png)
 
-If the above group has a path set to `user.data`, and if each field's key matches its label, the resulting output data will look like this:
+If the above group has a path set to `user.info`, and if each field's key matches its label, the resulting output data will look like this:
 
 ```
 {
   "user": {
-    "data": {
+    "info": {
       "surname": "Inco",
       "name": "Gnito",
       "age": 29

--- a/versioned_docs/version-8.3/components/modeler/forms/configuration/forms-config-data-binding.md
+++ b/versioned_docs/version-8.3/components/modeler/forms/configuration/forms-config-data-binding.md
@@ -39,7 +39,7 @@ Setting this field to value `21` would lead to the following output data:
 {
   "user": {
 	"info": {
-      "age": 21
+	  "age": 21
 	}
   }
 }
@@ -49,16 +49,16 @@ Setting this field to value `21` would lead to the following output data:
 
 In a form that utilizes **groups**, the group's **path** acts as a prefix to the key of each child field within that group. This effectively extends the key and allows for more intricate data mapping.
 
-For example, if the group's path is `user.data`, and a child field has a key of `age`, the complete key would become `user.info.age`. This is particularly useful to deal with nested data structure inputs and outputs.
+For example, if the group's path is `user.info`, and a child field has a key of `age`, the complete key would become `user.info.age`. This is particularly useful to deal with nested data structure inputs and outputs.
 
 ![Group Example Image](../assets/group-mapping-example.png)
 
-If the above group has a path set to `user.data`, and if each field's key matches its label, the resulting output data will look like this:
+If the above group has a path set to `user.info`, and if each field's key matches its label, the resulting output data will look like this:
 
 ```
 {
   "user": {
-    "data": {
+    "info": {
       "surname": "Inco",
       "name": "Gnito",
       "age": 29


### PR DESCRIPTION
## Description

The examples seem to mix up the paths `user.data` and `user.info`. I unified this to `user.info`. Please check if this was the intention.

## When should this change go live?

Up to you to decide. It fixes an issue in the current docs of the latest release 8.3.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
