### PR TITLE
docs(announcements): add note on updating Web Modeler 8.2 to a newer version

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -122,6 +122,14 @@ End of maintenance: 8th of October 2024
 [Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
+### Update from Web Modeler 8.2 to a later minor version
+
+Web Modeler versions 8.2.7 to 8.2.12 are affected by [camunda/issues#677](https://github.com/camunda/issues/issues/677).
+
+If you are using one of these versions, you should first update to Web Modeler 8.2.13 (or a subsequent patch version) before upgrading to a later minor version (8.3 or higher).
+
+If your current version of Web Modeler is 8.2.6 or earlier, you may directly upgrade to a later minor version.
+
 ### Do not update to Camunda 8.2.22
 
 :::caution

--- a/versioned_docs/version-8.2/reference/announcements.md
+++ b/versioned_docs/version-8.2/reference/announcements.md
@@ -22,6 +22,14 @@ End of maintenance: 8th of October 2024
 [Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
+### Update from Web Modeler 8.2 to a later minor version
+
+Web Modeler versions 8.2.7 to 8.2.12 are affected by [camunda/issues#677](https://github.com/camunda/issues/issues/677).
+
+If you are using one of these versions, you should first update to Web Modeler 8.2.13 (or a subsequent patch version) before upgrading to a later minor version (8.3 or higher).
+
+If your current version of Web Modeler is 8.2.6 or earlier, you may directly upgrade to a later minor version.
+
 ### Do not update to Camunda 8.2.22
 
 :::caution

--- a/versioned_docs/version-8.3/reference/announcements.md
+++ b/versioned_docs/version-8.3/reference/announcements.md
@@ -56,6 +56,14 @@ End of maintenance: 8th of October 2024
 [Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
+### Update from Web Modeler 8.2 to a later minor version
+
+Web Modeler versions 8.2.7 to 8.2.12 are affected by [camunda/issues#677](https://github.com/camunda/issues/issues/677).
+
+If you are using one of these versions, you should first update to Web Modeler 8.2.13 (or a subsequent patch version) before upgrading to a later minor version (8.3 or higher).
+
+If your current version of Web Modeler is 8.2.6 or earlier, you may directly upgrade to a later minor version.
+
 ### Do not update to Camunda 8.2.22
 
 :::caution

--- a/versioned_docs/version-8.4/reference/announcements.md
+++ b/versioned_docs/version-8.4/reference/announcements.md
@@ -122,6 +122,14 @@ End of maintenance: 8th of October 2024
 [Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
+### Update from Web Modeler 8.2 to a later minor version
+
+Web Modeler versions 8.2.7 to 8.2.12 are affected by [camunda/issues#677](https://github.com/camunda/issues/issues/677).
+
+If you are using one of these versions, you should first update to Web Modeler 8.2.13 (or a subsequent patch version) before upgrading to a later minor version (8.3 or higher).
+
+If your current version of Web Modeler is 8.2.6 or earlier, you may directly upgrade to a later minor version.
+
 ### Do not update to Camunda 8.2.22
 
 :::caution


### PR DESCRIPTION
## Description
Adds a note on how to update from Web Modeler 8.2 to a newer minor version (an update to the latest 8.2.x patch version is required first in some cases).
Closes https://github.com/camunda/web-modeler/issues/8535.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
  - Docs update should be published with the Web Modeler 8.2.13 patch release (due date April 9)
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.