### PR TITLE
clean up vague termminology

### DIFF
--- a/docs/apis-tools/cli-client/cli-get-started.md
+++ b/docs/apis-tools/cli-client/cli-get-started.md
@@ -49,7 +49,7 @@ Use the following command to verify everything is set up correctly:
 zbctl status
 ```
 
-As a result, you should receive a similar response:
+As a result, you will receive a similar response:
 
 ```bash
 Cluster size: 1

--- a/docs/apis-tools/go-client/go-get-started.md
+++ b/docs/apis-tools/go-client/go-get-started.md
@@ -112,7 +112,7 @@ func roleToString(role pb.Partition_PartitionBrokerRole) string {
 go run main.go
 ```
 
-You should note a similar output:
+You will note a similar output:
 
 ```
 Broker 0.0.0.0 : 26501
@@ -196,7 +196,7 @@ Add the following to `main.go` at the bottom of `func main()`.
 
 Run the program and verify the process deployed successfully.
 
-You should note a similar output:
+You will note a similar output:
 
 ```
 key:2251799813685254  processes:{bpmnProcessId:"order-process"  version:3  processDefinitionKey:2251799813685253  resourceName:"order-process.bpmn"}
@@ -231,7 +231,7 @@ A process instance is created by a specific version of the process, which can be
 	fmt.Println(msg.String())
 ```
 
-Run the program and verify the process instance is created. You should note an output similar to below:
+Run the program and verify the process instance is created. You will note an output similar to below:
 
 ```
 processKey:2251799813686742 bpmnProcessId:"order-process" version:3 processInstanceKey:2251799813686744
@@ -530,7 +530,7 @@ it encounters a problem while processing the job.
 
 When observing the current state of the process in Operate, you can note the process instance moved from the first service task to the next one.
 
-When you run the example above, you should note a similar output to the following:
+When you run the example above, note a similar output to the following:
 
 ```
 key:2251799813685256  deployments:{process:{bpmnProcessId:"order-process-4"  version:1  processDefinitionKey:2251799813685255  resourceName:"order-process.bpmn"}}

--- a/docs/apis-tools/java-client/job-worker.md
+++ b/docs/apis-tools/java-client/job-worker.md
@@ -171,7 +171,7 @@ It's also possible to set an overall timeout - so called `streamTimeout` - which
 
 Even with streaming enabled, job workers still occasionally poll the cluster for jobs. Due to implementation constraints, when a job is made activate-able, it is pushed out only if there exists a stream for it; if not, it remains untouched. Even if a stream is created afterwards, it remains untouched. However, if a stream exists, then streaming is always prioritized over polling.
 
-This ensures polling should not activate any new jobs, and the worker will back off and poll less often as long as it receives empty responses overtime.
+This ensures polling will not activate any new jobs, and the worker will back off and poll less often as long as it receives empty responses overtime.
 
 #### Backpressure
 

--- a/docs/apis-tools/tasklist-api/tasklist-api-graphql-to-rest-migration.md
+++ b/docs/apis-tools/tasklist-api/tasklist-api-graphql-to-rest-migration.md
@@ -14,7 +14,7 @@ and provide guidance on how to make the switch.
 
 GraphQL has been a popular and valuable tool for many of our customers, but we recognize that there are
 certain advantages to using a RESTful architecture. Our new REST API version provides a more structured
-and predictable way of accessing our data, which should lead to improved performance and greater reliability.
+and predictable way of accessing our data, which can improve performance and greater reliability.
 
 It's worth noting that all of our other APIs use REST, so moving to a RESTful architecture will align this API
 with the rest of our ecosystem. This will make it easier to maintain and enhance our APIs over time,
@@ -33,7 +33,7 @@ Instead of [task](../tasklist-api/queries/task.mdx) GraphQL query:
 task(id: String!): Task!
 ```
 
-The following [get task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#get-task) endpoint should be used:
+Use the following [get task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#get-task) endpoint:
 
 ```bash
 curl -X 'GET' \
@@ -62,7 +62,7 @@ Instead of [tasks](../tasklist-api/queries/tasks.mdx) GraphQL query:
 tasks(query: TaskQuery!): [Task!]!
 ```
 
-The following [search tasks](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-tasks) endpoint should be used:
+Use the following [search tasks](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-tasks) endpoint:
 
 ```bash
 curl -X 'POST' \
@@ -102,7 +102,7 @@ Instead of [variable](../tasklist-api/queries/variable.mdx) GraphQL query:
 variable(id: String!): Variable!
 ```
 
-The following [get variable](../tasklist-api-rest/controllers/tasklist-api-rest-variables-controller.md#get-variable) endpoint should be used:
+Use the following [get variable](../tasklist-api-rest/controllers/tasklist-api-rest-variables-controller.md#get-variable) endpoint:
 
 ```bash
 curl -X 'GET' \
@@ -120,7 +120,7 @@ Instead of [variables](../tasklist-api/queries/variables.mdx) GraphQL query:
 variables(taskId: String!, variableNames: [String!]!): [Variable!]!
 ```
 
-The following [search task variables](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-task-variables) endpoint should be used:
+Use the following [search task variables](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#search-task-variables) endpoint:
 
 ```bash
 curl -X 'POST' \
@@ -143,7 +143,7 @@ Instead of [form](../tasklist-api/queries/form.mdx) GraphQL query:
 form(id: String!, processDefinitionId: String!): Form
 ```
 
-The following [get form](../tasklist-api-rest/controllers/tasklist-api-rest-form-controller.md#get-form) endpoint should be used:
+Use the following [get form](../tasklist-api-rest/controllers/tasklist-api-rest-form-controller.md#get-form) endpoint:
 
 ```bash
 curl -X 'GET' \
@@ -171,7 +171,7 @@ Instead of [claimTasks](../tasklist-api/mutations/claim-task.mdx) GraphQL mutati
 claimTask(taskId: String!, assignee: String, allowOverrideAssignment: Boolean): Task!
 ```
 
-The following [assign task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#assign-task) endpoint should be used:
+Use the following [assign task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#assign-task) endpoint:
 
 ```bash
 curl -X 'PATCH' \
@@ -190,7 +190,7 @@ Instead of [unclaimTasks](../tasklist-api/mutations/unclaim-task.mdx) GraphQL mu
 unclaimTask(taskId: String!): Task!
 ```
 
-The following [unassign task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#unassign-task) endpoint should be used:
+Use the following [unassign task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#unassign-task) endpoint:
 
 ```bash
 curl -X 'PATCH' \
@@ -208,7 +208,7 @@ Instead of [completeTasks](../tasklist-api/mutations/complete-task.mdx) GraphQL 
 completeTask(taskId: String!, variables: [VariableInput!]!): Task!
 ```
 
-The following [complete task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#complete-task) endpoint should be used:
+Use the following [complete task](../tasklist-api-rest/controllers/tasklist-api-rest-task-controller.md#complete-task) endpoint:
 
 ```bash
 curl -X 'PATCH' \

--- a/docs/apis-tools/tasklist-api/tasklist-api-tutorial.md
+++ b/docs/apis-tools/tasklist-api/tasklist-api-tutorial.md
@@ -24,7 +24,7 @@ For this tutorial we'll need:
 
 ## Before moving forward
 
-If you have all the prerequisites from the getting started section above, you should have cloned a repo with the complete demo application we're going to build over this tutorial. The default branch in this repo has the complete application, so we need to `checkout` to the branch `0-getting-started` before proceeding.
+If you have all the prerequisites from the getting started section above, you will have cloned a repo with the complete demo application we're going to build over this tutorial. The default branch in this repo has the complete application, so we need to `checkout` to the branch `0-getting-started` before proceeding.
 
 Inside the repo folder, you'll find some files and two folders, one of these folders is called `demo-data/` and the other `frontend/`. As it might be evident inside each of these folders, there are two different projects.
 
@@ -53,7 +53,7 @@ import { Module } from "@nestjs/common";
 export class AppModule {}
 ```
 
-To check if everything is working as expected, run `yarn workspace api run start:dev` from the root folder on your terminal. You should observe a message similar to the one below:
+To check if everything is working as expected, run `yarn workspace api run start:dev` from the root folder on your terminal. You will observe a message similar to the one below:
 
 ```sh
 [00:00:00 AM] Starting compilation in watch mode...
@@ -175,7 +175,7 @@ To keep things concise, we have one query and one method here. To observe the co
 
 We have the implementation of our service, but we still can't make requests to the Tasklist API because we're not providing any credentials to the API.
 
-To achieve this, we need to rename the file `.env.example` to `.env` (the file needs to be on the root because we'll reuse it to generate the demo data), and the content of this file should look like this:
+To achieve this, we need to rename the file `.env.example` to `.env` (the file needs to be on the root because we'll reuse it to generate the demo data), and the content of this file must look like this:
 
 ```sh
 ZEEBE_ADDRESS="<cluster-id>.bru-2.zeebe.camunda.io:443"
@@ -186,7 +186,7 @@ TASKLIST_API_ADDRESS="https://bru-2.tasklist.camunda.io/<cluster-id>/graphql"
 ZEEBE_AUTHORIZATION_AUDIENCE="tasklist.camunda.io"
 ```
 
-You can find all this information on the **API** tab of the cluster page. The client id and secret should be on the file you downloaded in the getting started section.
+You can find all this information on the **API** tab of the cluster page. The client id and secret must be on the file you downloaded in the getting started section.
 
 Now that we have our credentials, we can authenticate and inject the JWT token into every request we make into Tasklist API.
 

--- a/docs/components/best-practices/architecture/understanding-human-tasks-management.md
+++ b/docs/components/best-practices/architecture/understanding-human-tasks-management.md
@@ -92,7 +92,7 @@ Transfer just the minimal amount of business data in between Camunda and your th
 
 For creating tasks, transfer just the taskId and important business data references/ids to your domain objects. As much as possible should be retrieved later, and just when needed (e.g. when displaying task forms to the user) by requesting data from the process engine or by requesting data directly from other systems.
 
-For completing tasks, transfer just the business data which originated from Camunda and was changed by the user. This means, in case you just maintain references, nothing needs to be transferred back. All other business data changed by the user should be directly transferred to the affected systems.
+For completing tasks, transfer just the business data which originated from Camunda and was changed by the user. This means, in case you just maintain references, nothing needs to be transferred back. All other business data changed by the user will be directly transferred to the affected systems.
 
 ### Task lists may not look like task lists
 

--- a/docs/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/docs/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -233,7 +233,7 @@ If you need to integrate with certain infrastructure regularly, for example your
 
 In general, we recommend not to start such Connectors too early. Don’t forget that such a Connector gets hard to adjust once in production and reused across multiple applications. Also, it is often much harder to extract all configuration parameters correctly and fill them from within the process, than it would be to have bespoke glue code in the programming language of your choice.
 
-Therefore, you should only extract a full-blown Connector if you understand exactly what you need.
+Therefore, only extract a full-blown Connector if you understand exactly what you need.
 
 Don’t forget about the possibility to extract common glue code in a simple library that is then used at different places.
 

--- a/docs/components/concepts/process-instance-modification.md
+++ b/docs/components/concepts/process-instance-modification.md
@@ -14,7 +14,7 @@ process. Consider the following example:
 ![The process instance is stuck in the message catch event.](assets/process-instance-modification/process-instance-modification-example-1.png)
 
 The process contains two service tasks and a message catch event in between. The process instance completed the first
-task `A` and waits on the message catch event `B`. An external system should publish the message, but the external
+task `A` and waits on the message catch event `B`. An external system will publish the message, but the external
 system is not available and can't continue the process. The process instance is stuck.
 
 ![We use the modification to skip the event and continue on the next task.](assets/process-instance-modification/process-instance-modification-example-2.png)
@@ -51,7 +51,7 @@ We can use the modification command to activate an element of the process. Consi
 ![The process instance waits on task. We use the modification command to activate a task from a parallel flow.](assets/process-instance-modification/process-instance-modification-activate-an-element.png)
 
 The process instance completed the first task `A` and waits on task `B`. Task `C` is connected to task `A` by a
-non-interrupting message catch event. An external system should publish the message, but it is not available.
+non-interrupting message catch event. An external system will publish the message, but it is not available.
 
 To correct the state of the process instance, we modify it and activate task `C`. As a result, task `C` is active, and a
 job worker can pick it up.
@@ -100,7 +100,7 @@ example:
 ![The process instance waits on task. We use the modification command to activate an interrupting event subprocess in the same scope.](assets/process-instance-modification/process-instance-modification-activate-interrupting-event-subprocess.png)
 
 The process instance completed the first task `A` and waits on task `B`. Task `C` is embedded in an interrupting message
-event subprocess. An external system should publish the message and interrupt the process, but it is not available.
+event subprocess. An external system will publish the message and interrupt the process, but it is not available.
 
 To correct the state of the process instance, we modify it and activate the interrupting event subprocess. As a result,
 the event subprocess is active and enters the start event. But the activation doesn't interrupt the process instance
@@ -120,7 +120,7 @@ Consider the following example:
 ![The process instance waits on task. We use the modification command to activate a task inside a non-interrupting message event subprocess.](assets/process-instance-modification/process-instance-modification-set-variables.png)
 
 The process instance completed the first task `A` and waited on task `B`. Task `C` is embedded in a non-interrupting
-message event subprocess. An external system should publish the message, but it is not available.
+message event subprocess. An external system will publish the message, but it is not available.
 
 To correct the state of the process instance, we modify it and activate the task `C` inside the non-interrupting message
 event subprocess. Additionally, we add variable instructions to the modification to set variables that should be

--- a/docs/components/connectors/custom-built-connectors/update-guide/030-to-040.md
+++ b/docs/components/connectors/custom-built-connectors/update-guide/030-to-040.md
@@ -35,4 +35,4 @@ To function properly, Spring Zeebe runtime requires connection to [Operate API](
 
 If you don't configure properly connection to Operate API, it will be not possible to poll process definitions from Operate. Therefore, the webhook functionality won't work.
 Additionally, you may observe exception spam in your log file every 5 seconds complaining of inability to connect to Operate.
-Overall, this is not critical and given there are no other issues, the Connector runtime should function properly.
+Overall, this is not critical and given there are no other issues, the Connector runtime will function properly.

--- a/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb.md
+++ b/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb.md
@@ -273,7 +273,7 @@ The **Amazon DynamoDB Connector** may throw the following exceptions:
 - AwsDynamoDbExecutionException: Thrown if there is an error executing a DynamoDB operation.
 - AwsDynamoDbConfigurationException: Thrown if the Connector is not properly configured.
 
-All of these checked exceptions are wrapped in a `RuntimeException`, so you should be prepared to handle this type of exception as well.
+All of these checked exceptions are wrapped in a `RuntimeException`, so be prepared to handle this type of exception as well.
 
 ## Troubleshooting
 

--- a/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
+++ b/docs/components/connectors/out-of-the-box-connectors/automation-anywhere.md
@@ -79,7 +79,7 @@ It corresponds directly to the respective Automation Anywhere API - [`Add Work I
 2. Populate **Authentication section** as described in the [respective section](#authentication).
 3. In the **Configuration** section, set the **Control Room URL** field as described in the [respective section](#control-room-url).
 4. In the **Input** section, set **Work queue ID**. This is the identifier of a queue, where an item will be fetched from.
-5. In the **Input** section, set **Work Item json Data** that you want to pass together with the item. The **Data** has to comply with the Automation Anywhere API, and should contain the following semantics:
+5. In the **Input** section, set **Work Item json Data** that you want to pass together with the item. The **Data** has to comply with the Automation Anywhere API, and must contain the following semantics:
 
 ```json
 {

--- a/docs/components/connectors/out-of-the-box-connectors/googledrive.md
+++ b/docs/components/connectors/out-of-the-box-connectors/googledrive.md
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 To find the Parent Folder ID for a Google Drive folder, follow these steps:
 
 1. Open the Google Drive folder in your web browser.
-2. Look at the URL in the address bar, which should look something like this:
+2. Look at the URL in the address bar, which will look something like this:
    ```
    https://docs.google.com/drive/folder/1whNL0a6WjZtYRHF2522FrCYUYxHve9ju-DHNkaTm9Sk
    ```
@@ -162,7 +162,7 @@ Some properties are applicable only for the token owners, like `folderColorRgb` 
 
 To find the Template ID for a Google Docs template, follow these steps:
 
-1. Open the link to the Google Docs template in your web browser. The URL should look something like this:
+1. Open the link to the Google Docs template in your web browser. The URL will look something like this:
    ```
    https://docs.google.com/document/d/1whNL0a6WjZtYRHF2522FrCYUYxHve9ju-DHNkaTm9Sk
    ```

--- a/docs/components/connectors/out-of-the-box-connectors/power-automate.md
+++ b/docs/components/connectors/out-of-the-box-connectors/power-automate.md
@@ -70,7 +70,7 @@ Select the **Power Automate Connector** and fill out the following properties un
 
 ##### OAuth Token Endpoint
 
-You should provide the **OAuth Token Endpoint** in the following format: https://login.microsoftonline.com/{tanantID}/oauth2/v2.0/token
+Provide the **OAuth Token Endpoint** in the following format: https://login.microsoftonline.com/{tanantID}/oauth2/v2.0/token
 
 Read more on how you can [find your tenantID](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant#find-tenant-id-through-the-azure-portal).
 

--- a/docs/components/connectors/out-of-the-box-connectors/twilio.md
+++ b/docs/components/connectors/out-of-the-box-connectors/twilio.md
@@ -72,8 +72,8 @@ See the [Twilio documentation](https://www.twilio.com/docs/sms/send-messages) fo
 
 ### List messages operation
 
-- `Date sent after`: (Optional) The date and time to start retrieving messages from. Messages sent on or after this date and time will be included in the results. The date and time should be in ISO 8601 format, such as `2023-04-19T08:30:00Z`.
-- `Date sent before`: (Optional) The date and time to stop retrieving messages at. Messages sent before this date and time will be included in the results. The date and time should be in ISO 8601 format, such as `2023-04-19T08:30:00Z`.
+- `Date sent after`: (Optional) The date and time to start retrieving messages from. Messages sent on or after this date and time will be included in the results. The date and time must be in ISO 8601 format, such as `2023-04-19T08:30:00Z`.
+- `Date sent before`: (Optional) The date and time to stop retrieving messages at. Messages sent before this date and time will be included in the results. The date and time must be in ISO 8601 format, such as `2023-04-19T08:30:00Z`.
 - `From`: (Optional) The phone number that the message was sent from. Only messages sent from this phone number will be included in the results.
 - `To`: (Optional) The phone number that the message was sent to. Only messages sent to this phone number will be included in the results.
 - `Page size`: (Optional) The maximum number of messages to retrieve per page. This value must be between 1 and 1000.

--- a/docs/components/connectors/out-of-the-box-connectors/uipath.md
+++ b/docs/components/connectors/out-of-the-box-connectors/uipath.md
@@ -85,7 +85,7 @@ For this section, fill out the following fields:
 2. _(Optional)_ **Defer date**: The earliest date and time at which the item is available for processing. If empty, the item can be processed as soon as possible. Expected date format is `yyyy-MM-dd`.
 3. _(Optional)_ **Due date**: The latest date and time at which the item should be processed. If empty, the item can be processed at any given time. Expected date format is `yyyy-MM-dd`.
 4. _(Optional)_ **Priority**: Select a value from the dropdown list to represent the priority level of the queue item to be added. This property is a criterion for the prioritization of queue items, alongside **Deadline** and **Postpone**.
-5. _(Optional)_ **Specific Content for UiPath Job**: Data that will be passed in to the job. This should be in JSON format.
+5. _(Optional)_ **Specific Content for UiPath Job**: Data that will be passed in to the job. This must be in JSON format.
 
 ```
 = {

--- a/docs/self-managed/concepts/access-control/resource-authorizations.md
+++ b/docs/self-managed/concepts/access-control/resource-authorizations.md
@@ -6,7 +6,7 @@ description: "Resource authorizations allow you to control the level of access a
 ---
 
 :::caution
-Resource authorizations are disabled by default and can be enabled by the use of environment variables. This feature should be enabled in all required components, see:
+Resource authorizations are disabled by default and can be enabled by the use of environment variables. This feature must be enabled in all required components, see:
 
 - [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags)
 - [Operate resource based permissions](../../../../self-managed/operate-deployment/operate-authentication/#resource-based-permissions)

--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -103,7 +103,7 @@ Identity requires the following parameters:
 ## Resource-based permissions
 
 1. Resource authorizations must be [enabled in Identity](/self-managed/concepts/access-control/resource-authorizations.md).
-2. Tasklist must be configured to use resource authorizations (see above configurations) and `camunda.tasklist.identity.resourcePermissionsEnabled` should be enabled.
+2. Tasklist must be configured to use resource authorizations (see above configurations) and `camunda.tasklist.identity.resourcePermissionsEnabled` must be enabled.
 
 Resource-based permissions are defined per process definition. Process definition is defined by **Process ID**, which is present in BPMN XML.
 

--- a/versioned_docs/version-8.2/self-managed/concepts/access-control/resource-authorizations.md
+++ b/versioned_docs/version-8.2/self-managed/concepts/access-control/resource-authorizations.md
@@ -6,7 +6,7 @@ description: "Resource authorizations allow you to control the level of access a
 ---
 
 :::caution
-Resource authorizations are disabled by default and can be enabled by the use of environment variables. This feature should be enabled in all required components, see:
+Resource authorizations are disabled by default and can be enabled by the use of environment variables. This feature must be enabled in all required components, see:
 
 - [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags)
 - [Operate resource based permissions](../../../../self-managed/operate-deployment/operate-authentication/#resource-based-permissions)

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -86,7 +86,7 @@ Identity requires the following parameters:
 ### Resource-based permissions
 
 1. Resource authorizations must be [enabled in Identity](/self-managed/concepts/access-control/resource-authorizations.md).
-2. Tasklist must be configured to use resource authorizations (see above configurations) and `camunda.tasklist.identity.resourcePermissionsEnabled` should be enabled.
+2. Tasklist must be configured to use resource authorizations (see above configurations) and `camunda.tasklist.identity.resourcePermissionsEnabled` must be enabled.
 
 Resource-based permissions are defined per process definition. Process definition is defined by **Process ID**, which is present in BPMN XML.
 

--- a/versioned_docs/version-8.3/self-managed/concepts/access-control/resource-authorizations.md
+++ b/versioned_docs/version-8.3/self-managed/concepts/access-control/resource-authorizations.md
@@ -6,7 +6,7 @@ description: "Resource authorizations allow you to control the level of access a
 ---
 
 :::caution
-Resource authorizations are disabled by default and can be enabled by the use of environment variables. This feature should be enabled in all required components, see:
+Resource authorizations are disabled by default and can be enabled by the use of environment variables. This feature must be enabled in all required components, see:
 
 - [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags)
 - [Operate resource based permissions](../../../../self-managed/operate-deployment/operate-authentication/#resource-based-permissions)

--- a/versioned_docs/version-8.3/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.3/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -87,7 +87,7 @@ Identity requires the following parameters:
 ### Resource-based permissions
 
 1. Resource authorizations must be [enabled in Identity](/self-managed/concepts/access-control/resource-authorizations.md).
-2. Tasklist must be configured to use resource authorizations (see above configurations) and `camunda.tasklist.identity.resourcePermissionsEnabled` should be enabled.
+2. Tasklist must be configured to use resource authorizations (see above configurations) and `camunda.tasklist.identity.resourcePermissionsEnabled` must be enabled.
 
 Resource-based permissions are defined per process definition. Process definition is defined by **Process ID**, which is present in BPMN XML.
 


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/developer-experience/issues/209.

The terminology in multi-tenancy was already cleaned up in a previous PR, so figured I would still get a little bang for my buck with this issue in other docs.

Added a note to add this to the WCoE. Most of these terms can be cleaned up on an as-found basis.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
