### PR TITLE
Adding cost statement to Dual region Backups

### DIFF
--- a/docs/components/concepts/backups.md
+++ b/docs/components/concepts/backups.md
@@ -33,7 +33,7 @@ When you create a cluster in Camunda 8 SaaS, you must specify a region for that 
 You also need to specify where the backups for that cluster will be located:
 
 - By default, the backups will be located in the same region as the cluster.
-- For disaster recovery reasons, you can select a "dual region" backup location. Backups will be automatically replicated in the secondary region to give you better protection in case the primary region experiences disruption.
+- For disaster recovery reasons, you can select a "dual region" backup location. Backups will be automatically replicated in the secondary region to give you better protection in case the primary region experiences disruption. Dual region backup is offered at no additional cost.
 
 #### Backup limits and rate limits
 


### PR DESCRIPTION
## Description

We released a feature in Alpha 2 - Dual region backups. One clarification is needed as we are getting customer question for support and CSM.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
