### PR TITLE
docs(choosing-the-dmn-hit-policy): Fix formatting

### DIFF
--- a/versioned_docs/version-8.4/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
+++ b/versioned_docs/version-8.4/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
@@ -45,7 +45,7 @@ Such tables either return the output of only one rule or aggregate the output of
 Camunda does not yet support the hit policy **priority**. In essence, priorities are specified as an ordered list of output values in decreasing order of priority. Such priorities are therefore independent from rule sequence! Though not yet supported, you can mimic that behavior using hit policy "(**C**)ollect" and determining a priority yourself; for example, by means of an execution listener attached to the end of your business rule task.
 :::
 
-- `**A**`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
+- `A`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
 
 **Collect** and **aggregate**: The output of all matching rules is aggregated by means of an operator:
 


### PR DESCRIPTION
## Description

Fixes this formatting issue:

<img width="863" alt="image" src="https://github.com/camunda/camunda-docs/assets/5685151/201e06b6-2835-4ef3-b749-a96ad544ecc0">

I fixed the trivial issue but there is more and I leave it up to you to decide what is correct:
* in one place it says "by means of an execution listener attached to the end of your business rule task." However, execution listeners are currently not support by C8, only by C7.
* the whole page assumes that the hit policy is visualized by a single letter, e.g. "U" for "Unique". But actually, it never only shows the single letter in the UI. If I'm not mistaken this was the old behaviour.

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist


- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
