### PR TITLE
feat: support referenced codeblocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -397,5 +397,8 @@ module.exports = {
       },
     }),
   },
-  themes: ["docusaurus-theme-openapi-docs"],
+  themes: [
+    "docusaurus-theme-openapi-docs",
+    "@saucelabs/theme-github-codeblock",
+  ],
 };

--- a/howtos/markdown-and-mdx-features.md
+++ b/howtos/markdown-and-mdx-features.md
@@ -1,4 +1,4 @@
-# Markdown and MDX Features
+# Markdown and MDX features
 
 The Docusaurus documentation provides a detailed explanation of the Markdown features at [https://v2.docusaurus.io/docs/markdown-features](https://v2.docusaurus.io/docs/markdown-features).
 
@@ -37,7 +37,21 @@ Embed a video with the `react-video` component:
 type: 'video/mp4'} ]} />
 ```
 
-## Code Blocks / Selector
+## Code references
+
+The docs support the ability to embed code blocks from external sources. This is useful for embedding code that changes outside the release cadence of the product.
+
+Code references should only point at source files from a Camunda-owned GitHub repository.
+
+To use a code reference, add a code block that specifies the `reference` attribute, the code source URL, and optionally a `title`:
+
+```yaml reference title="a description"
+https://github.com/camunda/some-project/some-file.yaml
+```
+
+This functionality is provided by [a plugin](https://github.com/saucelabs/docusaurus-theme-github-codeblock). See [the plugin documentation](https://docs.saucelabs.com/contributing/style-guide/#code-references) for more details.
+
+## Code blocks / selector
 
 Docusaurus supports [MDX](https://mdxjs.com/) that makes it easily possible to use code selectors for our docs. Two things need to be done:
 
@@ -96,7 +110,7 @@ Template:
 </Tabs>
 ```
 
-## Source Files for Images and Videos
+## Source files for images and videos
 
 Source files for images and videos can be put in:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/core": "^2.4.1",
         "@docusaurus/preset-classic": "^2.4.1",
         "@mdx-js/react": "^1.6.22",
+        "@saucelabs/theme-github-codeblock": "^0.2.3",
         "clsx": "^1.2.1",
         "docusaurus": "^1.14.7",
         "docusaurus-gtm-plugin": "0.0.2",
@@ -4448,6 +4449,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@saucelabs/theme-github-codeblock": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@saucelabs/theme-github-codeblock/-/theme-github-codeblock-0.2.3.tgz",
+      "integrity": "sha512-GSl3Lr/jOWm4OP3BPX2vXxc8FMSOXj1mJnls6cUqMwlGOfKQ1Ia9pq1O9/ES+5TrZHIzAws/n5FFSn1OkGJw/Q=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -32735,6 +32741,11 @@
         "redux-thunk": "^2.4.2",
         "reselect": "^4.1.8"
       }
+    },
+    "@saucelabs/theme-github-codeblock": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@saucelabs/theme-github-codeblock/-/theme-github-codeblock-0.2.3.tgz",
+      "integrity": "sha512-GSl3Lr/jOWm4OP3BPX2vXxc8FMSOXj1mJnls6cUqMwlGOfKQ1Ia9pq1O9/ES+5TrZHIzAws/n5FFSn1OkGJw/Q=="
     },
     "@sideway/address": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@docusaurus/core": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
+    "@saucelabs/theme-github-codeblock": "^0.2.3",
     "clsx": "^1.2.1",
     "docusaurus": "^1.14.7",
     "docusaurus-gtm-plugin": "0.0.2",

--- a/styles/camunda/all/codeBlocksAreOurs.yml
+++ b/styles/camunda/all/codeBlocksAreOurs.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "Improper codeblock source: '%s'. Please only reference codeblocks from Camunda GitHub orgs."
+level: error
+nonword: true
+scope: raw
+tokens:
+  # Captures any referenced codeblocks that point at a non-Camunda github org.
+  - "`{3}.*\nhttps://github.com/(?!camunda|camunda-cloud).*\n`{3}"


### PR DESCRIPTION
## Description

Replaces #3155.

* Introduces the infrastructure to do referenced codeblocks, using the [Sauce Labs theme](https://docs.saucelabs.com/contributing/style-guide/#code-references).
* Protects against non-Camunda-owned referenced codeblocks by introducing a Vale rule to err on URLs that don't start with `https://github.com/{camunda|camunda-cloud}`.
* Adds docs-on-docs for using this feature. 

### Proof that the referenced codeblocks will display as expected

I introduced a temporary change locally to prove this: 

<img width="1096" alt="image" src="https://github.com/camunda/camunda-docs/assets/1627089/bd134cf4-e05d-4b82-8c82-3fe9cdf59db2">

### Proof that the vale rule fails when a non-Camunda-owned snippet is referenced

I introduced a temporary change locally to prove this: 

<img width="1112" alt="image" src="https://github.com/camunda/camunda-docs/assets/1627089/5257fdbf-150f-46a5-a4c8-5a905e371786">

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## Follow-up work (not blocking this PR)

* @jessesimpson36 to move his referenced codeblocks in #3155 to a Camunda org, and open a new PR to reference them.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
