### PR TITLE
docs(web-modeler): start forms in self-managed

### DIFF
--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -165,6 +165,6 @@ A user task with an external task form referenced by a custom form key:
 ### References
 
 - [Tasklist](/components/tasklist/introduction-to-tasklist.md)
-- [User task linking in Modeler](/components/modeler/web-modeler/advanced-modeling/user-task-linking.md)
+- [Form linking in Modeler](/components/modeler/web-modeler/advanced-modeling/form-linking.md)
 - [Job handling](/components/concepts/job-workers.md)
 - [Variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)

--- a/docs/components/modeler/web-modeler/advanced-modeling/form-linking.md
+++ b/docs/components/modeler/web-modeler/advanced-modeling/form-linking.md
@@ -1,35 +1,39 @@
 ---
-id: user-task-linking
-title: User task linking
-description: Use one of the following approaches to link a form to be called by a user task.
+id: form-linking
+title: Form linking
+description: Use one of the following approaches to link a form to a user task or none start event.
 ---
 
 import FormLinkOverlayImg from './img/utl_overlay.png';
 import FormLinkOverlayLinkedImg from './img/utl_linked.png';
 
-You can use one of the following approaches to link a form to a [user task](/components/modeler/bpmn/user-tasks/user-tasks.md).
+You can use one of the following approaches to link a form to a [user task](/components/modeler/bpmn/user-tasks/user-tasks.md) or a [none start event](/components/modeler/bpmn/none-events/none-events.md#none-start-events).
+
+:::tip
+By linking a Camunda Form to a start event, process instances can be started with the form's input [via a public form](/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md) (SaaS only) or directly [in Tasklist](/components/tasklist/userguide/starting-processes.md).
+:::
 
 ## Using the link button
 
-1. Select a user task from the canvas and a link button will appear at the bottom right.
+1. Select a user task or none start event from the canvas and a link button will appear at the bottom right.
 2. Click on the button and choose any form from the same project.
 3. Click the **Link** button to complete the linking process.
-   In the properties panel, the value **Camunda form (linked)** is chosen for the **Type** property, and the form ID of the form you chose to link is automatically copied to the **Form ID** section.
+   In the properties panel, the value **Camunda Form (linked)** is chosen for the **Type** property, and the form ID of the form you chose to link is automatically copied to the **Form ID** section.
 
-<img src={FormLinkOverlayImg} style={{width: 400}} alt="Linking a Camunda form" />
+<img src={FormLinkOverlayImg} style={{width: 400}} alt="Linking a Camunda Form" />
 
-For user tasks that are already linked, clicking on the link button opens a dialog which shows a preview of the form the user task is linked to.
+For user tasks/start events that are already linked, clicking on the link button opens a dialog which shows a preview of the form the user task is linked to.
 It is possible to navigate to the linked form by clicking on it, or you can use the **Unlink** button to remove the link.
 
-<img src={FormLinkOverlayLinkedImg} style={{width: 400}} alt="Linked Camunda form preview" />
+<img src={FormLinkOverlayLinkedImg} style={{width: 400}} alt="Linked Camunda Form preview" />
 
 ## Using the properties panel
 
-Using the properties panel, you can connect a form to a user task via the **Form** section by choosing between different types.
+Using the properties panel, you can connect a form to a user task/start event via the **Form** section by choosing between different types.
 
-### Camunda form (linked)
+### Camunda Form (linked)
 
-Choosing **Camunda form (linked)** as type and entering form ID directly yields the same result as [using the link button on the modeling canvas](#using-the-link-button).
+Choosing **Camunda Form (linked)** as type and entering form ID directly yields the same result as [using the link button on the modeling canvas](#using-the-link-button).
 
 Using this type of linking is the recommended approach as it allows you to benefit from the form automatically being deployed along with the diagram.
 This means when deploying a BPMN diagram, Web Modeler will always deploy the latest version of all linked forms along with the diagram, so you do not have to manually re-link forms or [copy & paste JSON configuration](#camunda-form-embedded) when making changes.
@@ -44,9 +48,9 @@ To deploy to a Camunda 8 cluster with a version lower than 8.4, linked forms wil
 This conversion will only be applied to the XML deployed to the cluster; the diagram in Web Modeler will not be changed.
 :::
 
-### Camunda form (embedded)
+### Camunda Form (embedded)
 
-When choosing **Camunda form (embedded)** as type you have the option to directly paste the form's JSON schema into the **Form JSON configuration** field of the properties panel.
+When choosing **Camunda Form (embedded)** as type you have the option to directly paste the form's JSON schema into the **Form JSON configuration** field of the properties panel.
 The form will be embedded directly into the BPMN diagram's XML representation.
 
 This approach is not recommended anymore as it makes it harder to maintain the form and the diagram separately.
@@ -56,5 +60,5 @@ Use this option to ensure that the embedded form does not change when you or som
 
 ### Custom form key
 
-Choose **Custom form key** to create a custom reference to an external form, application, or web page, that you can consume in your custom applications.
+Choose **Custom form key** (only available for user tasks) to create a custom reference to an external form, application, or web page, that you can consume in your custom applications.
 Read more in the [user task forms reference](/components/modeler/bpmn/user-tasks/user-tasks.md#user-task-forms).

--- a/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md
+++ b/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md
@@ -35,24 +35,9 @@ To create a form for public access, follow these steps:
 
 3. Name your form.
 4. Design your form using the **component palette**.
+5. [Link form to start event](../run-or-publish-your-process.md#start-a-form).
 
 Once ready, return to your process. You can read more about form creation in the [form guide](/docs/guides/utilizing-forms.md).
-
-## Link form to start event
-
-To link the form to a start event, follow these steps:
-
-1. Make sure you are in **Implement** mode.
-   <img src={ImplementModeImg} style={{width: 250}} alt="Active implement mode tab" />
-2. Select the start event.
-   <img src={SelectStartEventImg} style={{width: 800}} alt="Start event of a human workflow" />
-3. Ensure the start event is a [none start event](../../bpmn/none-events/none-events.md#none-start-events). If it is not, change the start event type accordingly using the **wrench tool**.
-4. Use the blue **link icon** to open the form browser. If the icon does not appear, select the start event again.
-5. Select the form you have created and click **Link** to confirm.
-
-<img src={LinkStartFormImg} style={{width: 400}} alt="Linking a start form" />
-
-You can preview the linked form by clicking the **link icon** again.
 
 ## Enable public access
 

--- a/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md
+++ b/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md
@@ -35,7 +35,7 @@ To create a form for public access, follow these steps:
 
 3. Name your form.
 4. Design your form using the **component palette**.
-5. [Link form to start event](../run-or-publish-your-process.md#start-a-form).
+5. [Link form to start event](/components/modeler/web-modeler/advanced-modeling/form-linking.md#using-the-link-button).
 
 Once ready, return to your process. You can read more about form creation in the [form guide](/docs/guides/utilizing-forms.md).
 

--- a/docs/components/modeler/web-modeler/run-or-publish-your-process.md
+++ b/docs/components/modeler/web-modeler/run-or-publish-your-process.md
@@ -83,6 +83,10 @@ After the process instance has been started, you will receive a notification wit
 Starting an instance from Web Modeler [deploys](#deploy-a-process) recent changes to the target cluster, which changes future runs of this process definition in case it has already been deployed and used. Existing process instances are not affected.
 :::
 
+:::tip
+By [linking a Camunda Form to a start event](/components/modeler/web-modeler/advanced-modeling/form-linking.md), process instances can be started with the form's input [via a public form](#publish-via-a-public-form) (SaaS only) or directly [in Tasklist](#publish-to-tasklist).
+:::
+
 ### Schedule via timer
 
 You can also schedule a process to run at a specific time or interval using timers. Timers can be added to one or multiple start events of your process.
@@ -112,24 +116,6 @@ Read more in the [timers documentation](../bpmn/timer-events/timer-events.md).
 You can also define the success of your processes by setting key performance indicators (KPIs) for your process using [Optimize]($optimize$/components/what-is-optimize).
 :::
 
-### Start a form
-
-To link a form to a start event, take the following steps:
-
-1. Make sure you are in **Implement** mode.
-   <img src={ImplementModeImg} style={{width: 250}} alt="Active implement mode tab" />
-2. Select the start event.
-   <img src={SelectStartEventImg} style={{width: 800}} alt="Start event of a human workflow" />
-3. Ensure the start event is a [none start event](../bpmn/none-events/none-events.md#none-start-events). If it is not, change the start event type accordingly using the **wrench tool**.
-4. Use the blue **link icon** to open the form browser. If the icon does not appear, select the start event again.
-5. Select the form you have [created](../../../guides/utilizing-forms.md) and click **Link** to confirm.
-
-<img src={LinkStartFormImg} style={{width: 400}} alt="Linking a start form" />
-
-6. (Optional) Define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form and consume the data in the following steps. If you leave the output mapping empty, you can access all output variables of the form.
-
-You can preview the linked form by clicking the **link icon** again.
-
 ## Publishing a process
 
 Publishing a process means that you make it available to other users inside and outside of Camunda 8. Once published, other users can access and start instances of the process.
@@ -143,7 +129,6 @@ You have the following options to publish a process:
   - [Run manually from Modeler](#run-manually-from-modeler)
   - [Schedule via timer](#schedule-via-timer)
   - [Best practices for running a process](#best-practices-for-running-a-process)
-  - [Start a form](#start-a-form)
 - [Publishing a process](#publishing-a-process)
   - [Deploy to run programmatically](#deploy-to-run-programmatically)
   - [Publish via webhook](#publish-via-webhook)
@@ -206,7 +191,7 @@ Publishing a process via a public form allows you to share your process with ext
 
 <img src={PublicFormImg} alt="A public form" />
 
-To publish a process via a public form, you need first to [add a start form](#start-a-form), then you can follow these steps:
+To publish a process via a public form, you first need to [link a Camunda Form](/components/modeler/web-modeler/advanced-modeling/form-linking.md#using-the-link-button) to the process' start event, then you can follow these steps:
 
 #### Deploy process to the public
 

--- a/docs/components/modeler/web-modeler/run-or-publish-your-process.md
+++ b/docs/components/modeler/web-modeler/run-or-publish-your-process.md
@@ -10,6 +10,7 @@ import TabItem from "@theme/TabItem";
 import PublicationSectionImg from './img/publication-section.png';
 import LinkStartFormImg from './img/link-start-form.png';
 import ImplementModeImg from './img/implement-mode-active.png';
+import SelectStartEventImg from './img/select-start-event.png';
 import PublicLinkImg from './img/public-link.png';
 import PublicFormImg from './img/public-form.png';
 
@@ -111,6 +112,24 @@ Read more in the [timers documentation](../bpmn/timer-events/timer-events.md).
 You can also define the success of your processes by setting key performance indicators (KPIs) for your process using [Optimize]($optimize$/components/what-is-optimize).
 :::
 
+### Start a form
+
+You can link a form to a start event, following these steps:
+
+1. Make sure you are in **Implement** mode.
+   <img src={ImplementModeImg} style={{width: 250}} alt="Active implement mode tab" />
+2. Select the start event.
+   <img src={SelectStartEventImg} style={{width: 800}} alt="Start event of a human workflow" />
+3. Ensure the start event is a [none start event](../bpmn/none-events/none-events.md#none-start-events). If it is not, change the start event type accordingly using the **wrench tool**.
+4. Use the blue **link icon** to open the form browser. If the icon does not appear, select the start event again.
+5. Select the form you have [created](../../../guides/utilizing-forms.md) and click **Link** to confirm.
+
+<img src={LinkStartFormImg} style={{width: 400}} alt="Linking a start form" />
+
+6. Optionally, define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form, and consume the data in following steps. If you leave the output mapping empty, you can access all output variables of the form.
+
+You can preview the linked form by clicking the **link icon** again.
+
 ## Publishing a process
 
 Publishing a process means that you make it available to other users inside and outside of Camunda 8. Once published, other users can access and start instances of the process.
@@ -124,12 +143,12 @@ You have the following options to publish a process:
   - [Run manually from Modeler](#run-manually-from-modeler)
   - [Schedule via timer](#schedule-via-timer)
   - [Best practices for running a process](#best-practices-for-running-a-process)
+  - [Start a form](#start-a-form)
 - [Publishing a process](#publishing-a-process)
   - [Deploy to run programmatically](#deploy-to-run-programmatically)
   - [Publish via webhook](#publish-via-webhook)
   - [Publish to Tasklist](#publish-to-tasklist)
   - [Publish via a public form](#publish-via-a-public-form)
-    - [Add a start form](#add-a-start-form)
     - [Deploy process to the public](#deploy-process-to-the-public)
     - [Get the public link and share it](#get-the-public-link-and-share-it)
   - [Listen to message or signal events](#listen-to-message-or-signal-events)
@@ -187,19 +206,7 @@ Publishing a process via a public form allows you to share your process with ext
 
 <img src={PublicFormImg} alt="A public form" />
 
-To publish a process via a public form, follow these steps:
-
-#### Add a start form
-
-1. Select the start event.
-2. The start event must be a [none start event](../bpmn/none-events/none-events.md#none-start-events). If it isn't, change the start event type accordingly using the **wrench tool**.
-3. [Create a form](../../../guides/utilizing-forms.md) in your project, and return to the process.
-4. Use the blue **link icon** to open the form browser. If the icon does not appear, select the start event again.
-5. Select the form you have created, and click on **Link** to confirm.
-
-<img src={LinkStartFormImg} style={{width: 400}} alt="Embedding a start form" />
-
-6. Optionally, define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form, and consume the data in following steps. If you leave the output mapping empty, you can access all output variables of the form.
+To publish a process via a public form, you need first to [add a start form](#start-a-form), then you can follow these steps:
 
 #### Deploy process to the public
 

--- a/docs/components/modeler/web-modeler/run-or-publish-your-process.md
+++ b/docs/components/modeler/web-modeler/run-or-publish-your-process.md
@@ -10,7 +10,6 @@ import TabItem from "@theme/TabItem";
 import PublicationSectionImg from './img/publication-section.png';
 import LinkStartFormImg from './img/link-start-form.png';
 import ImplementModeImg from './img/implement-mode-active.png';
-import SelectStartEventImg from './img/select-start-event.png';
 import PublicLinkImg from './img/public-link.png';
 import PublicFormImg from './img/public-form.png';
 

--- a/docs/components/modeler/web-modeler/run-or-publish-your-process.md
+++ b/docs/components/modeler/web-modeler/run-or-publish-your-process.md
@@ -114,7 +114,7 @@ You can also define the success of your processes by setting key performance ind
 
 ### Start a form
 
-You can link a form to a start event, following these steps:
+To link a form to a start event, take the following steps:
 
 1. Make sure you are in **Implement** mode.
    <img src={ImplementModeImg} style={{width: 250}} alt="Active implement mode tab" />
@@ -126,7 +126,7 @@ You can link a form to a start event, following these steps:
 
 <img src={LinkStartFormImg} style={{width: 400}} alt="Linking a start form" />
 
-6. Optionally, define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form, and consume the data in following steps. If you leave the output mapping empty, you can access all output variables of the form.
+6. (Optional) Define the [output mapping](../../concepts/variables.md#output-mappings) for the fields of the form and consume the data in the following steps. If you leave the output mapping empty, you can access all output variables of the form.
 
 You can preview the linked form by clicking the **link icon** again.
 

--- a/docs/components/tasklist/userguide/starting-processes.md
+++ b/docs/components/tasklist/userguide/starting-processes.md
@@ -14,11 +14,11 @@ In the **Search** box, it's possible to filter the processes. Start typing the p
 
 To start a process, click **Start process** on the process you want to start.
 
-![tasklist-processes-start-with-form](img/tasklist-processes-start-with-form.png)
-
-If the start event of this process contains an [embedded form](/docs/components/modeler/web-modeler/advanced-modeling/publish-public-processes.md#embed-form-in-start-event), a modal window containing that form will automatically open.
-
 ![tasklist-processes-start](img/tasklist-processes-start.png)
+
+If the start event of this process contains a [linked or embedded Camunda Form](/docs/components/modeler/web-modeler/advanced-modeling/form-linking.md), a modal window containing that form will automatically open.
+
+![tasklist-processes-start-with-form](img/tasklist-processes-start-with-form.png)
 
 Tasklist will then wait for the process to be executed. If the process generates a task, you will be redirected to the generated task.
 

--- a/docs/guides/utilizing-forms.md
+++ b/docs/guides/utilizing-forms.md
@@ -74,7 +74,7 @@ With Camunda 8.4, we improved the way you can link forms to BPMN diagrams in Web
 - No need to manually re-link forms or use a JSON configuration.
 - Forms will be automatically deployed with the diagram.
 
-See the [user task linking reference](/components/modeler/web-modeler/advanced-modeling/user-task-linking.md#camunda-form-linked) for more details.
+See the [form linking reference](/components/modeler/web-modeler/advanced-modeling/form-linking.md#camunda-form-linked) for more details.
 :::
 
 ## Deploy your diagram and start an instance

--- a/sidebars.js
+++ b/sidebars.js
@@ -151,7 +151,7 @@ module.exports = {
               "Advanced modeling": [
                 "components/modeler/web-modeler/advanced-modeling/business-rule-task-linking",
                 "components/modeler/web-modeler/advanced-modeling/call-activity-linking",
-                "components/modeler/web-modeler/advanced-modeling/user-task-linking",
+                "components/modeler/web-modeler/advanced-modeling/form-linking",
                 "components/modeler/web-modeler/advanced-modeling/publish-public-processes",
               ],
             },

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -36,6 +36,9 @@ RewriteRule ^docs/guides/update-guide/(.*)$ /docs/self-managed/operational-guide
 RewriteRule ^docs/self-managed/backup-restore/(.*)$ /docs/self-managed/operational-guides/backup-restore/$1 [R=301,L]
 RewriteRule ^docs/self-managed/troubleshooting/log-levels/(.*)$ /docs/self-managed/operational-guides/troubleshooting/log-levels$1 [R=301,L]
 
+# 8.4 content movies
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/user-task-linking/?$ components/modeler/web-modeler/advanced-modeling/form-linking/ [R=301,L]
+
 # Condense Connectors
 RewriteRule ^docs/components/connectors/out-of-the-box-connectors/amazon-sns-inbound/(.*)$ /docs/components/connectors/out-of-the-box-connectors/amazon-sns/$1 [R=301,L]
 RewriteRule ^docs/8.2/components/connectors/out-of-the-box-connectors/amazon-sns-inbound/(.*)$ /docs/8.2/components/connectors/out-of-the-box-connectors/amazon-sns/$1 [R=301,L]


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/web-modeler/issues/7121

The feature itself was already available for SaaS users. However, it was wrapped with the "Publication" feature, which does not exist yet on Self-Managed.
In this PR, I have:
- Removed duplication around how to link a form with a none start event.
- Extracted the section above in a separate independent one (that is not targeted anymore to SaaS only).

Please let me know if we can improve anything.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
