### PR TITLE
Clarify TLS 1.3 for client communication

### DIFF
--- a/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -4,7 +4,7 @@ title: "Secure client communication"
 description: "Zeebe supports TLS between the gateway and all the officially supported clients. In this section, we will review how to configure these components."
 ---
 
-Zeebe supports TLS (transport layer security) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
+Zeebe supports transport layer security (TLS v1.3) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
 
 ## Gateway
 

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -4,7 +4,7 @@ title: "Secure client communication"
 description: "Zeebe supports TLS between the gateway and all the officially supported clients. In this section, we will review how to configure these components."
 ---
 
-Zeebe supports TLS (transport layer security) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
+Zeebe supports transport layer security (TLS v1.3) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
 
 ## Gateway
 

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -4,7 +4,7 @@ title: "Secure client communication"
 description: "Zeebe supports TLS between the gateway and all the officially supported clients. In this section, we will review how to configure these components."
 ---
 
-Zeebe supports TLS (transport layer security) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
+Zeebe supports transport layer security (TLS v1.3) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
 
 ## Gateway
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -4,7 +4,7 @@ title: "Secure client communication"
 description: "Zeebe supports TLS between the gateway and all the officially supported clients. In this section, we will review how to configure these components."
 ---
 
-Zeebe supports TLS (transport layer security) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
+Zeebe supports transport layer security (TLS v1.3) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
 
 ## Gateway
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -4,7 +4,7 @@ title: "Secure client communication"
 description: "Zeebe supports TLS between the gateway and all the officially supported clients. In this section, we will review how to configure these components."
 ---
 
-Zeebe supports TLS (transport layer security) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
+Zeebe supports transport layer security (TLS v1.3) between the gateway and all the officially supported clients. In this section, we will review how to configure these components.
 
 ## Gateway
 


### PR DESCRIPTION
## Description

Adds 1.3 explicitly to the top of the **Secure client communication** page for all supported versions.

From internal thread - https://camunda.slack.com/archives/C02AWA0RF8A/p1705947067435079

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
