### PR TITLE
docs(connectors): Add documentation and exemple for ConnectorRetryException

### DIFF
--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -244,6 +244,7 @@ package io.camunda.connector;
 
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import java.util.Collections;

--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -318,17 +318,14 @@ error should be associated with a specific error code, the Connector can throw a
 a `code` as shown in **(3)**.
 
 We recommend documenting the list of error codes as part of the Connector's API. Users can build on those codes
-by creating [BPMN errors](/components/connectors/use-connectors/index.md#bpmn-errors) in their Connector configurations.<br/>
+by creating [BPMN errors](/components/connectors/use-connectors/index.md#bpmn-errors) in their Connector configurations.
 
-As shown in **(5)**, the Connector can also throw a `ConnectorRetryException` to signal a retryable error (external API call in this case). Such errors will enable the connector to override the job retries and backoff duration values. Here are some specifics about the `ConnectorRetryException`.<br/>
-If `retries` or `backoffDuration` are not set, the Connector runtime will use the job values.<br/>
-As shown in **(6)**, the developer is responsible to set (decrease) the number of retries. The Connector runtime will use these values **as is** to override the job values.
+As shown in **(5)**, the Connector can also throw a `ConnectorRetryException` to signal a retryable error (external API call in this case). Such errors will enable the Connector to override the job retries and backoff duration values. Here are some specifics about the `ConnectorRetryException`:
 
-If the Connector has a result to return, it can create a new result data object and set
-its properties as shown in **(4)**.
-
-For best interoperability, Connector functions provide default meta-data via the `@OutboundConnector` annotation.
-Connector runtime environments can use this data to auto-discover provided Connector runtime behavior.
+- If `retries` or `backoffDuration` are not set, the Connector runtime will use the job values.
+- As shown in **(6)**, the developer is responsible to set (decrease) the number of retries. The Connector runtime will use these values **as is** to override the job values.
+- If the Connector has a result to return, it can create a new result data object and set its properties as shown in **(4)**.
+- For best interoperability, Connector functions provide default meta-data via the `@OutboundConnector` annotation. Connector runtime environments can use this data to auto-discover provided Connector runtime behavior.
 
 Using this outline, you start the business logic of your Connector in the `executeConnector` method
 and expand from there.

--- a/docs/components/connectors/custom-built-connectors/connector-sdk.md
+++ b/docs/components/connectors/custom-built-connectors/connector-sdk.md
@@ -298,7 +298,8 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
       throw new ConnectorRetryExceptionBuilder()
               .message("External API error")
               .errorCode("EXTERNAL_API_ERROR")
-              .retries(remainingRetries)
+              // (6)
+              .retries(remainingRetries--)
               .backoffDuration(Duration.ofSeconds(10))
               .build();
     }
@@ -320,7 +321,8 @@ We recommend documenting the list of error codes as part of the Connector's API.
 by creating [BPMN errors](/components/connectors/use-connectors/index.md#bpmn-errors) in their Connector configurations.<br/>
 
 As shown in **(5)**, the Connector can also throw a `ConnectorRetryException` to signal a retryable error (external API call in this case). Such errors will enable the connector to override the job retries and backoff duration values. Here are some specifics about the `ConnectorRetryException`.<br/>
-If `retries` or `backoffDuration` are not set, the Connector runtime will use the job values.
+If `retries` or `backoffDuration` are not set, the Connector runtime will use the job values.<br/>
+As shown in **(6)**, the developer is responsible to set (decrease) the number of retries. The Connector runtime will use these values **as is** to override the job values.
 
 If the Connector has a result to return, it can create a new result data object and set
 its properties as shown in **(4)**.


### PR DESCRIPTION
## Description

Related issue: https://github.com/camunda/team-connectors/issues/630
Related PR: https://github.com/camunda/connectors/pull/2146


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
