### PR TITLE
fix: add html form component to sidebar schema

### DIFF
--- a/docs/components/modeler/forms/sidebar-schema.js
+++ b/docs/components/modeler/forms/sidebar-schema.js
@@ -9,6 +9,7 @@ module.exports = {
       "Form Element Library": [
         lib_dir + "forms-element-library",
         lib_dir + "forms-element-library-text",
+        lib_dir + "forms-element-library-html",
         lib_dir + "forms-element-library-textfield",
         lib_dir + "forms-element-library-textarea",
         lib_dir + "forms-element-library-number",


### PR DESCRIPTION
## Description

This fix adds a missing reference to the newly added documentation page of the html component.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
