### PR TITLE
feat(self-managed): document multi-tenancy enabled flag

### DIFF
--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -66,7 +66,6 @@ The following configuration is required to enable multi-tenancy in Operate:
 | -------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |------------- | 
 | camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         | 
 
-
 :::caution
 To ensure seamless integration and functionality, the multi-tenancy feature should also be enabled across all associated components. This is done using their specific multi-tenancy feature flags.
 :::

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -62,9 +62,10 @@ the feature can be found in [the multi-tenancy documentation](../concepts/multi-
 
 The following configuration is required to enable multi-tenancy in Operate:
 
-| Name                                 | Description                                         | Default value |
-| ------------------------------------ | --------------------------------------------------- | ------------- |
-| camunda.operate.multiTenancy.enabled | Activates the multi-tenancy feature within Operate. | false         |
+| YAML path                              | Environment variable                  | Description                                                  | Default value | 
+| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |------------- | 
+| camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         | 
+
 
 :::caution
 To ensure seamless integration and functionality, the multi-tenancy feature should also be enabled across all associated components. This is done using their specific multi-tenancy feature flags.

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -62,9 +62,9 @@ the feature can be found in [the multi-tenancy documentation](../concepts/multi-
 
 The following configuration is required to enable multi-tenancy in Operate:
 
-| YAML path                              | Environment variable                  | Description                                                  | Default value | 
-| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |------------- | 
-| camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         | 
+| YAML path                            | Environment variable                 | Description                                         | Default value |
+| ------------------------------------ | ------------------------------------ | --------------------------------------------------- | ------------- |
+| camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         |
 
 :::caution
 To ensure seamless integration and functionality, the multi-tenancy feature should also be enabled across all associated components. This is done using their specific multi-tenancy feature flags.

--- a/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
@@ -66,7 +66,6 @@ The following configuration is required to enable multi-tenancy in Operate:
 | -------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |------------- | 
 | camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         | 
 
-
 :::caution
 To ensure seamless integration and functionality, the multi-tenancy feature should also be enabled across all associated components. This is done using their specific multi-tenancy feature flags.
 :::

--- a/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
@@ -62,9 +62,10 @@ the feature can be found in [the multi-tenancy documentation](../concepts/multi-
 
 The following configuration is required to enable multi-tenancy in Operate:
 
-| Name                                 | Description                                         | Default value |
-| ------------------------------------ | --------------------------------------------------- | ------------- |
-| camunda.operate.multiTenancy.enabled | Activates the multi-tenancy feature within Operate. | false         |
+| YAML path                              | Environment variable                  | Description                                                  | Default value | 
+| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |------------- | 
+| camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         | 
+
 
 :::caution
 To ensure seamless integration and functionality, the multi-tenancy feature should also be enabled across all associated components. This is done using their specific multi-tenancy feature flags.

--- a/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
@@ -62,9 +62,9 @@ the feature can be found in [the multi-tenancy documentation](../concepts/multi-
 
 The following configuration is required to enable multi-tenancy in Operate:
 
-| YAML path                              | Environment variable                  | Description                                                  | Default value | 
-| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------ |------------- | 
-| camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         | 
+| YAML path                            | Environment variable                 | Description                                         | Default value |
+| ------------------------------------ | ------------------------------------ | --------------------------------------------------- | ------------- |
+| camunda.operate.multiTenancy.enabled | CAMUNDA_OPERATE_MULTITENANCY_ENABLED | Activates the multi-tenancy feature within Operate. | false         |
 
 :::caution
 To ensure seamless integration and functionality, the multi-tenancy feature should also be enabled across all associated components. This is done using their specific multi-tenancy feature flags.


### PR DESCRIPTION
## Description

This adds the available `CAMUNDA_OPERATE_MULTITENANCY_ENABLED` env flag to the documentation.

Related to [this discussion](https://camunda.slack.com/archives/C9B5270DA/p1702288473663209).

Changes mirror naming in [other product components](https://docs.camunda.io/optimize/self-managed/optimize-deployment/configuration/multi-tenancy/#configuration). 

> :information_source: Note that you seem to swap `default value` and description (compared to other components). I did not clean that up.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
