### PR TITLE
fix: added helm equivalent values for env vars for generic oidc provider

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -46,6 +46,10 @@ values={[{label: 'Generic', value: 'generic' },{label: 'Microsoft Entra ID', val
    - Audience
 3. Set the following environment variables for the component you are configuring an app for:
 
+<Tabs groupId="optionsType" defaultValue="env"
+values={[{label: 'Environment Variables', value: 'env' },{label: 'Helm values', value: 'helm' }]} >
+<TabItem value="env">
+
 ```
    CAMUNDA_IDENTITY_TYPE=GENERIC
    CAMUNDA_IDENTITY_ISSUER=<URL_OF_ISSUER>
@@ -54,6 +58,40 @@ values={[{label: 'Generic', value: 'generic' },{label: 'Microsoft Entra ID', val
    CAMUNDA_IDENTITY_CLIENT_SECRET=<Client secret from step 2>
    CAMUNDA_IDENTITY_AUDIENCE=<Audience from step 2>
 ```
+
+</TabItem>
+<TabItem value="helm">
+
+```
+global:
+  identity:
+    auth:
+      issuer: <URL_OF_ISSUER>
+      # this is used for container to container communication
+      issuerBackendUrl: <URL_OF_ISSUER>
+      tokenUrl: <TOKEN_URL_ENDPOINT>
+      jwksUrl: <JWKS_URL>
+      type: "GENERIC"
+      operate:
+        clientId: <Client ID from step 2>
+        audience: <Audience from step 2>
+        existingSecret: <Client secret from step 2>
+      tasklist:
+        clientId: <Client ID from step 2>
+        audience: <Audience from step 2>
+        existingSecret: <Client secret from step 2>
+      optimize:
+        clientId: <Client ID from step 2>
+        audience: <Audience from step 2>
+        existingSecret: <Client secret from step 2>
+      zeebe:
+        clientId: <Client ID from step 2>
+        audience: <Audience from step 2>
+        existingSecret: <Client secret from step 2>
+```
+
+</TabItem>
+</Tabs>
 
 ### Additional considerations
 
@@ -84,6 +122,10 @@ Web Modeler does not yet support authentication with a generic OIDC provider.
 
 4. Set the following environment variables for the component you are configuring an app for:
 
+<Tabs groupId="optionsType" defaultValue="env"
+values={[{label: 'Environment Variables', value: 'env' },{label: 'Helm values', value: 'helm' }]} >
+<TabItem value="env">
+
 ```
    CAMUNDA_IDENTITY_TYPE=MICROSOFT
    CAMUNDA_IDENTITY_ISSUER=<URL_OF_ISSUER>
@@ -92,6 +134,40 @@ Web Modeler does not yet support authentication with a generic OIDC provider.
    CAMUNDA_IDENTITY_CLIENT_SECRET=<Client secret from step 3>
    CAMUNDA_IDENTITY_AUDIENCE=<Audience of your application>
 ```
+
+</TabItem>
+<TabItem value="helm">
+
+```
+global:
+  identity:
+    auth:
+      issuer: <URL_OF_ISSUER>
+      # this is used for container to container communication
+      issuerBackendUrl: <URL_OF_ISSUER>
+      tokenUrl: <TOKEN_URL_ENDPOINT>
+      jwksUrl: <JWKS_URL>
+      type: "MICROSOFT"
+      operate:
+        clientId: <Client ID from step 1>
+        audience: <Audience of your application>
+        existingSecret: <Client secret from step 3>
+      tasklist:
+        clientId: <Client ID from step 1>
+        audience: <Audience of your application>
+        existingSecret: <Client secret from step 3>
+      optimize:
+        clientId: <Client ID from step 1>
+        audience: <Audience of your application>
+        existingSecret: <Client secret from step 3>
+      zeebe:
+        clientId: <Client ID from step 1>
+        audience: <Audience of your application>
+        existingSecret: <Client secret from step 3>
+```
+
+</TabItem>
+</Tabs>
 
 ### Additional considerations
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -46,8 +46,7 @@ values={[{label: 'Generic', value: 'generic' },{label: 'Microsoft Entra ID', val
    - Audience
 3. Set the following environment variables for the component you are configuring an app for:
 
-<Tabs groupId="optionsType" defaultValue="env"
-values={[{label: 'Environment Variables', value: 'env' },{label: 'Helm values', value: 'helm' }]} >
+<Tabs groupId="optionsType" defaultValue="env" queryString values={[{label: 'Environment variables', value: 'env' },{label: 'Helm values', value: 'helm' }]} >
 <TabItem value="env">
 
 ```
@@ -108,7 +107,7 @@ Web Modeler does not yet support authentication with a generic OIDC provider.
 
 1. Access the Entra ID admin area
    and [register an application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app).
-   After registering the app, the **Overview** page will contain a Client ID; make a note of this value as it will be
+   After registering the app, the **Overview** page will contain a **Client ID**; make a note of this value as it will be
    required later on.
 
 2. Within the app registered in Step
@@ -116,14 +115,11 @@ Web Modeler does not yet support authentication with a generic OIDC provider.
    of type `web`. The expected redirect URI of the component you are configuring an app for can be found
    in [component-specific configuration](#component-specific-configuration).
 
-3. Once you have registered a platform for your app a client secret needs to be created, to do this,
-   see [adding a client secret](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app#add-a-client-secret).
-   Make a note of the value of the client secret as it will be required later on.
+3. Once you have registered a platform for your app a client secret needs to be created. To do this, see [adding a client secret](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app#add-a-client-secret). Make a note of the value of the client secret as it will be required later on.
 
 4. Set the following environment variables for the component you are configuring an app for:
 
-<Tabs groupId="optionsType" defaultValue="env"
-values={[{label: 'Environment Variables', value: 'env' },{label: 'Helm values', value: 'helm' }]} >
+<Tabs groupId="optionsType" defaultValue="env" queryString values={[{label: 'Environment variables', value: 'env' },{label: 'Helm values', value: 'helm' }]} >
 <TabItem value="env">
 
 ```


### PR DESCRIPTION
## Description

Previously, there were environment variables recommended to users who wish to authenticate with an OIDC provider (or Azure).  Existing helm chart users would read this documentation and expect to add env vars rather than configuring the helm chart options designed for this purpose.

This change includes 2 possible views of code snippets on this guide, 
1. One to view the environment variables necessary to configure
2. One to view the equivalent values.yaml variables necessary to edit.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

Hopefully prior to 8.4 release.

Also, should be merged after this PR gets merged:
https://github.com/camunda/camunda-platform-helm/pull/1155

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
