### PR TITLE
docs(self-managed): backup procedure slightly different for optimize

### DIFF
--- a/docs/self-managed/operational-guides/backup-restore/optimize-backup.md
+++ b/docs/self-managed/operational-guides/backup-restore/optimize-backup.md
@@ -34,7 +34,9 @@ backup:
 
 ## Create backup API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 The following endpoint can be used to trigger the backup process:
 
 ```
@@ -75,7 +77,9 @@ curl --request POST 'http://localhost:8092/actuator/backups' \
 
 ## Get backup info API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 Information about a specific backup can be retrieved using the following request:
 
 ```
@@ -140,7 +144,9 @@ Possible states of the backup:
 
 ## Delete backup API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 An existing backup can be deleted using the below API which deletes all Optimize snapshots associated with the supplied backupID.
 
 ```

--- a/docs/self-managed/operational-guides/backup-restore/optimize-backup.md
+++ b/docs/self-managed/operational-guides/backup-restore/optimize-backup.md
@@ -8,7 +8,7 @@ keywords: ["backup", "backups"]
 :::note
 This release introduces breaking changes, including the utilized URL.
 
-For example, `curl 'http://localhost:8080/actuator/backups'` rather than the previously used `backup`.
+For example, `curl 'http://localhost:8092/actuator/backups'` rather than the previously used `backup`.
 :::
 
 Optimize stores its data over multiple indices in Elasticsearch. To ensure data integrity across indices, a backup of Optimize data consists of two Elasticsearch snapshots, each containing a different set of Optimize indices. Each backup is identified by a positive integer backup ID. For example, a backup with ID `123456` consists of the following Elasticsearch snapshots:

--- a/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/optimize-backup.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/optimize-backup.md
@@ -34,7 +34,9 @@ backup:
 
 ## Create backup API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 The following endpoint can be used to trigger the backup process:
 
 ```
@@ -75,7 +77,9 @@ curl --request POST 'http://localhost:8092/actuator/backups' \
 
 ## Get backup info API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 Information about a specific backup can be retrieved using the following request:
 
 ```
@@ -140,7 +144,9 @@ Possible states of the backup:
 
 ## Delete backup API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 An existing backup can be deleted using the below API which deletes all Optimize snapshots associated with the supplied backupID.
 
 ```

--- a/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/optimize-backup.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/optimize-backup.md
@@ -8,7 +8,7 @@ keywords: ["backup", "backups"]
 :::note
 This release introduces breaking changes, including the utilized URL.
 
-For example, `curl 'http://localhost:8080/actuator/backups'` rather than the previously used `backup`.
+For example, `curl 'http://localhost:8092/actuator/backups'` rather than the previously used `backup`.
 :::
 
 Optimize stores its data over multiple indices in Elasticsearch. To ensure data integrity across indices, a backup of Optimize data consists of two Elasticsearch snapshots, each containing a different set of Optimize indices. Each backup is identified by a positive integer backup ID. For example, a backup with ID `123456` consists of the following Elasticsearch snapshots:

--- a/versioned_docs/version-8.4/self-managed/operational-guides/backup-restore/optimize-backup.md
+++ b/versioned_docs/version-8.4/self-managed/operational-guides/backup-restore/optimize-backup.md
@@ -34,7 +34,9 @@ backup:
 
 ## Create backup API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 The following endpoint can be used to trigger the backup process:
 
 ```
@@ -75,7 +77,9 @@ curl --request POST 'http://localhost:8092/actuator/backups' \
 
 ## Get backup info API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 Information about a specific backup can be retrieved using the following request:
 
 ```
@@ -140,7 +144,9 @@ Possible states of the backup:
 
 ## Delete backup API
 
-Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.  
+Note that the backup API can be reached via the `/actuator` management port, which by default is `8092`.
+The configured context path does not apply to the management port.
+
 An existing backup can be deleted using the below API which deletes all Optimize snapshots associated with the supplied backupID.
 
 ```

--- a/versioned_docs/version-8.4/self-managed/operational-guides/backup-restore/optimize-backup.md
+++ b/versioned_docs/version-8.4/self-managed/operational-guides/backup-restore/optimize-backup.md
@@ -8,7 +8,7 @@ keywords: ["backup", "backups"]
 :::note
 This release introduces breaking changes, including the utilized URL.
 
-For example, `curl 'http://localhost:8080/actuator/backups'` rather than the previously used `backup`.
+For example, `curl 'http://localhost:8092/actuator/backups'` rather than the previously used `backup`.
 :::
 
 Optimize stores its data over multiple indices in Elasticsearch. To ensure data integrity across indices, a backup of Optimize data consists of two Elasticsearch snapshots, each containing a different set of Optimize indices. Each backup is identified by a positive integer backup ID. For example, a backup with ID `123456` consists of the following Elasticsearch snapshots:


### PR DESCRIPTION
## Description
Hi Optimize-Team!
Very small changes, but maybe it will help so the backup procedure is better understood by users.
As normally you backup the entire stack, one could easily assume that it works the same way as for Operate / Tasklist. However, it's slightly different as it's the only tool that has a dedicated management port and will NOT use the contextpath then.
<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
