### PR TITLE
Remove rogue ::: in SM deploy

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -76,7 +76,6 @@ helm install camunda camunda/camunda-platform
 You can also add the `-n` flag to specify in which Kubernetes namespace the components should be installed.
 
 The command does not install Web Modeler by default. To enable Web Modeler, refer to the [installation instructions](#installing-web-modeler) below.
-:::
 
 Notice that this Kubernetes cluster can have services which are already running; Camunda components are simply installed as another set of services.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/deploy.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/deploy.md
@@ -76,7 +76,6 @@ helm install camunda camunda/camunda-platform
 You can also add the `-n` flag to specify in which Kubernetes namespace the components should be installed.
 
 The command does not install Web Modeler by default. To enable Web Modeler, refer to the [installation instructions](#installing-web-modeler) below.
-:::
 
 Notice that this Kubernetes cluster can have services which are already running; Camunda components are simply installed as another set of services.
 


### PR DESCRIPTION
## Description

Removes the rogue or extra ::: that looks like it was left after https://github.com/camunda/camunda-docs/commit/0ebba5ff4bcf902cf842faab33aa48fbc0c4e069#diff-f44dcc10786fc4c947fdcd613e96d4f7fd6e4f4fe460d972242d8043d215c796L64. 

If it makes sense to add this back, please do. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
