### PR TITLE
feat: document `zeebe:calledElement` bindings

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -378,6 +378,22 @@ The binding name of `correlationKey` is not applicable to message start events o
 
 :::
 
+#### `zeebe:calledElement`
+
+| **Binding `type`**          | `zeebe:calledElement`                                                |
+| --------------------------- | -------------------------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown`                   |
+| **Binding parameters**      | `property`: The name of the property (only `processId` is supported) |
+| **Mapping result**          | `<zeebe:calledElement [property]="[userInput]" />`                   |
+
+The `zeebe:calledElement` binding allows you to configure process called by a call activity.
+
+:::note
+
+For `zeebe:calledElement` bindings, variable propagation is not supported. To provide or retrieve variables, use `zeebe:input` and `zeebe:output` bindings.
+
+:::
+
 ### Optional bindings
 
 We support optional bindings that do not persist empty values in the underlying BPMN 2.0 XML.

--- a/versioned_docs/version-8.4/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.4/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -378,6 +378,22 @@ The binding name of `correlationKey` is not applicable to message start events o
 
 :::
 
+#### `zeebe:calledElement`
+
+| **Binding `type`**          | `zeebe:calledElement`                                                |
+| --------------------------- | -------------------------------------------------------------------- |
+| **Valid property `type`'s** | `String`<br />`Text`<br />`Hidden`<br />`Dropdown`                   |
+| **Binding parameters**      | `property`: The name of the property (only `processId` is supported) |
+| **Mapping result**          | `<zeebe:calledElement [property]="[userInput]" />`                   |
+
+The `zeebe:calledElement` binding allows you to configure process called by a call activity.
+
+:::note
+
+For `zeebe:calledElement` bindings, variable propagation is not supported. To provide or retrieve variables, use `zeebe:input` and `zeebe:output` bindings.
+
+:::
+
 ### Optional bindings
 
 We support optional bindings that do not persist empty values in the underlying BPMN 2.0 XML.


### PR DESCRIPTION
Related to https://github.com/camunda/product-hub/issues/1807

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
