### PR TITLE
docs(identity): Add note regarding single sign out limitation

### DIFF
--- a/docs/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -197,6 +197,9 @@ global:
 
 ### Additional considerations
 
+Due to technical limitations regarding [third party content](https://openid.net/specs/openid-connect-frontchannel-1_0.html#ThirdPartyContent),
+front channel single sign out is not supported. This means that when a user logs out of one component, they will not be logged out of the other components.
+
 For authentication, the Camunda components use the scopes `email`, `openid`, `offline_access`, `profile`,
 and `<CLIENT_UUID>/.default`. To ensure your users are able to successfully authenticate with Entra ID, you must
 ensure that either there is

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -184,6 +184,9 @@ global:
 
 ### Additional considerations
 
+Due to technical limitations regarding [third party content](https://openid.net/specs/openid-connect-frontchannel-1_0.html#ThirdPartyContent),
+front channel single sign out is not supported. This means that when a user logs out of one component, they will not be logged out of the other components.
+
 For authentication, the Camunda components use the scopes `email`, `openid`, `offline_access`, `profile`,
 and `<CLIENT_UUID>/.default`. To ensure your users are able to successfully authenticate with Entra ID, you must
 ensure that either there is


### PR DESCRIPTION
Closes https://github.com/camunda-cloud/identity/issues/2701

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Through the investigation and implementation of an upcoming piece of work we discovered that there are known limitations in the OpenID spec for front channel logout due to third party cookie settings.

This is something that we should make the customers aware of. The OpenID spec lists the limitation [here](https://openid.net/specs/openid-connect-frontchannel-1_0.html#ThirdPartyContent) and an example of this in the Microsoft docs is [here](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-spa-sign-in?tabs=javascript2#sign-out-behavior-on-browsers)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
