### PR TITLE
docs(self-managed): platform deployment keycloak irsa update: add cam…

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
@@ -179,7 +179,7 @@ identity:
 ```
 
 :::note
-You can refer to the [Camunda C8 Helm deployment Documentation](../../../deploy/) for more detailed information on Helm-based deployments.
+For additional details, refer to the [Camunda 8 Helm deployment documentation](../../../deploy/).
 :::
 
 ### Web Modeler

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
@@ -179,7 +179,7 @@ identity:
 ```
 
 :::note
-You can refer to the [Camunda C8 Helm deployment Documentation](../../../deploy/) for more detailed information on Helm-based deployments.
+For additional details, refer to the [Camunda 8 Helm deployment documentation](../../../deploy/).
 :::
 
 ### Web Modeler


### PR DESCRIPTION
Keycloak Image for AWS IRSA

## Description

Replacement of the previous documentation that explained how to build a custom Keycloak image with new documentation that points to the Keycloak image maintained by Camunda.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until https://github.com/camunda/keycloak/issues/26 is public and https://github.com/camunda/keycloak/pull/24 is merged

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
