### PR TITLE
Backport/forwardport 3449

### DIFF
--- a/docs/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
+++ b/docs/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
@@ -45,7 +45,7 @@ Such tables either return the output of only one rule or aggregate the output of
 Camunda does not yet support the hit policy **priority**. In essence, priorities are specified as an ordered list of output values in decreasing order of priority. Such priorities are therefore independent from rule sequence! Though not yet supported, you can mimic that behavior using hit policy "(**C**)ollect" and determining a priority yourself; for example, by means of an execution listener attached to the end of your business rule task.
 :::
 
-- `**A**`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
+- `A`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
 
 **Collect** and **aggregate**: The output of all matching rules is aggregated by means of an operator:
 

--- a/versioned_docs/version-1.3/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
+++ b/versioned_docs/version-1.3/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
@@ -45,7 +45,7 @@ Such tables either return the output of only one rule or aggregate the output of
 Camunda does not yet support the hit policy **priority**. In essence, priorities are specified as an ordered list of output values in decreasing order of priority. Such priorities are therefore independent from rule sequence! Though not yet supported, you can mimic that behavior using hit policy "(**C**)ollect" and determining a priority yourself; for example, by means of an execution listener attached to the end of your business rule task.
 :::
 
-* `**A**`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
+* `A`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
 
 **Collect** and **aggregate**: The output of all matching rules is aggregated by means of an operator:
 

--- a/versioned_docs/version-8.1/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
+++ b/versioned_docs/version-8.1/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
@@ -45,7 +45,7 @@ Such tables either return the output of only one rule or aggregate the output of
 Camunda does not yet support the hit policy **priority**. In essence, priorities are specified as an ordered list of output values in decreasing order of priority. Such priorities are therefore independent from rule sequence! Though not yet supported, you can mimic that behavior using hit policy "(**C**)ollect" and determining a priority yourself; for example, by means of an execution listener attached to the end of your business rule task.
 :::
 
-- `**A**`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
+- `A`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
 
 **Collect** and **aggregate**: The output of all matching rules is aggregated by means of an operator:
 

--- a/versioned_docs/version-8.2/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
+++ b/versioned_docs/version-8.2/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
@@ -45,7 +45,7 @@ Such tables either return the output of only one rule or aggregate the output of
 Camunda does not yet support the hit policy **priority**. In essence, priorities are specified as an ordered list of output values in decreasing order of priority. Such priorities are therefore independent from rule sequence! Though not yet supported, you can mimic that behavior using hit policy "(**C**)ollect" and determining a priority yourself; for example, by means of an execution listener attached to the end of your business rule task.
 :::
 
-- `**A**`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
+- `A`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
 
 **Collect** and **aggregate**: The output of all matching rules is aggregated by means of an operator:
 

--- a/versioned_docs/version-8.3/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
+++ b/versioned_docs/version-8.3/components/best-practices/modeling/choosing-the-dmn-hit-policy.md
@@ -45,7 +45,7 @@ Such tables either return the output of only one rule or aggregate the output of
 Camunda does not yet support the hit policy **priority**. In essence, priorities are specified as an ordered list of output values in decreasing order of priority. Such priorities are therefore independent from rule sequence! Though not yet supported, you can mimic that behavior using hit policy "(**C**)ollect" and determining a priority yourself; for example, by means of an execution listener attached to the end of your business rule task.
 :::
 
-- `**A**`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
+- `A`**ny**: Multiple matching rules must not make a difference: all matching rules must lead to the same output.
 
 **Collect** and **aggregate**: The output of all matching rules is aggregated by means of an operator:
 


### PR DESCRIPTION
## Description

Backport (and forwardport, lol) #3449. Thanks @tobiasschaefer! 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
