### PR TITLE
docs(self-managed): upgrade instractions fo components moved to top-level in v8.5

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -8,11 +8,11 @@ The following sections explain which adjustments must be made to migrate from Ca
 
 ## Helm chart
 
-:::caution Breaking Changes
-The Camunda Helm chart v10.0.0 that comes with Camunda 8.5 has major change in the values file stracture. Ensure to update the values keys before starting the chart upgrade.
+:::caution Breaking changes
+The Camunda Helm chart v10.0.0 that comes with Camunda 8.5 has major changes in the values file structure. Update the values keys before starting the chart upgrade.
 :::
 
-Carefully follow the [upgrade instractions](../../platform-deployment/helm-kubernetes/upgrade.md#v1000) to upgrade from Camunda Helm chart v9.x.x to Camunda Helm chart v10.x.x.
+Carefully follow the [upgrade instructions](../../platform-deployment/helm-kubernetes/upgrade.md#v1000) to upgrade from Camunda Helm chart v9.x.x to Camunda Helm chart v10.x.x.
 
 ## Zeebe
 

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -6,6 +6,14 @@ description: "Review which adjustments must be made to migrate from Camunda 8.4.
 
 The following sections explain which adjustments must be made to migrate from Camunda 8.4.x to 8.5.x for each component.
 
+## Helm chart
+
+:::caution Breaking Changes
+The Camunda Helm chart v10.0.0 that comes with Camunda 8.5 has major change in the values file stracture. Ensure to update the values keys before starting the chart upgrade.
+:::
+
+Carefully follow the [upgrade instractions](../../platform-deployment/helm-kubernetes/upgrade.md#v1000) to upgrade from Camunda Helm chart v9.x.x to Camunda Helm chart v10.x.x.
+
 ## Zeebe
 
 ### Deprecated broker health checks

--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -97,13 +97,15 @@ For more details on the Keycloak upgrade path, you can also read the [Bitnami Ke
 
 Camunda Release Cycle: 8.5
 
-:::caution Breaking Changes
-The Camunda Helm chart v10.0.0 has major change in the values file stracture. Ensure to follow upgrade steps for each component before starting the chart upgrade.
+:::caution Breaking changes
+The Camunda Helm chart v10.0.0 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
 :::
 
 #### Identity
 
-Before, Camunda Identity component was a sub-chart of the Camunda Helm chart. Now it is part of the parent Camunda Helm chart. No changes in the Identity keys, but since the LabelSelector MatchLabels of a Kubernetes resource are immutable, its deployment should be deleted because the label `app.kubernetes.io/name` has been changed from `identity` to `camunda-platform`.
+The Camunda Identity component was formerly a sub-chart of the Camunda Helm chart. Now, it is part of the parent Camunda Helm chart.
+
+There are no changes in the Identity keys, but since the `LabelSelector` `MatchLabels` of a Kubernetes resource are immutable, its deployment should be deleted as the label `app.kubernetes.io/name` has been changed from `identity` to `camunda-platform`.
 
 ```shell
 kubectl -n camunda delete -l app.kubernetes.io/name=identity deployment
@@ -111,7 +113,7 @@ kubectl -n camunda delete -l app.kubernetes.io/name=identity deployment
 
 #### Identity - Keycloak
 
-Identity Keycloak values key has been changed from `identity.keycloak` to `identityKeycloak`.
+The Identity Keycloak values key has been changed from `identity.keycloak` to `identityKeycloak`.
 To migrate, move the values under the new key in the values file.
 
 Old:
@@ -129,7 +131,7 @@ identityKeycloak:
 
 #### Identity - PostgreSQL
 
-Identity PostgreSQL values key has been changed from `identity.postgresql` to `identityPostgresql`.
+The Identity PostgreSQL values key has been changed from `identity.postgresql` to `identityPostgresql`.
 To migrate, move the values under the new key in the values file.
 
 Old:
@@ -147,7 +149,7 @@ identityPostgresql:
 
 #### Web Modeler - PostgreSQL
 
-WebModler PostgreSQL values key has been changed from `postgresql` to `webModelerPostgresql`.
+The WebModler PostgreSQL values key has been changed from `postgresql` to `webModelerPostgresql`.
 To migrate, move the values under the new key in the values file.
 
 Old:
@@ -164,7 +166,7 @@ webModelerPostgresql:
 
 #### Zeebe Gateway
 
-Zeebe Gateway values key has been changed from `zeebe-gateway` to `zeebeGateway`.
+The Zeebe Gateway values key has been changed from `zeebe-gateway` to `zeebeGateway`.
 To migrate, move the values under the new key in the values file.
 
 Old:

--- a/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -80,9 +80,9 @@ helm upgrade camunda camunda/camunda-platform\
   --set global.identity.auth.operate.existingSecret=$OPERATE_SECRET \
   --set global.identity.auth.connectors.existingSecret=$CONNECTORS_SECRET \
   --set global.identity.auth.zeebe.existingSecret=$ZEEBE_SECRET \
-  --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
-  --set identity.keycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
-  --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET
+  --set identityKeycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
+  --set identityKeycloak.auth.managementPassword=$KEYCLOAK_MANAGEMENT_SECRET \
+  --set identityKeycloak.postgresql.auth.password=$POSTGRESQL_SECRET
 ```
 
 :::note
@@ -93,7 +93,95 @@ For more details on the Keycloak upgrade path, you can also read the [Bitnami Ke
 
 ## Version update instructions
 
+### v10.0.0
+
+Camunda Release Cycle: 8.5
+
+:::caution Breaking Changes
+The Camunda Helm chart v10.0.0 has major change in the values file stracture. Ensure to follow upgrade steps for each component before starting the chart upgrade.
+:::
+
+#### Identity
+
+Before, Camunda Identity component was a sub-chart of the Camunda Helm chart. Now it is part of the parent Camunda Helm chart. No changes in the Identity keys, but since the LabelSelector MatchLabels of a Kubernetes resource are immutable, its deployment should be deleted because the label `app.kubernetes.io/name` has been changed from `identity` to `camunda-platform`.
+
+```shell
+kubectl -n camunda delete -l app.kubernetes.io/name=identity deployment
+```
+
+#### Identity - Keycloak
+
+Identity Keycloak values key has been changed from `identity.keycloak` to `identityKeycloak`.
+To migrate, move the values under the new key in the values file.
+
+Old:
+
+```yaml
+identity:
+  keycloak:
+```
+
+New:
+
+```yaml
+identityKeycloak:
+```
+
+#### Identity - PostgreSQL
+
+Identity PostgreSQL values key has been changed from `identity.postgresql` to `identityPostgresql`.
+To migrate, move the values under the new key in the values file.
+
+Old:
+
+```yaml
+identity:
+  postgresql:
+```
+
+New:
+
+```yaml
+identityPostgresql:
+```
+
+#### Web Modeler - PostgreSQL
+
+WebModler PostgreSQL values key has been changed from `postgresql` to `webModelerPostgresql`.
+To migrate, move the values under the new key in the values file.
+
+Old:
+
+```yaml
+postgresql:
+```
+
+New:
+
+```yaml
+webModelerPostgresql:
+```
+
+#### Zeebe Gateway
+
+Zeebe Gateway values key has been changed from `zeebe-gateway` to `zeebeGateway`.
+To migrate, move the values under the new key in the values file.
+
+Old:
+
+```yaml
+zeebe-gateway:
+```
+
+New:
+
+```yaml
+zeebeGateway:
+```
+
 ### v9.3.0
+
+Camunda Release Cycle: 8.4
 
 #### Enabling Console
 
@@ -116,6 +204,8 @@ To add the Console role:
 You should now be able to log into Console.
 
 ### v9.0.0
+
+Camunda Release Cycle: 8.4
 
 For full change log, view the Camunda Helm chart [v9.0.0 release notes](https://github.com/camunda/camunda-platform-helm/releases/tag/camunda-platform-9.0.0).
 
@@ -147,6 +237,8 @@ Elasticsearch image has been upgraded from 8.8.2 to 8.9.2.
 
 ### v8.3.1
 
+Camunda Release Cycle: 8.3
+
 :::caution
 The following steps are applied when upgrading from **any** previous version, including `8.3.0`.
 :::
@@ -175,6 +267,8 @@ The following resources have been renamed:
 - **ServiceAccount:** From `camunda-zeebe-gateway-gateway` to `camunda-zeebe-gateway`.
 
 ### v8.3.0 (minor)
+
+Camunda Release Cycle: 8.3
 
 :::caution
 Updating Operate, Tasklist, and Optimize from 8.2.x to 8.3.0 will potentially take longer than expected, depending on the data to be migrated.
@@ -406,6 +500,8 @@ webModeler:
 
 ### v8.2.9
 
+Camunda Release Cycle: 8.2
+
 #### Optimize
 
 For Optimize 3.10.1, a new environment variable introduced redirection URL. However, the change is not compatible with Camunda Helm charts until it is fixed in 3.10.3 (and Helm chart 8.2.9). Therefore, those versions are coupled to certain Camunda Helm chart versions:
@@ -418,6 +514,8 @@ For Optimize 3.10.1, a new environment variable introduced redirection URL. Howe
 No action is needed if you use Optimize 3.10.3 (shipped with this Helm chart version by default), but this Optimize version cannot be used out of the box with previous Helm chart versions.
 
 ### v8.2.3
+
+Camunda Release Cycle: 8.2
 
 #### Zeebe Gateway
 
@@ -437,6 +535,8 @@ To authenticate:
 - [Zeebe client (zbctl)](/docs/self-managed/zeebe-deployment/security/secure-client-communication/#zbctl).
 
 ### v8.2.0 (Minor)
+
+Camunda Release Cycle: 8.2
 
 #### Connectors
 
@@ -554,6 +654,8 @@ kubectl scale --replicas=1 deployment camunda-identity
 Then follow the [typical upgrade steps](#upgrading-where-identity-enabled).
 
 ### v8.0.13
+
+Camunda Release Cycle: 8.0
 
 If you installed Camunda 8 using Helm charts before `8.0.13`, you need to apply the following steps to handle the new Elasticsearch labels.
 


### PR DESCRIPTION
## Description

Due to the limitations of the Helm sub-chart structure where the sub-charts cannot access the parent or other sub-charts, we moved away from that structure. Also, renamed a couple of keys to make that possible and followed a unified naming.

This is a breaking change since the user needs to restructure the values file according to the new names.

## When should this change go live?

- [ ] This change is not yet live but could be merged.
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [x] The changes are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
