### PR TITLE
chore: synchronize sidebars for v8.1/3.9.0

### DIFF
--- a/optimize_versioned_sidebars/version-3.9.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.9.0-sidebars.json
@@ -96,7 +96,7 @@
             {
               "type": "link",
               "label": "Enable alpha features",
-              "href": "/docs/components/console/manage-organization/enable-alpha-features/"
+              "href": "/docs/8.1/components/console/manage-organization/enable-alpha-features/"
             },
             {
               "type": "link",
@@ -917,9 +917,18 @@
               "href": "/docs/8.1/components/connectors/out-of-the-box-connectors/kafka/"
             },
             {
-              "type": "link",
-              "label": "Microsoft Teams Connector",
-              "href": "/docs/8.1/components/connectors/out-of-the-box-connectors/microsoft-teams/"
+              "Microsoft": [
+                {
+                  "type": "link",
+                  "label": "Microsoft Teams Connector",
+                  "href": "/docs/8.1/components/connectors/out-of-the-box-connectors/microsoft-teams/"
+                },
+                {
+                  "type": "link",
+                  "label": "Microsoft 365 Connector",
+                  "href": "/docs/8.1/components/connectors/out-of-the-box-connectors/microsoft-o365-mail/"
+                }
+              ]
             },
             {
               "type": "link",
@@ -973,11 +982,6 @@
           "Protocol Connectors": [
             {
               "type": "link",
-              "label": "REST Connector",
-              "href": "/docs/8.1/components/connectors/protocol/rest/"
-            },
-            {
-              "type": "link",
               "label": "GraphQL Connector",
               "href": "/docs/8.1/components/connectors/protocol/graphql/"
             },
@@ -985,6 +989,16 @@
               "type": "link",
               "label": "HTTP Webhook Connector",
               "href": "/docs/8.1/components/connectors/protocol/http-webhook/"
+            },
+            {
+              "type": "link",
+              "label": "HTTP Polling Connector",
+              "href": "/docs/8.1/components/connectors/protocol/polling/"
+            },
+            {
+              "type": "link",
+              "label": "REST Connector",
+              "href": "/docs/8.1/components/connectors/protocol/rest/"
             }
           ]
         },

--- a/optimize_versioned_sidebars/version-3.9.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.9.0-sidebars.json
@@ -1863,6 +1863,16 @@
                   "type": "link",
                   "label": "Installing in an air-gapped environment",
                   "href": "/docs/8.1/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation/"
+                },
+                {
+                  "type": "link",
+                  "label": "Install Zeebe exporters",
+                  "href": "/docs/8.1/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters/"
+                },
+                {
+                  "type": "link",
+                  "label": "Running custom Connectors",
+                  "href": "/docs/8.1/self-managed/platform-deployment/helm-kubernetes/guides/running-custom-connectors/"
                 }
               ]
             },


### PR DESCRIPTION
## Description

Pre-work for #3151.

Synchronizes sidebars for the 8.1/3.9.0 versions of the docs.

## Not included

Synchronization for versions 1.3, 8.2, 8.3, or next.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule. Required for a release next week.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
