### PR TITLE
fix: quiet down noisy console logs from determineCanonical

### DIFF
--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -107,7 +107,7 @@ function determineCanonicalFromDoc(currentDoc, currentPlugin) {
     .find((doc) => doc.id === unversionedId);
 
   if (match) {
-    if (/(optimize|docs)((next|[0-9\.]*)\/)/.test(match.path)) {
+    if (/(optimize|docs)\/((next|[0-9\.]+)\/)/.test(match.path)) {
       // This finds docs whose matches are non-latest versions.
       //  These docs would probably benefit from adding canonical frontmatter.
       console.log(


### PR DESCRIPTION
## Description

The `determineCanonicalFromDoc` function, which is run on pretty much every page in the docs to identify a canonical source for it, is spamming the build output. It also pollutes the dev tools with an inaccurate warning message on each page.

It turns out...I used an incorrect regular expression to identify pages who pointed canonically at something other than the current version 😅 😬 

This PR corrects that regular expression. The result should be a cleaner build output, and more accuracy on the warnings that remain.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
