### PR TITLE
chore(optimize): add 3.13 Optimize migration notes

### DIFF
--- a/optimize/self-managed/optimize-deployment/migration-update/3.12_8.4-to-3.13_8.5.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/3.12_8.4-to-3.13_8.5.md
@@ -1,0 +1,35 @@
+---
+id: 3.12_8.4-to-3.13_8.5
+title: "Update notes (8.4/3.12 to 8.5/3.13)"
+---
+
+:::note Heads up!
+To update Optimize to version 8.5/3.13, perform the steps in the [migration and update instructions](./instructions.md).
+:::
+
+The update to 8.5/3.13 can be performed from any 8.4/3.12 release.
+
+Here you will find information about:
+
+- Limitations
+- Known issues
+- Changes in supported environments
+- Changes in behavior (for example, due to a new feature)
+- Changes in translation resources
+
+## Changes in supported environments
+
+### Camunda 7
+
+Optimize now supports up to `7.21.0+`.
+See the [supported environments]($docs$/reference/supported-environments/#camunda-platform-7--optimize-version-matrix) section for the full range of supported versions.
+
+## Changes in translation files
+
+### Localization file
+
+The following terms have been added to or removed from the localization file `en.json` since the last release:
+
+[en.json.diff](./translation-diffs/differences_localization_312_313.diff)
+
+- Lines with a `+` in the beginning mark the addition/update of a term; lines with a `-` mark the removal of a term.

--- a/optimize/self-managed/optimize-deployment/migration-update/instructions.md
+++ b/optimize/self-managed/optimize-deployment/migration-update/instructions.md
@@ -8,10 +8,10 @@ Optimize releases two new minor versions a year. These documents guide you throu
 
 If you want to update Optimize by several versions, you cannot do that at once, but you need to perform the updates in sequential order. For instance, if you want to update from 2.5 to 3.0, you need to update first from 2.5 to 2.6, then from 2.6 to 2.7, and finally from 2.7 to 3.0. The following table shows the recommended update paths to the latest version:
 
-| Update from      | Recommended update path to 8.3/3.11                               |
+| Update from      | Recommended update path to 8.5/3.13                               |
 | ---------------- | ----------------------------------------------------------------- |
-| 8.4/3.12         | You are on the latest version.                                    |
-| 3.0 - 8.3/3.11.x | Rolling update to 8.4/3.12                                        |
+| 8.5/3.13         | You are on the latest version.                                    |
+| 3.0 - 8.4/3.12.x | Rolling update to 8.5/3.13                                        |
 | 2.0 - 2.7        | 1. Rolling update to 2.7 <br /> 2. Rolling update from 2.7 to 3.0 |
 | 1.0 - 1.5        | No update possible. Use the latest version directly.              |
 

--- a/optimize/self-managed/optimize-deployment/migration-update/translation-diffs/differences_localization_312_313.diff
+++ b/optimize/self-managed/optimize-deployment/migration-update/translation-diffs/differences_localization_312_313.diff
@@ -1,25 +1,25 @@
 diff --git a/backend/src/main/resources/localization/en.json b/backend/src/main/resources/localization/en.json
-index 659a884148..12887fd12d 100644
+index 12887fd12d..659a884148 100644
 --- a/backend/src/main/resources/localization/en.json
 +++ b/backend/src/main/resources/localization/en.json
-@@ -27,9 +27,7 @@
+@@ -27,7 +27,9 @@
      "termsOfUse": "Terms of use",
      "imprint": "Imprint",
      "academy": "Camunda Academy",
--    "feedback": "Feedback and Support",
--    "opensearchPreview": "Opensearch preview release",
--    "opensearchWarningText": "This is a preview release of Optimize with OpenSearch support. The data import is fully functional, however the data visualization and evaluation features are in an experimental stage and should not be used for production use-cases."
-+    "feedback": "Feedback and Support"
+-    "feedback": "Feedback and Support"
++    "feedback": "Feedback and Support",
++    "opensearchPreview": "Opensearch preview release",
++    "opensearchWarningText": "This is a preview release of Optimize with OpenSearch support. The data import is fully functional, however the data visualization and evaluation features are in an experimental stage and should not be used for production use-cases."
    },
    "login": {
      "label": "Log in",
-@@ -48,8 +46,7 @@
+@@ -46,7 +48,8 @@
      "notConnected": "is not connected",
      "rightsReserved": "All Rights Reserved",
      "connectionError": "Connection Status Unknown (Cannot establish Websocket connection)",
--    "timezone": "Date and time displayed in local timezone:",
--    "database": "Database"
-+    "timezone": "Date and time displayed in local timezone:"
+-    "timezone": "Date and time displayed in local timezone:"
++    "timezone": "Date and time displayed in local timezone:",
++    "database": "Database"
    },
    "license": {
      "label": "License",

--- a/optimize/self-managed/optimize-deployment/migration-update/translation-diffs/differences_localization_312_313.diff
+++ b/optimize/self-managed/optimize-deployment/migration-update/translation-diffs/differences_localization_312_313.diff
@@ -1,0 +1,25 @@
+diff --git a/backend/src/main/resources/localization/en.json b/backend/src/main/resources/localization/en.json
+index 659a884148..12887fd12d 100644
+--- a/backend/src/main/resources/localization/en.json
++++ b/backend/src/main/resources/localization/en.json
+@@ -27,9 +27,7 @@
+     "termsOfUse": "Terms of use",
+     "imprint": "Imprint",
+     "academy": "Camunda Academy",
+-    "feedback": "Feedback and Support",
+-    "opensearchPreview": "Opensearch preview release",
+-    "opensearchWarningText": "This is a preview release of Optimize with OpenSearch support. The data import is fully functional, however the data visualization and evaluation features are in an experimental stage and should not be used for production use-cases."
++    "feedback": "Feedback and Support"
+   },
+   "login": {
+     "label": "Log in",
+@@ -48,8 +46,7 @@
+     "notConnected": "is not connected",
+     "rightsReserved": "All Rights Reserved",
+     "connectionError": "Connection Status Unknown (Cannot establish Websocket connection)",
+-    "timezone": "Date and time displayed in local timezone:",
+-    "database": "Database"
++    "timezone": "Date and time displayed in local timezone:"
+   },
+   "license": {
+     "label": "License",


### PR DESCRIPTION
related to 3.13 release

## Description

This adds the migration guide for the 3.13 Optimzie release.

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
