### PR TITLE
fix(web-modeler): fix rewrite rule for user task linking

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -37,7 +37,7 @@ RewriteRule ^docs/self-managed/backup-restore/(.*)$ /docs/self-managed/operation
 RewriteRule ^docs/self-managed/troubleshooting/log-levels/(.*)$ /docs/self-managed/operational-guides/troubleshooting/log-levels$1 [R=301,L]
 
 # 8.4 content movies
-RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/user-task-linking/?$ components/modeler/web-modeler/advanced-modeling/form-linking/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/user-task-linking/?$ /docs/next/components/modeler/web-modeler/advanced-modeling/form-linking/ [R=301,L]
 
 # Condense Connectors
 RewriteRule ^docs/components/connectors/out-of-the-box-connectors/amazon-sns-inbound/(.*)$ /docs/components/connectors/out-of-the-box-connectors/amazon-sns/$1 [R=301,L]


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Follow-up for #3066 

Fixes the rewrite rule which currently doesn't work: https://docs.camunda.io/docs/next/components/modeler/web-modeler/advanced-modeling/user-task-linking/

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
