### PR TITLE
Support process instance migration with active user tasks

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -838,6 +838,7 @@ Returned if:
 
 - Not all active elements in the given process instance are mapped to the elements in the target process definition
 - A mapping instruction changes the type of an element or event
+- A mapping instruction changes the implementation of a task
 - A mapping instruction refers to an unsupported element (i.e. some elements will be supported later on)
 - A mapping instruction refers to element in unsupported scenarios.
   (i.e. migrating active elements with event subscriptions will be supported later on)

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -153,6 +153,7 @@ The following limitations exist that may be supported in future versions:
   - An element that becomes nested in a newly added sub-process
   - An element that was nested in a sub-process is no longer nested in that sub-process
 - Mapping instructions cannot change the element type
+- Mapping instructions cannot change the task implementation
 - The process instance must be in a wait state, i.e. waiting for an event or external input like job completion. It may not be taking a sequence flow or triggering an event while migrating the instance
 
 A full overview of error codes can be found in the [migration command](/apis-tools/zeebe-api/gateway-service.md#migrateprocessinstance-rpc).

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -107,7 +107,7 @@ You do not have to provide a mapping instruction from the process instance's pro
 ## Jobs, expressions, and input mappings
 
 We do not recreate jobs, reevaluate expressions, and reapply input mappings of the active elements.
-Any existing variables and jobs continue to exist with the same values as previously assigned.
+Any existing variables, user tasks, and jobs continue to exist with the same values as previously assigned.
 
 Let's consider an active service task that created a job when it was activated with type `send_mail`.
 In the target process definition, the job type expression is changed as follows:

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -107,6 +107,7 @@ You do not have to provide a mapping instruction from the process instance's pro
 ## Jobs, expressions, and input mappings
 
 We do not recreate jobs, reevaluate expressions, and reapply input mappings of the active elements.
+We also don't adjust any static values if they differ between the two process definitions.
 Any existing variables, user tasks, and jobs continue to exist with the same values as previously assigned.
 
 Let's consider an active service task that created a job when it was activated with type `send_mail`.

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -142,6 +142,7 @@ The following limitations exist that may be supported in future versions:
 - Only elements of the following types can be migrated:
   - A process instance
   - A service task
+  - A user task
 - The following scenarios cannot be migrated:
   - A process instance with an incident
   - A process instance that is started from a call activity, i.e. a child process instance

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -154,7 +154,7 @@ The following limitations exist that may be supported in future versions:
   - An element that becomes nested in a newly added sub-process
   - An element that was nested in a sub-process is no longer nested in that sub-process
 - Mapping instructions cannot change the element type
-- Mapping instructions cannot change the task implementation, e.g. from a job worker user task to a zeebe user task
+- Mapping instructions cannot change the task implementation, e.g. from a job worker user task to a Zeebe user task
 - The process instance must be in a wait state, i.e. waiting for an event or external input like job completion. It may not be taking a sequence flow or triggering an event while migrating the instance
 
 A full overview of error codes can be found in the [migration command](/apis-tools/zeebe-api/gateway-service.md#migrateprocessinstance-rpc).

--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -154,7 +154,7 @@ The following limitations exist that may be supported in future versions:
   - An element that becomes nested in a newly added sub-process
   - An element that was nested in a sub-process is no longer nested in that sub-process
 - Mapping instructions cannot change the element type
-- Mapping instructions cannot change the task implementation
+- Mapping instructions cannot change the task implementation, e.g. from a job worker user task to a zeebe user task
 - The process instance must be in a wait state, i.e. waiting for an event or external input like job completion. It may not be taking a sequence flow or triggering an event while migrating the instance
 
 A full overview of error codes can be found in the [migration command](/apis-tools/zeebe-api/gateway-service.md#migrateprocessinstance-rpc).


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Zeebe and Operate `8.5.0-alpha1` support the migration of process instances with active user tasks.

Both task implementations are supported:
- `Job worker`
- `Zeebe user task`

Mapping instructions cannot change the task implementation.

All values of a job or a 'zeebe user task' are left unchanged after migration.

closes https://github.com/camunda/zeebe/issues/15964

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
