### PR TITLE
Add guides link to what-is-identity

### DIFF
--- a/docs/self-managed/identity/what-is-identity.md
+++ b/docs/self-managed/identity/what-is-identity.md
@@ -12,7 +12,7 @@ Identity is the component within the Camunda 8 stack responsible for authenticat
 - Permissions
 - Roles
 
-You can use Identity for authentication and authorization with or without Keycloak. The following guidance can be used during platform installation and deployment:
+You can use Identity for authentication with Keycloak. The following guidance can be used during platform installation and deployment:
 
 - [Use existing Keycloak](/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md)
 - [Connect to an OIDC provider](/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md)

--- a/docs/self-managed/identity/what-is-identity.md
+++ b/docs/self-managed/identity/what-is-identity.md
@@ -12,6 +12,11 @@ Identity is the component within the Camunda 8 stack responsible for authenticat
 - Permissions
 - Roles
 
+You can use Identity for authentication and authorization with or without Keycloak. The following guidance can be used during platform installation and deployment:
+
+- [Use existing Keycloak](/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md)
+- [Connect to an OIDC provider](/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md)
+
 ### Next steps
 
 If you're new to Identity, we suggest reviewing our [getting started guide](./getting-started/install-identity.md).

--- a/versioned_docs/version-8.4/self-managed/identity/what-is-identity.md
+++ b/versioned_docs/version-8.4/self-managed/identity/what-is-identity.md
@@ -12,6 +12,11 @@ Identity is the component within the Camunda 8 stack responsible for authenticat
 - Permissions
 - Roles
 
+You can use Identity for authentication with Keycloak. The following guidance can be used during platform installation and deployment:
+
+- [Use existing Keycloak](/self-managed/platform-deployment/helm-kubernetes/guides/using-existing-keycloak.md)
+- [Connect to an OIDC provider](/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md)
+
 ### Next steps
 
 If you're new to Identity, we suggest reviewing our [getting started guide](./getting-started/install-identity.md).


### PR DESCRIPTION
## Description

Cross link deployment guides on What is Identity page. ~Will backport after initial review~

Related to https://camunda.slack.com/archives/C06112NS4GJ/p1705065758885659.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
