### PR TITLE
fix: enable indexing in production (by swapping our default indexing strategy)

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -25,6 +25,8 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
+      - name: Enable Indexing
+        run: "sed -i 's/noIndex: true/noIndex: false/g' docusaurus.config.js"
       - name: Build
         run: npm run build
         env:

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -20,8 +20,6 @@ jobs:
           node-version: 16
       - name: Install Dependencies
         run: npm ci
-      - name: Disable Indexing
-        run: "sed -i 's/noIndex: false/noIndex: true/g' docusaurus.config.js"
       - name: Update URL
         run: 'sed -i ''s!url: "https://docs.camunda.io"!url: "https://stage.docs.camunda.io"!g'' docusaurus.config.js'
       - name: Update redirects for environment

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
   organizationName: "camunda", // Usually your GitHub org/user name.
   projectName: "camunda-docs", // Usually your repo name.
   trailingSlash: true,
-  // do not delete the following 'noIndex' line as it is modified for staging
+  // do not delete the following 'noIndex' line as it is modified for production
   noIndex: true,
   plugins: [
     //        ["@edno/docusaurus2-graphql-doc-generator",


### PR DESCRIPTION
In #2944, I mistakenly left a configuration change that set `noIndex: true`. I did this so that when I deployed that PR as a preview site, it didn't get picked up by crawlers. Unfortunately, I overlooked it before merging, and now the production site is _also_ not indexed. 😱 

This PR: 

1. Resolves the fact that production is currently not indexed.
2. Swaps our default `noIndex` strategy, so that _everything_ is not indexed by default, and only the production build toggles `noIndex` to false. 

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern (and should be released ASAP!).

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
