### PR TITLE
Revert #3402 (check-versions running on forks)

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -1,25 +1,22 @@
 name: Check versions
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   list-pr-changes:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout last two commits of the PR
+        # The last *two* commits are (1) everything in this branch, and (2) the parent of this branch.
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Fetch target base (what we're merging into)
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 2
 
       - name: Capture version configuration as environment variable
         run: echo "VERSION_CONFIG=$(jq -c . < .github/workflows/check-versions/version-config.json)" >> $GITHUB_ENV
 
       - name: Capture changed files as environment variable
-        run: echo "CHANGED_FILES=$(git diff --name-only HEAD..FETCH_HEAD | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
+        run: echo "CHANGED_FILES=$(git diff --name-only HEAD^ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
 
       - name: Identify missing changes
         id: identify-missing-changes


### PR DESCRIPTION
## Description

Reverts commit #3402. 

Those changes were resulting in inaccurate, noisy comments from the check-versions workflow. Rather than listing the differences between the PR and its target branch _at the time the PR was opened_, it was listing the differences between the PR and its target branch _right now_. When the `main` branch had evolved since opening the PR, that meant the check-versions comment listed basically everything that had been merged since the PR was opened. Reverting this PR will put us back in a place where the check-versions workflow doesn't work for forked PRs, but it is giving accurate messages for 99% of our PRs (which are local instead of forked).

I thought I'd tested this case in https://github.com/camunda/camunda-docs/pull/3396, but the workflow seems to be functioning differently than it was in my tests. 

I'll reopen #3358 to track the need to fix the check-versions workflow for forked PRs. 

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
