### PR TITLE
console: HEAD requests need to be accepted for alert-webhooks

### DIFF
--- a/docs/components/console/manage-clusters/manage-alerts.md
+++ b/docs/components/console/manage-clusters/manage-alerts.md
@@ -27,7 +27,7 @@ To create a new alert, take the following steps:
 
 4. If you select **Email**, click **Create**. No further information is needed. For **Webhook**, complete the additional steps below.
 
-5. To create a webhook alert, provide a valid webhook URL that accepts `POST` requests.
+5. To create a webhook alert, provide a valid webhook URL that accepts `POST` and `HEAD` requests.
 
 If your webhook requires [HMAC authentication](https://www.okta.com/identity-101/hmac/), you can specify an HMAC secret. The SHA-256 hash of the request body will then be generated using your HMAC secret, and it is included it in the HTTP header `X-Camunda-Signature-256` each time we send out a webhook alert to your endpoint.
 

--- a/versioned_docs/version-8.3/components/console/manage-clusters/manage-alerts.md
+++ b/versioned_docs/version-8.3/components/console/manage-clusters/manage-alerts.md
@@ -27,7 +27,7 @@ To create a new alert, take the following steps:
 
 4. If you select **Email**, click **Create**. No further information is needed. For **Webhook**, complete the additional steps below.
 
-5. To create a webhook alert, provide a valid webhook URL that accepts `POST` requests.
+5. To create a webhook alert, provide a valid webhook URL that accepts `POST` and `HEAD` requests.
 
 If your webhook requires [HMAC authentication](https://www.okta.com/identity-101/hmac/), you can specify an HMAC secret. The SHA-256 hash of the request body will then be generated using your HMAC secret, and it is included it in the HTTP header `X-Camunda-Signature-256` each time we send out a webhook alert to your endpoint.
 


### PR DESCRIPTION
## Description

make sure the requirement for `HEAD` requests when configuring alert-webhooks is reflected in the docs

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

documenting the status quo, can be pushed to prod anytime

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
