### PR TITLE
Document limitations of startinstructions

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -226,7 +226,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceRequest`
@@ -297,7 +297,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceWithResultRequest`

--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -225,6 +225,10 @@ use the latest deployed version.
 Only processes with none start events can be started through this command.
 :::
 
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+:::
+
 ### Input: `CreateProcessInstanceRequest`
 
 ```protobuf
@@ -290,6 +294,10 @@ Unlike `CreateProcessInstance` RPC, the response is returned when the process is
 
 :::note
 Only processes with none start events can be started through this command.
+:::
+
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
 :::
 
 ### Input: `CreateProcessInstanceWithResultRequest`

--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -226,7 +226,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceRequest`
@@ -297,7 +297,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.1/apis-tools/grpc.md
+++ b/versioned_docs/version-8.1/apis-tools/grpc.md
@@ -169,7 +169,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceRequest`
@@ -236,7 +236,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.1/apis-tools/grpc.md
+++ b/versioned_docs/version-8.1/apis-tools/grpc.md
@@ -169,7 +169,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceRequest`
@@ -236,7 +236,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.1/apis-tools/grpc.md
+++ b/versioned_docs/version-8.1/apis-tools/grpc.md
@@ -168,6 +168,10 @@ use the latest deployed version.
 Only processes with none start events can be started through this command.
 :::
 
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+:::
+
 #### Input: `CreateProcessInstanceRequest`
 
 ```protobuf
@@ -229,6 +233,10 @@ Unlike `CreateProcessInstance` RPC, the response is returned when the process is
 
 :::note
 Only processes with none start events can be started through this command.
+:::
+
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.2/apis-tools/grpc.md
+++ b/versioned_docs/version-8.2/apis-tools/grpc.md
@@ -197,7 +197,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceRequest`
@@ -264,7 +264,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.2/apis-tools/grpc.md
+++ b/versioned_docs/version-8.2/apis-tools/grpc.md
@@ -196,6 +196,10 @@ use the latest deployed version.
 Only processes with none start events can be started through this command.
 :::
 
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+:::
+
 #### Input: `CreateProcessInstanceRequest`
 
 ```protobuf
@@ -257,6 +261,10 @@ Unlike `CreateProcessInstance` RPC, the response is returned when the process is
 
 :::note
 Only processes with none start events can be started through this command.
+:::
+
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.2/apis-tools/grpc.md
+++ b/versioned_docs/version-8.2/apis-tools/grpc.md
@@ -197,7 +197,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceRequest`
@@ -264,7 +264,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.3/apis-tools/grpc.md
+++ b/versioned_docs/version-8.3/apis-tools/grpc.md
@@ -217,7 +217,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations).
 :::
 
 #### Input: `CreateProcessInstanceRequest`
@@ -288,7 +288,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.3/apis-tools/grpc.md
+++ b/versioned_docs/version-8.3/apis-tools/grpc.md
@@ -216,6 +216,10 @@ use the latest deployed version.
 Only processes with none start events can be started through this command.
 :::
 
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+:::
+
 #### Input: `CreateProcessInstanceRequest`
 
 ```protobuf
@@ -281,6 +285,10 @@ Unlike `CreateProcessInstance` RPC, the response is returned when the process is
 
 :::note
 Only processes with none start events can be started through this command.
+:::
+
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.3/apis-tools/grpc.md
+++ b/versioned_docs/version-8.3/apis-tools/grpc.md
@@ -288,7 +288,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 #### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
+++ b/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
@@ -226,7 +226,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceRequest`
@@ -297,7 +297,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
+++ b/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
@@ -225,6 +225,10 @@ use the latest deployed version.
 Only processes with none start events can be started through this command.
 :::
 
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
+:::
+
 ### Input: `CreateProcessInstanceRequest`
 
 ```protobuf
@@ -290,6 +294,10 @@ Unlike `CreateProcessInstance` RPC, the response is returned when the process is
 
 :::note
 Only processes with none start events can be started through this command.
+:::
+
+:::note
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations).
 :::
 
 ### Input: `CreateProcessInstanceWithResultRequest`

--- a/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
+++ b/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
@@ -226,7 +226,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceRequest`
@@ -297,7 +297,7 @@ Only processes with none start events can be started through this command.
 :::
 
 :::note
-Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification/#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
+Start instructions have the same [limitations as the process instance modification](/components/concepts/process-instance-modification.md#limitations), e.g., it is not possible to start an element in a multi-instance subprocess.
 :::
 
 ### Input: `CreateProcessInstanceWithResultRequest`


### PR DESCRIPTION
## Description

The gRPCs `CreateProcessInstance` and `CreateProcessInstanceWithResult` support start instructions, but these instructions have limitations that are undocumented, i.e., models may contain elements that cannot be used in start instructions. Since the start instructions use the same command as the `ModifyProcessInstance` call, a respective reference has been added as note.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
