### PR TITLE
docs(zeebe): fix broken zeebe links

### DIFF
--- a/docs/apis-tools/build-your-own-client.md
+++ b/docs/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"${ZEEBE_TOKEN_AUDIENCE}\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/docs/components/best-practices/architecture/sizing-your-environment.md
+++ b/docs/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/docs/components/best-practices/development/writing-good-workers.md
+++ b/docs/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/docs/components/zeebe/technical-concepts/architecture.md
+++ b/docs/components/zeebe/technical-concepts/architecture.md
@@ -72,4 +72,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/docs/components/zeebe/technical-concepts/protocols.md
+++ b/docs/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda-cloud/zeebe/tree/develop/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
 
 ## What is gRPC?
 

--- a/docs/components/zeebe/zeebe-overview.md
+++ b/docs/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premise) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (available through the [exporters](../../self-managed/zeebe-deployment/exporters/exporters.md) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/docs/components/zeebe/zeebe-overview.md
+++ b/docs/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premise) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/docs/components/zeebe/zeebe-overview.md
+++ b/docs/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premise) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -149,7 +149,7 @@ camunda.tasklist:
 Refer to [supported environments](../../reference/supported-environments.md#camunda-8-self-managed) to find out which versions of Elasticsearch or OpenSearch are supported in a Camunda 8 Self-Managed setup.
 :::
 
-For Elasticsearch, Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter). <br/>For OpenSearch, Tasklist imports data from indices created and filled in by the [Zeebe OpenSearch exporter](../zeebe-deployment/exporters/opensearch-exporter.md).
+For Elasticsearch, Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter). <br/>For OpenSearch, Tasklist imports data from indices created and filled in by the [Zeebe OpenSearch exporter](../zeebe-deployment/exporters/opensearch-exporter.md).
 
 Therefore, settings for this Elasticsearch or OpenSearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/docs/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/docs/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting, though you may find it easier to search through our [broker](broker.md) and [gateway](gateway.md) configuration documentation to adjust the templates:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/docs/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/docs/self-managed/zeebe-deployment/security/client-authorization.md
@@ -36,7 +36,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 

--- a/optimize/self-managed/optimize-deployment/configuration/getting-started.md
+++ b/optimize/self-managed/optimize-deployment/configuration/getting-started.md
@@ -24,7 +24,7 @@ To perform an import and provide the full set of features, Optimize requires a c
 
 ## Camunda 8 specific configuration
 
-For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
+For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
 
 ## Recommended additional configurations
 

--- a/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/getting-started.md
+++ b/optimize_versioned_docs/version-3.10.0/self-managed/optimize-deployment/configuration/getting-started.md
@@ -24,7 +24,7 @@ To perform an import and provide the full set of features, Optimize requires a c
 
 ## Camunda 8 specific configuration
 
-For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
+For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
 
 ## Recommended additional configurations
 

--- a/optimize_versioned_docs/version-3.11.0/self-managed/optimize-deployment/configuration/getting-started.md
+++ b/optimize_versioned_docs/version-3.11.0/self-managed/optimize-deployment/configuration/getting-started.md
@@ -24,7 +24,7 @@ To perform an import and provide the full set of features, Optimize requires a c
 
 ## Camunda 8 specific configuration
 
-For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
+For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
 
 ## Recommended additional configurations
 

--- a/optimize_versioned_docs/version-3.12.0/self-managed/optimize-deployment/configuration/getting-started.md
+++ b/optimize_versioned_docs/version-3.12.0/self-managed/optimize-deployment/configuration/getting-started.md
@@ -24,7 +24,7 @@ To perform an import and provide the full set of features, Optimize requires a c
 
 ## Camunda 8 specific configuration
 
-For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
+For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
 
 ## Recommended additional configurations
 

--- a/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/getting-started.md
+++ b/optimize_versioned_docs/version-3.9.0/self-managed/optimize-deployment/configuration/getting-started.md
@@ -22,7 +22,7 @@ To perform an import and provide the full set of features, Optimize requires a c
 
 ## Camunda 8 specific configuration
 
-For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
+For Camunda 8, Optimize is importing process data from exported zeebe records as created by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) from the same Elasticsearch cluster that Optimize used to store it's own data. For the relevant configuration options, refer to the [Camunda 8 import configuration](./system-configuration-platform-8.md).
 
 ## Recommended additional configurations
 

--- a/versioned_docs/version-1.3/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-1.3/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"zeebe.camunda.io\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-1.3/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-1.3/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"zeebe.camunda.io\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/1.3.14/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/1.3.14/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-1.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-1.3/apis-tools/java-client/job-worker.md
@@ -27,7 +27,7 @@ On `open`, the job worker waits `pollInterval` milliseconds and then polls for `
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-1.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-1.3/apis-tools/java-client/job-worker.md
@@ -27,7 +27,7 @@ On `open`, the job worker waits `pollInterval` milliseconds and then polls for `
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/1.3.14/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-1.3/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-1.3/components/best-practices/architecture/sizing-your-environment.md
@@ -81,7 +81,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 
 The data you attach to a process instance (process variables) will influence disk space requirements. For example, it makes a big difference if you only add one or two strings (requiring ~ 1kb of space) to your process instances, or a full JSON document containing 1MB.
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda Cloud SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/1.3.14/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda Cloud SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 * Zeebe: 75 kb / PI
 * Operate: 57 kb / PI
@@ -141,7 +141,7 @@ Camunda Cloud defines three fixed hardware packages you can select from. The tab
 | Max Total Number of Process Instances        | 5.4 M                           | 5.4 M                            |                                  |
 | Approx resources provisioned **\*\***        | 15 vCPU, 20 GB mem, 640 GB disk | 28 vCPU, 50 GB mem, 640 GB disk | 56 vCPU, 85 GB mem, 1320 GB disk |
 
-**\*** The numbers in the table where measured using Camunda Cloud 1.2.4 and [the official benchmark project](https://github.com/camunda/zeebe/tree/main/zeebe/benchmarks). It uses a [ten task process](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/ten_tasks.bpmn). To calculate day-based metrics, a equal distribution over 24 hours is assumed.
+**\*** The numbers in the table where measured using Camunda Cloud 1.2.4 and [the official benchmark project](https://github.com/camunda/zeebe/tree/1.3.14/benchmarks). It uses a [ten task process](https://github.com/camunda/zeebe/blob/1.3.14/benchmarks/project/src/main/resources/bpmn/ten_tasks.bpmn). To calculate day-based metrics, a equal distribution over 24 hours is assumed.
 
 
 **\*\***  These are the resource limits configured in the Kubernetes cluster and are always subject to change.
@@ -227,5 +227,5 @@ If you are in doubt about which package to choose, you can do a load test with a
 
 This is recommended if you exceed the above numbers of three million process instances per day.
 
-You can look at the [Zeebe benchmark project](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/setup/README.md#benchmarking-camunda-cloud-saas). While this project will not run out-of-the-box (e.g. you need need to build starter and worker code yourself and use self-created docker images), you can use it as a starting point for own endavours.
+You can look at the [Zeebe benchmark project](https://github.com/camunda/zeebe/blob/1.3.14/benchmarks/setup/README.md#benchmarking-camunda-cloud-saas). While this project will not run out-of-the-box (e.g. you need need to build starter and worker code yourself and use self-created docker images), you can use it as a starting point for own endavours.
 

--- a/versioned_docs/version-1.3/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-1.3/components/best-practices/architecture/sizing-your-environment.md
@@ -81,7 +81,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 
 The data you attach to a process instance (process variables) will influence disk space requirements. For example, it makes a big difference if you only add one or two strings (requiring ~ 1kb of space) to your process instances, or a full JSON document containing 1MB.
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda Cloud SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda Cloud SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 * Zeebe: 75 kb / PI
 * Operate: 57 kb / PI
@@ -141,7 +141,7 @@ Camunda Cloud defines three fixed hardware packages you can select from. The tab
 | Max Total Number of Process Instances        | 5.4 M                           | 5.4 M                            |                                  |
 | Approx resources provisioned **\*\***        | 15 vCPU, 20 GB mem, 640 GB disk | 28 vCPU, 50 GB mem, 640 GB disk | 56 vCPU, 85 GB mem, 1320 GB disk |
 
-**\*** The numbers in the table where measured using Camunda Cloud 1.2.4 and [the official benchmark project](https://github.com/camunda-cloud/zeebe/tree/develop/benchmarks). It uses a [ten task process](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/ten_tasks.bpmn). To calculate day-based metrics, a equal distribution over 24 hours is assumed.
+**\*** The numbers in the table where measured using Camunda Cloud 1.2.4 and [the official benchmark project](https://github.com/camunda/zeebe/tree/main/zeebe/benchmarks). It uses a [ten task process](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/ten_tasks.bpmn). To calculate day-based metrics, a equal distribution over 24 hours is assumed.
 
 
 **\*\***  These are the resource limits configured in the Kubernetes cluster and are always subject to change.
@@ -227,5 +227,5 @@ If you are in doubt about which package to choose, you can do a load test with a
 
 This is recommended if you exceed the above numbers of three million process instances per day.
 
-You can look at the [Zeebe benchmark project](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/setup/README.md#benchmarking-camunda-cloud-saas). While this project will not run out-of-the-box (e.g. you need need to build starter and worker code yourself and use self-created docker images), you can use it as a starting point for own endavours.
+You can look at the [Zeebe benchmark project](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/setup/README.md#benchmarking-camunda-cloud-saas). While this project will not run out-of-the-box (e.g. you need need to build starter and worker code yourself and use self-created docker images), you can use it as a starting point for own endavours.
 

--- a/versioned_docs/version-1.3/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-1.3/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/1.3.14/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-1.3/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-1.3/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-1.3/components/zeebe/open-source/community-contributions.md
+++ b/versioned_docs/version-1.3/components/zeebe/open-source/community-contributions.md
@@ -18,7 +18,7 @@ We use both the [Camunda Community Hub](https://github.com/Camunda-Community-Hub
 
 If you built something for the Zeebe ecosystem, we encourage you to [add it to the Camunda Community Hub](https://github.com/Camunda-Community-Hub/community/issues/new?assignees=&labels=&template=new-community-extension-proposal-template.md&title=) using the **New Community Extension Proposal** template.
 
-If you're interested in contributing to the main Zeebe repository (versus creating an extension that lives in its own repository), be sure to start with the [Contributing to Zeebe](https://github.com/camunda-cloud/zeebe/blob/master/CONTRIBUTING.md) guide in GitHub.
+If you're interested in contributing to the main Zeebe repository (versus creating an extension that lives in its own repository), be sure to start with the [Contributing to Zeebe](https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md) guide in GitHub.
 
 ## Next steps
 

--- a/versioned_docs/version-1.3/components/zeebe/open-source/exporters.md
+++ b/versioned_docs/version-1.3/components/zeebe/open-source/exporters.md
@@ -21,7 +21,7 @@ configuration file.
 Once an exporter is configured, the next time Zeebe is started the exporter starts receiving records. Note that it is only guaranteed to see records produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden of persisting data indefinitely.
 
@@ -34,7 +34,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -61,7 +61,7 @@ Different exporters can therefore depend on the same third-party libraries witho
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a simple `Map<String, Object>`, which is passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -71,7 +71,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-1.3/components/zeebe/open-source/exporters.md
+++ b/versioned_docs/version-1.3/components/zeebe/open-source/exporters.md
@@ -21,7 +21,7 @@ configuration file.
 Once an exporter is configured, the next time Zeebe is started the exporter starts receiving records. Note that it is only guaranteed to see records produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/1.3.14/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden of persisting data indefinitely.
 
@@ -34,7 +34,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/tree/1.3.14/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -61,7 +61,7 @@ Different exporters can therefore depend on the same third-party libraries witho
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a simple `Map<String, Object>`, which is passed directly
-in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/1.3.14/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -71,7 +71,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/1.3.14/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-1.3/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-1.3/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.

--- a/versioned_docs/version-1.3/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-1.3/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/1.3.14/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.

--- a/versioned_docs/version-1.3/components/zeebe/technical-concepts/exporters.md
+++ b/versioned_docs/version-1.3/components/zeebe/technical-concepts/exporters.md
@@ -29,7 +29,7 @@ starts receiving records. Note that it is only guaranteed to see records
 produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden
 of persisting data indefinitely.
@@ -44,7 +44,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition. 
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-1.3/components/zeebe/technical-concepts/exporters.md
+++ b/versioned_docs/version-1.3/components/zeebe/technical-concepts/exporters.md
@@ -29,7 +29,7 @@ starts receiving records. Note that it is only guaranteed to see records
 produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/1.3.14/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden
 of persisting data indefinitely.
@@ -44,7 +44,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/tree/1.3.14/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/1.3.14/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition. 
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/1.3.14/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-1.3/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-1.3/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda-cloud/zeebe/tree/develop/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-1.3/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-1.3/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/1.3.14/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-1.3/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-1.3/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda Cloud or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda Cloud Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda Cloud Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) added in Camunda Cloud Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda Cloud Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/index.md).

--- a/versioned_docs/version-1.3/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-1.3/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda Cloud or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda Cloud Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) added in Camunda Cloud Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/1.3.14/exporters/elasticsearch-exporter) added in Camunda Cloud Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda Cloud Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/index.md).

--- a/versioned_docs/version-1.3/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-1.3/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda Cloud or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda Cloud Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) added in Camunda Cloud Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter) added in Camunda Cloud Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda Cloud Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/index.md).

--- a/versioned_docs/version-1.3/self-managed/operate-deployment/configuration.md
+++ b/versioned_docs/version-1.3/self-managed/operate-deployment/configuration.md
@@ -103,7 +103,7 @@ camunda.operate:
 
 ## Zeebe Elasticsearch exporter
 
-Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-1.3/self-managed/operate-deployment/configuration.md
+++ b/versioned_docs/version-1.3/self-managed/operate-deployment/configuration.md
@@ -103,7 +103,7 @@ camunda.operate:
 
 ## Zeebe Elasticsearch exporter
 
-Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/1.3.14/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-1.3/self-managed/tasklist-deployment/configuration.md
+++ b/versioned_docs/version-1.3/self-managed/tasklist-deployment/configuration.md
@@ -129,7 +129,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-1.3/self-managed/tasklist-deployment/configuration.md
+++ b/versioned_docs/version-1.3/self-managed/tasklist-deployment/configuration.md
@@ -129,7 +129,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/1.3.14/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/1.3.14/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/1.3.14/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/1.3.14/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/1.3.14/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/operations/metrics.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/operations/metrics.md
@@ -94,7 +94,7 @@ The health of partitions in a broker can be monitored by the metric `zeebe_healt
 ## Grafana
 
 Zeebe comes with a pre-built dashboard, available in the repository:
-[monitor/grafana/zeebe.json](https://github.com/camunda/zeebe/tree/main/zeebe/monitor/grafana/zeebe.json).
+[monitor/grafana/zeebe.json](https://github.com/camunda/zeebe/tree/1.3.14/monitor/grafana/zeebe.json).
 
 [Import](https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard)
 it into your Grafana instance, then select the correct Prometheus data source (important if you have more than one), and

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/operations/metrics.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/operations/metrics.md
@@ -94,7 +94,7 @@ The health of partitions in a broker can be monitored by the metric `zeebe_healt
 ## Grafana
 
 Zeebe comes with a pre-built dashboard, available in the repository:
-[monitor/grafana/zeebe.json](https://github.com/camunda-cloud/zeebe/tree/develop/monitor/grafana/zeebe.json).
+[monitor/grafana/zeebe.json](https://github.com/camunda/zeebe/tree/main/zeebe/monitor/grafana/zeebe.json).
 
 [Import](https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard)
 it into your Grafana instance, then select the correct Prometheus data source (important if you have more than one), and

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/security/client-authorization.md
@@ -11,7 +11,7 @@ The gateway doesn't provide any way to validate these headers, so users must imp
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact a OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda Cloud authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda Cloud authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/1.3.14/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
 
 ## Credentials provider
 

--- a/versioned_docs/version-1.3/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-1.3/self-managed/zeebe-deployment/security/client-authorization.md
@@ -11,7 +11,7 @@ The gateway doesn't provide any way to validate these headers, so users must imp
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact a OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda Cloud authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda Cloud authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
 
 ## Credentials provider
 

--- a/versioned_docs/version-8.1/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.1/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"zeebe.camunda.io\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.1/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.1/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"zeebe.camunda.io\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/stable/8.1/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/stable/8.1/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.1/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.1/apis-tools/java-client/job-worker.md
@@ -30,7 +30,7 @@ For example, imagine you have 10 process instances and a single job worker confi
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-8.1/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.1/apis-tools/java-client/job-worker.md
@@ -30,7 +30,7 @@ For example, imagine you have 10 process instances and a single job worker confi
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/stable/8.1/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/stable/8.1/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-8.1/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.1/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/stable/8.1/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.1/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.1/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.1/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/stable/8.1/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.1/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.1/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.1/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.1/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/versioned_docs/version-8.1/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.1/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/versioned_docs/version-8.1/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.1/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda-cloud/zeebe/tree/develop/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.1/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.1/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/stable/8.1/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.1/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.1/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.1/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.1/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.1/self-managed/concepts/exporters.md
@@ -29,7 +29,7 @@ starts receiving records. Note that it is only guaranteed to see records
 produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.1/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden
 of persisting data indefinitely.
@@ -44,7 +44,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda/zeebe/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/blob/stable/8.1/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/stable/8.1/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/stable/8.1/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.1/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.1/self-managed/concepts/exporters.md
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.1/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/operate-deployment/operate-configuration.md
@@ -119,7 +119,7 @@ camunda.operate:
 
 ## Zeebe Elasticsearch exporter
 
-Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.1/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.1/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/operate-deployment/operate-configuration.md
@@ -119,7 +119,7 @@ camunda.operate:
 
 ## Zeebe Elasticsearch exporter
 
-Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+Operate imports data from Elasticsearch indices created and filled in by the [Zeebe Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.1/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -126,7 +126,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/stable/8.1/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.1/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -126,7 +126,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.1/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.1/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.1/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/stable/8.1/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/client-authorization.md
@@ -11,7 +11,7 @@ The gateway doesn't provide any way to validate these headers, so users must imp
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact a OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/stable/8.1/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
 
 ## Credentials provider
 

--- a/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.1/self-managed/zeebe-deployment/security/client-authorization.md
@@ -11,7 +11,7 @@ The gateway doesn't provide any way to validate these headers, so users must imp
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact a OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the `CredentialsProvider` interface as well as the built-in implementation.
 
 ## Credentials provider
 

--- a/versioned_docs/version-8.2/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.2/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"zeebe.camunda.io\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.2/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.2/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"zeebe.camunda.io\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/stable/8.2/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/stable/8.2/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.2/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.2/apis-tools/java-client/job-worker.md
@@ -30,7 +30,7 @@ For example, imagine you have 10 process instances and a single job worker confi
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/stable/8.2/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/stable/8.2/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-8.2/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.2/apis-tools/java-client/job-worker.md
@@ -30,7 +30,7 @@ For example, imagine you have 10 process instances and a single job worker confi
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-8.2/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.2/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.2/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.2/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/stable/8.2/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.2/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.2/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/stable/8.2/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.2/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.2/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.2/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.

--- a/versioned_docs/version-8.2/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.2/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://awesome.zeebe.io) are also available.

--- a/versioned_docs/version-8.2/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.2/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda-cloud/zeebe/tree/develop/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.2/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.2/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/stable/8.2/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.2/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.2/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.2/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.2/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.2/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.2/self-managed/concepts/exporters.md
@@ -29,7 +29,7 @@ starts receiving records. Note that it is only guaranteed to see records
 produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.2/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden
 of persisting data indefinitely.
@@ -44,7 +44,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda/zeebe/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/blob/stable/8.2/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/stable/8.2/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/stable/8.2/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.2/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.2/self-managed/concepts/exporters.md
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -126,7 +126,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -126,7 +126,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/stable/8.2/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.2/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.2/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.2/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/stable/8.2/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/security/client-authorization.md
@@ -38,7 +38,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/security/client-authorization.md
@@ -38,7 +38,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/stable/8.2/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 

--- a/versioned_docs/version-8.3/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.3/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"${ZEEBE_TOKEN_AUDIENCE}\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.3/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.3/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"${ZEEBE_TOKEN_AUDIENCE}\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/stable/8.3/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/stable/8.3/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
@@ -30,7 +30,7 @@ For example, imagine you have 10 process instances and a single job worker confi
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
@@ -30,7 +30,7 @@ For example, imagine you have 10 process instances and a single job worker confi
 
 When a poll fails with an error response, the job worker applies a backoff strategy. It waits for some time, after which it polls again for more jobs. This gives a Zeebe cluster some time to recover from a failure. In some cases, you may want to configure this backoff strategy to better fit your situation.
 
-The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/camunda/zeebe/blob/stable/8.3/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java). You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/camunda/zeebe/blob/stable/8.3/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
 
 By default, the job worker uses an exponential backoff implementation, which you can configure using `BackoffSupplier.newBackoffBuilder()`.
 

--- a/versioned_docs/version-8.3/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.3/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.3/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.3/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/stable/8.3/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.3/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/stable/8.3/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.3/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.3/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.3/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/versioned_docs/version-8.3/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.3/components/zeebe/technical-concepts/architecture.md
@@ -67,4 +67,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.3/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/versioned_docs/version-8.3/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.3/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda-cloud/zeebe/tree/develop/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.3/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.3/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/stable/8.3/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.3/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.3/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.3/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.3/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premises) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.3/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.3/self-managed/concepts/exporters.md
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.3/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.3/self-managed/concepts/exporters.md
@@ -29,7 +29,7 @@ starts receiving records. Note that it is only guaranteed to see records
 produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.3/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden
 of persisting data indefinitely.
@@ -44,7 +44,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda/zeebe/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/blob/stable/8.3/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/stable/8.3/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/stable/8.3/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.3/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -126,7 +126,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.3/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -126,7 +126,7 @@ camunda.tasklist:
 
 ## Zeebe Elasticsearch exporter
 
-Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/stable/8.3/exporters/elasticsearch-exporter).
 
 Therefore, settings for this Elasticsearch connection must be defined and correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.3/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.3/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.3/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/stable/8.3/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/client-authorization.md
@@ -36,7 +36,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/client-authorization.md
@@ -36,7 +36,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/stable/8.3/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 

--- a/versioned_docs/version-8.4/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.4/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"${ZEEBE_TOKEN_AUDIENCE}\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda-cloud/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.4/apis-tools/build-your-own-client.md
+++ b/versioned_docs/version-8.4/apis-tools/build-your-own-client.md
@@ -71,10 +71,10 @@ export ACCESS_TOKEN=$(curl -s --request POST \
   --data "{\"client_id\":\"${ZEEBE_CLIENT_ID}\",\"client_secret\":\"${ZEEBE_CLIENT_SECRET}\",\"audience\":\"${ZEEBE_TOKEN_AUDIENCE}\",\"grant_type\":\"client_credentials\"}" | sed 's/.*access_token":"\([^"]*\)".*/\1/' )
 ```
 
-4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto)):
+4. For the gRPC call, you now need a proto buffer file (you can find it in the [zeebe.io repository](https://raw.githubusercontent.com/camunda/zeebe/stable/8.4/gateway-protocol/src/main/proto/gateway.proto)):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/camunda/zeebe/main/zeebe/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
+curl -sSL https://raw.githubusercontent.com/camunda/zeebe/stable/8.4/gateway-protocol/src/main/proto/gateway.proto > /tmp/gateway.proto
 ```
 
 5. Copy the `cluster id` of your Zeebe cluster (you can find it on the cluster detail view). Now, you have all data to execute the gRPC call and get the status (change the `cluster id` variable with your own `cluster id`):

--- a/versioned_docs/version-8.4/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.4/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda-cloud/zeebe/blob/develop/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.4/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.4/components/best-practices/architecture/sizing-your-environment.md
@@ -93,7 +93,7 @@ Furthermore, data is also sent Operate and Optimize, which store data in Elastic
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
-Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
+Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/zeebe/blob/stable/8.4/benchmarks/project/src/main/resources/bpmn/typical_payload.json) we measured the following approximations for disk space requirements using Camunda 8 SaaS 1.2.4. Please note, that these are not exact numbers, but they might give you an idea what to expect:
 
 - Zeebe: 75 kb / PI
 - Operate: 57 kb / PI

--- a/versioned_docs/version-8.4/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/stable/8.4/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.4/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/writing-good-workers.md
@@ -118,7 +118,7 @@ public void retrieveMoney(final JobClient client, final ActivatedJob job) {
 }
 ```
 
-In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
+In the background, a worker starts a polling component and [a thread pool](https://github.com/camunda-cloud/zeebe/blob/d24b31493b8e22ad3405ee183adfd5a546b7742e/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java#L179-L183) to [handle the polled jobs](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java#L109-L111). The [**default thread pool size is one**](https://github.com/camunda-cloud/zeebe/blob/760074f59bc1bcfb483fab4645501430f362a475/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L49). If you need more, you can enable a thread pool:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()

--- a/versioned_docs/version-8.4/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.4/components/zeebe/technical-concepts/architecture.md
@@ -72,4 +72,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.4/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/versioned_docs/version-8.4/components/zeebe/technical-concepts/architecture.md
+++ b/versioned_docs/version-8.4/components/zeebe/technical-concepts/architecture.md
@@ -72,4 +72,4 @@ The exporter system provides an event stream of state changes within Zeebe. This
 - Analysis of historic process data for auditing, business intelligence, etc.
 - Tracking [incidents](/components/concepts/incidents.md) created by Zeebe
 
-The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/master/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.
+The exporter includes an API you can use to stream data into a storage system of your choice. Zeebe includes an out-of-the-box [Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter), and other [community-contributed exporters](https://github.com/camunda-community-hub/awesome-camunda-platform-8) are also available.

--- a/versioned_docs/version-8.4/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.4/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda-cloud/zeebe/tree/develop/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.4/components/zeebe/technical-concepts/protocols.md
+++ b/versioned_docs/version-8.4/components/zeebe/technical-concepts/protocols.md
@@ -7,7 +7,7 @@ description: "Let's discuss gRPC and supported clients."
 Zeebe clients connect to brokers via a stateless gateway.
 
 For the communication between client and gateway, [gRPC](https://grpc.io/) is used. The communication protocol is defined using Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
-[Zeebe repository](https://github.com/camunda/zeebe/tree/main/zeebe/gateway-protocol).
+[Zeebe repository](https://github.com/camunda/zeebe/tree/stable/8.4/gateway-protocol).
 
 ## What is gRPC?
 

--- a/versioned_docs/version-8.4/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.4/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premise) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.4/components/zeebe/zeebe-overview.md
+++ b/versioned_docs/version-8.4/components/zeebe/zeebe-overview.md
@@ -15,7 +15,7 @@ With Zeebe you can:
 - Use as part of a software as a service (SaaS) offering with Camunda 8 or deploy with Docker and Kubernetes (in the cloud or on-premise) with Camunda 8 Self-Managed.
 - Scale horizontally to handle very high throughput.
 - Rely on fault tolerance and high availability for your processes.
-- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
+- Export processes data for monitoring and analysis (currently only available through the [Elasticsearch exporter](../../self-managed/zeebe-deployment/exporters/elasticsearch-exporter) added in Camunda 8 Self-Managed).
 - Engage with an active community.
 
 For documentation on deploying Zeebe as part of Camunda 8 Self-Managed, refer to the [deployment guide](../../self-managed/zeebe-deployment/zeebe-installation.md).

--- a/versioned_docs/version-8.4/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.4/self-managed/concepts/exporters.md
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda-cloud/zeebe/tree/develop/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda-cloud/zeebe/tree/develop/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.4/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.4/self-managed/concepts/exporters.md
@@ -29,7 +29,7 @@ starts receiving records. Note that it is only guaranteed to see records
 produced from that point on.
 
 Find a reference implementation in the form of the Zeebe-maintained
-[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter).
+[Elasticsearch exporter](https://github.com/camunda/zeebe/tree/stable/8.4/exporters/elasticsearch-exporter).
 
 The main impact exporters have on a Zeebe cluster is that they remove the burden
 of persisting data indefinitely.
@@ -44,7 +44,7 @@ If no exporters are configured, Zeebe automatically erases data when it is not n
 
 Regardless of how an exporter is loaded (whether through an external JAR or not),
 all exporters interact in the same way with the broker, which is defined by the
-[exporter interface](https://github.com/camunda/zeebe/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
+[exporter interface](https://github.com/camunda/zeebe/blob/stable/8.4/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading
 
@@ -75,7 +75,7 @@ Additionally, exporters use the system class loader for system classes, or class
 
 Exporter-specific configuration is handled through the exporter's `[exporters.args]`
 nested map. This provides a `Map<String, Object>` passed directly
-in the form of a [configuration](https://github.com/camunda/zeebe/tree/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
+in the form of a [configuration](https://github.com/camunda/zeebe/tree/stable/8.4/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Configuration.java) object when the broker calls the `Exporter#configure(Configuration)` method.
 
 Configuration occurs at two different phases: during the broker startup phase, and
 once every time a leader is elected for a partition.
@@ -85,7 +85,7 @@ once every time a leader is elected for a partition.
 At any given point, there is exactly one leader node for a given partition.
 
 Whenever a node becomes the leader for a partition, it runs an instance of an
-[exporter stream processor](https://github.com/camunda/zeebe/tree/main/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
+[exporter stream processor](https://github.com/camunda/zeebe/tree/stable/8.4/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java).
 
 This stream processor creates exactly one instance of each configured exporter,
 and forwards every record written on the stream to each of these in turn.

--- a/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -149,7 +149,7 @@ camunda.tasklist:
 Refer to [supported environments](../../reference/supported-environments.md#camunda-8-self-managed) to find out which versions of Elasticsearch or OpenSearch are supported in a Camunda 8 Self-Managed setup.
 :::
 
-For Elasticsearch, Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter). <br/>For OpenSearch, Tasklist imports data from indices created and filled in by the [Zeebe OpenSearch exporter](../zeebe-deployment/exporters/opensearch-exporter.md).
+For Elasticsearch, Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/stable/8.4/exporters/elasticsearch-exporter). <br/>For OpenSearch, Tasklist imports data from indices created and filled in by the [Zeebe OpenSearch exporter](../zeebe-deployment/exporters/opensearch-exporter.md).
 
 Therefore, settings for this Elasticsearch or OpenSearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -149,7 +149,7 @@ camunda.tasklist:
 Refer to [supported environments](../../reference/supported-environments.md#camunda-8-self-managed) to find out which versions of Elasticsearch or OpenSearch are supported in a Camunda 8 Self-Managed setup.
 :::
 
-For Elasticsearch, Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter). <br/>For OpenSearch, Tasklist imports data from indices created and filled in by the [Zeebe OpenSearch exporter](../zeebe-deployment/exporters/opensearch-exporter.md).
+For Elasticsearch, Tasklist imports data from Elasticsearch indices created and filled in by [Zeebe Elasticsearch Exporter](https://github.com/camunda/zeebe/tree/main/zeebe/exporters/elasticsearch-exporter). <br/>For OpenSearch, Tasklist imports data from indices created and filled in by the [Zeebe OpenSearch exporter](../zeebe-deployment/exporters/opensearch-exporter.md).
 
 Therefore, settings for this Elasticsearch or OpenSearch connection must be defined and must correspond to the settings on the Zeebe side.
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting, though you may find it easier to search through our [broker](broker.md) and [gateway](gateway.md) configuration documentation to adjust the templates:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda-cloud/zeebe/tree/develop/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/configuration/configuration.md
@@ -31,10 +31,10 @@ The default configuration is not suitable for a standalone gateway node. To run 
 
 We provide templates that contain all possible configuration settings, along with explanations for each setting, though you may find it easier to search through our [broker](broker.md) and [gateway](gateway.md) configuration documentation to adjust the templates:
 
-- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
-- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
-- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/main/zeebe/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
+- [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.4/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.4/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development.
+- [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/camunda/zeebe/tree/stable/8.4/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster.
+- [`config/gateway.yaml.template`](https://github.com/camunda/zeebe/tree/stable/8.4/dist/src/main/config/gateway.yaml.template) - Complete configuration template for a standalone gateway.
 
 :::note
 These templates also include the corresponding environment variables to use for every setting.

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/client-authorization.md
@@ -36,7 +36,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/client-authorization.md
@@ -36,7 +36,7 @@ Zeebe clients also provide a way for users to modify gRPC call headers, namely t
 
 Users can modify gRPC headers using Zeebe's built-in `OAuthCredentialsProvider`, which uses user-specified credentials to contact an OAuth authorization server. The authorization server should return an access token that is then appended to each gRPC request.
 
-Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/main/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
+Although, by default `OAuthCredentialsProvider` is configured with to use a Camunda 8 authorization server, it can be configured to use any user-defined server. Users can also write a custom [CredentialsProvider](https://github.com/camunda/zeebe/blob/stable/8.4/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java). In the following sections, we'll describe the usage of the default `OAuthCredentialsProvider` as well as the `CredentialsProvider` interface that can be extended for implementing a custom provider.
 
 ### OAuthCredentialsProvider
 


### PR DESCRIPTION
## Description

- Fix broken link for `Elasticsearch exporter` in zeebe overview
- Fix several broken zeebe github links as a result of repo migration and restructure

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.


closes #3505 