### PR TITLE
Add update job timeout docs

### DIFF
--- a/docs/apis-tools/grpc.md
+++ b/docs/apis-tools/grpc.md
@@ -1137,6 +1137,44 @@ Returned if:
 
 - Retries is not greater than 0.
 
+### `UpdateJobTimeout` RPC
+
+Updates the deadline of a job using the timeout (in ms) provided. This can be used for extending or shortening
+the job deadline.
+
+#### Input: `UpdateJobTimeoutRequest`
+
+```protobuf
+message UpdateJobTimeoutRequest {
+  // the unique job identifier, as obtained from ActivateJobsResponse
+  int64 jobKey = 1;
+  // the duration of the new timeout in ms, starting from the current moment
+  int64 timeout = 2;
+}
+```
+
+#### Output: `UpdateJobTimeoutResponse`
+
+```protobuf
+message UpdateJobTimeoutResponse {
+}
+```
+
+#### Errors
+
+##### GRPC_STATUS_NOT_FOUND
+
+Returned if:
+
+- No job exists with the given key.
+- No job was found with the given key for the tenants the user is authorized to work with.
+
+##### GRPC_STATUS_INVALID_STATE
+
+Returned if:
+
+- The job is not active.
+
 ### `DeleteResource` RPC
 
 #### Input `DeleteResourceRequest`

--- a/docs/apis-tools/grpc.md
+++ b/docs/apis-tools/grpc.md
@@ -1139,8 +1139,8 @@ Returned if:
 
 ### `UpdateJobTimeout` RPC
 
-Updates the deadline of a job using the timeout (in ms) provided. This can be used for extending or shortening
-the job deadline.
+Updates the deadline of a job using the timeout (in milliseconds) provided. This can be used for extending or shortening
+the job deadline. The new deadline will be calculated from the current time, adding the timeout provided.
 
 #### Input: `UpdateJobTimeoutRequest`
 

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -96,11 +96,11 @@ The fact that jobs may be worked on more than once means that Zeebe is an "at le
 
 ### Timeout update
 
-When a job worker activates a job it can specify a timeout for how long the job should remain activated.
+When a job worker activates a job it can specify a timeout for how long the job should remain activated. This timout can be updated, for example in the following scenarios:
 
-However, there are jobs which have an elastic timespan, meaning they can potentially run for 5 minutes, but can be also 24+ hours and longer. That can cause a problem when the workers picking up the jobs do not know in advance how long the given process takes thus they can't accurately estimate a timeout.
+- When there are jobs which have an elastic timespan. They can potentially run for 5 minutes, but can be also 24+ hours and longer. That can cause a problem when the workers picking up the jobs do not know in advance how long the given process takes thus they can't accurately estimate a timeout.
 
-Also, in case of a long-running job the scenario can occur where there is a problem with the job worker but the task will be unavailable until the timeout is reached.
+- In case of a long-running job. The scenario can occur where there is a problem with the job worker but the task will be unavailable until the timeout is reached.
 
 In the scenarios described above job timeout can be dynamically extended or shortened using `UpdateJobTimeout` gRPC command. This command takes a duration. This is not the duration with which the timeout will be extended or shortened. Instead, this will be the new duration the timeout is set to from the current time. This allows to not only extend the timeout of a Job, but also to shorten the timeout.
 

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -96,19 +96,19 @@ The fact that jobs may be worked on more than once means that Zeebe is an "at le
 
 ### Timeout update
 
-When a job worker activates a job it can specify a timeout for how long the job should remain activated. This timout can be updated, for example in the following scenarios:
+When a job worker activates a job it can specify a timeout for how long the job should remain activated. For example, this timeout can be updated in the following scenarios:
 
-- When there are jobs which have an elastic timespan. They can potentially run for 5 minutes, but can be also 24+ hours and longer. That can cause a problem when the workers picking up the jobs do not know in advance how long the given process takes thus they can't accurately estimate a timeout.
+- When there are jobs which have an elastic timespan. They can potentially run for five minutes, but can be also 24+ hours. That can cause a problem when the workers picking up the jobs do not know in advance how long the given process takes, thus they can't accurately estimate a timeout.
 
-- In case of a long-running job. The scenario can occur where there is a problem with the job worker but the task will be unavailable until the timeout is reached.
+- In case of a long-running job. The scenario can occur where there is a problem with the job worker, but the task will be unavailable until the timeout is reached.
 
-In the scenarios described above job timeout can be dynamically extended or shortened using `UpdateJobTimeout` gRPC command. This command takes a duration. This is not the duration with which the timeout will be extended or shortened. Instead, this will be the new duration the timeout is set to from the current time. This allows to not only extend the timeout of a Job, but also to shorten the timeout.
+In the scenarios described above, job timeout can be dynamically extended or shortened using `UpdateJobTimeout` gRPC command. This command takes a duration. This is not the duration with which the timeout will be extended or shortened. Instead, this will be the new duration the timeout is set to from the current time. This allows to not only extend the timeout of a job, but also to shorten the timeout.
 
 That means the worker does not need to estimate job timeout accurately at the very beginning. It can use some “standard” initial value and then extend or shorten the timeout as necessary.
 
-A job worker should not wait until the last second to update a job timeout as some time might be needed in order to process the update and there is a chance that in between the job could already time out. A buffer should be applied to avoid this issue.
+A job worker should not wait until the last second to update a job timeout as some time might be needed to process the update and there is a chance that in between the job could already time out. A buffer should be applied to avoid this issue.
 
-Job timeout can be updated [using `UpdateJobTimeout` command](../../apis-tools/grpc.md#updatejobtimeout-rpc).
+Job timeout can be updated [using the `UpdateJobTimeout` command](../../apis-tools/grpc.md#updatejobtimeout-rpc).
 
 ## Job streaming
 


### PR DESCRIPTION
## Description

Adding the documentation for Update Job Timeout epic (please see the details [here](https://github.com/camunda/zeebe/issues/15020))

The following files were updated and the changes were verified locally:
- `grpc.md` new `UpdateJobTimeout` section added
- `job-workers.md` new `Timeout update` section added.

@abbasadel could you please verify the wording and let me know who else should be added to this PR?

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2862

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
