### PR TITLE
docs: add user task changes to the update guide

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/830-to-840.md
+++ b/docs/self-managed/operational-guides/update-guide/830-to-840.md
@@ -6,7 +6,7 @@ description: "Review which adjustments must be made to migrate from Camunda 8.3.
 
 The following sections explain which adjustments must be made to migrate from Camunda 8.3.x to 8.4.x for each component.
 
-### Helm chart
+## Helm chart
 
 As of the 8.4 release, the Camunda 8 **Helm chart** version is decoupled from the version of the application. The Helm chart release still follows the applications release cycle, but it has an independent version. (e.g., in the application release cycle 8.4, the chart version is 9.0.0).
 
@@ -14,7 +14,7 @@ For more details about the applications version included in the Helm chart, revi
 
 ## Zeebe
 
-## Verifying configuration
+### Verifying configuration
 
 Zeebe will not log configuration at startup anymore, but instead makes it available via the management endpoint at [http://localhost:9600/actuator/configprops](http://localhost:9600/actuator/configprops). See [the configuration page](/self-managed/zeebe-deployment/configuration/configuration.md) for more.
 

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -19,3 +19,15 @@ The broker health check routes have moved, and the old routes are now deprecated
 | http://{zeebe-broker-host}:9600/startup | **http://{zeebe-broker-host}:9600/actuator/health/startup**   |
 
 Please migrate to the new routes in your deployments. **If you're using the official Helm charts, then you don't have to do anything here.**
+
+### Changes to exported records
+
+The `UserTask` events like `UserTask:CREATED` don't export the string value attributes `candidateUsers` and `candidateGroups` anymore.
+As a replacement, user task events now feature the string array attributes `candidateUsersList` and `candidateGroupsList`.
+Custom exporters using these events must be modified accordingly.
+
+:::warning Breaking Change
+The values of the `candidateUsers` and `candidateGroups` attributes in user task records are lost during an update from `8.4` to `8.5`.
+There is no data migration that moves the values from `candidateUsers` and `candidateGroups` to `candidateUsersList` and `candidateGroupsList`
+since the Zeebe user tasks are only experimental in `8.4`.
+:::

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -31,6 +31,6 @@ The values of the `candidateUsers` and `candidateGroups` properties in user task
 There is no data migration that moves the values from `candidateUsers` and `candidateGroups` to `candidateUsersList` and `candidateGroupsList`
 since the Zeebe user tasks are only experimental in `8.4`.
 
-If you need the data on migrated user task instances, you can reactivate them using [Process Instance Modification](https://docs.camunda.io/docs/next/components/concepts/process-instance-modification/).
+If you need the data on migrated user task instances, you can reactivate them using [Process Instance Modification](/components/concepts/process-instance-modification.md).
 This results in a `UserTask:CANCELED` event for the existing user task and a new `UserTask:CREATED` event with the `candidateUsersList` and `candidateGroupsList` filled based on what is configured in the process model.
 :::

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -22,12 +22,15 @@ Please migrate to the new routes in your deployments. **If you're using the offi
 
 ### Changes to exported records
 
-The `UserTask` events like `UserTask:CREATED` don't export the string value attributes `candidateUsers` and `candidateGroups` anymore.
-As a replacement, user task events now feature the string array attributes `candidateUsersList` and `candidateGroupsList`.
+The `UserTask` events like `UserTask:CREATED` don't export the string value properties `candidateUsers` and `candidateGroups` anymore.
+As a replacement, user task events now feature the string array properties `candidateUsersList` and `candidateGroupsList`.
 Custom exporters using these events must be modified accordingly.
 
 :::warning Breaking Change
-The values of the `candidateUsers` and `candidateGroups` attributes in user task records are lost during an update from `8.4` to `8.5`.
+The values of the `candidateUsers` and `candidateGroups` properties in user task records are lost during an update from `8.4` to `8.5`.
 There is no data migration that moves the values from `candidateUsers` and `candidateGroups` to `candidateUsersList` and `candidateGroupsList`
 since the Zeebe user tasks are only experimental in `8.4`.
+
+If you need the data on migrated user task instances, you can reactivate them using [Process Instance Modification](https://docs.camunda.io/docs/next/components/concepts/process-instance-modification/).
+This results in a `UserTask:CANCELED` event for the existing user task and a new `UserTask:CREATED` event with the `candidateUsersList` and `candidateGroupsList` filled based on what is configured in the process model.
 :::

--- a/versioned_docs/version-8.4/self-managed/operational-guides/update-guide/830-to-840.md
+++ b/versioned_docs/version-8.4/self-managed/operational-guides/update-guide/830-to-840.md
@@ -6,7 +6,7 @@ description: "Review which adjustments must be made to migrate from Camunda 8.3.
 
 The following sections explain which adjustments must be made to migrate from Camunda 8.3.x to 8.4.x for each component.
 
-### Helm chart
+## Helm chart
 
 As of the 8.4 release, the Camunda 8 **Helm chart** version is decoupled from the version of the application. The Helm chart release still follows the applications release cycle, but it has an independent version. (e.g., in the application release cycle 8.4, the chart version is 9.0.0).
 
@@ -14,7 +14,7 @@ For more details about the applications version included in the Helm chart, revi
 
 ## Zeebe
 
-## Verifying configuration
+### Verifying configuration
 
 Zeebe will not log configuration at startup anymore, but instead makes it available via the management endpoint at [http://localhost:9600/actuator/configprops](http://localhost:9600/actuator/configprops). See [the configuration page](/self-managed/zeebe-deployment/configuration/configuration.md) for more.
 


### PR DESCRIPTION
## Description

* Details what changes for user task records from 8.4 to 8.5, including the breaking changes for candidate attributes.
* Fixes headings for the 8.3 to 8.4 update guide

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
