### PR TITLE
docs(variables): document escaped characters handling

### DIFF
--- a/docs/components/concepts/variables.md
+++ b/docs/components/concepts/variables.md
@@ -113,6 +113,8 @@ Input mappings can be used to create new variables. They can be defined on servi
 
 When an input mapping is applied, it creates a new **local variable** in the scope where the mapping is defined.
 
+For string literals containing escaped characters (e.g., a newline character `\n`), the string is returned in its original form as expected (without double escaping).
+
 Examples:
 
 | Process instance variables             | Input mappings                                                                                               | New variables                               |

--- a/versioned_docs/version-8.3/components/concepts/variables.md
+++ b/versioned_docs/version-8.3/components/concepts/variables.md
@@ -113,6 +113,8 @@ Input mappings can be used to create new variables. They can be defined on servi
 
 When an input mapping is applied, it creates a new **local variable** in the scope where the mapping is defined.
 
+For string literals containing escaped characters (e.g., a newline character `\n`), the string is returned in its original form as expected (without double escaping).
+
 Examples:
 
 | Process instance variables             | Input mappings                                                                                               | New variables                               |


### PR DESCRIPTION
## Description
This PR document the new corrected behavior changes in FEEL [bug](https://github.com/camunda/feel-scala/issues/701) fix

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
