### PR TITLE
feat: execute tag manager script right before loading osano.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,6 +33,8 @@ module.exports = {
     //            }
     //          },
     //        ],
+    // This custom Osano plugin must precede the gtm-plugin.
+    "./static/plugins/osano",
     [
       require.resolve("docusaurus-gtm-plugin"),
       {
@@ -106,33 +108,6 @@ module.exports = {
         },
       },
     ],
-  ],
-  headTags: [
-    {
-      tagName: "script",
-      innerHTML: `
-        // Required prior to loading osano.js script.
-        window.dataLayer = window.dataLayer || []
-        function gtag() {
-          dataLayer.push(arguments)
-        }
-        gtag('consent', 'default', {
-          ad_storage: 'denied',
-          analytics_storage: 'denied',
-          ad_user_data: 'denied',
-          ad_personalization: 'denied',
-          wait_for_update: 500,
-        })
-        gtag('set', 'ads_data_redaction', true)
-      `,
-      attributes: {},
-    },
-    {
-      tagName: "script",
-      attributes: {
-        src: "https://cmp.osano.com/16CVvwSNKHi9t1grQ/2ce963c0-31c9-4b54-b052-d66a2a948ccc/osano.js",
-      },
-    },
   ],
   scripts: [
     {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -107,6 +107,33 @@ module.exports = {
       },
     ],
   ],
+  headTags: [
+    {
+      tagName: "script",
+      innerHTML: `
+        // Required prior to loading osano.js script.
+        window.dataLayer = window.dataLayer || []
+        function gtag() {
+          dataLayer.push(arguments)
+        }
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          analytics_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          wait_for_update: 500,
+        })
+        gtag('set', 'ads_data_redaction', true)
+      `,
+      attributes: {},
+    },
+    {
+      tagName: "script",
+      attributes: {
+        src: "https://cmp.osano.com/16CVvwSNKHi9t1grQ/2ce963c0-31c9-4b54-b052-d66a2a948ccc/osano.js",
+      },
+    },
+  ],
   scripts: [
     {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -7,17 +7,12 @@ import Footer from "@theme-original/Footer";
 
 import { Auth0Provider, useAuth0 } from "@auth0/auth0-react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import Head from "@docusaurus/Head";
 import mixpanel from "mixpanel-browser";
 
 export default function FooterWrapper(props) {
   return (
     <>
       <Footer {...props} />
-      <Head>
-        {/* Osano (Consent) */}
-        <script src="https://cmp.osano.com/16CVvwSNKHi9t1grQ/2ce963c0-31c9-4b54-b052-d66a2a948ccc/osano.js"></script>
-      </Head>
       <AnalyticsEvents></AnalyticsEvents>
     </>
   );
@@ -53,6 +48,7 @@ const MixpanelElement = () => {
     <BrowserOnly>
       {() => {
         const osano = window.Osano;
+        console.log("sjh", osano.cm);
         if (osano?.cm?.analytics) {
           const { getAccessTokenSilently, isAuthenticated, user } = useAuth0();
           // check if mixpanel is initiated

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -48,7 +48,6 @@ const MixpanelElement = () => {
     <BrowserOnly>
       {() => {
         const osano = window.Osano;
-        console.log("sjh", osano.cm);
         if (osano?.cm?.analytics) {
           const { getAccessTokenSilently, isAuthenticated, user } = useAuth0();
           // check if mixpanel is initiated

--- a/static/plugins/osano/index.js
+++ b/static/plugins/osano/index.js
@@ -1,0 +1,37 @@
+// This is implemented as a plugin because script order is important.
+module.exports = function () {
+  return {
+    name: "osano-plugin",
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: "script",
+            innerHTML: `
+              // Required prior to loading osano.js script.
+              window.dataLayer = window.dataLayer || []
+              function gtag() {
+                dataLayer.push(arguments)
+              }
+              gtag('consent', 'default', {
+                ad_storage: 'denied',
+                analytics_storage: 'denied',
+                ad_user_data: 'denied',
+                ad_personalization: 'denied',
+                wait_for_update: 500,
+              })
+              gtag('set', 'ads_data_redaction', true)
+            `,
+            attributes: {},
+          },
+          {
+            tagName: "script",
+            attributes: {
+              src: "https://cmp.osano.com/16CVvwSNKHi9t1grQ/2ce963c0-31c9-4b54-b052-d66a2a948ccc/osano.js",
+            },
+          },
+        ],
+      };
+    },
+  };
+};


### PR DESCRIPTION
## Description

Requested by @antantunes (I think, assuming I guessed correctly from the username), [in Slack](https://camunda.slack.com/archives/C026U8GBNSW/p1708440411893479).

Adds a script that does some Google Tag Manager things prior to loading the Osano.js script. 

TBH I don't really know what it is doing and how that's fixing the problem (or even what the problem is to require this change), but I hope that doesn't matter. I recognize it as referencing Google Tag Manager, so it doesn't seem unsafe to me, but 🤷 

[Below is updated:]

Below is a screenshot of the source for a page when running locally, to prove that scripts run in the following sequence in the `head` element: 

1. Google Consent Mode Default Script
2. Osano dependency
3. Google Tag Manager initialization

![image](https://github.com/camunda/camunda-docs/assets/1627089/8dc1563c-42e4-4e23-a963-321ee70585c4)

## Implementation notes

To control the order of scripts, including the GTM initialization, I moved things into a custom plugin, which registers two blocks of script for the head prior to the GTM initialization. (Similar to the bpmn-js implementation, which I mentioned previously as another option 😅 FORESHADOWING )

### Old implementation notes
I had to redo how we're loading the script from Osano, because I couldn't get Docusaurus to cooperate with complex scripts embedded directly in a React component (i.e. the `Footer` component, where we were previously loading that script.) I also considered stashing the new code in a script file, and loading that directly before the Osano.js script, but that wouldn't guarantee that the code in the new script file would run prior to loading the Osano.js script. I actually like that the final implementation moved a script load out of a component -- that seems like the kind of thing to use Docusaurus's architecture for.

~This is where I ended up -- adding a couple items to the `headTags` property of the docusaurus configuration. If we wanted to, we could wrap this into a plugin instead of littering it all on the main configuration -- similar to how [the bpmn-js plugin](https://github.com/camunda/camunda-docs/blob/fbfc9fae5828cccdee0a94c4b3c695bdafce4364/static/plugins/bpmn-js/index.js) is configured.

## Testing

Ummmmmm I don't really know how to test that this works? I don't know if the appropriate things run in environments other than production; I also don't know _what_ I'm testing for. Maybe @antantunes can help us out with that?

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
