### PR TITLE
docs( feel-built-in-functions-conversion): Fix invalid date time syntax

### DIFF
--- a/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -188,8 +188,8 @@ date and time(from: string): date and time
 **Examples**
 
 ```feel
-date and time("2018-04-29T009:30:00")
-// date and time("2018-04-29T009:30:00")
+date and time("2018-04-29T09:30:00")
+// date and time("2018-04-29T09:30:00")
 ```
 
 ## date and time(date, time)


### PR DESCRIPTION
## Description

I copy & pasted an `date and time` example from the docs and I didn't have a clue why it didn't work. Turned out the date time syntax was invalid, i.e. one `0` to many.

## When should this change go live?

Preferably ASAP - I don't want others to stumble across the wrong example. The change is trivial.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

Note: I don't have permission to set @christinaausley  as assignee.
