### PR TITLE
docs(tasklist): describe the auto-select option

### DIFF
--- a/docs/components/tasklist/userguide/using-tasklist.md
+++ b/docs/components/tasklist/userguide/using-tasklist.md
@@ -81,3 +81,9 @@ To add a new variable, click **Add Variable**.
 You will now see the completed task by selecting the **Completed** task list:
 
 ![tasklist-task-completed](img/tasklist-task-completed_light.png)
+
+## Options
+
+### Auto-select first available task
+
+If this is enabled, whenever you open Tasks, change filter options, or complete a task Tasklist will automatically select the first task in the list.

--- a/docs/components/tasklist/userguide/using-tasklist.md
+++ b/docs/components/tasklist/userguide/using-tasklist.md
@@ -86,4 +86,4 @@ You will now see the completed task by selecting the **Completed** task list:
 
 ### Auto-select first available task
 
-If this is enabled, whenever you open Tasks, change filter options, or complete a task Tasklist will automatically select the first task in the list.
+If this is enabled, whenever you open tasks, change filter options, or complete a task, Tasklist will automatically select the first task in the list.


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->
Documentation update for https://github.com/camunda/tasklist/pull/4325

Describe the Auto-select feature being added into the next release.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until 8.5.0-alpha1 (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
