### PR TITLE
experiment: can I compare the PR branch to the target base from a fork?

### DIFF
--- a/.github/workflows/compare-to-target.yaml
+++ b/.github/workflows/compare-to-target.yaml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Fetch target base
         run: git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/compare-to-target.yaml
+++ b/.github/workflows/compare-to-target.yaml
@@ -13,4 +13,7 @@ jobs:
         run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Compare branch to target
-        run: git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]'
+        run: |
+          git rev-parse FETCH_HEAD
+          git rev-parse HEAD
+          git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]'

--- a/.github/workflows/compare-to-target.yaml
+++ b/.github/workflows/compare-to-target.yaml
@@ -1,0 +1,16 @@
+name: Compare to target
+
+on: pull_request_target
+
+jobs:
+  list-pr-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Fetch target base
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Compare branch to target
+        run: git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]')

--- a/.github/workflows/compare-to-target.yaml
+++ b/.github/workflows/compare-to-target.yaml
@@ -3,7 +3,7 @@ name: Compare to target
 on: pull_request_target
 
 jobs:
-  list-pr-changes:
+  compare-to-target:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -13,4 +13,4 @@ jobs:
         run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Compare branch to target
-        run: git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]')
+        run: git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]'

--- a/.github/workflows/compare-to-target.yaml
+++ b/.github/workflows/compare-to-target.yaml
@@ -20,3 +20,8 @@ jobs:
           git rev-parse FETCH_HEAD
           git rev-parse HEAD
           git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]'
+      - name: Comment on PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            :wave: :robot: Just saying hi.

--- a/docs/guides/create-account.md
+++ b/docs/guides/create-account.md
@@ -5,6 +5,8 @@ slug: /guides/getting-started/
 description: "Set up your Camunda 8 account to get started."
 ---
 
+Create an account, yo!
+
 <span class="badge badge--beginner">Beginner</span>
 <span class="badge badge--medium">Time estimate: Under 5 minutes</span>
 


### PR DESCRIPTION
## Description

DO NOT MERGE!

I am messing around to see if I can make the check-versions workflow work on a forked PR (more specifically, I'm trying to get equal functionality between forks & non-forks for diff'ing the PR branch against the target base.)

## Test cases

- ✅ one commit in a local PR -- diff shows the correct files changed. https://github.com/camunda/camunda-docs/actions/runs/8103616920/job/22148582835?pr=3397
- ✅ one commit in a forked PR -- diff shows the correct files changed. https://github.com/camunda/camunda-docs/actions/runs/8103669683/job/22148754658?pr=3398
- ✅ two commits in a local PR -- diff shows the correct files changed. https://github.com/camunda/camunda-docs/actions/runs/8103713502/job/22148893204?pr=3397
- ✅ two commits in a forked PR -- diff shows the correct files changed! https://github.com/camunda/camunda-docs/actions/runs/8103719153/job/22148911948?pr=3398
- ✅ target branch changes since the local PR was opened -- diff compares to the original target. https://github.com/camunda/camunda-docs/actions/runs/8113727073/job/22177682173?pr=3397
- ✅ target branch changes since the forked PR was opened -- diff compares to the original target. https://github.com/camunda/camunda-docs/actions/runs/8113755195/job/22177798717?pr=3398
- ✅  workflow can comment on local PR -- https://github.com/camunda/camunda-docs/pull/3397#issuecomment-1973482325
- ✅  workflow can comment on forked PR -- https://github.com/camunda/camunda-docs/pull/3398#issuecomment-1973483120
