### PR TITLE
console-webhook-alerts: HEAD is now optional again

### DIFF
--- a/docs/components/console/manage-clusters/manage-alerts.md
+++ b/docs/components/console/manage-clusters/manage-alerts.md
@@ -27,7 +27,7 @@ To create a new alert, take the following steps:
 
 4. If you select **Email**, click **Create**. No further information is needed. For **Webhook**, complete the additional steps below.
 
-5. To create a webhook alert, provide a valid webhook URL that accepts `POST` and `HEAD` requests.
+5. To create a webhook alert, provide a valid webhook URL that accepts `POST` requests.
 
 If your webhook requires [HMAC authentication](https://www.okta.com/identity-101/hmac/), you can specify an HMAC secret. The SHA-256 hash of the request body will then be generated using your HMAC secret, and it is included it in the HTTP header `X-Camunda-Signature-256` each time we send out a webhook alert to your endpoint.
 

--- a/versioned_docs/version-8.4/components/console/manage-clusters/manage-alerts.md
+++ b/versioned_docs/version-8.4/components/console/manage-clusters/manage-alerts.md
@@ -27,7 +27,7 @@ To create a new alert, take the following steps:
 
 4. If you select **Email**, click **Create**. No further information is needed. For **Webhook**, complete the additional steps below.
 
-5. To create a webhook alert, provide a valid webhook URL that accepts `POST` and `HEAD` requests.
+5. To create a webhook alert, provide a valid webhook URL that accepts `POST` requests.
 
 If your webhook requires [HMAC authentication](https://www.okta.com/identity-101/hmac/), you can specify an HMAC secret. The SHA-256 hash of the request body will then be generated using your HMAC secret, and it is included it in the HTTP header `X-Camunda-Signature-256` each time we send out a webhook alert to your endpoint.
 


### PR DESCRIPTION
related to https://github.com/camunda-cloud/camunda-cloud-management-apps/issues/1946 - https://github.com/camunda/product-hub/issues/2007

change is already on production