### PR TITLE
Remove operate feedback page and redirect

### DIFF
--- a/docs/components/operate/userguide/operate-feedback-and-questions.md
+++ b/docs/components/operate/userguide/operate-feedback-and-questions.md
@@ -1,7 +1,0 @@
----
-id: operate-feedback-and-questions
-title: Giving feedback and asking questions
-description: "Have questions or feedback about Operate? Contact us."
----
-
-Have questions or feedback about Operate? [Contact us](/contact).

--- a/sidebars.js
+++ b/sidebars.js
@@ -377,7 +377,6 @@ module.exports = {
             "components/operate/userguide/delete-resources",
             "components/operate/userguide/process-instance-modification",
             "components/operate/userguide/process-instance-migration",
-            "components/operate/userguide/operate-feedback-and-questions",
           ],
         },
       ],

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -3,6 +3,15 @@ RewriteEngine on
 RewriteCond %{SERVER_PORT} !^443$
 RewriteRule (.*) https://%{SERVER_NAME}/$1 [R=301,L]
 
+# Remove Operate feedback page
+RewriteRule ^docs/components/operate/userguide/operate-feedback-and-questions/?$ /contact/$1 [R=301,L]
+RewriteRule ^docs/next/components/operate/userguide/operate-feedback-and-questions/?$ /contact/$1 [R=301,L]
+RewriteRule ^docs/8.4/components/operate/userguide/operate-feedback-and-questions/?$ /contact/$1 [R=301,L]
+RewriteRule ^docs/8.3/components/operate/userguide/operate-feedback-and-questions/?$ /contact/$1 [R=301,L]
+RewriteRule ^docs/8.2/components/operate/userguide/operate-feedback-and-questions/?$ /contact/$1 [R=301,L]
+RewriteRule ^docs/8.1/components/operate/userguide/operate-feedback-and-questions/?$ /contact/$1 [R=301,L]
+
+
 # Redirect to Connectors overview upon deprecation of Power Automate Connector
 RewriteRule ^docs/components/connectors/out-of-the-box-connectors/power-automate/?$ /docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/ [R=301,L]
 RewriteRule ^docs/next/components/connectors/out-of-the-box-connectors/power-automate/?$ /docs/next/components/connectors/out-of-the-box-connectors/available-connectors-overview/ [R=301,L]

--- a/versioned_docs/version-8.1/components/operate/userguide/operate-feedback-and-questions.md
+++ b/versioned_docs/version-8.1/components/operate/userguide/operate-feedback-and-questions.md
@@ -1,7 +1,0 @@
----
-id: operate-feedback-and-questions
-title: Giving feedback and asking questions
-description: "Have questions or feedback about Operate? Contact us."
----
-
-Have questions or feedback about Operate? [Contact us](/contact).

--- a/versioned_docs/version-8.2/components/operate/userguide/operate-feedback-and-questions.md
+++ b/versioned_docs/version-8.2/components/operate/userguide/operate-feedback-and-questions.md
@@ -1,7 +1,0 @@
----
-id: operate-feedback-and-questions
-title: Giving feedback and asking questions
-description: "Have questions or feedback about Operate? Contact us."
----
-
-Have questions or feedback about Operate? [Contact us](/contact).

--- a/versioned_docs/version-8.3/components/operate/userguide/operate-feedback-and-questions.md
+++ b/versioned_docs/version-8.3/components/operate/userguide/operate-feedback-and-questions.md
@@ -1,7 +1,0 @@
----
-id: operate-feedback-and-questions
-title: Giving feedback and asking questions
-description: "Have questions or feedback about Operate? Contact us."
----
-
-Have questions or feedback about Operate? [Contact us](/contact).

--- a/versioned_docs/version-8.4/components/operate/userguide/operate-feedback-and-questions.md
+++ b/versioned_docs/version-8.4/components/operate/userguide/operate-feedback-and-questions.md
@@ -1,7 +1,0 @@
----
-id: operate-feedback-and-questions
-title: Giving feedback and asking questions
-description: "Have questions or feedback about Operate? Contact us."
----
-
-Have questions or feedback about Operate? [Contact us](/contact).

--- a/versioned_sidebars/version-8.1-sidebars.json
+++ b/versioned_sidebars/version-8.1-sidebars.json
@@ -393,7 +393,6 @@
             "components/operate/userguide/resolve-incidents-update-variables",
             "components/operate/userguide/selections-operations",
             "components/operate/userguide/delete-finished-instances",
-            "components/operate/userguide/operate-feedback-and-questions",
             "components/operate/userguide/process-instance-modification"
           ]
         }

--- a/versioned_sidebars/version-8.2-sidebars.json
+++ b/versioned_sidebars/version-8.2-sidebars.json
@@ -426,7 +426,6 @@
             "components/operate/userguide/resolve-incidents-update-variables",
             "components/operate/userguide/selections-operations",
             "components/operate/userguide/delete-finished-instances",
-            "components/operate/userguide/operate-feedback-and-questions",
             "components/operate/userguide/process-instance-modification"
           ]
         }

--- a/versioned_sidebars/version-8.3-sidebars.json
+++ b/versioned_sidebars/version-8.3-sidebars.json
@@ -460,8 +460,7 @@
             "components/operate/userguide/selections-operations",
             "components/operate/userguide/delete-finished-instances",
             "components/operate/userguide/delete-resources",
-            "components/operate/userguide/process-instance-modification",
-            "components/operate/userguide/operate-feedback-and-questions"
+            "components/operate/userguide/process-instance-modification"
           ]
         }
       ],

--- a/versioned_sidebars/version-8.4-sidebars.json
+++ b/versioned_sidebars/version-8.4-sidebars.json
@@ -471,8 +471,7 @@
             "components/operate/userguide/delete-finished-instances",
             "components/operate/userguide/delete-resources",
             "components/operate/userguide/process-instance-modification",
-            "components/operate/userguide/process-instance-migration",
-            "components/operate/userguide/operate-feedback-and-questions"
+            "components/operate/userguide/process-instance-migration"
           ]
         }
       ],


### PR DESCRIPTION
## Description

We don't need an individual page for feedback and support for Operate. I've removed this and redirect to the Contact page.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
