### PR TITLE
chore(opt): add notice about user groups in C8

### DIFF
--- a/optimize/components/userguide/collections-dashboards-reports.md
+++ b/optimize/components/userguide/collections-dashboards-reports.md
@@ -26,6 +26,10 @@ To [create a dashboard](./creating-dashboards.md) or [report](./creating-reports
 
 ## User permissions
 
+:::note
+Adding user groups to Collections is currently only available in Camunda Platform 7.
+:::
+
 By default, if you create a collection, only you can access the collection and the contents within. To share a collection with other users, add them to the collection.
 
 ![users and user groups](./img/users.png)

--- a/optimize/components/userguide/collections-dashboards-reports.md
+++ b/optimize/components/userguide/collections-dashboards-reports.md
@@ -27,7 +27,7 @@ To [create a dashboard](./creating-dashboards.md) or [report](./creating-reports
 ## User permissions
 
 :::note
-Adding user groups to Collections is currently only available in Camunda Platform 7.
+Adding user groups to collections is currently only available in Camunda 7.
 :::
 
 By default, if you create a collection, only you can access the collection and the contents within. To share a collection with other users, add them to the collection.

--- a/optimize_versioned_docs/version-3.10.0/components/userguide/collections-dashboards-reports.md
+++ b/optimize_versioned_docs/version-3.10.0/components/userguide/collections-dashboards-reports.md
@@ -26,6 +26,10 @@ To [create a dashboard](./creating-dashboards.md) or [report](./creating-reports
 
 ## User permissions
 
+:::note
+Adding user groups to collections is currently only available in Camunda 7.
+:::
+
 By default, if you create a collection, only you can access the collection and the contents within. To share a collection with other users, add them to the collection.
 
 ![users and user groups](./img/users.png)

--- a/optimize_versioned_docs/version-3.11.0/components/userguide/collections-dashboards-reports.md
+++ b/optimize_versioned_docs/version-3.11.0/components/userguide/collections-dashboards-reports.md
@@ -26,6 +26,10 @@ To [create a dashboard](./creating-dashboards.md) or [report](./creating-reports
 
 ## User permissions
 
+:::note
+Adding user groups to collections is currently only available in Camunda 7.
+:::
+
 By default, if you create a collection, only you can access the collection and the contents within. To share a collection with other users, add them to the collection.
 
 ![users and user groups](./img/users.png)

--- a/optimize_versioned_docs/version-3.7.0/components/userguide/collections-dashboards-reports.md
+++ b/optimize_versioned_docs/version-3.7.0/components/userguide/collections-dashboards-reports.md
@@ -22,6 +22,10 @@ To create a dashboard or report, use the **Create New** button available in the 
 
 ## User permissions
 
+:::note
+Adding user groups to collections is currently only available in Camunda 7.
+:::
+
 By default, if you create a collection, only you can access the collection and the contents within. To share a collection with other users, add them to the collection.
 
 ![users and user groups](./img/users.png)


### PR DESCRIPTION
related to OPT-7413

## Description

User groups are currently not available to assign in Optimize collections for SaaS and CCSM: https://jira.camunda.com/browse/OPT-7413

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
