### PR TITLE
Document new Zeebe broker health checks

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -14,7 +14,7 @@ The broker health check routes have moved, and the old routes are now deprecated
 
 | Old route                               | **New route**                                                 |
 | --------------------------------------- | ------------------------------------------------------------- |
-| http://{zeebe-broker-host}:9600/health  | **http://{zeebe-broker-host}:9600/actuator/health**           |
+| http://{zeebe-broker-host}:9600/health  | **http://{zeebe-broker-host}:9600/actuator/health/status**    |
 | http://{zeebe-broker-host}:9600/ready   | **http://{zeebe-broker-host}:9600/actuator/health/readiness** |
 | http://{zeebe-broker-host}:9600/startup | **http://{zeebe-broker-host}:9600/actuator/health/startup**   |
 

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -1,0 +1,21 @@
+---
+id: 840-to-850
+title: Update 8.4 to 8.5
+description: "Review which adjustments must be made to migrate from Camunda 8.4.x to Camunda 8.5.0."
+---
+
+The following sections explain which adjustments must be made to migrate from Camunda 8.4.x to 8.5.x for each component.
+
+## Zeebe
+
+### Deprecated broker health checks
+
+The broker health check routes have moved, and the old routes are now deprecated. Specifically, the following routes will return [a status code of 301](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) and redirect you. See the table below about the new mappings:
+
+| Old route                               | **New route**                                                 |
+| --------------------------------------- | ------------------------------------------------------------- |
+| http://{zeebe-broker-host}:9600/health  | **http://{zeebe-broker-host}:9600/actuator/health**           |
+| http://{zeebe-broker-host}:9600/ready   | **http://{zeebe-broker-host}:9600/actuator/health/readiness** |
+| http://{zeebe-broker-host}:9600/startup | **http://{zeebe-broker-host}:9600/actuator/health/startup**   |
+
+Please migrate to the new routes in your deployments. **If you're using the official Helm charts, then you don't have to do anything here.**

--- a/docs/self-managed/zeebe-deployment/operations/health.md
+++ b/docs/self-managed/zeebe-deployment/operations/health.md
@@ -14,8 +14,8 @@ Zeebe broker exposes three HTTP endpoints to query its health status:
 
 ### Startup check
 
-Startup check endpoint is exposed via `http://{zeebe-broker-host}:9600/startup`.
-This endpoint returns an empty 204 response. If it is not ready, it will return a 503 error.
+Startup check endpoint is exposed via `http://{zeebe-broker-host}:9600/actuator/health/startup`.
+This endpoint returns a 200 response. If it is not ready, it will return a 503 error.
 
 A broker has successfully started when:
 
@@ -28,8 +28,8 @@ The broker is ready only after startup has successfully completed.
 
 ### Ready check
 
-Ready check endpoint is exposed via `http://{zeebe-broker-host}:9600/ready`.
-This endpoint returns an empty 204 response. If it is not ready, it will return a 503 error.
+Ready check endpoint is exposed via `http://{zeebe-broker-host}:9600/actuator/health/readiness`.
+This endpoint returns a 200 response. If it is not ready, it will return a 503 error.
 
 A broker is ready when it installs all necessary services to start processing in all partitions.
 If a broker is ready, it doesn't mean it's the leader for the partitions.
@@ -42,8 +42,8 @@ By configuring a `readinessProbe` that uses the ready check endpoint, we can inf
 
 ### Health check
 
-Health check endpoint is exposed via `http://{zeebe-broker-host}:9600/health`.
-This endpoint returns an empty 204 response if the broker is healthy. If it is not healthy, it will return a 503 error.
+Health check endpoint is exposed via `http://{zeebe-broker-host}:9600/actuator/health`.
+This endpoint returns a 200 response if the broker is healthy. If it is not healthy, it will return a 503 error.
 A broker is never healthy before it is ready.
 Unlike ready check, a broker can become unhealthy after it is healthy.
 Hence, it gives a better status of a running broker.

--- a/docs/self-managed/zeebe-deployment/operations/health.md
+++ b/docs/self-managed/zeebe-deployment/operations/health.md
@@ -42,7 +42,7 @@ By configuring a `readinessProbe` that uses the ready check endpoint, we can inf
 
 ### Health check
 
-Health check endpoint is exposed via `http://{zeebe-broker-host}:9600/actuator/health`.
+Health check endpoint is exposed via `http://{zeebe-broker-host}:9600/actuator/health/status`.
 This endpoint returns a 200 response if the broker is healthy. If it is not healthy, it will return a 503 error.
 A broker is never healthy before it is ready.
 Unlike ready check, a broker can become unhealthy after it is healthy.

--- a/sidebars.js
+++ b/sidebars.js
@@ -853,6 +853,7 @@ module.exports = {
             id: "self-managed/operational-guides/update-guide/introduction",
           },
           items: [
+            "self-managed/operational-guides/update-guide/840-to-850",
             "self-managed/operational-guides/update-guide/830-to-840",
             "self-managed/operational-guides/update-guide/820-to-830",
             "self-managed/operational-guides/update-guide/810-to-820",


### PR DESCRIPTION
## Description

Documents the changes to the Zeebe broker health checks done in https://github.com/camunda/zeebe/pull/15913, namely:

- Routes are migrated to the health actuator
- The old routes will now return a 301

closes #3221 

## When should this change go live?

- [x] This change is not yet live and should not be merged until 2024-01-22
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
