### PR TITLE
Clarify Operate and Tasklist Backup prerequisity

### DIFF
--- a/docs/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
+++ b/docs/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
@@ -36,25 +36,31 @@ The backup API can be reached via the Actuator management port, which by default
 
 Before you can use the backup and restore feature:
 
-1. The Elasticsearch repository must be configured.
+1. The [Elasticsearch snapshot repository](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html) must be configured.
 2. Operate and Tasklist must be configured with the repository name using the following configuration parameters:
 
 ```yaml
 for Operate:
-camunda.operate: backup.repositoryName=<repository name>
+camunda:
+  operate:
+    backup:
+      repositoryName: <es snapshot repository name>
 
 for Tasklist:
-camunda.tasklist: backup.repositoryName=<repository name>
+camunda:
+  tasklist:
+    backup:
+      repositoryName: <es snapshot repository name>
 ```
 
 or with environmental variables:
 
 ```
 for Operate:
-CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME=<repository name>
+CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME=<es snapshot repository name>
 
 for Tasklist:
-CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME=<repository name>
+CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME=<es snapshot repository name>
 
 ```
 

--- a/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
@@ -57,10 +57,10 @@ or with environmental variables:
 
 ```
 for Operate:
-CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME=<repository name>
+CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME=<es snapshot repository name>
 
 for Tasklist:
-CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME=<repository name>
+CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME=<es snapshot repository name>
 
 ```
 

--- a/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
@@ -36,15 +36,21 @@ The backup API can be reached via the Actuator management port, which by default
 
 Before you can use the backup and restore feature:
 
-1. The Elasticsearch repository must be configured.
+1. The [Elasticsearch snapshot repository](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html) must be configured.
 2. Operate and Tasklist must be configured with the repository name using the following configuration parameters:
 
 ```yaml
 for Operate:
-camunda.operate: backup.repositoryName=<repository name>
+camunda:
+  operate:
+    backup:
+      repositoryName: <es snapshot repository name>
 
 for Tasklist:
-camunda.tasklist: backup.repositoryName=<repository name>
+camunda:
+  tasklist:
+    backup:
+      repositoryName: <es snapshot repository name>
 ```
 
 or with environmental variables:


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Currently, the docs state that a "repository" has to be present on ES side.

I was confused by this term (as it can have some meanings) and found out it means snapshot repository and that Elastic has a guide about it.

Also, the yaml has been fixed.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

Minor improvement

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
