### PR TITLE
Backport follow up on #3273

### DIFF
--- a/versioned_docs/version-1.3/reference/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/versioned_docs/version-1.3/reference/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -61,7 +61,7 @@ date and time(date and time("2012-12-25T11:00:00"),time("T23:59:00"))
 // date and time("2012-12-25T23:59:00")
 
 date and time(birthday) 
-// date and time("2018-04-29T009:30:00")
+// date and time("2018-04-29T09:30:00")
 ```
 
 ## duration()

--- a/versioned_docs/version-8.1/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/versioned_docs/version-8.1/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -62,7 +62,7 @@ date and time(date and time("2012-12-25T11:00:00"),time("T23:59:00"))
 // date and time("2012-12-25T23:59:00")
 
 date and time(birthday)
-// date and time("2018-04-29T009:30:00")
+// date and time("2018-04-29T09:30:00")
 ```
 
 ## duration()

--- a/versioned_docs/version-8.2/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/versioned_docs/version-8.2/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -188,8 +188,8 @@ date and time(from: string): date and time
 **Examples**
 
 ```feel
-date and time("2018-04-29T009:30:00")
-// date and time("2018-04-29T009:30:00")
+date and time("2018-04-29T09:30:00")
+// date and time("2018-04-29T09:30:00")
 ```
 
 ## date and time(date, time)

--- a/versioned_docs/version-8.3/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/versioned_docs/version-8.3/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -188,8 +188,8 @@ date and time(from: string): date and time
 **Examples**
 
 ```feel
-date and time("2018-04-29T009:30:00")
-// date and time("2018-04-29T009:30:00")
+date and time("2018-04-29T09:30:00")
+// date and time("2018-04-29T09:30:00")
 ```
 
 ## date and time(date, time)

--- a/versioned_docs/version-8.4/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/versioned_docs/version-8.4/components/modeler/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -188,8 +188,8 @@ date and time(from: string): date and time
 **Examples**
 
 ```feel
-date and time("2018-04-29T009:30:00")
-// date and time("2018-04-29T009:30:00")
+date and time("2018-04-29T09:30:00")
+// date and time("2018-04-29T09:30:00")
 ```
 
 ## date and time(date, time)


### PR DESCRIPTION
## Description

Backport follow up on #3273, as reported by @tobiasschaefer - thank you!

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
