### PR TITLE
Clarify Optimize alerting (webhooks and email)

### DIFF
--- a/optimize/components/userguide/additional-features/alerts.md
+++ b/optimize/components/userguide/additional-features/alerts.md
@@ -4,10 +4,6 @@ title: Alerts
 description: Get a notification as soon as your system is behaving in an unexpected manner.
 ---
 
-:::note
-Alerting with webhooks is only available for Camunda 7.
-:::
-
 Optimize's alerting functionality can be used to notify you when your report hits a predefined critical value. You can create alerts for any number reports that exist within a collection.
 
 To configure an alert, take the following steps:
@@ -35,5 +31,9 @@ Finally, you'll get a resolve notification as soon as the report value is within
 ![Notifications graph](./img/alert-notifications-graph.png)
 
 ## Send alerts to external systems
+
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
 
 It's possible to configure Optimize to send alerts to an external system when needed. For details on how to configure and add target systems, visit the [technical guide](/self-managed/optimize-deployment/configuration/system-configuration.md#alert-notification-webhooks). Once at least one target system is configured, alerts will have a new input option to select one of the configured systems.

--- a/optimize/components/userguide/additional-features/alerts.md
+++ b/optimize/components/userguide/additional-features/alerts.md
@@ -4,6 +4,10 @@ title: Alerts
 description: Get a notification as soon as your system is behaving in an unexpected manner.
 ---
 
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
+
 Optimize's alerting functionality can be used to notify you when your report hits a predefined critical value. You can create alerts for any number reports that exist within a collection.
 
 To configure an alert, take the following steps:

--- a/optimize/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -205,6 +205,8 @@ Settings influencing the process digest feature.
 
 ### Alert notification webhooks
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 Settings for webhooks which can receive custom alert notifications. You can configure multiple webhooks which will be available to select from when creating or editing alerts. Each webhook configuration should have a unique human readable name which will appear in the Optimize UI.
 
 | YAML path                                                | Default value | Description                                                                                                                                                                                                                                         |

--- a/optimize/self-managed/optimize-deployment/configuration/webhooks.md
+++ b/optimize/self-managed/optimize-deployment/configuration/webhooks.md
@@ -4,6 +4,8 @@ title: "Webhooks"
 description: "Read about how to configure alert notification webhooks for alerts on custom systems."
 ---
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 In addition to email notifications, you can configure webhooks in Optimize to receive alert notifications on custom systems. This page describes how to set up your webhook configurations using the example of a simple Slack app.
 
 ## The alert webhook configuration

--- a/optimize_versioned_docs/version-3.10.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.10.0/components/userguide/additional-features/alerts.md
@@ -4,6 +4,14 @@ title: Alerts
 description: Get a notification as soon as your system is behaving in an unexpected manner.
 ---
 
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
+
+:::note
+Alerting via email not available in Camunda 8 Self-Managed.
+:::
+
 Optimize's alerting functionality can be used to notify you when your report hits a predefined critical value. You can create alerts for any number reports that exist within a collection.
 
 To configure an alert, take the following steps:

--- a/optimize_versioned_docs/version-3.10.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.10.0/components/userguide/additional-features/alerts.md
@@ -5,10 +5,6 @@ description: Get a notification as soon as your system is behaving in an unexpec
 ---
 
 :::note
-Alerting with webhooks is only available for Camunda 7.
-:::
-
-:::note
 Alerting via email not available in Camunda 8 Self-Managed.
 :::
 
@@ -39,5 +35,9 @@ Finally, you'll get a resolve notification as soon as the report value is within
 ![Notifications graph](./img/alert-notifications-graph.png)
 
 ## Send alerts to external systems
+
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
 
 It's possible to configure Optimize to send alerts to an external system when needed. For details on how to configure and add target systems, visit the [technical guide](/self-managed/optimize-deployment/configuration/system-configuration.md#alert-notification-webhooks). Once at least one target system is configured, alerts will have a new input option to select one of the configured systems.

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -205,6 +205,8 @@ Settings influencing the process digest feature.
 
 ### Alert Notification Webhooks
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 Settings for webhooks which can receive custom alert notifications. You can configure multiple webhooks which will be available to select from when creating or editing alerts. Each webhook configuration should have a unique human readable name which will appear in the Optimize UI.
 
 | YAML Path                                                | Default Value | Description                                                                                                                                                                                                                                         |

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/webhooks.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/webhooks.md
@@ -4,6 +4,8 @@ title: "Webhooks"
 description: "Read about how to configure alert notification webhooks for alerts on custom systems."
 ---
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 In addition to email notifications, you can configure webhooks in Optimize to receive alert notifications on custom systems. This page describes how to set up your webhook configurations using the example of a simple Slack app.
 
 ## The alert webhook configuration

--- a/optimize_versioned_docs/version-3.11.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.11.0/components/userguide/additional-features/alerts.md
@@ -4,6 +4,14 @@ title: Alerts
 description: Get a notification as soon as your system is behaving in an unexpected manner.
 ---
 
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
+
+:::note
+Alerting via email not available in Camunda 8 Self-Managed.
+:::
+
 Optimize's alerting functionality can be used to notify you when your report hits a predefined critical value. You can create alerts for any number reports that exist within a collection.
 
 To configure an alert, take the following steps:

--- a/optimize_versioned_docs/version-3.11.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.11.0/components/userguide/additional-features/alerts.md
@@ -5,10 +5,6 @@ description: Get a notification as soon as your system is behaving in an unexpec
 ---
 
 :::note
-Alerting with webhooks is only available for Camunda 7.
-:::
-
-:::note
 Alerting via email not available in Camunda 8 Self-Managed.
 :::
 
@@ -39,5 +35,9 @@ Finally, you'll get a resolve notification as soon as the report value is within
 ![Notifications graph](./img/alert-notifications-graph.png)
 
 ## Send alerts to external systems
+
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
 
 It's possible to configure Optimize to send alerts to an external system when needed. For details on how to configure and add target systems, visit the [technical guide](/self-managed/optimize-deployment/configuration/system-configuration.md#alert-notification-webhooks). Once at least one target system is configured, alerts will have a new input option to select one of the configured systems.

--- a/optimize_versioned_docs/version-3.11.0/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize_versioned_docs/version-3.11.0/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -205,6 +205,8 @@ Settings influencing the process digest feature.
 
 ### Alert Notification Webhooks
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 Settings for webhooks which can receive custom alert notifications. You can configure multiple webhooks which will be available to select from when creating or editing alerts. Each webhook configuration should have a unique human readable name which will appear in the Optimize UI.
 
 | YAML Path                                                | Default Value | Description                                                                                                                                                                                                                                         |

--- a/optimize_versioned_docs/version-3.11.0/self-managed/optimize-deployment/configuration/webhooks.md
+++ b/optimize_versioned_docs/version-3.11.0/self-managed/optimize-deployment/configuration/webhooks.md
@@ -4,6 +4,8 @@ title: "Webhooks"
 description: "Read about how to configure alert notification webhooks for alerts on custom systems."
 ---
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 In addition to email notifications, you can configure webhooks in Optimize to receive alert notifications on custom systems. This page describes how to set up your webhook configurations using the example of a simple Slack app.
 
 ## The alert webhook configuration

--- a/optimize_versioned_docs/version-3.12.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.12.0/components/userguide/additional-features/alerts.md
@@ -32,4 +32,8 @@ Finally, you'll get a resolve notification as soon as the report value is within
 
 ## Send alerts to external systems
 
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
+
 It's possible to configure Optimize to send alerts to an external system when needed. For details on how to configure and add target systems, visit the [technical guide](/self-managed/optimize-deployment/configuration/system-configuration.md#alert-notification-webhooks). Once at least one target system is configured, alerts will have a new input option to select one of the configured systems.

--- a/optimize_versioned_docs/version-3.12.0/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize_versioned_docs/version-3.12.0/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -205,6 +205,8 @@ Settings influencing the process digest feature.
 
 ### Alert notification webhooks
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 Settings for webhooks which can receive custom alert notifications. You can configure multiple webhooks which will be available to select from when creating or editing alerts. Each webhook configuration should have a unique human readable name which will appear in the Optimize UI.
 
 | YAML path                                                | Default value | Description                                                                                                                                                                                                                                         |

--- a/optimize_versioned_docs/version-3.12.0/self-managed/optimize-deployment/configuration/webhooks.md
+++ b/optimize_versioned_docs/version-3.12.0/self-managed/optimize-deployment/configuration/webhooks.md
@@ -4,6 +4,8 @@ title: "Webhooks"
 description: "Read about how to configure alert notification webhooks for alerts on custom systems."
 ---
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 In addition to email notifications, you can configure webhooks in Optimize to receive alert notifications on custom systems. This page describes how to set up your webhook configurations using the example of a simple Slack app.
 
 ## The alert webhook configuration

--- a/optimize_versioned_docs/version-3.9.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.9.0/components/userguide/additional-features/alerts.md
@@ -4,6 +4,10 @@ title: Alerts
 description: Get a notification as soon as your system is behaving in an unexpected manner.
 ---
 
+:::note
+Alerting via email not available in Camunda 8 Self-Managed.
+:::
+
 Optimize's alerting functionality can be used to notify you when your report hits a predefined critical value. You can create alerts for any number reports that exist within a collection.
 
 To configure an alert, take the following steps:

--- a/optimize_versioned_docs/version-3.9.0/components/userguide/additional-features/alerts.md
+++ b/optimize_versioned_docs/version-3.9.0/components/userguide/additional-features/alerts.md
@@ -36,4 +36,8 @@ Finally, you'll get a resolve notification as soon as the report value is within
 
 ## Send alerts to external systems
 
+:::note
+Alerting with webhooks is only available for Camunda 7.
+:::
+
 It's possible to configure Optimize to send alerts to an external system when needed. For details on how to configure and add target systems, visit the [technical guide](/self-managed/optimize-deployment/configuration/system-configuration.md#alert-notification-webhooks). Once at least one target system is configured, alerts will have a new input option to select one of the configured systems.

--- a/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/system-configuration.md
+++ b/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/system-configuration.md
@@ -202,6 +202,8 @@ Settings influencing the process digest feature.
 
 ### Alert Notification Webhooks
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 Settings for webhooks which can receive custom alert notifications. You can configure multiple webhooks which will be available to select from when creating or editing alerts. Each webhook configuration should have a unique human readable name which will appear in the Optimize UI.
 
 | YAML Path                                                | Default Value | Description                                                                                                                                                                                                                                         |

--- a/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/webhooks.md
+++ b/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/webhooks.md
@@ -4,6 +4,8 @@ title: "Webhooks"
 description: "Read about how to configure alert notification webhooks for alerts on custom systems."
 ---
 
+<span class="badge badge--platform">Camunda 7 only</span>
+
 In addition to email notifications, you can configure webhooks in Optimize to receive alert notifications on custom systems. This page describes how to set up your webhook configurations using the example of a simple Slack app.
 
 ## The alert webhook configuration


### PR DESCRIPTION
## Description

Reported via #3205 by @nareshgoswami1508. I chose to over-document with both labels and admonitions for the most transparency possible. This does mean some pages have two admonitions at the top of the page.

Reviewers - please double check that the edits per version are correct. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented - reported by a customer
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
