### PR TITLE
doc(self-managed): expand docs on unsupported multi-tenancy components

### DIFF
--- a/docs/apis-tools/cli-client/cli-get-started.md
+++ b/docs/apis-tools/cli-client/cli-get-started.md
@@ -6,6 +6,11 @@ sidebar_label: "Getting started with the CLI client"
 
 In this tutorial, you will learn to use the CLI client `zbctl` to interact with Camunda 8.
 
+:::note
+The CLI client doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
+more details on multi-tenancy [here](../../self-managed/concepts/multi-tenancy.md).
+:::
+
 ## Prerequisites
 
 - [Camunda 8 account](/guides/create-account.md)

--- a/docs/apis-tools/cli-client/cli-get-started.md
+++ b/docs/apis-tools/cli-client/cli-get-started.md
@@ -7,8 +7,7 @@ sidebar_label: "Getting started with the CLI client"
 In this tutorial, you will learn to use the CLI client `zbctl` to interact with Camunda 8.
 
 :::note
-The CLI client doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
-more details on multi-tenancy [here](../../self-managed/concepts/multi-tenancy.md).
+The CLI client doesn't support [multi-tenancy](../../self-managed/concepts/multi-tenancy.md) and can only be used when multi-tenancy is disabled.
 :::
 
 ## Prerequisites

--- a/docs/apis-tools/go-client/go-get-started.md
+++ b/docs/apis-tools/go-client/go-get-started.md
@@ -12,8 +12,7 @@ In this tutorial, you will learn how to use the Go client in a Go application to
 You can find a complete example on [GitHub](https://github.com/camunda/camunda-platform-get-started/tree/main/go).
 
 :::note
-The Go client doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
-more details on multi-tenancy [here](../../self-managed/concepts/multi-tenancy.md).
+The Go client doesn't support [multi-tenancy](../../self-managed/concepts/multi-tenancy.md) and can only be used when multi-tenancy is disabled.
 :::
 
 ## Prerequisites

--- a/docs/apis-tools/go-client/go-get-started.md
+++ b/docs/apis-tools/go-client/go-get-started.md
@@ -12,7 +12,7 @@ In this tutorial, you will learn how to use the Go client in a Go application to
 You can find a complete example on [GitHub](https://github.com/camunda/camunda-platform-get-started/tree/main/go).
 
 :::note
-The Go client currently doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
+The Go client doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
 more details on multi-tenancy [here](../../self-managed/concepts/multi-tenancy.md).
 :::
 

--- a/docs/self-managed/concepts/multi-tenancy.md
+++ b/docs/self-managed/concepts/multi-tenancy.md
@@ -107,10 +107,19 @@ For a standalone Zeebe installation, multi-tenancy is currently available with t
   with Zeebe.
 
 :::note
+
 It's not possible to use multi-tenancy on the full Camunda 8 stack when
 [integrating an external tenant-managing component](../zeebe-deployment/zeebe-gateway/interceptors.md#implementing-a-tenant-providing-interceptor)
 in Zeebe, as the remaining Camunda 8 components don't support this setup.
 
+:::
+
 ## Unsupported features
 
 Multi-tenancy only works for Self-Managed installations with authentication enabled [through Identity](../../../self-managed/identity/what-is-identity/).
+
+Furthermore, the following Camunda-maintained clients don't support multi-tenancy, and can only be used when
+multi-tenancy is disabled:
+
+- [Zeebe Go client](../../apis-tools/go-client/go-get-started.md)
+- [Zeebe CLI client](../../apis-tools/cli-client/cli-get-started.md)

--- a/versioned_docs/version-8.3/apis-tools/go-client/go-get-started.md
+++ b/versioned_docs/version-8.3/apis-tools/go-client/go-get-started.md
@@ -12,7 +12,7 @@ In this tutorial, you will learn how to use the Go client in a Go application to
 You can find a complete example on [GitHub](https://github.com/camunda/camunda-platform-get-started/tree/main/go).
 
 :::note
-The Go client currently doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
+The Go client doesn't support multi-tenancy and can only be used when multi-tenancy is disabled. You can find
 more details on multi-tenancy [here](../../self-managed/concepts/multi-tenancy.md).
 :::
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->
Document that the Go and CLI clients don't support multi-tenancy in Camunda 8.4 as well.

closes #2893
closes #2894 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
