### PR TITLE
fix(web-modeler): remove mention of 8.4 features

### DIFF
--- a/versioned_docs/version-8.3/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
+++ b/versioned_docs/version-8.3/guides/devops-lifecycle/integrate-web-modeler-in-ci-cd.md
@@ -78,13 +78,25 @@ Synchronize files between Web Modeler and version control systems (VCS) and vice
 
 For automatic file synchronization, consider maintaining a secondary system of record for mapping Web Modeler projects to VCS repositories. This system also monitors the project-to-repository mapping and update timestamps.
 
-To listen to changes in Web Modeler, you currently need to implement a polling approach that compares the update dates with the last sync dates recorded. Use the `POST /api/v1/files/search` [endpoint](https://modeler.cloud.camunda.io/swagger-ui/index.html#/Files/searchFiles) with the following payload to identify files updated after the last sync date:
+To listen to changes in Web Modeler, you currently need to implement a polling approach that compares the update dates with the last sync dates recorded. Use the `POST /api/v1/files/search` [endpoint](https://modeler.cloud.camunda.io/swagger-ui/index.html#/Files/searchFiles) with this payload to identify recently updated files:
 
 ```json title="POST /api/v1/files/search"
 {
   "filter": {
-    "projectId": "(PROJECT TO SYNC)",
-    "updated": ">(LAST SYNC DATE)"
+    "projectId": "<PROJECT TO SYNC>",
+    "updated": "<LAST SYNC DATE>"
+  },
+  "page": 0,
+  "size": 50
+}
+```
+
+For real-time synchronization, employ a polling approach comparing update dates with last sync dates. Use the `POST /api/v1/files/search` [endpoint](https://modeler.cloud.camunda.io/swagger-ui/index.html#/Files/searchFiles) with the following payload to discover recently updated files, and compare the `updated` date with your last sync date:
+
+```json title="POST /api/v1/files/search"
+{
+  "filter": {
+    "projectId": "<PROJECT TO SYNC>"
   },
   "page": 0,
   "size": 50
@@ -103,12 +115,12 @@ Real-time synchronization isn't always what you need. Consider Web Modeler as a 
 
 A milestone reflects a state of a file in Web Modeler with a certain level of qualification, such as being ready for deployment. You can use this property to trigger deployments when a certain milestone is created.
 
-Currently, you have to poll for milestones to listen to new ones created. Use the `POST /api/v1/milestones/search` [endpoint](https://modeler.cloud.camunda.io/swagger-ui/index.html#/Milestones/searchMilestones) with the following payload to identify milestones created after the last sync date:
+Currently, you have to poll for milestones to listen to new ones created. Use the `POST /api/v1/milestones/search` [endpoint](https://modeler.cloud.camunda.io/swagger-ui/index.html#/Milestones/searchMilestones) with the following payload to find recently created milestones:
 
 ```json title="POST /api/v1/milestones/search"
 {
   "filter": {
-    "created": ">(YOUR LAST SYNC DATE)"
+    "created": "<YOUR LAST SYNC DATE>"
   },
   "page": 0,
   "size": 50
@@ -128,6 +140,18 @@ You will receive a response similar to this, where the `fileId` indicates the fi
     },
     ...
   ]
+}
+```
+
+You have to poll for milestones to listen to new ones created. Use the `POST /api/v1/milestones/search` [endpoint](https://modeler.cloud.camunda.io/swagger-ui/index.html#/Milestones/searchMilestones) and compare the `created` date with your last sync date to identify recent additions:
+
+```json title="POST /api/v1/milestones/search"
+{
+  "filter": {
+    "fileId": "<FILE YOU ARE INTERESTED IN>"
+  },
+  "page": 0,
+  "size": 50
 }
 ```
 
@@ -176,7 +200,7 @@ Pipeline-driven deployment can be executed for a single file or an entire projec
 ```json title="POST /api/v1/files/search"
 {
   "filter": {
-    "projectId": "(PROJECT ID)"
+    "projectId": "<PROJECT ID>"
   },
   "page": 0,
   "size": 50


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Closes #3348

Partially reverts https://github.com/camunda/camunda-docs/pull/3054, see also https://camunda.slack.com/archives/C026U8GBNSW/p1708120962924399

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
