### PR TITLE
chore: synchronize sidebars for v8.3/3.11.0

### DIFF
--- a/optimize_versioned_sidebars/version-3.11.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.11.0-sidebars.json
@@ -2300,7 +2300,17 @@
                 {
                   "type": "link",
                   "label": "Install AWS Marketplace",
-                  "href": "/docs/self-managed/platform-deployment/helm-kubernetes/guides/aws-marketplace"
+                  "href": "/docs/self-managed/platform-deployment/helm-kubernetes/guides/aws-marketplace/"
+                },
+                {
+                  "type": "link",
+                  "label": "Install Zeebe exporters",
+                  "href": "/docs/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters/"
+                },
+                {
+                  "type": "link",
+                  "label": "Running custom Connectors",
+                  "href": "/docs/self-managed/platform-deployment/helm-kubernetes/guides/running-custom-connectors/"
                 }
               ]
             },
@@ -2408,6 +2418,11 @@
           "type": "link",
           "label": "Exporters",
           "href": "/docs/self-managed/concepts/exporters/"
+        },
+        {
+          "type": "link",
+          "label": "Multi-tenancy",
+          "href": "/docs/self-managed/concepts/multi-tenancy/"
         }
       ]
     },
@@ -2821,6 +2836,15 @@
                   "type": "link",
                   "label": "Generating machine-to-machine (M2M) tokens",
                   "href": "/docs/self-managed/identity/user-guide/authorizations/generating-m2m-tokens/"
+                }
+              ]
+            },
+            {
+              "Tenants": [
+                {
+                  "type": "link",
+                  "label": "Managing tenants",
+                  "href": "/docs/self-managed/identity/user-guide/tenants/managing-tenants/"
                 }
               ]
             },

--- a/optimize_versioned_sidebars/version-3.11.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.11.0-sidebars.json
@@ -130,7 +130,7 @@
             },
             {
               "type": "link",
-              "label": "Usage Alerts",
+              "label": "Usage alerts",
               "href": "/docs/components/console/manage-organization/usage-alerts/"
             },
             {
@@ -145,7 +145,7 @@
             },
             {
               "type": "link",
-              "label": "Connect your IDP with Camunda",
+              "label": "Connect your IdP with Camunda",
               "href": "/docs/components/console/manage-organization/external-sso/"
             },
             {
@@ -184,7 +184,7 @@
             },
             {
               "type": "link",
-              "label": "Manage IP Whitelists",
+              "label": "Manage IP whitelists",
               "href": "/docs/components/console/manage-clusters/manage-ip-whitelists/"
             },
             {
@@ -230,6 +230,11 @@
               "type": "link",
               "label": "Cancel Starter plan subscription",
               "href": "/docs/components/console/manage-plan/cancel-starter-subscription/"
+            },
+            {
+              "type": "link",
+              "label": "Migrate from the Professional to the Starter plan",
+              "href": "/docs/components/console/manage-plan/migrate-from-prof-to-starter/"
             }
           ]
         },
@@ -740,6 +745,11 @@
                   "type": "link",
                   "label": "Functions",
                   "href": "/docs/components/modeler/feel/language-guide/feel-functions/"
+                },
+                {
+                  "type": "link",
+                  "label": "Error handling",
+                  "href": "/docs/components/modeler/feel/language-guide/feel-error-handling/"
                 }
               ]
             },
@@ -1058,9 +1068,18 @@
               "href": "/docs/components/connectors/out-of-the-box-connectors/kafka/"
             },
             {
-              "type": "link",
-              "label": "Microsoft Teams Connector",
-              "href": "/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/"
+              "Microsoft": [
+                {
+                  "type": "link",
+                  "label": "Microsoft Teams Connector",
+                  "href": "/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/"
+                },
+                {
+                  "type": "link",
+                  "label": "Microsoft 365 Connector",
+                  "href": "/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail/"
+                }
+              ]
             },
             {
               "type": "link",
@@ -1118,11 +1137,6 @@
           "Protocol Connectors": [
             {
               "type": "link",
-              "label": "REST Connector",
-              "href": "/docs/components/connectors/protocol/rest/"
-            },
-            {
-              "type": "link",
               "label": "GraphQL Connector",
               "href": "/docs/components/connectors/protocol/graphql/"
             },
@@ -1134,7 +1148,12 @@
             {
               "type": "link",
               "label": "HTTP Polling Connector",
-              "href": "/docs/components/connectors/protocol/polling"
+              "href": "/docs/components/connectors/protocol/polling/"
+            },
+            {
+              "type": "link",
+              "label": "REST Connector",
+              "href": "/docs/components/connectors/protocol/rest/"
             }
           ]
         },
@@ -1297,13 +1316,18 @@
             },
             {
               "type": "link",
-              "label": "Giving feedback and asking questions",
-              "href": "/docs/components/operate/userguide/operate-feedback-and-questions/"
+              "label": "Delete resources",
+              "href": "/docs/components/operate/userguide/delete-resources/"
             },
             {
               "type": "link",
               "label": "Process instance modification",
               "href": "/docs/components/operate/userguide/process-instance-modification/"
+            },
+            {
+              "type": "link",
+              "label": "Giving feedback and asking questions",
+              "href": "/docs/components/operate/userguide/operate-feedback-and-questions/"
             }
           ]
         }


### PR DESCRIPTION
## Description

Pre-work for #3151.

Synchronizes sidebars for the 8.3/3.11.0 versions of the docs.

## Not included

Synchronization for versions 1.3, 8.1, 8.2, or next.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule. Required for a release next week.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
