### PR TITLE
feat(announcements): add known limitations section

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -38,6 +38,27 @@ As of the 8.4 release, Zeebe, Operate, and Tasklist are now compatible with [Ama
 The Helm charts are not yet prepared with the OpenSearch configurations as templates/pre-filled. The Helm charts can still be used to install for OpenSearch, but some adjustments are needed beforehand. Refer to the [Helm deployment documentation](/self-managed/platform-deployment/helm-kubernetes/deploy.md) for further details.
 :::
 
+### Known limitations
+
+This release contains the following limitations:
+
+- In **Operate `8.4.0`**
+  - **Bug**
+    - **Description:** Instance migration always points to the latest process version
+    - **Reference:** https://github.com/camunda/operate/issues/6091
+    - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
+  - **Bug**
+    - **Description:** Backwards migration over multiple versions does not work
+    - **Reference:** https://github.com/camunda/operate/issues/6089
+    - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
+- In **Camunda HELM `9.0.0`**
+  - **Limitation**
+    - **Description:** The existing Helm charts use the Elasticsearch configurations by default and are not yet prepared with the OpenSearch configurations as templates/pre-filled. The Helm charts can still be used to install for OpenSearch, but some adjustments are needed beforehand.
+    - **Reference:** n/a
+    - **Mitigation:**
+      1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration
+      2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases
+
 ## Camunda 8.3
 
 Release date: 10th of October 2023

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -45,11 +45,11 @@ This release contains the following limitations:
 - In **Operate `8.4.0`**
   - **Bug**
     - **Description:** Instance migration always points to the latest process version
-    - **Reference:** https://github.com/camunda/operate/issues/6091
+    - **Reference:** https://github.com/camunda/issues/issues/567
     - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
   - **Bug**
     - **Description:** Backwards migration over multiple versions does not work
-    - **Reference:** https://github.com/camunda/operate/issues/6089
+    - **Reference:** https://github.com/camunda/issues/issues/568
     - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
 - In **Camunda HELM `9.0.0`**
   - **Limitation**

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -56,15 +56,15 @@ This release contains the following limitations:
     - **Description:** The existing Helm charts use the Elasticsearch configurations by default and are not yet prepared with the OpenSearch configurations as templates/pre-filled. The Helm charts can still be used to install for OpenSearch, but some adjustments are needed beforehand.
     - **Reference:** n/a
     - **Mitigation:**
-      1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration
-      2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases
+      1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration.
+      2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases.
 - In **Connectors `8.4.0`**
   - **Missing feature**
     - **Description:** Custom OIDC provider support for Connectors is missing
     - **Reference:** https://github.com/camunda/issues/issues/569
     - **Mitigation:**
-      1. Feature is planned to be delivered with upcoming `8.4.1` release
-      2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider
+      1. Feature is planned to be delivered with upcoming `8.4.1` release.
+      2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider.
 
 ## Camunda 8.3
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -58,6 +58,13 @@ This release contains the following limitations:
     - **Mitigation:**
       1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration
       2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases
+- In **Connectors `8.4.0`**
+  - **Missing feature**
+    - **Description:** Custom OIDC provider support for Connectors is missing
+    - **Reference:** https://github.com/camunda/issues/issues/569
+    - **Mitigation:**
+      1. Feature is planned to be delivered with upcoming `8.4.1` release
+      2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider
 
 ## Camunda 8.3
 

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -38,6 +38,27 @@ As of the 8.4 release, Zeebe, Operate, and Tasklist are now compatible with [Ama
 The Helm charts are not yet prepared with the OpenSearch configurations as templates/pre-filled. The Helm charts can still be used to install for OpenSearch, but some adjustments are needed beforehand. Refer to the [Helm deployment documentation](/self-managed/platform-deployment/helm-kubernetes/deploy.md) for further details.
 :::
 
+### Known limitations
+
+This release contains the following limitations:
+
+- In **Operate `8.4.0`**
+  - **Bug**
+    - **Description:** Instance migration always points to the latest process version
+    - **Reference:** https://github.com/camunda/operate/issues/6091
+    - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
+  - **Bug**
+    - **Description:** Backwards migration over multiple versions does not work
+    - **Reference:** https://github.com/camunda/operate/issues/6089
+    - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
+- In **Camunda HELM `9.0.0`**
+  - **Limitation**
+    - **Description:** The existing Helm charts use the Elasticsearch configurations by default and are not yet prepared with the OpenSearch configurations as templates/pre-filled. The Helm charts can still be used to install for OpenSearch, but some adjustments are needed beforehand.
+    - **Reference:** n/a
+    - **Mitigation:**
+      1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration
+      2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases
+
 ## Camunda 8.3
 
 Release date: 10th of October 2023

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -45,11 +45,11 @@ This release contains the following limitations:
 - In **Operate `8.4.0`**
   - **Bug**
     - **Description:** Instance migration always points to the latest process version
-    - **Reference:** https://github.com/camunda/operate/issues/6091
+    - **Reference:** https://github.com/camunda/issues/issues/567
     - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
   - **Bug**
     - **Description:** Backwards migration over multiple versions does not work
-    - **Reference:** https://github.com/camunda/operate/issues/6089
+    - **Reference:** https://github.com/camunda/issues/issues/568
     - **Mitigation:** Bug is planned to be fixed with upcoming `8.4.1` release
 - In **Camunda HELM `9.0.0`**
   - **Limitation**

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -56,15 +56,15 @@ This release contains the following limitations:
     - **Description:** The existing Helm charts use the Elasticsearch configurations by default and are not yet prepared with the OpenSearch configurations as templates/pre-filled. The Helm charts can still be used to install for OpenSearch, but some adjustments are needed beforehand.
     - **Reference:** n/a
     - **Mitigation:**
-      1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration
-      2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases
+      1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration.
+      2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases.
 - In **Connectors `8.4.0`**
   - **Missing feature**
     - **Description:** Custom OIDC provider support for Connectors is missing
     - **Reference:** https://github.com/camunda/issues/issues/569
     - **Mitigation:**
-      1. Feature is planned to be delivered with upcoming `8.4.1` release
-      2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider
+      1. Feature is planned to be delivered with upcoming `8.4.1` release.
+      2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider.
 
 ## Camunda 8.3
 

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -58,6 +58,13 @@ This release contains the following limitations:
     - **Mitigation:**
       1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration
       2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases
+- In **Connectors `8.4.0`**
+  - **Missing feature**
+    - **Description:** Custom OIDC provider support for Connectors is missing
+    - **Reference:** https://github.com/camunda/issues/issues/569
+    - **Mitigation:**
+      1. Feature is planned to be delivered with upcoming `8.4.1` release
+      2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider
 
 ## Camunda 8.3
 


### PR DESCRIPTION
## Description

* This PR adds a section about known limiations to annoucements
* The idea is to ensure that customer can discover centrally, what we know about limitations of certain releases
* The idea would be to use this as a standard section within announcements going forward

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
