### PR TITLE
Update naming-technically-relevant-ids.md

### DIFF
--- a/versioned_docs/version-8.3/components/best-practices/modeling/naming-technically-relevant-ids.md
+++ b/versioned_docs/version-8.3/components/best-practices/modeling/naming-technically-relevant-ids.md
@@ -17,7 +17,7 @@ Examine the IDs shown in the following example:
 
 <div bpmn="best-practices/naming-technically-relevant-ids-assets/TweetApprovalProcess.bpmn" callouts="Participant_TweetApproval,StartEvent_NewTweetWritten,Task_ReviewTweet,Gateway_TweetApproved,SequenceFlow_ApprovedNo,BoundaryEvent_TweetDuplicated,EndEvent_TweetPublished" />
 
-The following table provides you with a guideline that we would use in a context where developers are comfortable with _Java_ and its typical _camelCase_ naming style. You may adapt these suggestions to typical naming conventions used in your programming context.
+The following table provides you with a guideline that we would use in a context where developers are comfortable with _Java_ and _PascalCase_ naming style. You may adapt these suggestions to typical naming conventions used in your programming context.
 
 |       |                   | XML Attribute        | Prefix or Suffix | Resulting ID                  |
 | ----- | ----------------- | -------------------- | ---------------- | ----------------------------- |


### PR DESCRIPTION
## Description

The Consulting team recommends using PascalCase and follows the [table](https://camunda.slack.com/archives/C0589TC88UU/p1704455580711979?thread_ts=1699019041.707659&cid=C0589TC88UU), but the description mentions camelCase

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
