### PR TITLE
docs(webhook): Document webhook correlation result

### DIFF
--- a/docs/components/connectors/protocol/http-webhook.md
+++ b/docs/components/connectors/protocol/http-webhook.md
@@ -294,3 +294,29 @@ When working with `request` data, use the following references to access data:
 - URL parameters: `request.params.`.
 
 You can also use FEEL expressions to modify the data you return.
+
+In addition to the `request` object you have access to the `correlation` result.
+
+The data available via the `correlation` object depends on the type of BPMN element you are using the Webhook Connector with.
+
+A start event with a message definition uses message publishing internally to correlate an incoming
+request with Zeebe. A successful correlation will therefore lead to a published message and the `correlation` object will contain the following properties:
+
+```json
+{
+  "messageKey": 2251799813774245,
+  "tenantId": "<default>"
+}
+```
+
+If a Webhook request is processed more than once using the same _Message ID_ (because of a retry for example) the `correlation` object will be empty.
+
+A start event without a message will create a new process instance. You therefore have access to the
+newly create process instance key when accessing the `correlation` object:
+
+```json
+{
+  "processInstanceKey": 6755399441144562,
+  "tenantId": "<default>"
+}
+```

--- a/docs/components/connectors/use-connectors/inbound.md
+++ b/docs/components/connectors/use-connectors/inbound.md
@@ -19,10 +19,6 @@ When you **deploy** such a BPMN diagram with an inbound Connector, the Connector
 
 ### Modeling the Connector start event
 
-:::caution
-Inbound Connector start events are on deprecation path. Please use inbound Connector message start event instead.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an inbound Connector of your choice (e.g., HTTP webhook, or a message queue subscription).
 3. Fill in all required properties.

--- a/versioned_docs/version-8.1/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.1/components/connectors/use-connectors/inbound.md
@@ -19,10 +19,6 @@ When you **deploy** such a BPMN diagram with an inbound Connector, the Connector
 
 ### Modeling the Connector start event
 
-:::caution
-Inbound Connector start events are on deprecation path. Please use inbound Connector message start event instead.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an inbound Connector of your choice (e.g., HTTP webhook, or a message queue subscription).
 3. Fill in all required properties.

--- a/versioned_docs/version-8.2/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.2/components/connectors/use-connectors/inbound.md
@@ -19,10 +19,6 @@ When you **deploy** such a BPMN diagram with an inbound Connector, the Connector
 
 ### Modeling the Connector start event
 
-:::caution
-Inbound Connector start events are on deprecation path. Please use inbound Connector message start event instead.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an inbound Connector of your choice (e.g., HTTP webhook, or a message queue subscription).
 3. Fill in all required properties.

--- a/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
@@ -294,3 +294,33 @@ When working with `request` data, use the following references to access data:
 - URL parameters: `request.params.`.
 
 You can also use FEEL expressions to modify the data you return.
+
+In addition to the `request` object you have access to the `correlation` result.
+
+:::note
+Access to the `correlation` object is available since the Connectors 8.3.3 patch release.
+:::
+
+The data available via the `correlation` object depends on the type of BPMN element you are using the Webhook Connector with.
+
+A start event with a message definition uses message publishing internally to correlate an incoming
+request with Zeebe. A successful correlation will therefore lead to a published message and the `correlation` object will contain the following properties:
+
+```
+{
+  "messageKey":2251799813774245,
+  "tenantId":"<default>"
+}
+```
+
+If a Webhook request is processed more than once using the same _Message ID_ (because of a retry for example) the `correlation` object will be empty.
+
+A start event without a message will create a new process instance. You therefore have access to the
+newly create process instance key when accessing the `correlation` object:
+
+```
+{
+  "processInstanceKey":6755399441144562,
+  "tenantId":"<default>"
+}
+```

--- a/versioned_docs/version-8.3/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.3/components/connectors/use-connectors/inbound.md
@@ -19,10 +19,6 @@ When you **deploy** such a BPMN diagram with an inbound Connector, the Connector
 
 ### Modeling the Connector start event
 
-:::caution
-Inbound Connector start events are on deprecation path. Please use inbound Connector message start event instead.
-:::
-
 1. Start building your BPMN diagram with a **Start Event** building block.
 2. Change its template to an inbound Connector of your choice (e.g., HTTP webhook, or a message queue subscription).
 3. Fill in all required properties.


### PR DESCRIPTION
## Description

The webhook response expression now supports access to the correlation result via the `correlation` object.

## When should this change go live?

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] It should be merged with the 8.4 release

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
