### PR TITLE
fix(connectors): typo in the inbound project outline

### DIFF
--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -348,7 +348,7 @@ public class Authentication {
 
 There are multiple parts of a Connector that enables it for reuse, as a
 reusable building block, for modeling, and for the runtime behavior.
-For example, the following parts make up an outbound Connector:
+For example, the following parts make up an inbound Connector:
 
 ```
 my-connector

--- a/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.1/components/connectors/custom-built-connectors/connector-sdk.md
@@ -355,7 +355,7 @@ public class Authentication {
 
 There are multiple parts of a Connector that enables it for reuse, as a
 reusable building block, for modeling, and for the runtime behavior.
-For example, the following parts make up an outbound Connector:
+For example, the following parts make up an inbound Connector:
 
 ```
 my-connector

--- a/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.2/components/connectors/custom-built-connectors/connector-sdk.md
@@ -355,7 +355,7 @@ public class Authentication {
 
 There are multiple parts of a Connector that enables it for reuse, as a
 reusable building block, for modeling, and for the runtime behavior.
-For example, the following parts make up an outbound Connector:
+For example, the following parts make up an inbound Connector:
 
 ```
 my-connector

--- a/versioned_docs/version-8.3/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/versioned_docs/version-8.3/components/connectors/custom-built-connectors/connector-sdk.md
@@ -351,7 +351,7 @@ public class Authentication {
 
 There are multiple parts of a Connector that enables it for reuse, as a
 reusable building block, for modeling, and for the runtime behavior.
-For example, the following parts make up an outbound Connector:
+For example, the following parts make up an inbound Connector:
 
 ```
 my-connector


### PR DESCRIPTION
## Description

Copy-paste error fix in the inbound connector project outline.
<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

This is just a typo fix, so nothing urgent, but the sooner the better
<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
