### PR TITLE
fix: make check-versions workflow function on forked PRs

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -1,22 +1,25 @@
 name: Check versions
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   list-pr-changes:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout last two commits of the PR
-        # The last *two* commits are (1) everything in this branch, and (2) the parent of this branch.
+      - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch target base (what we're merging into)
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Capture version configuration as environment variable
         run: echo "VERSION_CONFIG=$(jq -c . < .github/workflows/check-versions/version-config.json)" >> $GITHUB_ENV
 
       - name: Capture changed files as environment variable
-        run: echo "CHANGED_FILES=$(git diff --name-only HEAD^ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
+        run: echo "CHANGED_FILES=$(git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
 
       - name: Identify missing changes
         id: identify-missing-changes


### PR DESCRIPTION
## Description

Addresses #3358. 

Updates the check-versions workflow to _check out_ the PR branch, and _fetch_ the target branch, and use those for a comparison to determine which files have changed in this PR. This should function equally on local and forked PRs, which the current approach does not do. 

See #3396, #3397, and #3398 for an experiment that proves this new approach.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
