### PR TITLE
fix: prevent large images from stretching locally

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -386,6 +386,7 @@ span.callout + p::after {
   border-color: lightgray;
   border-width: 1px;
   box-shadow: 4px 4px 4px 1px lightgray;
+  height: auto;
 }
 
 .theme-doc-markdown table img {


### PR DESCRIPTION
## Description

Adds a `height:auto` property to images in the docs, so that large ones don't stretch vertically when running locally. 

This style _will_ apply in staging/production, also....but those already have the same style applied, so it should cause no noticeable difference.

cc @philippfromme @nikku who reported this in slack during the fallout of #3069.

## Before this change

<img width="1765" alt="image" src="https://github.com/camunda/camunda-docs/assets/1627089/f863b130-c6f4-4a40-af0c-97d5577dd4b6">


## After this change

<img width="1836" alt="image" src="https://github.com/camunda/camunda-docs/assets/1627089/8a1c75c0-c60d-47ff-8957-6683066a6e91">

## I don't know why this issue is occurring

In production, a CSS module is adding a `height:auto` property to images. 

![image](https://github.com/camunda/camunda-docs/assets/1627089/4b5f95b4-93bc-43f7-8acd-96a22513267c)

For some reason that style is not applied locally. I don't see anything in our source that mentions this style (except in the changes introduced in this PR). 🤷 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
