### PR TITLE
fix: appropriate font-size for bottom-right OpenAPI explorer panel

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -477,6 +477,10 @@ span.callout + p::after {
   color: var(--ifm-color-primary);
 }
 
+.openapi-explorer__playground-editor pre {
+  font-size: var(--openapi-explorer-font-size-code);
+}
+
 /* Internal links (they don't pop out, but they cause a context change that's worth noting.) */
 .internalLink a::after {
   content: "(internal link)";


### PR DESCRIPTION
## Description

The OpenAPI explorers have a very small font size for the bottom right panel (where the sample request body appears).

I finally figured out a way to pinpoint the font size of this panel, and I made it more like the panel in the top right. 

Tested in Edge, Chrome, Firefox, and Safari. 

## Before

![image](https://github.com/camunda/camunda-docs/assets/1627089/7c020249-bd68-4ed7-b491-c4486a90f541)

## After

![image](https://github.com/camunda/camunda-docs/assets/1627089/54413034-eebd-4210-a932-bbaccb7c30cf)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
