### PR TITLE
fix(announcements): correct connector version reference

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -58,12 +58,12 @@ This release contains the following limitations:
     - **Mitigation:**
       1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration.
       2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases.
-- In **Connectors `8.4.0`**
+- In **Connectors `8.4.0` and `8.4.1`**
   - **Missing feature**
     - **Description:** Custom OIDC provider support for Connectors is missing
     - **Reference:** https://github.com/camunda/issues/issues/569
     - **Mitigation:**
-      1. Feature is planned to be delivered with upcoming `8.4.1` release.
+      1. Feature is planned to be delivered with an upcoming patch release. Please see [issue](https://github.com/camunda/issues/issues/569) for latest progress.
       2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider.
 
 ## Camunda 8.3

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -58,12 +58,12 @@ This release contains the following limitations:
     - **Mitigation:**
       1. Refer to our docs for the installation, the docs include guidance about necessary adjustments of the Helm chart configuration.
       2. The OpenSearch configuration in Helm charts will be provided in one of our future Helm releases.
-- In **Connectors `8.4.0`**
+- In **Connectors `8.4.0` and `8.4.1`**
   - **Missing feature**
     - **Description:** Custom OIDC provider support for Connectors is missing
     - **Reference:** https://github.com/camunda/issues/issues/569
     - **Mitigation:**
-      1. Feature is planned to be delivered with upcoming `8.4.1` release.
+      1. Feature is planned to be delivered with an upcoming patch release. Please see [issue](https://github.com/camunda/issues/issues/569) for latest progress.
       2. [Disable Connectors component](../self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md#configuration) when configuring a custom OIDC provider.
 
 ## Camunda 8.3


### PR DESCRIPTION
* We had to relaese 8.4.1 due to a high criticality bug. Hence the 8.4.1 mention is not correct anymore. This commit fixes that.

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
