### PR TITLE
chore: sync sidebars based on new API Explorers

### DIFF
--- a/hacks/generateOptimizeSidebars.md
+++ b/hacks/generateOptimizeSidebars.md
@@ -38,7 +38,7 @@ The script is run in the browser dev tools console, and the results are pasted i
 
    **Steps for each page**
 
-   1. Execute the script by running `await generateOptimizeSidebars()` in the console.
+   1. Execute the script by running `await generateSidebarDefinition()` in the console.
    2. Paste the contents of your clipboard into the _opposite_ instance's corresponding version sidebars file than the page you visited to generate the definitions. If you visited an Optimize v3.11.0 page, the generated definitions should go in the main instance's v8.3 sidebars file. If you visited a main docs v8.2 page, the generated definitions should go in the Optimize instances v3.10.0 sidebars.
 
       - The generated definitions should not replace the _entire_ sidebar file. They should merge into the existing sidebar file, replacing only the top-navigation category for which they were generated.

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -19,7 +19,7 @@ Depending on the instance and version, location of source files and sidebar navi
 
 ### Sidebar drift
 
-Several sections of the sidebar navigation are shared across the Optimize and main sections of the docs: Components, Self-Managed, and APIs & Clients. To preserve a consistent user experience in the docs, the structure of sidebars should always match across instances for these sections. When it doesn't match, the user will experience sections of navigation appearing and disappearing depending on which doc they're reading.
+Several sections of the sidebar navigation are shared across the Optimize and main sections of the docs: Components, Self-Managed, and APIs & Tools. To preserve a consistent user experience in the docs, the structure of sidebars should always match across instances for these sections. When it doesn't match, the user will experience sections of navigation appearing and disappearing depending on which doc they're reading.
 
 It's likely that the structure will drift over time. To resolve the drift, see [the docs on generating sidebars](../hacks/generateOptimizeSidebars.md).
 

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1364,11 +1364,20 @@ module.exports = {
               "Authentication",
               "apis-tools/administration-api/authentication/"
             ),
+            docsLink("Tutorial", "apis-tools/administration-api/tutorial/"),
           ],
         },
         {
           "Operate API (REST)": [
             docsLink("Overview", "apis-tools/operate-api/overview/"),
+            docsLink(
+              "Operate API Explorer",
+              "/api/operate/docs/operate-public-api/"
+            ),
+            docsLink(
+              "Authentication",
+              "apis-tools/operate-api/operate-api-authentication/"
+            ),
             docsLink("Tutorial", "apis-tools/operate-api/tutorial/"),
           ],
         },
@@ -1546,132 +1555,20 @@ module.exports = {
               "apis-tools/tasklist-api-rest/tasklist-api-rest-overview/"
             ),
             docsLink(
+              "Tasklist API (REST) Explorer",
+              "/api/tasklist/docs/tasklist-rest-api/"
+            ),
+            docsLink(
               "Authentication",
               "apis-tools/tasklist-api-rest/tasklist-api-rest-authentication/"
             ),
-
-            {
-              Controllers: [
-                docsLink(
-                  "Form API",
-                  "apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-form-controller/"
-                ),
-                docsLink(
-                  "Task API",
-                  "apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller/"
-                ),
-                docsLink(
-                  "Variables API",
-                  "apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-variables-controller/"
-                ),
-              ],
-            },
-
-            {
-              Schemas: [
-                {
-                  Enums: [
-                    docsLink(
-                      "Operator",
-                      "apis-tools/tasklist-api-rest/schemas/enums/operator/"
-                    ),
-                    docsLink(
-                      "Sort",
-                      "apis-tools/tasklist-api-rest/schemas/enums/sort/"
-                    ),
-                    docsLink(
-                      "TaskSortFields",
-                      "apis-tools/tasklist-api-rest/schemas/enums/task-sort-fields/"
-                    ),
-                    docsLink(
-                      "TaskState",
-                      "apis-tools/tasklist-api-rest/schemas/enums/task-state/"
-                    ),
-                  ],
-                },
-
-                {
-                  Models: [
-                    docsLink(
-                      "DateFilter",
-                      "apis-tools/tasklist-api-rest/schemas/models/date-filter-input/"
-                    ),
-                    docsLink(
-                      "IncludeVariable",
-                      "apis-tools/tasklist-api-rest/schemas/models/include-variable/"
-                    ),
-                    docsLink(
-                      "TaskOrderBy",
-                      "apis-tools/tasklist-api-rest/schemas/models/task-order-by/"
-                    ),
-                    docsLink(
-                      "TaskVariables",
-                      "apis-tools/tasklist-api-rest/schemas/models/task-variables/"
-                    ),
-                  ],
-                },
-
-                {
-                  Requests: [
-                    docsLink(
-                      "SaveVariablesRequest",
-                      "apis-tools/tasklist-api-rest/schemas/requests/save-variable-request/"
-                    ),
-                    docsLink(
-                      "TaskAssignRequest",
-                      "apis-tools/tasklist-api-rest/schemas/requests/task-assign-request/"
-                    ),
-                    docsLink(
-                      "TaskCompleteRequest",
-                      "apis-tools/tasklist-api-rest/schemas/requests/task-complete-request/"
-                    ),
-                    docsLink(
-                      "TaskSearchRequest",
-                      "apis-tools/tasklist-api-rest/schemas/requests/task-search-request/"
-                    ),
-                    docsLink(
-                      "VariableInput",
-                      "apis-tools/tasklist-api-rest/schemas/requests/variable-input/"
-                    ),
-                    docsLink(
-                      "VariablesSearchRequest",
-                      "apis-tools/tasklist-api-rest/schemas/requests/variables-search-request/"
-                    ),
-                  ],
-                },
-
-                {
-                  Responses: [
-                    docsLink(
-                      "ErrorResponse",
-                      "apis-tools/tasklist-api-rest/schemas/responses/error-response/"
-                    ),
-                    docsLink(
-                      "FormResponse",
-                      "apis-tools/tasklist-api-rest/schemas/responses/form-response/"
-                    ),
-                    docsLink(
-                      "TaskResponse",
-                      "apis-tools/tasklist-api-rest/schemas/responses/task-response/"
-                    ),
-                    docsLink(
-                      "TaskSearchResponse",
-                      "apis-tools/tasklist-api-rest/schemas/responses/task-search-response/"
-                    ),
-                    docsLink(
-                      "VariableResponse",
-                      "apis-tools/tasklist-api-rest/schemas/responses/variable-response/"
-                    ),
-                    docsLink(
-                      "VariableSearchResponse",
-                      "apis-tools/tasklist-api-rest/schemas/responses/variable-search-response/"
-                    ),
-                  ],
-                },
-              ],
-            },
+            docsLink(
+              "Migrate to Zeebe user tasks",
+              "apis-tools/tasklist-api-rest/migrate-to-zeebe-user-tasks/"
+            ),
           ],
         },
+
         {
           "Web Modeler API (REST)": [
             docsLink("Overview", "apis-tools/web-modeler-api/overview/"),
@@ -1719,6 +1616,7 @@ module.exports = {
               "Getting started with the Go client",
               "apis-tools/go-client/go-get-started/"
             ),
+            docsLink("Job worker", "apis-tools/go-client/job-worker/"),
           ],
         },
         {
@@ -1795,6 +1693,54 @@ module.exports = {
         },
 
         docsLink("Build your own client", "apis-tools/build-your-own-client/"),
+      ],
+    },
+
+    {
+      "Frontend development": [
+        docsLink(
+          "Introduction to task applications",
+          "apis-tools/frontend-development/introduction-to-task-applications/"
+        ),
+
+        {
+          Forms: [
+            docsLink(
+              "Introduction to forms",
+              "apis-tools/frontend-development/forms/introduction-to-forms/"
+            ),
+
+            {
+              "Embed forms": [
+                docsLink(
+                  "Concepts",
+                  "apis-tools/frontend-development/forms/embed-forms/form-js-concepts/"
+                ),
+                docsLink(
+                  "Embed forms in JavaScript",
+                  "apis-tools/frontend-development/forms/embed-forms/embed-forms-in-javascript/"
+                ),
+              ],
+            },
+
+            {
+              "Customize & extend": [
+                docsLink(
+                  "Styling",
+                  "apis-tools/frontend-development/forms/customize-and-extend/form-styling/"
+                ),
+                docsLink(
+                  "Custom components",
+                  "apis-tools/frontend-development/forms/customize-and-extend/custom-components/"
+                ),
+                docsLink(
+                  "Integrate API data",
+                  "apis-tools/frontend-development/forms/customize-and-extend/integrate-api-data/"
+                ),
+              ],
+            },
+          ],
+        },
       ],
     },
   ],

--- a/optimize_versioned_sidebars/version-3.12.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.12.0-sidebars.json
@@ -1678,6 +1678,11 @@
               "type": "link",
               "label": "Authentication",
               "href": "/docs/apis-tools/administration-api/authentication/"
+            },
+            {
+              "type": "link",
+              "label": "Tutorial",
+              "href": "/docs/apis-tools/administration-api/tutorial/"
             }
           ]
         },
@@ -1687,6 +1692,16 @@
               "type": "link",
               "label": "Overview",
               "href": "/docs/apis-tools/operate-api/overview/"
+            },
+            {
+              "type": "link",
+              "label": "Operate API Explorer",
+              "href": "/api/operate/docs/operate-public-api/"
+            },
+            {
+              "type": "link",
+              "label": "Authentication",
+              "href": "/docs/apis-tools/operate-api/operate-api-authentication/"
             },
             {
               "type": "link",
@@ -1943,147 +1958,13 @@
             },
             {
               "type": "link",
+              "label": "Tasklist API (REST) Explorer",
+              "href": "/api/tasklist/docs/tasklist-rest-api/"
+            },
+            {
+              "type": "link",
               "label": "Authentication",
               "href": "/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-authentication/"
-            },
-            {
-              "Controllers": [
-                {
-                  "type": "link",
-                  "label": "Form API",
-                  "href": "/docs/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-form-controller/"
-                },
-                {
-                  "type": "link",
-                  "label": "Task API",
-                  "href": "/docs/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller/"
-                },
-                {
-                  "type": "link",
-                  "label": "Variables API",
-                  "href": "/docs/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-variables-controller/"
-                }
-              ]
-            },
-            {
-              "Schemas": [
-                {
-                  "Enums": [
-                    {
-                      "type": "link",
-                      "label": "Operator",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/enums/operator/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "Sort",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/enums/sort/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskSortFields",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/enums/task-sort-fields/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskState",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/enums/task-state/"
-                    }
-                  ]
-                },
-                {
-                  "Models": [
-                    {
-                      "type": "link",
-                      "label": "DateFilter",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/models/date-filter-input/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "IncludeVariable",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/models/include-variable/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskOrderBy",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/models/task-order-by/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskVariables",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/models/task-variables/"
-                    }
-                  ]
-                },
-                {
-                  "Requests": [
-                    {
-                      "type": "link",
-                      "label": "SaveVariablesRequest",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/requests/save-variable-request/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskAssignRequest",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/requests/task-assign-request/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskCompleteRequest",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/requests/task-complete-request/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskSearchRequest",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/requests/task-search-request/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "VariableInput",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/requests/variable-input/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "VariablesSearchRequest",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/requests/variables-search-request/"
-                    }
-                  ]
-                },
-                {
-                  "Responses": [
-                    {
-                      "type": "link",
-                      "label": "ErrorResponse",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/responses/error-response/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "FormResponse",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/responses/form-response/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskResponse",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/responses/task-response/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "TaskSearchResponse",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/responses/task-search-response/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "VariableResponse",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/responses/variable-response/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "VariableSearchResponse",
-                      "href": "/docs/apis-tools/tasklist-api-rest/schemas/responses/variable-search-response/"
-                    }
-                  ]
-                }
-              ]
             }
           ]
         },
@@ -2154,6 +2035,11 @@
               "type": "link",
               "label": "Getting started with the Go client",
               "href": "/docs/apis-tools/go-client/go-get-started/"
+            },
+            {
+              "type": "link",
+              "label": "Job worker",
+              "href": "/docs/apis-tools/go-client/job-worker/"
             }
           ]
         },
@@ -2287,6 +2173,16 @@
           "type": "link",
           "label": "Build your own client",
           "href": "/docs/apis-tools/build-your-own-client/"
+        }
+      ]
+    },
+
+    {
+      "Frontend development": [
+        {
+          "type": "link",
+          "label": "Introduction to task applications",
+          "href": "/docs/apis-tools/frontend-development/introduction-to-task-applications/"
         }
       ]
     }


### PR DESCRIPTION
## Description

collaboration with @christinaausley 

Synchronizes the sidebars for the Optimize instance, versions Next and Current, based on the release of our new API Explorers. I missed this when I published the explorers.

Note that we will need to do synchronization again for the upcoming release, and this PR only covers the API Explorer changes, intentionally. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
