### PR TITLE
docs(interceptors): improve custom interceptor doc.

### DIFF
--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
@@ -168,7 +168,7 @@ for the same language level as Zeebe's (i.e. currently JDK 11) or lower.
 
 :::note
 
-file path in jar should match package name. e.g, your package name is `com.example`, then you should packaging jar as `jar cvfm LoggingInterceptor.jar ./MANIFEST.MF ./com/example/*.class ./lib`
+The file path for `jar` should match the package name. For example, if your package name is `com.example`, you should package `jar` as `jar cvfm LoggingInterceptor.jar ./MANIFEST.MF ./com/example/*.class ./lib`.
 
 :::
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
@@ -166,6 +166,13 @@ in order to place the libraries' classes on the classpath.
 Similar to your interceptor class, any libraries you package must be compiled
 for the same language level as Zeebe's (i.e. currently JDK 11) or lower.
 
+:::note
+
+file path in jar should match package name. e.g, your package name is `com.example`, then you should packaging jar as `jar cvfm LoggingInterceptor.jar ./MANIFEST.MF ./com/example/*.class ./lib`
+
+:::
+
+
 ```sh
 # both runtime libraries and the manifest must be packaged together with the compiled classes
 jar cvfm LoggingInterceptor.jar ./MANIFEST.MF ./*.class ./lib


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
