### PR TITLE
feat(connectors): add MSFT O365 Connector

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,6 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
+- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Producer Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,7 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
-- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
+- [Microsoft 365 Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [Microsoft 365](https://outlook.office.com/mail/) mail from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Producer Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -38,6 +38,11 @@ and/or repetitive processes.
 
 ### OAuth2 client credentials flow authentication
 
+:::note
+In the client credential flow, an application gets access to all accounts associated with the organization.
+For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+:::
+
 To be able to proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint

--- a/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,28 +1,28 @@
 ---
 id: microsoft-o365-mail
-title: Microsoft Office 365 Mail Connector
-sidebar_label: O365 Mail Connector
-description: Send and read O365 mails from your BPMN process
+title: Microsoft 365 Connector
+sidebar_label: Microsoft 365 Connector
+description: Send and read Microsoft 365 emails from your BPMN process.
 ---
 
-The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+The **Microsoft 365 Connector** is an outbound Connector that allows you to connect your BPMN service with [Microsoft 365](https://outlook.office.com/mail/) mail to send, read e-mails, and manage folders.
 
 ## Prerequisites
 
-To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
-You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
-set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+- To use the **Microsoft 365 Connector**, you must have a [Microsoft 365](https://outlook.office.com/mail/) mail instance.
+- You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app;
+  set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions and assign an app to u user.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 :::note
 It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
 Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create a Microsoft Office 365 Mail Connector task
+## Create a Microsoft 365 Connector task
 
-To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+To use the **Microsoft 365 Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
 
 ## Access control
 
@@ -33,41 +33,42 @@ Each operation requires permissions to be assigned by a system administrator. Le
 If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
 Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
 
-Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
-and/or repetitive processes.
+:::note
+Default TTL for bearer tokens is 3600 seconds. Therefore, this approach might not work for long-living and/or repetitive processes.
+:::
 
 ### OAuth2 client credentials flow authentication
 
 :::note
 In the client credential flow, an application gets access to all accounts associated with the organization.
-For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+For example, if an app has permissions `Mail.Read`, it will be able to read emails of all users.
 :::
 
-To be able to proceed with this step, you'll need the following data:
+To proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint
-- Client ID, AKA Application ID
-- Client secret, can be created at your application page
+- Client ID (Application ID)
+- Client secret; can be created on your application page
 
-The app needs to be assigned to a user.
+The app must be assigned to a user.
 
 If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
-Enter above data into respective fields.
+Enter the above data into the respective fields.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 ## Select operation to execute
 
-Select desired operation from the **Operations** section.
+Select the desired operation from the **Operations** section.
 
-### Get user's folders
+### Get user folders
 
 Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -79,17 +80,17 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Folder display name** string value.
 
-### Get user's messages
+### Get user messages
 
 Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -101,14 +102,14 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Subject** string value.
-3. Select **Body content type** from a dropdown.
+3. Select **Body content type** from the dropdown.
 4. Enter desired content in the field **Body content**.
-5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
-6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`.
+6. (Optional) Pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`.
 
 ## Handle Connector response
 
-The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
-handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).
+The **Microsoft 365 Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+[handling response is still applicable](/components/connectors/protocol/rest.md#response).

--- a/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,0 +1,109 @@
+---
+id: microsoft-o365-mail
+title: Microsoft Office 365 Mail Connector
+sidebar_label: O365 Mail Connector
+description: Send and read O365 mails from your BPMN process
+---
+
+The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+
+## Prerequisites
+
+To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
+You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
+set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+:::note
+It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
+Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create a Microsoft Office 365 Mail Connector task
+
+To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Access control
+
+Each operation requires permissions to be assigned by a system administrator. Learn more about [Microsoft permissions](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview).
+
+### Bearer token authentication
+
+If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
+Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
+
+Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
+and/or repetitive processes.
+
+### OAuth2 client credentials flow authentication
+
+To be able to proceed with this step, you'll need the following data:
+
+- OAuth 2.0 token endpoint
+- Client ID, AKA Application ID
+- Client secret, can be created at your application page
+
+The app needs to be assigned to a user.
+
+If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
+Enter above data into respective fields.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+## Select operation to execute
+
+Select desired operation from the **Operations** section.
+
+### Get user's folders
+
+Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Create mail folder for a user
+
+Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Folder display name** string value.
+
+### Get user's messages
+
+Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Send mail on behalf of a user
+
+Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Subject** string value.
+3. Select **Body content type** from a dropdown.
+4. Enter desired content in the field **Body content**.
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
+6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+
+## Handle Connector response
+
+The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).

--- a/docs/components/connectors/protocol/http-webhook.md
+++ b/docs/components/connectors/protocol/http-webhook.md
@@ -149,9 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **Activation Condition**: `=(request.body.action = "opened")`.
-7. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-8. Click `Deploy`.
+6. **HMAC Scopes**: `=["BODY"]` or leave empty
+7. **Activation Condition**: `=(request.body.action = "opened")`.
+8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
+9. Click `Deploy`.
 
 ### How to configure API key authorization
 

--- a/docs/components/connectors/protocol/http-webhook.md
+++ b/docs/components/connectors/protocol/http-webhook.md
@@ -149,10 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **HMAC Scopes**: `=["BODY"]` or leave empty
+6. **HMAC Scopes**: `=["BODY"]` or leave empty.
 7. **Activation Condition**: `=(request.body.action = "opened")`.
 8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-9. Click `Deploy`.
+9. Click **Deploy**.
 
 ### How to configure API key authorization
 

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -822,7 +822,7 @@ module.exports = {
                   "components/connectors/out-of-the-box-connectors//"
                 ),
                 docsLink(
-                  "Microsoft Office 365 Mail Connector",
+                  "Microsoft 365 Connector",
                   "components/connectors/out-of-the-box-connectors/microsoft-o365-mail/"
                 ),
               ],

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -814,10 +814,19 @@ module.exports = {
               "Kafka Connector",
               "components/connectors/out-of-the-box-connectors/kafka/"
             ),
-            docsLink(
-              "Microsoft Teams Connector",
-              "components/connectors/out-of-the-box-connectors/microsoft-teams/"
-            ),
+
+            {
+              Microsoft: [
+                docsLink(
+                  "Microsoft Teams Connector",
+                  "components/connectors/out-of-the-box-connectors//"
+                ),
+                docsLink(
+                  "Microsoft Office 365 Mail Connector",
+                  "components/connectors/out-of-the-box-connectors/microsoft-o365-mail/"
+                ),
+              ],
+            },
             docsLink(
               "OpenAI Connector",
               "components/connectors/out-of-the-box-connectors/openai/"

--- a/sidebars.js
+++ b/sidebars.js
@@ -296,7 +296,12 @@ module.exports = {
               ],
             },
             "components/connectors/out-of-the-box-connectors/kafka",
-            "components/connectors/out-of-the-box-connectors/microsoft-teams",
+            {
+              Microsoft: [
+                "components/connectors/out-of-the-box-connectors/microsoft-teams",
+                "components/connectors/out-of-the-box-connectors/microsoft-o365-mail",
+              ],
+            },
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,6 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
+- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,7 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
-- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
+- [Microsoft 365 Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [Microsoft 365](https://outlook.office.com/mail/) mail from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -38,6 +38,11 @@ and/or repetitive processes.
 
 ### OAuth2 client credentials flow authentication
 
+:::note
+In the client credential flow, an application gets access to all accounts associated with the organization.
+For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+:::
+
 To be able to proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,28 +1,28 @@
 ---
 id: microsoft-o365-mail
-title: Microsoft Office 365 Mail Connector
-sidebar_label: O365 Mail Connector
-description: Send and read O365 mails from your BPMN process
+title: Microsoft 365 Connector
+sidebar_label: Microsoft 365 Connector
+description: Send and read Microsoft 365 emails from your BPMN process.
 ---
 
-The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+The **Microsoft 365 Connector** is an outbound Connector that allows you to connect your BPMN service with [Microsoft 365](https://outlook.office.com/mail/) mail to send, read e-mails, and manage folders.
 
 ## Prerequisites
 
-To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
-You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
-set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+- To use the **Microsoft 365 Connector**, you must have a [Microsoft 365](https://outlook.office.com/mail/) mail instance.
+- You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app;
+  set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions and assign an app to u user.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 :::note
 It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
 Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create a Microsoft Office 365 Mail Connector task
+## Create a Microsoft 365 Connector task
 
-To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+To use the **Microsoft 365 Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
 
 ## Access control
 
@@ -33,41 +33,42 @@ Each operation requires permissions to be assigned by a system administrator. Le
 If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
 Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
 
-Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
-and/or repetitive processes.
+:::note
+Default TTL for bearer tokens is 3600 seconds. Therefore, this approach might not work for long-living and/or repetitive processes.
+:::
 
 ### OAuth2 client credentials flow authentication
 
 :::note
 In the client credential flow, an application gets access to all accounts associated with the organization.
-For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+For example, if an app has permissions `Mail.Read`, it will be able to read emails of all users.
 :::
 
-To be able to proceed with this step, you'll need the following data:
+To proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint
-- Client ID, AKA Application ID
-- Client secret, can be created at your application page
+- Client ID (Application ID)
+- Client secret; can be created on your application page
 
-The app needs to be assigned to a user.
+The app must be assigned to a user.
 
 If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
-Enter above data into respective fields.
+Enter the above data into the respective fields.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 ## Select operation to execute
 
-Select desired operation from the **Operations** section.
+Select the desired operation from the **Operations** section.
 
-### Get user's folders
+### Get user folders
 
 Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -79,17 +80,17 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Folder display name** string value.
 
-### Get user's messages
+### Get user messages
 
 Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -101,14 +102,14 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Subject** string value.
-3. Select **Body content type** from a dropdown.
+3. Select **Body content type** from the dropdown.
 4. Enter desired content in the field **Body content**.
-5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
-6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`.
+6. (Optional) Pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`.
 
 ## Handle Connector response
 
-The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
-handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).
+The **Microsoft 365 Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+[handling response is still applicable](/components/connectors/protocol/rest.md#response).

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,0 +1,109 @@
+---
+id: microsoft-o365-mail
+title: Microsoft Office 365 Mail Connector
+sidebar_label: O365 Mail Connector
+description: Send and read O365 mails from your BPMN process
+---
+
+The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+
+## Prerequisites
+
+To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
+You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
+set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+:::note
+It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
+Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create a Microsoft Office 365 Mail Connector task
+
+To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Access control
+
+Each operation requires permissions to be assigned by a system administrator. Learn more about [Microsoft permissions](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview).
+
+### Bearer token authentication
+
+If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
+Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
+
+Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
+and/or repetitive processes.
+
+### OAuth2 client credentials flow authentication
+
+To be able to proceed with this step, you'll need the following data:
+
+- OAuth 2.0 token endpoint
+- Client ID, AKA Application ID
+- Client secret, can be created at your application page
+
+The app needs to be assigned to a user.
+
+If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
+Enter above data into respective fields.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+## Select operation to execute
+
+Select desired operation from the **Operations** section.
+
+### Get user's folders
+
+Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Create mail folder for a user
+
+Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Folder display name** string value.
+
+### Get user's messages
+
+Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Send mail on behalf of a user
+
+Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Subject** string value.
+3. Select **Body content type** from a dropdown.
+4. Enter desired content in the field **Body content**.
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
+6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+
+## Handle Connector response
+
+The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).

--- a/versioned_docs/version-8.1/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.1/components/connectors/protocol/http-webhook.md
@@ -149,9 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **Activation Condition**: `=(request.body.action = "opened")`.
-7. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-8. Click `Deploy`.
+6. **HMAC Scopes**: `=["BODY"]` or leave empty
+7. **Activation Condition**: `=(request.body.action = "opened")`.
+8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
+9. Click `Deploy`.
 
 ### How to configure API key authorization
 

--- a/versioned_docs/version-8.1/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.1/components/connectors/protocol/http-webhook.md
@@ -149,10 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **HMAC Scopes**: `=["BODY"]` or leave empty
+6. **HMAC Scopes**: `=["BODY"]` or leave empty.
 7. **Activation Condition**: `=(request.body.action = "opened")`.
 8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-9. Click `Deploy`.
+9. Click **Deploy**.
 
 ### How to configure API key authorization
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,6 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
+- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,7 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
-- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
+- [Microsoft 365 Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [Microsoft 365](https://outlook.office.com/mail/) mail from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -38,6 +38,11 @@ and/or repetitive processes.
 
 ### OAuth2 client credentials flow authentication
 
+:::note
+In the client credential flow, an application gets access to all accounts associated with the organization.
+For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+:::
+
 To be able to proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,28 +1,28 @@
 ---
 id: microsoft-o365-mail
-title: Microsoft Office 365 Mail Connector
-sidebar_label: O365 Mail Connector
-description: Send and read O365 mails from your BPMN process
+title: Microsoft 365 Connector
+sidebar_label: Microsoft 365 Connector
+description: Send and read Microsoft 365 emails from your BPMN process.
 ---
 
-The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+The **Microsoft 365 Connector** is an outbound Connector that allows you to connect your BPMN service with [Microsoft 365](https://outlook.office.com/mail/) mail to send, read e-mails, and manage folders.
 
 ## Prerequisites
 
-To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
-You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
-set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+- To use the **Microsoft 365 Connector**, you must have a [Microsoft 365](https://outlook.office.com/mail/) mail instance.
+- You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app;
+  set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions and assign an app to u user.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 :::note
 It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
 Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create a Microsoft Office 365 Mail Connector task
+## Create a Microsoft 365 Connector task
 
-To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+To use the **Microsoft 365 Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
 
 ## Access control
 
@@ -33,41 +33,42 @@ Each operation requires permissions to be assigned by a system administrator. Le
 If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
 Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
 
-Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
-and/or repetitive processes.
+:::note
+Default TTL for bearer tokens is 3600 seconds. Therefore, this approach might not work for long-living and/or repetitive processes.
+:::
 
 ### OAuth2 client credentials flow authentication
 
 :::note
 In the client credential flow, an application gets access to all accounts associated with the organization.
-For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+For example, if an app has permissions `Mail.Read`, it will be able to read emails of all users.
 :::
 
-To be able to proceed with this step, you'll need the following data:
+To proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint
-- Client ID, AKA Application ID
-- Client secret, can be created at your application page
+- Client ID (Application ID)
+- Client secret; can be created on your application page
 
-The app needs to be assigned to a user.
+The app must be assigned to a user.
 
 If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
-Enter above data into respective fields.
+Enter the above data into the respective fields.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 ## Select operation to execute
 
-Select desired operation from the **Operations** section.
+Select the desired operation from the **Operations** section.
 
-### Get user's folders
+### Get user folders
 
 Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -79,17 +80,17 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Folder display name** string value.
 
-### Get user's messages
+### Get user messages
 
 Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -101,14 +102,14 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Subject** string value.
-3. Select **Body content type** from a dropdown.
+3. Select **Body content type** from the dropdown.
 4. Enter desired content in the field **Body content**.
-5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
-6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`.
+6. (Optional) Pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`.
 
 ## Handle Connector response
 
-The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
-handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).
+The **Microsoft 365 Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+[handling response is still applicable](/components/connectors/protocol/rest.md#response).

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,0 +1,109 @@
+---
+id: microsoft-o365-mail
+title: Microsoft Office 365 Mail Connector
+sidebar_label: O365 Mail Connector
+description: Send and read O365 mails from your BPMN process
+---
+
+The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+
+## Prerequisites
+
+To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
+You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
+set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+:::note
+It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
+Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create a Microsoft Office 365 Mail Connector task
+
+To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Access control
+
+Each operation requires permissions to be assigned by a system administrator. Learn more about [Microsoft permissions](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview).
+
+### Bearer token authentication
+
+If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
+Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
+
+Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
+and/or repetitive processes.
+
+### OAuth2 client credentials flow authentication
+
+To be able to proceed with this step, you'll need the following data:
+
+- OAuth 2.0 token endpoint
+- Client ID, AKA Application ID
+- Client secret, can be created at your application page
+
+The app needs to be assigned to a user.
+
+If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
+Enter above data into respective fields.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+## Select operation to execute
+
+Select desired operation from the **Operations** section.
+
+### Get user's folders
+
+Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Create mail folder for a user
+
+Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Folder display name** string value.
+
+### Get user's messages
+
+Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Send mail on behalf of a user
+
+Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Subject** string value.
+3. Select **Body content type** from a dropdown.
+4. Enter desired content in the field **Body content**.
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
+6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+
+## Handle Connector response
+
+The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).

--- a/versioned_docs/version-8.2/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.2/components/connectors/protocol/http-webhook.md
@@ -149,9 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **Activation Condition**: `=(request.body.action = "opened")`.
-7. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-8. Click `Deploy`.
+6. **HMAC Scopes**: `=["BODY"]` or leave empty
+7. **Activation Condition**: `=(request.body.action = "opened")`.
+8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
+9. Click `Deploy`.
 
 ### How to configure API key authorization
 

--- a/versioned_docs/version-8.2/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.2/components/connectors/protocol/http-webhook.md
@@ -149,10 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **HMAC Scopes**: `=["BODY"]` or leave empty
+6. **HMAC Scopes**: `=["BODY"]` or leave empty.
 7. **Activation Condition**: `=(request.body.action = "opened")`.
 8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-9. Click `Deploy`.
+9. Click **Deploy**.
 
 ### How to configure API key authorization
 

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,6 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
+- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Producer Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/available-connectors-overview.md
@@ -44,7 +44,7 @@ import TabItem from "@theme/TabItem";
 - [Google Sheets Connector](/components/connectors/out-of-the-box-connectors/google-sheets.md) - Allows you to work with an existing or new empty spreadsheet on [Google Drive](https://drive.google.com/) from your BPMN process.
 - [Kafka Producer Connector](/components/connectors/out-of-the-box-connectors/kafka.md) - Produce messages to [Kafka](https://kafka.apache.org/) from your BPMN process.
 - [Microsoft Teams Connector](/components/connectors/out-of-the-box-connectors/microsoft-teams.md) - Interactions with [Microsoft Teams](https://www.microsoft.com/microsoft-teams/) from your BPMN process.
-- [Microsoft Office 365 Mail Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [O365 Mail](https://outlook.office.com/mail/) from your BPMN process.
+- [Microsoft 365 Connector](/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md) - Interactions with [Microsoft 365](https://outlook.office.com/mail/) mail from your BPMN process.
 - [OpenAI Connector](/components/connectors/out-of-the-box-connectors/openai.md) - Interact with [ChatGPT](https://chat.openai.com/) and [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation/overview).
 - [Power Automate Connector](/components/connectors/out-of-the-box-connectors/power-automate.md) - Orchestrate your [Power Automate](https://powerautomate.microsoft.com) Flows with Camunda.
 - [RabbitMQ Producer Connector](/components/connectors/out-of-the-box-connectors/rabbitmq-outbound.md) - Send messages to [RabbitMQ](https://www.rabbitmq.com/) from your BPMN process.

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -38,6 +38,11 @@ and/or repetitive processes.
 
 ### OAuth2 client credentials flow authentication
 
+:::note
+In the client credential flow, an application gets access to all accounts associated with the organization.
+For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+:::
+
 To be able to proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,28 +1,28 @@
 ---
 id: microsoft-o365-mail
-title: Microsoft Office 365 Mail Connector
-sidebar_label: O365 Mail Connector
-description: Send and read O365 mails from your BPMN process
+title: Microsoft 365 Connector
+sidebar_label: Microsoft 365 Connector
+description: Send and read Microsoft 365 emails from your BPMN process.
 ---
 
-The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+The **Microsoft 365 Connector** is an outbound Connector that allows you to connect your BPMN service with [Microsoft 365](https://outlook.office.com/mail/) mail to send, read e-mails, and manage folders.
 
 ## Prerequisites
 
-To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
-You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
-set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+- To use the **Microsoft 365 Connector**, you must have a [Microsoft 365](https://outlook.office.com/mail/) mail instance.
+- You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app;
+  set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions and assign an app to u user.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 :::note
 It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
 Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
 :::
 
-## Create a Microsoft Office 365 Mail Connector task
+## Create a Microsoft 365 Connector task
 
-To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+To use the **Microsoft 365 Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
 
 ## Access control
 
@@ -33,41 +33,42 @@ Each operation requires permissions to be assigned by a system administrator. Le
 If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
 Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
 
-Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
-and/or repetitive processes.
+:::note
+Default TTL for bearer tokens is 3600 seconds. Therefore, this approach might not work for long-living and/or repetitive processes.
+:::
 
 ### OAuth2 client credentials flow authentication
 
 :::note
 In the client credential flow, an application gets access to all accounts associated with the organization.
-For example, if an app has permissions `Mail.Read`, it will be able to read mails of all users.
+For example, if an app has permissions `Mail.Read`, it will be able to read emails of all users.
 :::
 
-To be able to proceed with this step, you'll need the following data:
+To proceed with this step, you'll need the following data:
 
 - OAuth 2.0 token endpoint
-- Client ID, AKA Application ID
-- Client secret, can be created at your application page
+- Client ID (Application ID)
+- Client secret; can be created on your application page
 
-The app needs to be assigned to a user.
+The app must be assigned to a user.
 
 If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
-Enter above data into respective fields.
+Enter the above data into the respective fields.
 
-You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+Learn more about [creating, configuring, and authorizing Microsoft App](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
 
 ## Select operation to execute
 
-Select desired operation from the **Operations** section.
+Select the desired operation from the **Operations** section.
 
-### Get user's folders
+### Get user folders
 
 Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -79,17 +80,17 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Folder display name** string value.
 
-### Get user's messages
+### Get user messages
 
 Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
 
-For example, if you wish to pass an OData `$top` URL parameter, simply do:
+For example, if you wish to pass an OData `$top` URL parameter, execute the following:
 
 ```json
 {
@@ -101,14 +102,14 @@ For example, if you wish to pass an OData `$top` URL parameter, simply do:
 
 Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
 
-1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+1. Enter user's email or system UUID to fetch all their folders in the **User ID** field.
 2. In the **Request** section, enter a **Subject** string value.
-3. Select **Body content type** from a dropdown.
+3. Select **Body content type** from the dropdown.
 4. Enter desired content in the field **Body content**.
-5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
-6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`.
+6. (Optional) Pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`.
 
 ## Handle Connector response
 
-The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
-handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).
+The **Microsoft 365 Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+[handling response is still applicable](/components/connectors/protocol/rest.md#response).

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/microsoft-o365-mail.md
@@ -1,0 +1,109 @@
+---
+id: microsoft-o365-mail
+title: Microsoft Office 365 Mail Connector
+sidebar_label: O365 Mail Connector
+description: Send and read O365 mails from your BPMN process
+---
+
+The **Microsoft Office 365 Mail Connector** is an outbound Connector that allows you to connect your BPMN service with [O365 Mail](https://outlook.office.com/mail/) to send, read e-mails, and manage folders.
+
+## Prerequisites
+
+To use the **Microsoft Office 365 Mail Connector**, you must have a [O365 Mail](https://outlook.office.com/mail/) instance.
+You might also need to have sufficient access rights at [Microsoft Entra](https://entra.microsoft.com) to create a new app,
+set [Microsoft Graph](https://developer.microsoft.com/en-us/graph) permissions, and assign an app to u user.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+:::note
+It is highly recommended not to expose your Microsoft credentials as plain text. Instead, use Camunda secrets.
+Refer to our documentation on [managing secrets](/components/console/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create a Microsoft Office 365 Mail Connector task
+
+To use the **Microsoft Office 365 Mail Connector** in your process, either change the type of existing task by clicking on it and using the wrench-shaped **Change type** context menu icon, or create a new Connector task by using the **Append Connector** context menu. Follow our [guide to using Connectors](/components/connectors/use-connectors/index.md) to learn more.
+
+## Access control
+
+Each operation requires permissions to be assigned by a system administrator. Learn more about [Microsoft permissions](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview).
+
+### Bearer token authentication
+
+If you own a bearer token, in the **Authentication** section select a **Bearer token** in the **Type** field.
+Enter a bearer token in the field **Bearer token**. It is recommended to use Camunda secrets.
+
+Please, keep in mind that default TTL for bearer tokens is 3600 seconds thus this approach might not work for long-living
+and/or repetitive processes.
+
+### OAuth2 client credentials flow authentication
+
+To be able to proceed with this step, you'll need the following data:
+
+- OAuth 2.0 token endpoint
+- Client ID, AKA Application ID
+- Client secret, can be created at your application page
+
+The app needs to be assigned to a user.
+
+If you own a bearer token, in the **Authentication** section select a **OAuth 2.0** in the **Type** field.
+Enter above data into respective fields.
+
+You can learn more about creating, configuring, and authorizing Microsoft App [here](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
+
+## Select operation to execute
+
+Select desired operation from the **Operations** section.
+
+### Get user's folders
+
+Related Microsoft Graph API: [user: list mailFolders](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Create mail folder for a user
+
+Related Microsoft Graph API: [user: create mailFolder](https://learn.microsoft.com/en-us/graph/api/user-post-mailfolders)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Folder display name** string value.
+
+### Get user's messages
+
+Related Microsoft Graph API: [user: list messages](https://learn.microsoft.com/en-us/graph/api/user-list-messages)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. You can also pass [OData parameters](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http) in the **Query parameters** field.
+
+For example, if you wish to pass an OData `$top` URL parameter, simply do:
+
+```json
+{
+  "$top": 10
+}
+```
+
+### Send mail on behalf of a user
+
+Related Microsoft Graph API: [user: sendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail)
+
+1. Enter user's email or system UUID, to fetch all their folders in the **User ID** field.
+2. In the **Request** section, enter a **Subject** string value.
+3. Select **Body content type** from a dropdown.
+4. Enter desired content in the field **Body content**.
+5. Pass an array of emails into the **To recipients** field, for example `["myuser1@mycompany.com", "myuser2@mycompany.com"]`
+6. Optionally pass an array of emails into the **CC recipients** field, for example `["myuser3@mycompany.com", "myuser4@mycompany.com"]`
+
+## Handle Connector response
+
+The **Microsoft Office 365 Mail Connector** is a protocol Connector, meaning it is built on top of the **HTTP REST Connector**, therefore
+handling response is still applicable [as described](/components/connectors/protocol/rest.md#response).

--- a/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
@@ -149,9 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **Activation Condition**: `=(request.body.action = "opened")`.
-7. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-8. Click `Deploy`.
+6. **HMAC Scopes**: `=["BODY"]` or leave empty
+7. **Activation Condition**: `=(request.body.action = "opened")`.
+8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
+9. Click `Deploy`.
 
 ### How to configure API key authorization
 

--- a/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
@@ -149,10 +149,10 @@ Therefore, you would need to set the following:
 3. **HMAC Secret Key**: `mySecretKey` or `{{secrets.MY_GH_SECRET}}`.
 4. **HMAC Header**: `X-Hub-Signature-256`.
 5. **HMAC Algorithm**: `SHA-256`.
-6. **HMAC Scopes**: `=["BODY"]` or leave empty
+6. **HMAC Scopes**: `=["BODY"]` or leave empty.
 7. **Activation Condition**: `=(request.body.action = "opened")`.
 8. **Variable Mapping**: `={prUrl: request.body.pull_request.url}`.
-9. Click `Deploy`.
+9. Click **Deploy**.
 
 ### How to configure API key authorization
 

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -339,7 +339,12 @@
               ]
             },
             "components/connectors/out-of-the-box-connectors/kafka",
-            "components/connectors/out-of-the-box-connectors/microsoft-teams",
+            {
+              "Microsoft": [
+                "components/connectors/out-of-the-box-connectors/microsoft-teams",
+                "components/connectors/out-of-the-box-connectors/microsoft-o365-mail"
+              ]
+            },
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -366,7 +366,12 @@
               ]
             },
             "components/connectors/out-of-the-box-connectors/kafka",
-            "components/connectors/out-of-the-box-connectors/microsoft-teams",
+            {
+              "Microsoft": [
+                "components/connectors/out-of-the-box-connectors/microsoft-teams",
+                "components/connectors/out-of-the-box-connectors/microsoft-o365-mail"
+              ]
+            },
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",

--- a/versioned_sidebars/version-8.3-sidebars.json
+++ b/versioned_sidebars/version-8.3-sidebars.json
@@ -384,7 +384,12 @@
               ]
             },
             "components/connectors/out-of-the-box-connectors/kafka",
-            "components/connectors/out-of-the-box-connectors/microsoft-teams",
+            {
+              "Microsoft": [
+                "components/connectors/out-of-the-box-connectors/microsoft-teams",
+                "components/connectors/out-of-the-box-connectors/microsoft-o365-mail"
+              ]
+            },
             "components/connectors/out-of-the-box-connectors/openai",
             "components/connectors/out-of-the-box-connectors/operate",
             "components/connectors/out-of-the-box-connectors/power-automate",


### PR DESCRIPTION
## Description

Adds doc related to Microsoft Office 365 Mail Connector.

## When should this change go live?

With release 2023-12-12.

- [x] This change is not yet live and should not be merged until 2023-12-12 (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
