### PR TITLE
Remove POST only admonition for http webhook connector

### DIFF
--- a/docs/components/connectors/protocol/http-webhook.md
+++ b/docs/components/connectors/protocol/http-webhook.md
@@ -119,10 +119,6 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 Once you click the **Deploy** button, your HTTP Webhook will be activated and publicly available.
 You can trigger it by making a POST request to the generated URL.
 
-:::note
-HTTP Webhook Connector currently supports only POST requests.
-:::
-
 URLs of the exposed HTTP Webhooks adhere to the following pattern:
 
 `http(s)://<base URL>/inbound/<webhook ID>>`

--- a/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/http-webhook.md
@@ -119,10 +119,6 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 Once you click the **Deploy** button, your HTTP Webhook will be activated and publicly available.
 You can trigger it by making a POST request to the generated URL.
 
-:::note
-HTTP Webhook Connector currently supports only POST requests.
-:::
-
 URLs of the exposed HTTP Webhooks adhere to the following pattern:
 
 `http(s)://<base URL>/inbound/<webhook ID>>`

--- a/versioned_docs/version-8.4/components/connectors/protocol/http-webhook.md
+++ b/versioned_docs/version-8.4/components/connectors/protocol/http-webhook.md
@@ -119,10 +119,6 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 Once you click the **Deploy** button, your HTTP Webhook will be activated and publicly available.
 You can trigger it by making a POST request to the generated URL.
 
-:::note
-HTTP Webhook Connector currently supports only POST requests.
-:::
-
 URLs of the exposed HTTP Webhooks adhere to the following pattern:
 
 `http(s)://<base URL>/inbound/<webhook ID>>`


### PR DESCRIPTION
## Description

Remove admonition as http webhook connector supports GET, not just POST.

This may need further backporting, but I cannot find exactly when this was introduced.

Internal Slack thread - https://camunda.slack.com/archives/C0637A56SVD/p1704917832213219?thread_ts=1702497257.276749&cid=C0637A56SVD

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
