### PR TITLE
Fix typo in Modeler guide

### DIFF
--- a/docs/components/modeler/desktop-modeler/connect-to-camunda-8.md
+++ b/docs/components/modeler/desktop-modeler/connect-to-camunda-8.md
@@ -10,7 +10,7 @@ Desktop Modeler can directly deploy diagrams and start process instances in Camu
 
 ![deployment icon](./img/deploy-icon.png)
 
-1. Click **Camunda 8 SaaS**:
+2. Click **Camunda 8 SaaS**:
 
 ![deployment configuration](./img/deploy-diagram-camunda-cloud.png)
 

--- a/versioned_docs/version-8.2/components/modeler/desktop-modeler/connect-to-camunda-8.md
+++ b/versioned_docs/version-8.2/components/modeler/desktop-modeler/connect-to-camunda-8.md
@@ -10,7 +10,7 @@ Desktop Modeler can directly deploy diagrams and start process instances in Camu
 
 ![deployment icon](./img/deploy-icon.png)
 
-1. Click **Camunda 8 SaaS**:
+2. Click **Camunda 8 SaaS**:
 
 ![deployment configuration](./img/deploy-diagram-camunda-cloud.png)
 

--- a/versioned_docs/version-8.3/components/modeler/desktop-modeler/connect-to-camunda-8.md
+++ b/versioned_docs/version-8.3/components/modeler/desktop-modeler/connect-to-camunda-8.md
@@ -10,7 +10,7 @@ Desktop Modeler can directly deploy diagrams and start process instances in Camu
 
 ![deployment icon](./img/deploy-icon.png)
 
-1. Click **Camunda 8 SaaS**:
+2. Click **Camunda 8 SaaS**:
 
 ![deployment configuration](./img/deploy-diagram-camunda-cloud.png)
 


### PR DESCRIPTION
## Description

Desktop Modeler deploy diagram guide had two "1.'s" in some versions.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
