### PR TITLE
Document configuration changes to the Exporter Context

### DIFF
--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -59,7 +59,7 @@ During the loading phase, the configuration for each exporter is validated, such
 - An exporter instance throws an exception in its `Exporter#configure` method.
 
 The last point is there to provide individual exporters to perform lightweight
-validation of their configuration (e.g. fail if missing arguments). For validation call, to configure the exporter context we pass a null partition id, which gets replaced with the correct one at runtime.
+validation of their configuration (e.g. fail if missing arguments). For this validation call, the given context will report a partition ID (via `Context#getPartitionId()`) with a pseudo-null value, i.e. `Context#NULL_PARTITION_VALUE`). However, at runtime, it will report the appropriate partition ID on which the exporter is running.
 
 One caveat is that an instance of an exporter is created and immediately thrown away. Therefore, exporters should not perform any computationally
 heavy work during instantiation/configuration.

--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -59,7 +59,7 @@ During the loading phase, the configuration for each exporter is validated, such
 - An exporter instance throws an exception in its `Exporter#configure` method.
 
 The last point is there to provide individual exporters to perform lightweight
-validation of their configuration (e.g. fail if missing arguments).
+validation of their configuration (e.g. fail if missing arguments). For validation call, to configure the exporter context we pass a null partition id, which gets replaced with the correct one at runtime.
 
 One caveat is that an instance of an exporter is created and immediately thrown away. Therefore, exporters should not perform any computationally
 heavy work during instantiation/configuration.

--- a/versioned_docs/version-8.4/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.4/self-managed/concepts/exporters.md
@@ -59,7 +59,7 @@ During the loading phase, the configuration for each exporter is validated, such
 - An exporter instance throws an exception in its `Exporter#configure` method.
 
 The last point is there to provide individual exporters to perform lightweight
-validation of their configuration (e.g. fail if missing arguments).
+validation of their configuration (e.g. fail if missing arguments). For this validation call, the given context will report a partition ID (via `Context#getPartitionId()`) with a pseudo-null value, i.e. `Context#NULL_PARTITION_VALUE`). However, at runtime, it will report the appropriate partition ID on which the exporter is running.
 
 One caveat is that an instance of an exporter is created and immediately thrown away. Therefore, exporters should not perform any computationally
 heavy work during instantiation/configuration.


### PR DESCRIPTION
## Description

This Pr documents changes that had to be made in order to expose partitionId on Exporter Context in the exporter API. Namely During the loading phase, the configuration when each exporter is validated, on instantiating the Exporter Context, we pass a null partition id, which gets replaced by the correct one at runtime.

See https://github.com/camunda/zeebe/pull/16070 and https://github.com/camunda/zeebe/issues/15418#issuecomment-1900442019
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
