### PR TITLE
docs(self-managed): Mention the Camunda Docker registry for air-gapped install

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -13,6 +13,15 @@ To find out the necessary Docker images for your Helm release, note that the req
 helm template camunda/camunda-platform -f values.yaml | grep 'image:'
 ```
 
+Please note that all the required Docker images, available on DockerHub's Camunda organization, are also provided publicly via Camunda's Docker registry: `registry.camunda.cloud/camunda/<image>`
+
+For example, the Docker image of Zeebe can be pulled via DockerHub or via the Camunda's Docker Registry:
+
+```bash
+docker pull camunda/zeebe:latest
+docker pull registry.camunda.cloud/camunda/zeebe:latest
+```
+
 ## Required Docker images
 
 The following images must be available in your air-gapped environment:

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -25,6 +25,15 @@ The following images must be available in your air-gapped environment:
   - `web-modeler-ee/modeler-webapp`
   - `web-modeler-ee/modeler-websockets`
 
+Please note that all the required Docker images, available on DockerHub's Camunda organization, are also provided publicly via Camunda's Docker registry: `registry.camunda.cloud/camunda/<image>`
+
+For example, the Docker image of Zeebe can be pulled via DockerHub or via the Camunda's Docker Registry:
+
+```bash
+docker pull camunda/zeebe:latest
+docker pull registry.camunda.cloud/camunda/zeebe:latest
+```
+
 ## Required Helm charts
 
 The following charts must be available in your air-gapped environment:

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -25,6 +25,15 @@ The following images must be available in your air-gapped environment:
   - `web-modeler-ee/modeler-webapp`
   - `web-modeler-ee/modeler-websockets`
 
+Please note that all the required Docker images, available on DockerHub's Camunda organization, are also provided publicly via Camunda's Docker registry: `registry.camunda.cloud/camunda/<image>`
+
+For example, the Docker image of Zeebe can be pulled via DockerHub or via the Camunda's Docker Registry:
+
+```bash
+docker pull camunda/zeebe:latest
+docker pull registry.camunda.cloud/camunda/zeebe:latest
+```
+
 ## Required Helm charts
 
 The following charts must be available in your air-gapped environment:

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -33,6 +33,15 @@ The following images must be available in your air-gapped environment:
   - `web-modeler-ee/modeler-webapp`
   - `web-modeler-ee/modeler-websockets`
 
+Please note that all the required Docker images, available on DockerHub's Camunda organization, are also provided publicly via Camunda's Docker registry: `registry.camunda.cloud/camunda/<image>`
+
+For example, the Docker image of Zeebe can be pulled via DockerHub or via the Camunda's Docker Registry:
+
+```bash
+docker pull camunda/zeebe:latest
+docker pull registry.camunda.cloud/camunda/zeebe:latest
+```
+
 ## Required Helm charts
 
 The following charts must be available in your air-gapped environment:


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/product-hub/issues/1075

A simple change to clarify that the images required for an air-gapped installation, which are hosted on Camunda's DockerHub organization, are also hosted on Camunda's Docker Registry.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
