### PR TITLE
Revised Camunda 8.4 Announcement For Form Linking Bug

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -11,7 +11,9 @@ Release date: 9th of January 2024
 End of maintenance: 9th of July 2025
 
 :::caution
-The [form linking](/components/modeler/web-modeler/advanced-modeling/form-linking.md#using-the-link-button) feature is facing an [issue](https://github.com/camunda/zeebe/issues/16311) where forms are linked with any new user task instance, effectively corrupting the user task instance and process instance affected by this bug. If you use this feature, update to `8.4.3` as the `8.4.0`, `8.4.1`, and `8.4.2` releases are affected by this issue.
+The [form linking](/components/modeler/web-modeler/advanced-modeling/form-linking.md#using-the-link-button) feature is impacted by an [issue](https://github.com/camunda/zeebe/issues/16311) where the wrong forms can get linked with new user task instances, effectively corrupting the user task instance. If you make use of this feature and run either `8.4.0`, `8.4.1` or `8.4.2`, we urge you to update to the newest `8.4.3` patch that includes the required fix.
+
+We are also working on preparing instructions to repair affected user task instances and will inform you shortly about those.
 :::
 
 ### Versioning changes in Helm chart

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -11,7 +11,9 @@ Release date: 9th of January 2024
 End of maintenance: 9th of July 2025
 
 :::caution
-The [form linking](/components/modeler/web-modeler/advanced-modeling/form-linking.md#using-the-link-button) feature is facing an [issue](https://github.com/camunda/zeebe/issues/16311) where forms are linked with any new user task instance, effectively corrupting the user task instance and process instance affected by this bug. If you use this feature, update to `8.4.3` as the `8.4.0`, `8.4.1`, and `8.4.2` releases are affected by this issue.
+The [form linking](/components/modeler/web-modeler/advanced-modeling/form-linking.md#using-the-link-button) feature is impacted by an [issue](https://github.com/camunda/zeebe/issues/16311) where the wrong forms can get linked with new user task instances, effectively corrupting the user task instance. If you make use of this feature and run either `8.4.0`, `8.4.1` or `8.4.2`, we urge you to update to the newest `8.4.3` patch that includes the required fix.
+
+We are also working on preparing instructions to repair affected user task instances and will inform you shortly about those.
 :::
 
 ### Versioning changes in Helm chart


### PR DESCRIPTION
## Description

The term wrong was missing in the announcement, making it harder to understand.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
