### PR TITLE
Add indexSuffixDatePattern to ES exporter config

### DIFF
--- a/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
@@ -75,6 +75,7 @@ and process values).
 | ----------------------------- | ------------------------------------------------------------------------------------------------------- | ------------ |
 | prefix                        | This prefix will be appended to every index created by the exporter; must not contain `_` (underscore). | zeebe-record |
 | createTemplate                | If `true` missing indexes will be created automatically.                                                | `true`       |
+| indexSuffixDatePattern        | This suffix will be appended to every index created by the exporter; The pattern is based on the Java [DateTimeFormater](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html) and supports the same syntax. This is useful when indexes should be created in a different interval, like hourly instead of daily. | `"yyyy-MM-dd'"` |
 | command                       | If `true` command records will be exported                                                              | `false`      |
 | event                         | If `true` event records will be exported                                                                | `true`       |
 | rejection                     | If `true` rejection records will be exported                                                            | `false`      |
@@ -201,6 +202,8 @@ exporters:
       index:
         prefix: zeebe-record
         createTemplate: true
+
+        indexSuffixDatePattern: "yyyy-MM-dd"
 
         command: false
         event: true


### PR DESCRIPTION
## Description

Describe the new suffix pattern configuration, which allows to change the index suffixes

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
