### PR TITLE
Add simple release announcement to Slack

### DIFF
--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -17,4 +17,4 @@ jobs:
               "release": "${{ github.event.release.tag_name }} - ${{ github.event.release.html_url }} is going live now!"
             }
 env:
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ASK_DEVEX_WEBHOOK_URL }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ASK_C8_DOCUMENTATION }}

--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -1,0 +1,20 @@
+name: Send message to Slack when a release is published
+on:
+  release:
+    types: [published]
+
+jobs:
+  slack-send:
+    name: Send message to Slack
+    runs-on: ubuntu-latest
+    steps:
+      - id: slack
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "release": "${{ github.event.release.tag_name }} - ${{ github.event.release.html_url }} is going live now!"
+            }
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ASK_DEVEX_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

A GitHub Action to post a simple message on #ask-c8-documentation with the tag name and release URL. This uses the Slack Workflow builder - Docs Release Bot

Closes https://github.com/camunda/developer-experience/issues/21.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
