### PR TITLE
Backport tasklist data retention page

### DIFF
--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/data-retention.md
@@ -1,0 +1,53 @@
+---
+id: data-retention
+title: Data retention
+description: "Let's take a closer look at how Tasklist stores and archives data."
+---
+
+## How the data is stored and archived
+
+Tasklist imports data from Zeebe and stores it in Elasticsearch indices with a defined prefix (default: `tasklist`). Specifically, this includes the following:
+
+- Deployed processes, including the diagrams.
+- The state of process instances, including variables and flow nodes, activated within instance execution, incidents, etc.
+
+It additionally stores some Tasklist-specific data:
+
+- Operations performed by the user
+- List of users
+- Technical data, like the state of Zeebe import, etc.
+
+The data representing process instance state becomes immutable after the process instance is finished. Currently, the data may be archived, meaning it is moved to a dated index, e.g. `tasklist_variables_2020-01-01`, where date represents the date on which the given process instance was finished. The same is valid for user operations; after they are finished, the related data is moved to dated indices.
+
+:::note
+All Tasklist data present in Elasticsearch (from both **main** and **dated** indices) are visible from the UI.
+:::
+
+## Archive period
+
+The default time between a process instance finishing and being moved to a dated index is one hour. This can be modified by setting the [waitPeriodBeforeArchiving](importer-and-archiver.md#archive-period) configuration parameter.
+
+## Data cleanup
+
+In case of intensive Zeebe usage, the amount of data can grow significantly overtime. Therefore, you should consider the data cleanup strategy.
+
+Dated indices may be safely removed from Elasticsearch. "Safely" means only finished process instances are deleted together with all related data, and the rest of the data stays consistent. You can use Elasticsearch Curator or other tools/scripts to delete old data.
+
+Users updating from Elasticsearch 7 to Elasticsearch 8 will encounter issues with the Elasticsearch Curator. To resolve this, Tasklist allows configuring an Index Lifecycle Management (ILM) Policy using the `archiver` configuration options:
+
+### Snippet from application.yml
+
+```yaml
+camunda.tasklist:
+  archiver:
+    ilmEnabled: true
+    ilmMinAgeForDeleteArchivedIndices: 30d
+```
+
+`ilmMinAgeForDeleteArchivedIndices` defines the duration for which archived data will be stored before deletion. The values use [Elasticsearch TimeUnit format](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units).
+
+This ILM Policy works on Elasticsearch 7 as well, and can function as a replacement for the Elasticsearch Curator.
+
+:::note
+Only indices containing dates in their suffix may be deleted.
+:::

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -1,0 +1,112 @@
+---
+id: importer-and-archiver
+title: Importer and archiver
+description: "Let's analyze how Tasklist is organized by modules to import and archive data."
+---
+
+Tasklist consists of three modules:
+
+- **Web app**: Contains the UI and operation executor functionality.
+- **Importer**: Responsible for importing data from Zeebe.
+- **Archiver**: Responsible for archiving "old" data (finished process instances and user operations.) See [data retention](data-retention.md).
+
+## Configuration
+
+Modules can be run together or separately in any combination and can be scaled. When you run a Tasklist instance, by default, all modules are enabled. To disable them, use the following configuration parameters:
+
+| Configuration parameter          | Description                            | Default value |
+| -------------------------------- | -------------------------------------- | ------------- |
+| camunda.tasklist.importerEnabled | When true, Importer module is enabled. | True          |
+| camunda.tasklist.archiverEnabled | When true, Archiver module is enabled. | True          |
+| camunda.tasklist.webappEnabled   | When true, Webapp module is enabled.   | True          |
+
+## Scaling
+
+Additionally, you can have several importer and archiver nodes to increase throughput. Internally, they will spread their work based on Zeebe partitions.
+
+For example, if your Zeebe runs 10 partitions and you configure two importer nodes, they will import data from five partitions each.
+
+Each single importer/archiver node must be configured using the following configuration parameters:
+
+| Configuration parameter                    | Description                                                                            | Default value                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| camunda.tasklist.clusterNode.partitionIds  | Array of Zeebe partition ids this importer (or archiver) node must be responsible for. | Empty array, meaning all partitions data is loaded. |
+| camunda.tasklist.clusterNode.nodeCount     | Total amount of Importer (or archiver) nodes in the cluster.                           | 1                                                   |
+| camunda.tasklist.clusterNode.currentNodeId | Id of current Importer (or archiver) node, starting from 0.                            | 0                                                   |
+
+It's enough to configure either `partitionIds` or a pair of `nodeCount` and `currentNodeId`. If you provide `nodeCount` and `currentNodeId`, each node will automatically guess the Zeebe partitions they're responsible for.
+
+:::note
+`nodeCount` always represents the number of nodes of one specific type.
+:::
+
+For example, the configuration of a cluster with one web app node, two importer nodes, and one archiver node could look like the following:
+
+```
+Webapp node
+
+camunda.tasklist:
+  archiverEnabled: false
+  importerEnabled: false
+  #other configuration...
+
+Importer node #1
+
+camunda.tasklist:
+  archiverEnabled: false
+  webappEnabled: false
+  clusterNode:
+    nodeCount: 2
+    currentNodeId: 0
+  #other configuration...
+
+Importer node #2
+
+camunda.tasklist:
+  archiverEnabled: false
+  webappEnabled: false
+  clusterNode:
+    nodeCount: 2
+    currentNodeId: 1
+  #other configuration...
+
+Archiver node
+
+camunda.tasklist:
+  webappEnabled: false
+  importerEnabled: false
+
+```
+
+You can further parallelize archiver and/or importer within one node using the following configuration parameters:
+
+| Configuration parameter                | Description                                       | Default value |
+| -------------------------------------- | ------------------------------------------------- | ------------- |
+| camunda.tasklist.archiver.threadsCount | Number of threads in which data will be archived. | 1             |
+| camunda.tasklist.importer.threadsCount | Number of threads in which data will be imported. | 3             |
+
+:::note
+Parallelization of import and archiving within one node will also happen based on Zeebe partitions, meaning only configurations with (number of nodes) \* (threadsCount) <= (total number of Zeebe partitions) will make sense. Too many threads and nodes will still work, but some of them will be idle.
+:::
+
+## Archive period
+
+The time between a process instance finishing and being archived can be set using the following configuration parameter:
+
+| Configuration parameter                             | Description                                  | Default value |
+| --------------------------------------------------- | -------------------------------------------- | ------------- |
+| camunda.tasklist.archiver.waitPeriodBeforeArchiving | Amount of time before data will be archived. | 1h            |
+
+By default, the archive period is set to "1h" (one hour). This means the data for the finished process instances will be kept in the "main" index for one hour after the process instance has finished, and then it will be moved to a "dated" index.
+
+The syntax for the parameter uses Elasticsearch date math. See the table below for reference:
+
+| Value | Description |
+| ----- | ----------- |
+| y     | Years       |
+| M     | Months      |
+| w     | Weeks       |
+| d     | Days        |
+| h     | Hours       |
+| m     | Minutes     |
+| s     | Seconds     |

--- a/versioned_docs/version-8.3/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.3/self-managed/tasklist-deployment/data-retention.md
@@ -1,0 +1,53 @@
+---
+id: data-retention
+title: Data retention
+description: "Let's take a closer look at how Tasklist stores and archives data."
+---
+
+## How the data is stored and archived
+
+Tasklist imports data from Zeebe and stores it in Elasticsearch indices with a defined prefix (default: `tasklist`). Specifically, this includes the following:
+
+- Deployed processes, including the diagrams.
+- The state of process instances, including variables and flow nodes, activated within instance execution, incidents, etc.
+
+It additionally stores some Tasklist-specific data:
+
+- Operations performed by the user
+- List of users
+- Technical data, like the state of Zeebe import, etc.
+
+The data representing process instance state becomes immutable after the process instance is finished. Currently, the data may be archived, meaning it is moved to a dated index, e.g. `tasklist_variables_2020-01-01`, where date represents the date on which the given process instance was finished. The same is valid for user operations; after they are finished, the related data is moved to dated indices.
+
+:::note
+All Tasklist data present in Elasticsearch (from both **main** and **dated** indices) are visible from the UI.
+:::
+
+## Archive period
+
+The default time between a process instance finishing and being moved to a dated index is one hour. This can be modified by setting the [waitPeriodBeforeArchiving](importer-and-archiver.md#archive-period) configuration parameter.
+
+## Data cleanup
+
+In case of intensive Zeebe usage, the amount of data can grow significantly overtime. Therefore, you should consider the data cleanup strategy.
+
+Dated indices may be safely removed from Elasticsearch. "Safely" means only finished process instances are deleted together with all related data, and the rest of the data stays consistent. You can use Elasticsearch Curator or other tools/scripts to delete old data.
+
+Users updating from Elasticsearch 7 to Elasticsearch 8 will encounter issues with the Elasticsearch Curator. To resolve this, Tasklist allows configuring an Index Lifecycle Management (ILM) Policy using the `archiver` configuration options:
+
+### Snippet from application.yml
+
+```yaml
+camunda.tasklist:
+  archiver:
+    ilmEnabled: true
+    ilmMinAgeForDeleteArchivedIndices: 30d
+```
+
+`ilmMinAgeForDeleteArchivedIndices` defines the duration for which archived data will be stored before deletion. The values use [Elasticsearch TimeUnit format](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#time-units).
+
+This ILM Policy works on Elasticsearch 7 as well, and can function as a replacement for the Elasticsearch Curator.
+
+:::note
+Only indices containing dates in their suffix may be deleted.
+:::

--- a/versioned_docs/version-8.3/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.3/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -1,0 +1,112 @@
+---
+id: importer-and-archiver
+title: Importer and archiver
+description: "Let's analyze how Tasklist is organized by modules to import and archive data."
+---
+
+Tasklist consists of three modules:
+
+- **Web app**: Contains the UI and operation executor functionality.
+- **Importer**: Responsible for importing data from Zeebe.
+- **Archiver**: Responsible for archiving "old" data (finished process instances and user operations.) See [data retention](data-retention.md).
+
+## Configuration
+
+Modules can be run together or separately in any combination and can be scaled. When you run a Tasklist instance, by default, all modules are enabled. To disable them, use the following configuration parameters:
+
+| Configuration parameter          | Description                            | Default value |
+| -------------------------------- | -------------------------------------- | ------------- |
+| camunda.tasklist.importerEnabled | When true, Importer module is enabled. | True          |
+| camunda.tasklist.archiverEnabled | When true, Archiver module is enabled. | True          |
+| camunda.tasklist.webappEnabled   | When true, Webapp module is enabled.   | True          |
+
+## Scaling
+
+Additionally, you can have several importer and archiver nodes to increase throughput. Internally, they will spread their work based on Zeebe partitions.
+
+For example, if your Zeebe runs 10 partitions and you configure two importer nodes, they will import data from five partitions each.
+
+Each single importer/archiver node must be configured using the following configuration parameters:
+
+| Configuration parameter                    | Description                                                                            | Default value                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| camunda.tasklist.clusterNode.partitionIds  | Array of Zeebe partition ids this importer (or archiver) node must be responsible for. | Empty array, meaning all partitions data is loaded. |
+| camunda.tasklist.clusterNode.nodeCount     | Total amount of Importer (or archiver) nodes in the cluster.                           | 1                                                   |
+| camunda.tasklist.clusterNode.currentNodeId | Id of current Importer (or archiver) node, starting from 0.                            | 0                                                   |
+
+It's enough to configure either `partitionIds` or a pair of `nodeCount` and `currentNodeId`. If you provide `nodeCount` and `currentNodeId`, each node will automatically guess the Zeebe partitions they're responsible for.
+
+:::note
+`nodeCount` always represents the number of nodes of one specific type.
+:::
+
+For example, the configuration of a cluster with one web app node, two importer nodes, and one archiver node could look like the following:
+
+```
+Webapp node
+
+camunda.tasklist:
+  archiverEnabled: false
+  importerEnabled: false
+  #other configuration...
+
+Importer node #1
+
+camunda.tasklist:
+  archiverEnabled: false
+  webappEnabled: false
+  clusterNode:
+    nodeCount: 2
+    currentNodeId: 0
+  #other configuration...
+
+Importer node #2
+
+camunda.tasklist:
+  archiverEnabled: false
+  webappEnabled: false
+  clusterNode:
+    nodeCount: 2
+    currentNodeId: 1
+  #other configuration...
+
+Archiver node
+
+camunda.tasklist:
+  webappEnabled: false
+  importerEnabled: false
+
+```
+
+You can further parallelize archiver and/or importer within one node using the following configuration parameters:
+
+| Configuration parameter                | Description                                       | Default value |
+| -------------------------------------- | ------------------------------------------------- | ------------- |
+| camunda.tasklist.archiver.threadsCount | Number of threads in which data will be archived. | 1             |
+| camunda.tasklist.importer.threadsCount | Number of threads in which data will be imported. | 3             |
+
+:::note
+Parallelization of import and archiving within one node will also happen based on Zeebe partitions, meaning only configurations with (number of nodes) \* (threadsCount) <= (total number of Zeebe partitions) will make sense. Too many threads and nodes will still work, but some of them will be idle.
+:::
+
+## Archive period
+
+The time between a process instance finishing and being archived can be set using the following configuration parameter:
+
+| Configuration parameter                             | Description                                  | Default value |
+| --------------------------------------------------- | -------------------------------------------- | ------------- |
+| camunda.tasklist.archiver.waitPeriodBeforeArchiving | Amount of time before data will be archived. | 1h            |
+
+By default, the archive period is set to "1h" (one hour). This means the data for the finished process instances will be kept in the "main" index for one hour after the process instance has finished, and then it will be moved to a "dated" index.
+
+The syntax for the parameter uses Elasticsearch date math. See the table below for reference:
+
+| Value | Description |
+| ----- | ----------- |
+| y     | Years       |
+| M     | Months      |
+| w     | Weeks       |
+| d     | Days        |
+| h     | Hours       |
+| m     | Minutes     |
+| s     | Seconds     |

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -1043,6 +1043,7 @@
       "Tasklist": [
         "self-managed/tasklist-deployment/install-and-start",
         "self-managed/tasklist-deployment/tasklist-configuration",
+        "self-managed/tasklist-deployment/data-retention",
         "self-managed/tasklist-deployment/tasklist-authentication",
         "self-managed/tasklist-deployment/usage-metrics"
       ],

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -1044,6 +1044,7 @@
         "self-managed/tasklist-deployment/install-and-start",
         "self-managed/tasklist-deployment/tasklist-configuration",
         "self-managed/tasklist-deployment/data-retention",
+        "self-managed/tasklist-deployment/importer-and-archiver",
         "self-managed/tasklist-deployment/tasklist-authentication",
         "self-managed/tasklist-deployment/usage-metrics"
       ],

--- a/versioned_sidebars/version-8.3-sidebars.json
+++ b/versioned_sidebars/version-8.3-sidebars.json
@@ -1125,6 +1125,7 @@
       "Tasklist": [
         "self-managed/tasklist-deployment/install-and-start",
         "self-managed/tasklist-deployment/tasklist-configuration",
+        "self-managed/tasklist-deployment/data-retention",
         "self-managed/tasklist-deployment/tasklist-authentication",
         "self-managed/tasklist-deployment/usage-metrics"
       ],

--- a/versioned_sidebars/version-8.3-sidebars.json
+++ b/versioned_sidebars/version-8.3-sidebars.json
@@ -1126,6 +1126,7 @@
         "self-managed/tasklist-deployment/install-and-start",
         "self-managed/tasklist-deployment/tasklist-configuration",
         "self-managed/tasklist-deployment/data-retention",
+        "self-managed/tasklist-deployment/importer-and-archiver",
         "self-managed/tasklist-deployment/tasklist-authentication",
         "self-managed/tasklist-deployment/usage-metrics"
       ],


### PR DESCRIPTION
## Description

Partially addresses feedback from https://github.com/camunda/product-gaps/issues/140.

~TODO: Should this page also be included in the backport? Or did the importer and archiver not exist? https://docs.camunda.io/docs/self-managed/tasklist-deployment/importer-and-archiver/#archive-period~

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
