### PR TITLE
docs(call activity): add `propagateAllParentVariables`

### DIFF
--- a/docs/components/modeler/bpmn/call-activities/call-activities.md
+++ b/docs/components/modeler/bpmn/call-activities/call-activities.md
@@ -32,13 +32,19 @@ When a non-interrupting boundary event is triggered, the created process instanc
 
 ## Variable mappings
 
-When the call activity is activated, all variables of the call activity scope are copied to the created process instance.
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created process instance.
 
 If the attribute `propagateAllChildVariables` is set (default: `true`), all variables of the created process instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity and only those variables that are defined in the output mappings are propagated.
 
 It's recommended to disable the attribute `propagateAllChildVariables` or define output mappings if the call activity is in a parallel flow (e.g. when it is marked as [parallel multi-instance](../multi-instance/multi-instance.md#variable-mappings)). Otherwise, variables can be accidentally overridden when they are changed in the parallel flow.
+
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 ## Additional resources
 
@@ -51,6 +57,19 @@ A call activity with static process id and propagation of all child variables tu
   <bpmn:extensionElements>
     <zeebe:calledElement processId="child-process-a" propagateAllChildVariables="true" />
   </bpmn:extensionElements>
+</bpmn:callActivity>
+```
+
+A call activity with copying of all variables to the child process turned off:
+
+```xml
+<bpmn:callActivity id="Call_Activity" name="Call Process A">
+    <bpmn:extensionElements>
+        <zeebe:calledElement processId="child-process-id" propagateAllParentVariables="false" />
+        <zeebe:ioMapping>
+            <zeebe:input source="=variableValue" target="variableName" />
+        </zeebe:ioMapping>
+    </bpmn:extensionElements>
 </bpmn:callActivity>
 ```
 

--- a/versioned_docs/version-8.2/components/modeler/bpmn/call-activities/call-activities.md
+++ b/versioned_docs/version-8.2/components/modeler/bpmn/call-activities/call-activities.md
@@ -32,7 +32,9 @@ When a non-interrupting boundary event is triggered, the created process instanc
 
 ## Variable mappings
 
-When the call activity is activated, all variables of the call activity scope are copied to the created process instance.
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created process instance.
 
@@ -51,6 +53,19 @@ A call activity with static process id and propagation of all child variables tu
   <bpmn:extensionElements>
     <zeebe:calledElement processId="child-process-a" propagateAllChildVariables="true" />
   </bpmn:extensionElements>
+</bpmn:callActivity>
+```
+
+A call activity with copying of all variables to the child process turned off:
+
+```xml
+<bpmn:callActivity id="Call_Activity" name="Call Process A">
+    <bpmn:extensionElements>
+        <zeebe:calledElement processId="child-process-id" propagateAllParentVariables="false" />
+        <zeebe:ioMapping>
+            <zeebe:input source="=variableValue" target="variableName" />
+        </zeebe:ioMapping>
+    </bpmn:extensionElements>
 </bpmn:callActivity>
 ```
 

--- a/versioned_docs/version-8.3/components/modeler/bpmn/call-activities/call-activities.md
+++ b/versioned_docs/version-8.3/components/modeler/bpmn/call-activities/call-activities.md
@@ -32,13 +32,19 @@ When a non-interrupting boundary event is triggered, the created process instanc
 
 ## Variable mappings
 
-When the call activity is activated, all variables of the call activity scope are copied to the created process instance.
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created process instance.
 
 If the attribute `propagateAllChildVariables` is set (default: `true`), all variables of the created process instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity and only those variables that are defined in the output mappings are propagated.
 
 It's recommended to disable the attribute `propagateAllChildVariables` or define output mappings if the call activity is in a parallel flow (e.g. when it is marked as [parallel multi-instance](../multi-instance/multi-instance.md#variable-mappings)). Otherwise, variables can be accidentally overridden when they are changed in the parallel flow.
+
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 ## Additional resources
 
@@ -51,6 +57,19 @@ A call activity with static process id and propagation of all child variables tu
   <bpmn:extensionElements>
     <zeebe:calledElement processId="child-process-a" propagateAllChildVariables="true" />
   </bpmn:extensionElements>
+</bpmn:callActivity>
+```
+
+A call activity with copying of all variables to the child process turned off:
+
+```xml
+<bpmn:callActivity id="Call_Activity" name="Call Process A">
+    <bpmn:extensionElements>
+        <zeebe:calledElement processId="child-process-id" propagateAllParentVariables="false" />
+        <zeebe:ioMapping>
+            <zeebe:input source="=variableValue" target="variableName" />
+        </zeebe:ioMapping>
+    </bpmn:extensionElements>
 </bpmn:callActivity>
 ```
 

--- a/versioned_docs/version-8.4/components/modeler/bpmn/call-activities/call-activities.md
+++ b/versioned_docs/version-8.4/components/modeler/bpmn/call-activities/call-activities.md
@@ -32,13 +32,19 @@ When a non-interrupting boundary event is triggered, the created process instanc
 
 ## Variable mappings
 
-When the call activity is activated, all variables of the call activity scope are copied to the created process instance.
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created process instance.
 
 If the attribute `propagateAllChildVariables` is set (default: `true`), all variables of the created process instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity and only those variables that are defined in the output mappings are propagated.
 
 It's recommended to disable the attribute `propagateAllChildVariables` or define output mappings if the call activity is in a parallel flow (e.g. when it is marked as [parallel multi-instance](../multi-instance/multi-instance.md#variable-mappings)). Otherwise, variables can be accidentally overridden when they are changed in the parallel flow.
+
+By default, all variables of the call activity scope are copied to the created process instance. This can be limited to copying only the local variables of the call activity, by setting the attribute `propagateAllParentVariables` to `false`.
+
+By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
 ## Additional resources
 
@@ -51,6 +57,19 @@ A call activity with static process id and propagation of all child variables tu
   <bpmn:extensionElements>
     <zeebe:calledElement processId="child-process-a" propagateAllChildVariables="true" />
   </bpmn:extensionElements>
+</bpmn:callActivity>
+```
+
+A call activity with copying of all variables to the child process turned off:
+
+```xml
+<bpmn:callActivity id="Call_Activity" name="Call Process A">
+    <bpmn:extensionElements>
+        <zeebe:calledElement processId="child-process-id" propagateAllParentVariables="false" />
+        <zeebe:ioMapping>
+            <zeebe:input source="=variableValue" target="variableName" />
+        </zeebe:ioMapping>
+    </bpmn:extensionElements>
 </bpmn:callActivity>
 ```
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

closes: #2979 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
