### PR TITLE
Quick win - link to Connectors dependencies in release assets

### DIFF
--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -2891,7 +2891,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.5.0-alpha1) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.5.0-alpha1) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -2891,13 +2891,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-### Connector SDK
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Out-of-the-box Connectors
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.5.0-alpha1) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -2891,7 +2891,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.5.0-alpha1) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.5.0-alpha1) as software bill of materials (SBOMs) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.1/reference/dependencies.md
+++ b/versioned_docs/version-8.1/reference/dependencies.md
@@ -2427,7 +2427,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.0) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.0) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.1/reference/dependencies.md
+++ b/versioned_docs/version-8.1/reference/dependencies.md
@@ -2427,13 +2427,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-### Connector SDK
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Out-of-the-box Connectors
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.0) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.1/reference/dependencies.md
+++ b/versioned_docs/version-8.1/reference/dependencies.md
@@ -2427,7 +2427,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.0) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.0) as software bill of materials (SBOMs) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.2/reference/dependencies.md
+++ b/versioned_docs/version-8.2/reference/dependencies.md
@@ -2683,7 +2683,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 ### Connector SDK
 
-Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.2) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.2) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.2/reference/dependencies.md
+++ b/versioned_docs/version-8.2/reference/dependencies.md
@@ -2683,11 +2683,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 ### Connector SDK
 
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Out-of-the-box Connectors
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.2) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.2/reference/dependencies.md
+++ b/versioned_docs/version-8.2/reference/dependencies.md
@@ -2683,7 +2683,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 ### Connector SDK
 
-Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.2) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/0.23.2) as software bill of materials (SBOMs) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.3/reference/dependencies.md
+++ b/versioned_docs/version-8.3/reference/dependencies.md
@@ -3124,7 +3124,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.3.0) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.3.0) as software bill of materials (SBOMs) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.3/reference/dependencies.md
+++ b/versioned_docs/version-8.3/reference/dependencies.md
@@ -3124,13 +3124,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-### Connector SDK
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Out-of-the-box Connectors
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.3.0) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.3/reference/dependencies.md
+++ b/versioned_docs/version-8.3/reference/dependencies.md
@@ -3124,7 +3124,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 <TabItem value='connectors'>
 
-Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.3.0) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.3.0) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.4/reference/dependencies.md
+++ b/versioned_docs/version-8.4/reference/dependencies.md
@@ -2854,11 +2854,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 ### Connector SDK
 
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connector-sdk/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
-
-### Out-of-the-box Connectors
-
-Find an up-to-date list of third-party libraries used and their license terms in the [THIRD_PARTY_NOTICES](https://github.com/camunda/connectors-bundle/blob/main/THIRD_PARTY_NOTICES), located in the root of the source code repository.
+Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.4.0) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.4/reference/dependencies.md
+++ b/versioned_docs/version-8.4/reference/dependencies.md
@@ -2854,7 +2854,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 ### Connector SDK
 
-Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.4.0) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.4.0) as software bill of materials (SBOMs) in XML or JSON.
 
 </TabItem>
 

--- a/versioned_docs/version-8.4/reference/dependencies.md
+++ b/versioned_docs/version-8.4/reference/dependencies.md
@@ -2854,7 +2854,7 @@ Desktop Modeler is a desktop modeling application that builds upon a number of t
 
 ### Connector SDK
 
-Connectors depedencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.4.0) as SBOMs (software bill of materials) in XML or JSON.
+Connectors dependencies are packaged with the [release assets](https://github.com/camunda/connectors/releases/tag/8.4.0) as SBOMs (software bill of materials) in XML or JSON.
 
 </TabItem>
 


### PR DESCRIPTION
## Description

Adds a link to the Connectors release that includes the SBOMs. These links currently go to an archived repo or 404.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
