### PR TITLE
3324 retro review

### DIFF
--- a/docs/components/modeler/reference/modeling-guidance/rules/history-time-to-live.md
+++ b/docs/components/modeler/reference/modeling-guidance/rules/history-time-to-live.md
@@ -8,11 +8,11 @@ import MarkerGuideline from "@site/src/mdx/MarkerGuideline";
 
 <span class="badge badge--platform">Camunda 7 only</span>
 
-Each execution of a model resource (BPMN, DMN, and CMMN) generates historic data during execution that is stored in the database. In Camunda 7 [history cleanup](https://docs.camunda.org/manual/latest/user-guide/process-engine/history/) removes this historic data from the database based on a defined history time to live (HTTL).
+Each execution of a model resource (BPMN, DMN, and CMMN) generates historic data during execution that is stored in the database. In Camunda 7, [history cleanup](https://docs.camunda.org/manual/latest/user-guide/process-engine/history/) removes this historic data from the database based on a defined **history time to live (HTTL)**.
 
-Starting [from Camunda 7.20](https://docs.camunda.org/manual/develop/update/minor/719-to-720/#enforce-history-time-to-live) you must configure HTTL in one of the following ways:
+From [Camunda 7.20](https://docs.camunda.org/manual/develop/update/minor/719-to-720/#enforce-history-time-to-live) onwards, you must configure HTTL in one of the following ways:
 
-- Define HTTL per model directly in the Camunda Desktop Modeler.
+- Define HTTL per model directly in Desktop Modeler.
 - Set a default HTTL via an engine configuration.
 - Switch off the HTTL check via an engine configuration if history cleanup is not used.
 

--- a/docs/components/modeler/reference/modeling-guidance/rules/history-time-to-live.md
+++ b/docs/components/modeler/reference/modeling-guidance/rules/history-time-to-live.md
@@ -20,6 +20,8 @@ From [Camunda 7.20](https://docs.camunda.org/manual/develop/update/minor/719-to-
 
 ![History time to live not configured](./img/history-time-to-live/info.png)
 
+In the screenshot above, note that the time to live must be defined under **History cleanup** in the properties panel.
+
 ## References
 
 - [History documentation](https://docs.camunda.org/manual/latest/user-guide/process-engine/history/)


### PR DESCRIPTION
## Description

Retro review of https://github.com/camunda/camunda-docs/pull/3324.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
