### PR TITLE
backport 3546

### DIFF
--- a/docs/components/best-practices/development/routing-events-to-processes.md
+++ b/docs/components/best-practices/development/routing-events-to-processes.md
@@ -151,7 +151,7 @@ You can also use [`CreateProcessInstanceWithResult`](/apis-tools/zeebe-api/gatew
 As soon as you have multiple possible starting points, you have to use named messages to start process instances. The API method is [`PublishMessage`](/apis-tools/zeebe-api/gateway-service.md#publishmessage-rpc):
 
 ```java
-client.newPublishMessageComment()
+client.newPublishMessageCommand()
   .messageName("message_invoiceReceived") // <1>
   .corrlationKey(invoiceId) // <2>
   .variables( // <3>

--- a/versioned_docs/version-8.1/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/routing-events-to-processes.md
@@ -155,7 +155,7 @@ You can also use [`CreateProcessInstanceWithResult`](/apis-tools/grpc.md/#create
 As soon as you have multiple possible starting points, you have to use named messages to start process instances. The API method is [`PublishMessage`](/apis-tools/grpc.md/#publishmessage-rpc):
 
 ```java
-client.newPublishMessageComment()
+client.newPublishMessageCommand()
   .messageName("message_invoiceReceived") // <1>
   .corrlationKey(invoiceId) // <2>
   .variables( // <3>

--- a/versioned_docs/version-8.2/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/routing-events-to-processes.md
@@ -155,7 +155,7 @@ You can also use [`CreateProcessInstanceWithResult`](../../../apis-tools/grpc.md
 As soon as you have multiple possible starting points, you have to use named messages to start process instances. The API method is [`PublishMessage`](../../../apis-tools/grpc.md#publishmessage-rpc):
 
 ```java
-client.newPublishMessageComment()
+client.newPublishMessageCommand()
   .messageName("message_invoiceReceived") // <1>
   .corrlationKey(invoiceId) // <2>
   .variables( // <3>

--- a/versioned_docs/version-8.3/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/routing-events-to-processes.md
@@ -155,7 +155,7 @@ You can also use [`CreateProcessInstanceWithResult`](../../../apis-tools/grpc.md
 As soon as you have multiple possible starting points, you have to use named messages to start process instances. The API method is [`PublishMessage`](../../../apis-tools/grpc.md#publishmessage-rpc):
 
 ```java
-client.newPublishMessageComment()
+client.newPublishMessageCommand()
   .messageName("message_invoiceReceived") // <1>
   .corrlationKey(invoiceId) // <2>
   .variables( // <3>


### PR DESCRIPTION
## Description

Backporting https://github.com/camunda/camunda-docs/pull/3546.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
