### PR TITLE
Update CLA config to camundait user

### DIFF
--- a/howtos/configuration.md
+++ b/howtos/configuration.md
@@ -55,7 +55,7 @@ The container id sits in `./docusaurus.config.js`.
 
 ## CLA assistant
 
-The [CLA assistant](https://cla-assistant.io/) is a SAP-maintained tool for OSS projects. It uses a Gist file to host the CLA. A Gist file is associated with a personal or user account, so the Camunda CLA is hosted by @akeller via https://gist.github.com/akeller/14cb81f38748edb3f553bc447c218198.
+The [CLA assistant](https://cla-assistant.io/) is a SAP-maintained tool for OSS projects. It uses a Gist file to host the CLA. A Gist file is associated with a personal or user account, so the Camunda CLA is hosted by @camundait via cla_camunda.md (as referenced by other Camunda org projects).
 
 Logging into the CLA assistant UI via GitHub Auth appears to require re-authorization every time. In the CLA assistant UI, you can find the configuration for adding or updating the CLA, including a new Gist (the list only shows your personal Gists), excluding users, organizations, and bots, or updating the link to the Camunda Privacy Policy.
 


### PR DESCRIPTION
## Description

#2732 included a temporary adjustment where @akeller hosted the gist for the CLA. This has been fixed via https://github.com/camunda/developer-experience/issues/118#issuecomment-1768758672, but the documentation was not updated.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
