### PR TITLE
fix: update incorrect link target

### DIFF
--- a/docs/apis-tools/go-client/job-worker.md
+++ b/docs/apis-tools/go-client/job-worker.md
@@ -50,7 +50,7 @@ The retry delay (i.e. the time the job worker waits after an error before the ne
 
 By default, the job worker uses an exponential backoff implementation, which you can configure by making your own [`ExponentialBackoffSupplier`](https://github.com/camunda/zeebe/blob/main/clients/go/pkg/worker/exponentialBackoffSupplier.go).
 
-The backoff strategy is especially useful for dealing with the `GRPC_STATUS_RESOURCE_EXHAUSTED` error response (refer to [gRPC technical error handling](/apis-tools/grpc.md#technical-error-handling)).
+The backoff strategy is especially useful for dealing with the `GRPC_STATUS_RESOURCE_EXHAUSTED` error response (refer to [gRPC technical error handling](/apis-tools/zeebe-api/technical-error-handling.md)).
 
 This error code indicates the Zeebe cluster is currently under too large of a load and has decided to reject this request.
 


### PR DESCRIPTION
## Description

This PR fixes `main`, which is currently not building.

#3150 and #3095 crossed streams during merge -- 3150 reorganized files, one of which 3095 was linking to....after 3150 merged, 3095 didn't update from main, and we ended up merging in a broken link. No one did anything wrong, it was just bad timing!

This PR corrects the link target that was failing the build.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern. It fixes the broken build.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
