### PR TITLE
Update local-kubernetes-cluster.md, wrong command for switching the c…

### DIFF
--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster.md
@@ -27,7 +27,7 @@ kind create cluster --name camunda-platform-local
 Next, switch to the new cluster context using the following command:
 
 ```
-kubectl cluster-info --context kind-camunda-platform-local
+kubectl config use-context kind-camunda-platform-local
 ```
 
 ## Deploy


### PR DESCRIPTION
Documentation shows the wrong command for switching the context using `kubectl`: 
`kubectl cluster-info --context kind-camunda-platform-local` 
It should be:
`kubectl config use-context kind-camunda-platform-local`

However, if you create the cluster using `kind` just shortly before, the context will be switched automatically to the new cluster.

