### PR TITLE
fix(docs): Camunda Docker registry is mentionned in the wrong part of the air-gapped guide

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -15,15 +15,6 @@ helm repo update
 helm template camunda/camunda-platform -f values.yaml | grep 'image:'
 ```
 
-Please note that all the required Docker images, available on DockerHub's Camunda organization, are also provided publicly via Camunda's Docker registry: `registry.camunda.cloud/camunda/<image>`
-
-For example, the Docker image of Zeebe can be pulled via DockerHub or via the Camunda's Docker Registry:
-
-```bash
-docker pull camunda/zeebe:latest
-docker pull registry.camunda.cloud/camunda/zeebe:latest
-```
-
 ## Required Docker images
 
 The following images must be available in your air-gapped environment:
@@ -45,6 +36,15 @@ The following images must be available in your air-gapped environment:
   - `web-modeler-ee/modeler-websockets`
 
 We currently have a script in the [camunda-helm-respository](https://github.com/camunda/camunda-platform-helm/blob/c6a6e0c327f2acb8746802fbe03b3774b8284de3/scripts/download-chart-docker-images.sh) that will assist in pulling and saving Docker images.
+
+Please note that all the required Docker images, available on DockerHub's Camunda organization, are also provided publicly via Camunda's Docker registry: `registry.camunda.cloud/camunda/<image>`
+
+For example, the Docker image of Zeebe can be pulled via DockerHub or via the Camunda's Docker Registry:
+
+```bash
+docker pull camunda/zeebe:latest
+docker pull registry.camunda.cloud/camunda/zeebe:latest
+```
 
 ## Required Helm charts
 


### PR DESCRIPTION
## Description

Related to the last update of the air-gapped guide (see [PR](https://github.com/camunda/camunda-docs/pull/2931)).
I have just noticed that the Camunda Docker registry is mentioned in the wrong section of the air-gapped guide. Sorry for the inconvenience.
This only concerns the `next` version.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
