### PR TITLE
chore: add note to turn properties to ENV_VARS

### DIFF
--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -6,7 +6,15 @@ title: Configuration
 Operate is a Spring Boot application. This means every way to [configure](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)
 a Spring Boot application can be applied.
 
-By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`. The following parts are configurable:
+By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
+
+:::note
+Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+
+For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
+:::
+
+The following parts are configurable:
 
 ## Webserver
 

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
+Configuration properties can also be defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/versioned_docs/version-8.2/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/operate-deployment/operate-configuration.md
@@ -6,7 +6,15 @@ title: Configuration
 Operate is a Spring Boot application. This means every way to [configure](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)
 a Spring Boot application can be applied.
 
-By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`. The following parts are configurable:
+By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
+
+:::note
+Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+
+For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
+:::
+
+The following parts are configurable:
 
 - [Webserver](#webserver)
   - [Security](#security)

--- a/versioned_docs/version-8.2/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/versioned_docs/version-8.2/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
+Configuration properties can also be defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
@@ -6,7 +6,15 @@ title: Configuration
 Operate is a Spring Boot application. This means every way to [configure](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)
 a Spring Boot application can be applied.
 
-By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`. The following parts are configurable:
+By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
+
+:::note
+Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+
+For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
+:::
+
+The following parts are configurable:
 
 ## Webserver
 

--- a/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
+Configuration properties can also be defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/versioned_docs/version-8.4/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/operate-deployment/operate-configuration.md
@@ -6,7 +6,15 @@ title: Configuration
 Operate is a Spring Boot application. This means every way to [configure](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)
 a Spring Boot application can be applied.
 
-By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`. The following parts are configurable:
+By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
+
+:::note
+Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+
+For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
+:::
+
+The following parts are configurable:
 
 ## Webserver
 

--- a/versioned_docs/version-8.4/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to UPPERCASE and replacing delimiters with `_`.
+Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::

--- a/versioned_docs/version-8.4/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/operate-deployment/operate-configuration.md
@@ -9,7 +9,7 @@ a Spring Boot application can be applied.
 By default, the configuration for Operate is stored in a YAML file (`application.yml`). All Operate-related settings are prefixed with `camunda.operate`.
 
 :::note
-Configuration properties can also defined as environment variables by converting to uppercase and replacing delimiters with `_`.
+Configuration properties can also be defined as environment variables by converting to uppercase and replacing delimiters with `_`.
 
 For example, the property `camunda.operate.elasticsearch.clustername` can be defined as the environment variable `CAMUNDA_OPERATE_ELASTICSEARCH_CLUSTERNAME`.
 :::


### PR DESCRIPTION
## Description
Add a small note to provide a bit more guidance for customers on how to turn configuration properties into environment variables.

- We opted to not do this on 8.1 docs since that version is almost out of support.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
