### PR TITLE
docs(resource-planning): align snapshot period with current default configuration

### DIFF
--- a/docs/self-managed/zeebe-deployment/operations/resource-planning.md
+++ b/docs/self-managed/zeebe-deployment/operations/resource-planning.md
@@ -58,7 +58,7 @@ Config file
       broker:
         data:
           logSegmentSize: 128MB
-          snapshotPeriod: 5m
+          snapshotPeriod: 15m
         cluster:
           partitionsCount: 1
           replicationFactor: 1
@@ -66,7 +66,7 @@ Config file
 
 Environment Variables
   ZEEBE_BROKER_DATA_LOGSEGMENTSIZE = 128MB
-  ZEEBE_BROKER_DATA_SNAPSHOTPERIOD = 5m
+  ZEEBE_BROKER_DATA_SNAPSHOTPERIOD = 15m
   ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT = 1
   ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR = 1
   ZEEBE_BROKER_CLUSTER_CLUSTERSIZE = 1
@@ -117,7 +117,7 @@ We make sure that event log segments are not deleted too early. No event log seg
 
 ### Snapshots
 
-The running state of the partition is captured periodically on the leader in a snapshot. By default, this period is every five minutes. This can be changed in the [configuration](../configuration/configuration.md).
+The running state of the partition is captured periodically on the leader in a snapshot. By default, this period is every 15 minutes. This can be changed in the [configuration](../configuration/configuration.md).
 
 A snapshot is a projection of all events that represent the current running state of the processes running on the partition. It contains all active data, for example, deployed processes, active process instances, and not yet completed jobs.
 


### PR DESCRIPTION
align snapshot period with current default configuration

## Description
While reviewing the default configuration i spotted a mismatch between the resource-planning guide and the default configuration

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [X] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [X] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
