### PR TITLE
docs: describe referenced codeblocks

### DIFF
--- a/howtos/markdown-and-mdx-features.md
+++ b/howtos/markdown-and-mdx-features.md
@@ -37,6 +37,18 @@ Embed a video with the `react-video` component:
 type: 'video/mp4'} ]} />
 ```
 
+## Code References
+
+The docs support the ability to embed code blocks from external sources. This is useful for embedding code that changes outside the release cadence of the product. A code reference can point at any source file available on the web, including files in GitHub repositories.
+
+To use a code reference, add a code block that specifies the `reference` attribute, the code source URL, and optionally a `title`:
+
+```yaml reference title="a description"
+https://an/example/url.yaml
+```
+
+This functionality is provided by [a plugin](https://github.com/saucelabs/docusaurus-theme-github-codeblock). See [the plugin documentation](https://docs.saucelabs.com/contributing/style-guide/#code-references) for more details.
+
 ## Code Blocks / Selector
 
 Docusaurus supports [MDX](https://mdxjs.com/) that makes it easily possible to use code selectors for our docs. Two things need to be done:


### PR DESCRIPTION
## Description

Adds some docs-on-docs for #3155.

Note that this PR targets the branch in #3155. Merge order is unimportant to me.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
