### PR TITLE
docs(ingress-nginx): correct nginx mentionings and replace NGINX Ingress usage

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Helm chart doesn't manage or deploy Ingress controllers, it only deplo
 
 ## Preparation
 
-- An Ingress controller should be deployed in advance. The examples below use `Nginx` Ingress controller, but any Ingress controller could be used by setting `ingress.className`.
+- An Ingress controller should be deployed in advance. The examples below use the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx), but any Ingress controller could be used by setting `ingress.className`.
 - TLS configuration is not handled in the examples because it varies between different workflows. It could be configured directly using `ingress.tls` options or via an external tool like [Cert-Manager](https://github.com/cert-manager/cert-manager) using `ingress.annotations`. For more details, check available [configuration options](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#configuration).
 
 ## Combined Ingress setup
@@ -207,7 +207,7 @@ controller:
     enabled: false
 ```
 
-To install this `ingress-nginx Controller` to your local cluster, execute the following command:
+To install this [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) to your local cluster, execute the following command:
 
 ```shell
 helm install -f ingress_nginx_values.yml \

--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -191,21 +191,31 @@ Ingress resources require the cluster to have an [Ingress Controller](https://ku
 
 ### Example local configuration
 
-An Ingress Controller is also required when working a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [Nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/):
+An Ingress Controller is also required when working on a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [ingress-nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters/):
 
 ```yaml
-# nginx_ingress_values.yml
+# ingress_nginx_values.yml
 controller:
-  replicaCount: 1
-  hostNetwork: true
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   service:
     type: NodePort
+
+  publishService:
+    enabled: false
 ```
 
-To install this Ingress Controller to your local cluster, execute the following command:
+To install this `ingress-nginx Controller` to your local cluster, execute the following command:
 
 ```shell
-helm install -f nginx_ingress_values.yaml nginx-ingress oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.0
+helm install -f ingress_nginx_values.yml \
+ingress-nginx ingress-nginx \
+--repo https://kubernetes.github.io/ingress-nginx \
+--version "4.9.0" \
+--namespace ingress-nginx \
+--create-namespace
 ```
 
 ## Troubleshooting

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -30,4 +30,4 @@ It's recommended to use `Performance (SSD) persistent disks` volume type with at
 
 ### Zeebe Ingress
 
-Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not Nginx Ingress, you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).
+Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not [ingress-nginx](https://github.com/kubernetes/ingress-nginx), you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -35,6 +35,6 @@ should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress
 
-**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx).
+**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
 Currently, the Azure Application Gateway Ingress controller doesn't support `gRPC`. For more details, follow the upstream [GitHub issue about gRPC/HTTP2 support](https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1015).

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -269,7 +269,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
 
 ### Prerequisite
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -269,7 +269,15 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress Controllers instead, for example, the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx).
+
+:::warning
+
+Do not confuse the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
+
+If you should decide to use the Rad Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift), you would require additional adjustments done to the Camunda 8 ingress objects and the NGINX Ingress Controlle itself, to make `gRPC` and `HTTP/2` connections work. In that case, please refer to the [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+
+:::
 
 ### Prerequisite
 

--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -269,7 +269,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead; for example, [NGINX](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift).
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
 
 ### Prerequisite
 

--- a/docs/self-managed/platform-deployment/troubleshooting.md
+++ b/docs/self-managed/platform-deployment/troubleshooting.md
@@ -36,14 +36,14 @@ global:
 
 Zeebe requires an Ingress controller that supports `gRPC` which is built on top of `HTTP/2` transport layer. Therefore, to expose Zeebe-Gateway externally, you need the following:
 
-1. An Ingress controller that supports `gRPC` ([Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
+1. An Ingress controller that supports `gRPC` ([ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
 2. TLS (HTTPS) via [Application-Layer Protocol Negotiation (ALPN)](https://www.rfc-editor.org/rfc/rfc7301.html) enabled in the Zeebe-Gateway Ingress object.
 
 However, according to the official Kubernetes documentation about [Ingress TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls):
 
 > There is a gap between TLS features supported by various Ingress controllers. Please refer to documentation on nginx, GCE, or any other platform specific Ingress controller to understand how TLS works in your environment.
 
-Therefore, if you are not using the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
+Therefore, if you are not using the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
 
 ## Identity `contextPath`
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Helm chart doesn't manage or deploy Ingress controllers, it only deplo
 
 ## Preparation
 
-- An Ingress controller should be deployed in advance. The examples below use `Nginx` Ingress controller, but any Ingress controller could be used by setting `ingress.className`.
+- An Ingress controller should be deployed in advance. The examples below use the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx), but any Ingress controller could be used by setting `ingress.className`.
 - TLS configuration is not handled in the examples because it varies between different workflows. It could be configured directly using `ingress.tls` options or via an external tool like [Cert-Manager](https://github.com/cert-manager/cert-manager) using `ingress.annotations`. For more details, check available [configuration options](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#configuration).
 
 ## Combined Ingress setup
@@ -199,7 +199,7 @@ controller:
     enabled: false
 ```
 
-To install this `ingress-nginx Controller` to your local cluster, execute the following command:
+To install this [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) to your local cluster, execute the following command:
 
 ```shell
 helm install -f ingress_nginx_values.yml \

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -183,21 +183,31 @@ Ingress resources require the cluster to have an [Ingress Controller](https://ku
 
 ### Example local configuration
 
-An Ingress Controller is also required when working a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [Nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/):
+An Ingress Controller is also required when working on a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [ingress-nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters/):
 
 ```yaml
-# nginx_ingress_values.yml
+# ingress_nginx_values.yml
 controller:
-  replicaCount: 1
-  hostNetwork: true
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   service:
     type: NodePort
+
+  publishService:
+    enabled: false
 ```
 
-To install this Ingress Controller to your local cluster, execute the following command:
+To install this `ingress-nginx Controller` to your local cluster, execute the following command:
 
 ```shell
-helm install -f nginx_ingress_values.yaml nginx-ingress oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.0
+helm install -f ingress_nginx_values.yml \
+ingress-nginx ingress-nginx \
+--repo https://kubernetes.github.io/ingress-nginx \
+--version "4.9.0" \
+--namespace ingress-nginx \
+--create-namespace
 ```
 
 ## Troubleshooting

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -30,4 +30,4 @@ It's recommended to use `Performance (SSD) persistent disks` volume type with at
 
 ### Zeebe Ingress
 
-Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not Nginx Ingress, you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).
+Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not [ingress-nginx](https://github.com/kubernetes/ingress-nginx), you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -35,6 +35,6 @@ should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress
 
-**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx).
+**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
 Currently, the Azure Application Gateway Ingress controller doesn't support `gRPC`. For more details, follow the upstream [GitHub issue about gRPC/HTTP2 support](https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1015).

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -272,7 +272,15 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress Controllers instead, for example, the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx).
+
+:::warning
+
+Do not confuse the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
+
+If you should decide to use the Rad Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift), you would require additional adjustments done to the Camunda 8 ingress objects and the NGINX Ingress Controlle itself, to make `gRPC` and `HTTP/2` connections work. In that case, please refer to the [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+
+:::
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -272,7 +272,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -272,7 +272,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead; for example, [NGINX](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift).
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/troubleshooting.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/troubleshooting.md
@@ -40,14 +40,14 @@ Changing this property after the initial install will require manual corrections
 
 Zeebe requires an Ingress controller that supports `gRPC` which is built on top of `HTTP/2` transport layer. Therefore, to expose Zeebe-Gateway externally, you need the following:
 
-1. An Ingress controller that supports `gRPC` ([Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
+1. An Ingress controller that supports `gRPC` ([ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
 2. TLS enabled (HTTPS) in the Zeebe-Gateway Ingress object.
 
 However, according to the official Kubernetes documentation about [Ingress TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls):
 
 > There is a gap between TLS features supported by various Ingress controllers. Please refer to documentation on nginx, GCE, or any other platform specific Ingress controller to understand how TLS works in your environment.
 
-Therefore, if you are not using the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
+Therefore, if you are not using the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
 
 ## Identity `contextPath`
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Helm chart doesn't manage or deploy Ingress controllers, it only deplo
 
 ## Preparation
 
-- An Ingress controller should be deployed in advance. The examples below use `Nginx` Ingress controller, but any Ingress controller could be used by setting `ingress.className`.
+- An Ingress controller should be deployed in advance. The examples below use the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx), but any Ingress controller could be used by setting `ingress.className`.
 - TLS configuration is not handled in the examples because it varies between different workflows. It could be configured directly using `ingress.tls` options or via an external tool like [Cert-Manager](https://github.com/cert-manager/cert-manager) using `ingress.annotations`. For more details, check available [configuration options](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#configuration).
 
 ## Combined Ingress setup
@@ -207,7 +207,7 @@ controller:
     enabled: false
 ```
 
-To install this `ingress-nginx Controller` to your local cluster, execute the following command:
+To install this [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) to your local cluster, execute the following command:
 
 ```shell
 helm install -f ingress_nginx_values.yml \

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -191,21 +191,31 @@ Ingress resources require the cluster to have an [Ingress Controller](https://ku
 
 ### Example local configuration
 
-An Ingress Controller is also required when working a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [Nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/):
+An Ingress Controller is also required when working on a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [ingress-nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters/):
 
 ```yaml
-# nginx_ingress_values.yml
+# ingress_nginx_values.yml
 controller:
-  replicaCount: 1
-  hostNetwork: true
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   service:
     type: NodePort
+
+  publishService:
+    enabled: false
 ```
 
-To install this Ingress Controller to your local cluster, execute the following command:
+To install this `ingress-nginx Controller` to your local cluster, execute the following command:
 
 ```shell
-helm install -f nginx_ingress_values.yaml nginx-ingress oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.0
+helm install -f ingress_nginx_values.yml \
+ingress-nginx ingress-nginx \
+--repo https://kubernetes.github.io/ingress-nginx \
+--version "4.9.0" \
+--namespace ingress-nginx \
+--create-namespace
 ```
 
 ## Troubleshooting

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -30,4 +30,4 @@ It's recommended to use `Performance (SSD) persistent disks` volume type with at
 
 ### Zeebe Ingress
 
-Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not Nginx Ingress, you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).
+Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not [ingress-nginx](https://github.com/kubernetes/ingress-nginx), you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -35,6 +35,6 @@ should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress
 
-**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx).
+**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
 Currently, the Azure Application Gateway Ingress controller doesn't support `gRPC`. For more details, follow the upstream [GitHub issue about gRPC/HTTP2 support](https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1015).

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -275,7 +275,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -275,7 +275,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead; for example, [NGINX](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift).
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -275,7 +275,15 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress Controllers instead, for example, the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx).
+
+:::warning
+
+Do not confuse the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
+
+If you should decide to use the Rad Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift), you would require additional adjustments done to the Camunda 8 ingress objects and the NGINX Ingress Controlle itself, to make `gRPC` and `HTTP/2` connections work. In that case, please refer to the [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+
+:::
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/troubleshooting.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/troubleshooting.md
@@ -40,14 +40,14 @@ Changing this property after the initial install will require manual corrections
 
 Zeebe requires an Ingress controller that supports `gRPC` which is built on top of `HTTP/2` transport layer. Therefore, to expose Zeebe-Gateway externally, you need the following:
 
-1. An Ingress controller that supports `gRPC` ([Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
+1. An Ingress controller that supports `gRPC` ([ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
 2. TLS (HTTPS) via [Application-Layer Protocol Negotiation (ALPN)](https://www.rfc-editor.org/rfc/rfc7301.html) enabled in the Zeebe-Gateway Ingress object.
 
 However, according to the official Kubernetes documentation about [Ingress TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls):
 
 > There is a gap between TLS features supported by various Ingress controllers. Please refer to documentation on nginx, GCE, or any other platform specific Ingress controller to understand how TLS works in your environment.
 
-Therefore, if you are not using the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
+Therefore, if you are not using the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
 
 ## Identity `contextPath`
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Helm chart doesn't manage or deploy Ingress controllers, it only deplo
 
 ## Preparation
 
-- An Ingress controller should be deployed in advance. The examples below use `Nginx` Ingress controller, but any Ingress controller could be used by setting `ingress.className`.
+- An Ingress controller should be deployed in advance. The examples below use the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx), but any Ingress controller could be used by setting `ingress.className`.
 - TLS configuration is not handled in the examples because it varies between different workflows. It could be configured directly using `ingress.tls` options or via an external tool like [Cert-Manager](https://github.com/cert-manager/cert-manager) using `ingress.annotations`. For more details, check available [configuration options](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform#configuration).
 
 ## Combined Ingress setup
@@ -207,7 +207,7 @@ controller:
     enabled: false
 ```
 
-To install this `ingress-nginx Controller` to your local cluster, execute the following command:
+To install this [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) to your local cluster, execute the following command:
 
 ```shell
 helm install -f ingress_nginx_values.yml \

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup.md
@@ -191,21 +191,31 @@ Ingress resources require the cluster to have an [Ingress Controller](https://ku
 
 ### Example local configuration
 
-An Ingress Controller is also required when working a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [Nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/):
+An Ingress Controller is also required when working on a local Camunda 8 installation. Take a look at an Ingress Controller configuration using the [ingress-nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters/):
 
 ```yaml
-# nginx_ingress_values.yml
+# ingress_nginx_values.yml
 controller:
-  replicaCount: 1
-  hostNetwork: true
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   service:
     type: NodePort
+
+  publishService:
+    enabled: false
 ```
 
-To install this Ingress Controller to your local cluster, execute the following command:
+To install this `ingress-nginx Controller` to your local cluster, execute the following command:
 
 ```shell
-helm install -f nginx_ingress_values.yaml nginx-ingress oci://ghcr.io/nginxinc/charts/nginx-ingress --version 0.18.0
+helm install -f ingress_nginx_values.yml \
+ingress-nginx ingress-nginx \
+--repo https://kubernetes.github.io/ingress-nginx \
+--version "4.9.0" \
+--namespace ingress-nginx \
+--create-namespace
 ```
 
 ## Troubleshooting

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -30,4 +30,4 @@ It's recommended to use `Performance (SSD) persistent disks` volume type with at
 
 ### Zeebe Ingress
 
-Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not Nginx Ingress, you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).
+Zeebe requires an Ingress controller that supports `gRPC`, so if you are using [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) (ingress-gce), not [ingress-nginx](https://github.com/kubernetes/ingress-nginx), you might need to do extra steps. Namely, using `cloud.google.com/app-protocols` annotation in Zeebe Service. For more details, visit the GKE guide [using HTTP/2 for load balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-http2).

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -35,6 +35,6 @@ should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress
 
-**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx).
+**Azure Application Gateway Ingress cannot be used as an Ingress for Zeebe/Zeebe-Gateway** because Zeebe requires an Ingress controller that supports `gRPC`. You should use any other Ingress controller that supports `gRPC`, like the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
 Currently, the Azure Application Gateway Ingress controller doesn't support `gRPC`. For more details, follow the upstream [GitHub issue about gRPC/HTTP2 support](https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1015).

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -269,7 +269,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -269,7 +269,15 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The latter would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work, please have a look at this [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress Controllers instead, for example, the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx).
+
+:::warning
+
+Do not confuse the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
+
+If you should decide to use the Rad Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift), you would require additional adjustments done to the Camunda 8 ingress objects and the NGINX Ingress Controlle itself, to make `gRPC` and `HTTP/2` connections work. In that case, please refer to the [example and the prerequisites](https://github.com/nginxinc/kubernetes-ingress/blob/main/examples/ingress-resources/grpc-services/README.md).
+
+:::
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -269,7 +269,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 ### Alternatives
 
-An alternative is to install the Ingress Controller of choice and use this instead; for example, [NGINX](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift).
+An alternative is to install the Ingress Controller of choice and use this instead. This may require additional adjustments on the Camunda 8 ingress since it heavily focuses on the [ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx). Do not confuse the controller with the Red Hat endorsed [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift). The later would require additional adjustments on the Camunda 8 ingress and `NGINX Ingress Controller` to make `grpc` and `http2` work.
 
 ### Prerequisite
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/troubleshooting.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/troubleshooting.md
@@ -36,14 +36,14 @@ global:
 
 Zeebe requires an Ingress controller that supports `gRPC` which is built on top of `HTTP/2` transport layer. Therefore, to expose Zeebe-Gateway externally, you need the following:
 
-1. An Ingress controller that supports `gRPC` ([Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
+1. An Ingress controller that supports `gRPC` ([ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) supports it out of the box).
 2. TLS (HTTPS) via [Application-Layer Protocol Negotiation (ALPN)](https://www.rfc-editor.org/rfc/rfc7301.html) enabled in the Zeebe-Gateway Ingress object.
 
 However, according to the official Kubernetes documentation about [Ingress TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls):
 
 > There is a gap between TLS features supported by various Ingress controllers. Please refer to documentation on nginx, GCE, or any other platform specific Ingress controller to understand how TLS works in your environment.
 
-Therefore, if you are not using the [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
+Therefore, if you are not using the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), ensure you pay attention to TLS configuration of the Ingress controller of your choice. Find more details about the Zeebe Ingress setup in the [Kubernetes platforms supported by Camunda](./helm-kubernetes/platforms/platforms.md).
 
 ## Identity `contextPath`
 


### PR DESCRIPTION
## Description

related to https://github.com/camunda/team-infrastructure-experience/issues/24.

[ingress-nginx Controller](https://github.com/kubernetes/ingress-nginx) and [NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) are often homogeneously used and abstracted by just `nginx`, `ingress controller`, `nginx ingress controller`. All of which results in confusion of which one to use as both have different target groups and histories.

The Camunda 8 Helm chart heavily focuses on `ingress-nginx`, which results in e.g. `NGINX Ingress Controller` not working out of the box since first it doesn't have `http2` enabled out of the box = no grpc and second annotations are missing to make it work. It can be done but we have nothing documented about it.

This PR aims to fix the confusion and just stick to `ingress-nginx`. Any other mentioning was adjusted to be specific about the used controller. Additionally switches the usage of `NGINX Ingress Controller` for `ingress-nginx` as in theory it could have never worked with the mentioned documentation.

Lastly, for OpenShift the paragraph about alternatives was extended and an example was referenced which could be enough to make it work with `Ingress NGINX Controller`, the reason for keeping is due to Red Hat officially endorsing this controller for OpenShift. For `ingress-nginx` I would require tests to confirm that it works as their docs don't mention anything and I could imagine some security fixes are required to make it work under OpenShift.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix ~or security concern.~

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
