### PR TITLE
feat: errors for non-ours referenced codeblocks

### DIFF
--- a/styles/camunda/all/codeBlocksOurOurs.yml
+++ b/styles/camunda/all/codeBlocksOurOurs.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "Improper codeblock source: '%s'. Please only reference codeblocks from Camunda GitHub orgs."
+level: error
+nonword: true
+scope: raw
+tokens:
+  # Captures anything that is hardcoded to our production URL.
+  - "`{3}.*\nhttps://github.com/(?!camunda|camunda-cloud).*\n`{3}"


### PR DESCRIPTION
## Description

Resolves #3268.

Applies the logic from https://github.com/camunda/camunda-docs/pull/3155#issuecomment-1909357087 as a vale rule to @jessesimpson36's branch for #3155.

## When should this change go live?

Should probably be merged into #3155 and go live with that one.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
