### PR TITLE
docs(connectors): Add the ConnectorRetryException documentation and example

### DIFF
--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -312,18 +312,20 @@ The Connector runtime environment initializes the context and allows the followi
 If the Connector handles exceptional cases, it can use any exception to express technical errors. If a technical
 error should be associated with a specific error code, the Connector can throw a `ConnectorException` and define
 a `code` as shown in **(3)**.
+
 We recommend documenting the list of error codes as part of the Connector's API. Users can build on those codes
 by creating [BPMN errors](/components/connectors/use-connectors/index.md#bpmn-errors) in their Connector configurations.<br/>
 
 ###### Retryable errors
 
 :::note
-Your connector needs to fetch the `retryContext` variable as shown in **(6)**. Otherwise, the Connector runtime environment will treat this exception as a regular exception (using the job's retry configuration).
+Your Connector needs to fetch the `retryContext` variable as shown in **(6)**. Otherwise, the Connector runtime environment will treat this exception as a regular exception (using the job's retry configuration).
 :::
+
 As shown in **(4)**, the Connector can also throw a `ConnectorRetryException` to signal a retryable error (external API call in this case). Such errors can be handled by the Connector runtime environment to retry the Connector function execution. Here are some specifics about the `ConnectorRetryException`:
 
 - You can use the `errorCode(String code)` method to define a specific error code for the `ConnectorRetryException`. Retries are on a per-error-code basis.
-- If you don't define an error code, the Connector runtime environment will use a **default** value. This means that all ConnectorRetryExceptions without a specific error code will be treated as the same error and will share the total number of retries.
+- If you don't define an error code, the Connector runtime environment will use a **default** value. This means that all `ConnectorRetryExceptions` without a specific error code will be treated as the same error and will share the total number of retries.
 
 If the Connector has a result to return, it can create a new result data object and set
 its properties as shown in **(5)**.


### PR DESCRIPTION
## Description

- Add some documentation about the new `ConnectorRetryException`. 
- Update the existing example as well.

Related to [this](https://github.com/camunda/team-connectors/issues/630) issue.

I'm not sure if the feature will be backported to 8.4, I'll update this PR (with **/versioned_docs**) if necessary.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
