### PR TITLE
feat(components/modeler): document `default-httl` flag

### DIFF
--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -34,6 +34,7 @@ Flags passed as command line arguments take precedence over those configured via
 | "disable-dmn"                                              | false                               |
 | "disable-form"                                             | false                               |
 | ["disable-httl-hint"](#disable-history-time-to-live-hint)  | false                               |
+| ["default-httl"](#default-history-time-to-live)            | false                               |
 | "disable-platform"                                         | false                               |
 | "disable-zeebe"                                            | false                               |
 | "disable-remote-interaction"                               | false                               |
@@ -74,6 +75,18 @@ To disable the [history time to live hint](../../reference/modeling-guidance/rul
 ```js
 {
     "disable-httl-hint": true
+}
+```
+
+### Default `history-time-to-live`
+
+<span class="badge badge--platform">Camunda 7 only</span>
+
+To set a default [history time to live](../../reference/modeling-guidance/rules/history-time-to-live.md) value to be used in newly created models, configure `flags.json`:
+
+```js
+{
+    "default-httl": 30
 }
 ```
 


### PR DESCRIPTION
## Description

Documents the newly added `default-httl` flag, contributed via https://github.com/camunda/camunda-modeler/pull/4147 and https://github.com/camunda/camunda-modeler/pull/4162.

Depends on https://github.com/camunda/camunda-docs/pull/3387

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
