### PR TITLE
chore: add on assignments a link to user task restrictions

### DIFF
--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -39,6 +39,11 @@ attributes can be specified simultaneously:
 - `candidateUsers`: Specifies the users that the task can be assigned to.
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
+:::info
+Assignments resources also can be used for set user task restrictions ([SaaS](/components/concepts/access-control/user-task-access-restrictions.md)/[Self-Managed](docs/self-managed/concepts/access-control/user-task-access-restrictions.md)), where users will see only the tasks
+that they have authorization to work.
+:::
+
 Typically, the assignee, candidate users, and candidate groups are defined as [static values](/docs/components/concepts/expressions.md#expressions-vs-static-values) (e.g. `some_username`, `some_username, another_username` and
 `sales, operations`), but they can also be defined as
 [expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= remove(reviewers, book.author)` and `= reviewer_roles`). The expressions are evaluated on activating the user task and must result in a

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -40,8 +40,7 @@ attributes can be specified simultaneously:
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
 :::info
-Assignments resources also can be used for set user task restrictions ([SaaS](/components/concepts/access-control/user-task-access-restrictions.md)/[Self-Managed](docs/self-managed/concepts/access-control/user-task-access-restrictions.md)), where users will see only the tasks
-that they have authorization to work.
+Assignment resources can also be used for set user task restrictions ([SaaS](/components/concepts/access-control/user-task-access-restrictions.md)/[Self-Managed](docs/self-managed/concepts/access-control/user-task-access-restrictions.md)), where users will see only the tasks they have authorization to work on.
 :::
 
 Typically, the assignee, candidate users, and candidate groups are defined as [static values](/docs/components/concepts/expressions.md#expressions-vs-static-values) (e.g. `some_username`, `some_username, another_username` and


### PR DESCRIPTION
## Description

Add an info board on User Task for modeler on assignment section




## When should this change go live?

It can be merged after the approval, once the component is live already. 
