### PR TITLE
fix(docs): clarify availability for enterprise customers

### DIFF
--- a/docs/components/modeler/web-modeler/collaborate-with-modes.md
+++ b/docs/components/modeler/web-modeler/collaborate-with-modes.md
@@ -10,6 +10,10 @@ Collaboration between business and IT professionals can be challenging, which is
 
 The **Design** mode view is tailored to business users, and the **Implement** and **Play** mode views are tailored to developers.
 
+:::note
+**Play** mode is an alpha feature that is being progressively rolled out. Review the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
+:::
+
 Business users can now focus on modeling, sharing, and collaborating, while developers can work on implementation and debugging with ease.
 
 When accessing a BPMN diagram for the [first time](/components/modeler/web-modeler/model-your-first-diagram.md), the **Design** mode is the first selected option. To switch between modes, you can select one of the tabs on the left side of the screen, above the diagram; any further selection is remembered and kept for the next sessions.
@@ -18,7 +22,4 @@ When accessing a BPMN diagram for the [first time](/components/modeler/web-model
 
 :::note
 When a process template is selected, the default mode is **Implement**.
-:::
-:::note
-The **Play** is an alpha feature that is being progressively rolled out. Read the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
 :::

--- a/docs/components/modeler/web-modeler/collaborate-with-modes.md
+++ b/docs/components/modeler/web-modeler/collaborate-with-modes.md
@@ -15,9 +15,10 @@ Business users can now focus on modeling, sharing, and collaborating, while deve
 When accessing a BPMN diagram for the [first time](/components/modeler/web-modeler/model-your-first-diagram.md), the **Design** mode is the first selected option. To switch between modes, you can select one of the tabs on the left side of the screen, above the diagram; any further selection is remembered and kept for the next sessions.
 
 ![modes tab navigation](img/mode-tab-navigation.png)
+
 :::note
 When a process template is selected, the default mode is **Implement**.
 :::
 :::note
-The **Play** mode is an alpha feature and is not yet available for Enterprise users.
+The **Play** is an alpha feature that is being progressively rolled out. Read the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
 :::

--- a/versioned_docs/version-8.2/components/modeler/web-modeler/collaborate-with-modes.md
+++ b/versioned_docs/version-8.2/components/modeler/web-modeler/collaborate-with-modes.md
@@ -20,5 +20,5 @@ When accessing a BPMN diagram for the [first time](/components/modeler/web-model
 When a process template is selected, the default mode is **Implement**.
 :::
 :::note
-The **Play** mode is an alpha feature and is not yet available for Enterprise users.
+The **Play** is an alpha feature that is being progressively rolled out. Read the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
 :::

--- a/versioned_docs/version-8.2/components/modeler/web-modeler/collaborate-with-modes.md
+++ b/versioned_docs/version-8.2/components/modeler/web-modeler/collaborate-with-modes.md
@@ -10,6 +10,10 @@ Collaboration between business and IT professionals can be challenging, which is
 
 The **Design** mode view is tailored to business users, and the **Implement** and **Play** mode views are tailored to developers.
 
+:::note
+**Play** mode is an alpha feature that is being progressively rolled out. Review the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
+:::
+
 Business users can now focus on modeling, sharing, and collaborating, while developers can work on implementation and debugging with ease.
 
 When accessing a BPMN diagram for the [first time](/components/modeler/web-modeler/model-your-first-diagram.md), the **Design** mode is the first selected option. To switch between modes, you can select one of the tabs on the left side of the screen, above the diagram; any further selection is remembered and kept for the next sessions.
@@ -18,7 +22,4 @@ When accessing a BPMN diagram for the [first time](/components/modeler/web-model
 
 :::note
 When a process template is selected, the default mode is **Implement**.
-:::
-:::note
-The **Play** is an alpha feature that is being progressively rolled out. Read the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
 :::

--- a/versioned_docs/version-8.3/components/modeler/web-modeler/collaborate-with-modes.md
+++ b/versioned_docs/version-8.3/components/modeler/web-modeler/collaborate-with-modes.md
@@ -10,6 +10,10 @@ Collaboration between business and IT professionals can be challenging, which is
 
 The **Design** mode view is tailored to business users, and the **Implement** and **Play** mode views are tailored to developers.
 
+:::note
+**Play** mode is an alpha feature that is being progressively rolled out. Review the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
+:::
+
 Business users can now focus on modeling, sharing, and collaborating, while developers can work on implementation and debugging with ease.
 
 When accessing a BPMN diagram for the [first time](/components/modeler/web-modeler/model-your-first-diagram.md), the **Design** mode is the first selected option. To switch between modes, you can select one of the tabs on the left side of the screen, above the diagram; any further selection is remembered and kept for the next sessions.
@@ -18,7 +22,4 @@ When accessing a BPMN diagram for the [first time](/components/modeler/web-model
 
 :::note
 When a process template is selected, the default mode is **Implement**.
-:::
-:::note
-The **Play** is an alpha feature that is being progressively rolled out. Read the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
 :::

--- a/versioned_docs/version-8.3/components/modeler/web-modeler/collaborate-with-modes.md
+++ b/versioned_docs/version-8.3/components/modeler/web-modeler/collaborate-with-modes.md
@@ -15,9 +15,10 @@ Business users can now focus on modeling, sharing, and collaborating, while deve
 When accessing a BPMN diagram for the [first time](/components/modeler/web-modeler/model-your-first-diagram.md), the **Design** mode is the first selected option. To switch between modes, you can select one of the tabs on the left side of the screen, above the diagram; any further selection is remembered and kept for the next sessions.
 
 ![modes tab navigation](img/mode-tab-navigation.png)
+
 :::note
 When a process template is selected, the default mode is **Implement**.
 :::
 :::note
-The **Play** mode is an alpha feature and is not yet available for Enterprise users.
+The **Play** is an alpha feature that is being progressively rolled out. Read the [Play documentation](/components/modeler/web-modeler/play-your-process.md) for details.
 :::


### PR DESCRIPTION
## Description

Generalizing Play's availability so the documentation is robust as we roll out Play to more organizations.

## When should this change go live?

Sometime this week (by 8 Dec) is ideal

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
