### PR TITLE
Document how to verify Zeebe configuration starting with 8.4

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/830-to-840.md
+++ b/docs/self-managed/operational-guides/update-guide/830-to-840.md
@@ -14,6 +14,10 @@ For more details about the applications version included in the Helm chart, chec
 
 ## Zeebe
 
+## Verifying configuration
+
+Zeebe will not log configuration at startup anymore, but instead makes it available via the management endpoint at [http://localhost:9600/actuator/configprops](http://localhost:9600/actuator/configprops). See [the configuration page](/self-managed/zeebe-deployment/configuration/configuration.md) for more.
+
 ### Dockerfile numeric ID
 
 The Dockerfile now uses a numeric user ID instead of a non-numeric user.

--- a/docs/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/docs/self-managed/zeebe-deployment/configuration/configuration.md
@@ -106,7 +106,7 @@ This will ensure the defaults defined in the classpath resources will be used (u
 
 ## Verifying configuration
 
-To verify the configuration was applied, simply start Zeebe. If the configuration could be read, Zeebe will expose it via the monitoring port at the following URL: [http://localhost:9600/actuator/configprops/zeebe](http://localhost:9600/actuator/configprops/zeebe). This will show you both the resolved configuration and its inputs.
+Start Zeebe to verify the configuration was applied. If the configuration could be read, Zeebe will expose it via the monitoring port at [http://localhost:9600/actuator/configprops/zeebe](http://localhost:9600/actuator/configprops/zeebe). This will show you both the resolved configuration and its inputs.
 
 :::note
 

--- a/docs/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/docs/self-managed/zeebe-deployment/configuration/configuration.md
@@ -106,26 +106,15 @@ This will ensure the defaults defined in the classpath resources will be used (u
 
 ## Verifying configuration
 
-To verify the configuration was applied, start Zeebe and look at the log.
+To verify the configuration was applied, simply start Zeebe. If the configuration could be read, Zeebe will expose it via the monitoring port at the following URL: [http://localhost:9600/actuator/configprops/zeebe](http://localhost:9600/actuator/configprops/zeebe). This will show you both the resolved configuration and its inputs.
 
-If the configuration could be read, Zeebe will log out the effective configuration during startup:
+:::note
 
-```
-17:13:13.120 [] [main] INFO  io.camunda.zeebe.broker.system - Starting broker 0 with configuration {
-  "network": {
-    "host": "0.0.0.0",
-    "portOffset": 0,
-    "maxMessageSize": {
-      "bytes": 4194304
-    },
-    "commandApi": {
-      "defaultPort": 26501,
-      "host": "0.0.0.0",
-      "port": 26501,
-...
-```
+Zeebe uses the Spring Boot [configprops](https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#configprops) actuator for this, so any documentation listed there applies as well.
 
-In some cases of invalid configuration, Zeebe will fail to start with a warning that explains which configuration setting could not be read.
+:::
+
+In some cases of invalid configuration, Zeebe will fail to start and log a warning that explains which configuration setting could not be read.
 
 ```
 17:17:38.796 [] [main] ERROR org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter -

--- a/versioned_docs/version-8.4/self-managed/operational-guides/update-guide/830-to-840.md
+++ b/versioned_docs/version-8.4/self-managed/operational-guides/update-guide/830-to-840.md
@@ -14,6 +14,10 @@ For more details about the applications version included in the Helm chart, chec
 
 ## Zeebe
 
+## Verifying configuration
+
+Zeebe will not log configuration at startup anymore, but instead makes it available via the management endpoint at [http://localhost:9600/actuator/configprops](http://localhost:9600/actuator/configprops). See [the configuration page](/self-managed/zeebe-deployment/configuration/configuration.md) for more.
+
 ### Dockerfile numeric ID
 
 The Dockerfile now uses a numeric user ID instead of a non-numeric user.

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
@@ -106,7 +106,7 @@ This will ensure the defaults defined in the classpath resources will be used (u
 
 ## Verifying configuration
 
-To verify the configuration was applied, simply start Zeebe. If the configuration could be read, Zeebe will expose it via the monitoring port at the following URL: [http://localhost:9600/actuator/configprops/zeebe](http://localhost:9600/actuator/configprops/zeebe). This will show you both the resolved configuration and its inputs.
+Start Zeebe to verify the configuration was applied. If the configuration could be read, Zeebe will expose it via the monitoring port at [http://localhost:9600/actuator/configprops/zeebe](http://localhost:9600/actuator/configprops/zeebe). This will show you both the resolved configuration and its inputs.
 
 :::note
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
@@ -106,26 +106,15 @@ This will ensure the defaults defined in the classpath resources will be used (u
 
 ## Verifying configuration
 
-To verify the configuration was applied, start Zeebe and look at the log.
+To verify the configuration was applied, simply start Zeebe. If the configuration could be read, Zeebe will expose it via the monitoring port at the following URL: [http://localhost:9600/actuator/configprops/zeebe](http://localhost:9600/actuator/configprops/zeebe). This will show you both the resolved configuration and its inputs.
 
-If the configuration could be read, Zeebe will log out the effective configuration during startup:
+:::note
 
-```
-17:13:13.120 [] [main] INFO  io.camunda.zeebe.broker.system - Starting broker 0 with configuration {
-  "network": {
-    "host": "0.0.0.0",
-    "portOffset": 0,
-    "maxMessageSize": {
-      "bytes": 4194304
-    },
-    "commandApi": {
-      "defaultPort": 26501,
-      "host": "0.0.0.0",
-      "port": 26501,
-...
-```
+Zeebe uses the Spring Boot [configprops](https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#configprops) actuator for this, so any documentation listed there applies as well.
 
-In some cases of invalid configuration, Zeebe will fail to start with a warning that explains which configuration setting could not be read.
+:::
+
+In some cases of invalid configuration, Zeebe will fail to start and log a warning that explains which configuration setting could not be read.
 
 ```
 17:17:38.796 [] [main] ERROR org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter -


### PR DESCRIPTION
## Description

With https://github.com/camunda/zeebe/issues/14398 we stopped logging the configuration at startup and instead make it available via the monitoring API. This change documents that in both the configuration page (i.e. https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/#verifying-configuration) and in the update announcement.

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
