### PR TITLE
docs(ootbc): Update timeout settings in network communication docs

### DIFF
--- a/docs/components/connectors/protocol/graphql.md
+++ b/docs/components/connectors/protocol/graphql.md
@@ -177,11 +177,11 @@ Variables:
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/docs/components/connectors/protocol/graphql.md
+++ b/docs/components/connectors/protocol/graphql.md
@@ -177,10 +177,13 @@ Variables:
 }
 ```
 
-### Connection Timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection Timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response mapping
 

--- a/docs/components/connectors/protocol/rest.md
+++ b/docs/components/connectors/protocol/rest.md
@@ -167,11 +167,11 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/docs/components/connectors/protocol/rest.md
+++ b/docs/components/connectors/protocol/rest.md
@@ -7,7 +7,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST Connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
 
 :::
 
@@ -167,10 +167,13 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Connection timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response
 

--- a/versioned_docs/version-8.1/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.1/components/connectors/protocol/graphql.md
@@ -177,11 +177,11 @@ Variables:
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.1/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.1/components/connectors/protocol/graphql.md
@@ -177,10 +177,13 @@ Variables:
 }
 ```
 
-### Connection Timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection Timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response mapping
 

--- a/versioned_docs/version-8.1/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.1/components/connectors/protocol/rest.md
@@ -167,11 +167,11 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.1/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.1/components/connectors/protocol/rest.md
@@ -7,7 +7,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST Connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
 
 :::
 
@@ -167,10 +167,13 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Connection timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response
 

--- a/versioned_docs/version-8.2/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.2/components/connectors/protocol/graphql.md
@@ -177,11 +177,11 @@ Variables:
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.2/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.2/components/connectors/protocol/graphql.md
@@ -177,10 +177,13 @@ Variables:
 }
 ```
 
-### Connection Timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection Timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response mapping
 

--- a/versioned_docs/version-8.2/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.2/components/connectors/protocol/rest.md
@@ -167,11 +167,11 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.2/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.2/components/connectors/protocol/rest.md
@@ -7,7 +7,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST Connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
 
 :::
 
@@ -167,10 +167,13 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Connection timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response
 

--- a/versioned_docs/version-8.3/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/graphql.md
@@ -177,11 +177,11 @@ Variables:
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.3/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/graphql.md
@@ -177,10 +177,13 @@ Variables:
 }
 ```
 
-### Connection Timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection Timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response mapping
 

--- a/versioned_docs/version-8.3/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/rest.md
@@ -167,11 +167,11 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.3/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.3/components/connectors/protocol/rest.md
@@ -7,7 +7,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST Connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
 
 :::
 
@@ -167,10 +167,13 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Connection timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response
 

--- a/versioned_docs/version-8.4/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.4/components/connectors/protocol/graphql.md
@@ -177,11 +177,11 @@ Variables:
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.4/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.4/components/connectors/protocol/graphql.md
@@ -177,10 +177,13 @@ Variables:
 }
 ```
 
-### Connection Timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection Timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response mapping
 

--- a/versioned_docs/version-8.4/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.4/components/connectors/protocol/rest.md
@@ -167,11 +167,11 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Network Communication Timeouts
+### Network communication timeouts
 
-- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+- **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
 
-- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
 - **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 

--- a/versioned_docs/version-8.4/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.4/components/connectors/protocol/rest.md
@@ -7,7 +7,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST Connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
 
 :::
 
@@ -167,10 +167,13 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
-### Connection timeout
+### Network Communication Timeouts
 
-To set connection timeout in your request, set it in seconds in the **Connection timeout** section.
-This is not a required field, with a default value of 20 seconds. To set an infinite timeout, set this value to `0`.
+- **Connection timeout in seconds** setting determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.
+
+- **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, you can set this to 0.
+
+- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
 
 ## Response
 


### PR DESCRIPTION
## Description

Update timeout settings in network communication docs

related : 
https://github.com/camunda/web-modeler/pull/8689

## When should this change go live?
April release
<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until the April release.
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`)
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer,
