### PR TITLE
docs: document boundary events migration limitation

### DIFF
--- a/docs/apis-tools/grpc.md
+++ b/docs/apis-tools/grpc.md
@@ -824,7 +824,7 @@ Returned if:
 
 - No process instance exists with the given key, or it is not active
 - No process definition exists with the given target definition key
-- No process instance exists with the given key for the tenants the user is authorized to work with
+- No process instance exists with the given key for the tenants the user is authorized to work with.
 
 ##### GRPC_STATUS_INVALID_ARGUMENT
 

--- a/docs/apis-tools/grpc.md
+++ b/docs/apis-tools/grpc.md
@@ -824,6 +824,7 @@ Returned if:
 
 - No process instance exists with the given key, or it is not active
 - No process definition exists with the given target definition key
+- No process instance exists with the given key for the tenants the user is authorized to work with
 
 ##### GRPC_STATUS_INVALID_ARGUMENT
 

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -177,6 +177,7 @@ The following limitations exist that may be supported in future versions:
 - The following scenarios cannot be migrated:
   - A process instance with an incident
   - A process instance that is started from a call activity, i.e. a child process instance
+  - A process instance with a service task when a boundary event is active
   - An element that becomes nested in a newly added sub-process
   - An element that was nested in a sub-process is no longer nested in that sub-process
 - Mapping instructions cannot change the element type

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -177,7 +177,9 @@ The following limitations exist that may be supported in future versions:
 - The following scenarios cannot be migrated:
   - A process instance with an incident
   - A process instance that is started from a call activity, i.e. a child process instance
-  - A process instance with a service task when a boundary event is active
+  - A process instance with an active service task that has a boundary event
+  - A process instance that contains event subprocess
+  - A target process definition that contains event subprocess
   - An element that becomes nested in a newly added sub-process
   - An element that was nested in a sub-process is no longer nested in that sub-process
 - Mapping instructions cannot change the element type


### PR DESCRIPTION
## Description
List PR document the limitation that resulted by [Revert Migrate task instances with recreated event subscriptions](https://github.com/camunda/zeebe/issues/15659)

Closes #3089 

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
