### PR TITLE
docs: document REST & management configuration

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -28,6 +28,21 @@ The broker health check routes have moved, and the old routes are now deprecated
 
 Please migrate to the new routes in your deployments. **If you're using the official Helm charts, then you don't have to do anything here.**
 
+### Management properties
+
+The `server.*` configuration properties are now used to configure _only the REST server_. This means if you wish to modify the management server properties, you now have to prefix them with `management.`. Note that not all properties are supported on the management context, but most are - [refer to official documentation for more](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.monitoring).
+
+If you were setting any of the properties below, you will now have to change them as shown in the table:
+
+| Old property                         | **New property**                                |
+| ------------------------------------ | ----------------------------------------------- |
+| `server.address`                     | `management.server.address`                     |
+| `server.host`                        | `management.server.host`                        |
+| `server.host`                        | `management.server.port`                        |
+| `server.ssl.enabled`                 | `management.server.ssl.enabled`                 |
+| `server.ssl.certificate`             | `management.server.ssl.certificate`             |
+| `server.ssl.certificate-private-key` | `management.server.ssl.certificate-private-key` |
+
 ### Changes to exported records
 
 The `UserTask` events like `UserTask:CREATED` don't export the string value properties `candidateUsers` and `candidateGroups` anymore.

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -30,7 +30,7 @@ Please migrate to the new routes in your deployments. **If you're using the offi
 
 ### Management properties
 
-The `server.*` configuration properties are now used to configure _only the REST server_. This means if you wish to modify the management server properties, you now have to prefix them with `management.`. Note that not all properties are supported on the management context, but most are - [refer to official documentation for more](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.monitoring).
+The `server.*` configuration properties are now used to configure _only the REST server_. This means if you wish to modify the management server properties, you now have to prefix them with `management.server.*`. Note that not all properties are supported on the management context, but most are - [refer to official documentation for more](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.monitoring).
 
 If you were setting any of the properties below, you will now have to change them as shown in the table:
 

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -30,7 +30,11 @@ Please migrate to the new routes in your deployments. **If you're using the offi
 
 ### Management properties
 
-The `server.*` configuration properties are now used to configure _only the REST server_. This means if you wish to modify the management server properties, you now have to prefix them with `management.server.*`. Note that not all properties are supported on the management context, but most are - [refer to official documentation for more](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.monitoring).
+The `server.*` configuration properties are now used to configure _only the REST server_. This means if you wish to modify the management server properties, you now have to prefix them with `management.server.*`.
+
+:::note
+Not all properties are supported on the management context, but most are - [refer to the official Spring documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.monitoring) for more details.
+:::
 
 If you were setting any of the properties below, you will now have to change them as shown in the table:
 

--- a/docs/self-managed/zeebe-deployment/configuration/broker.md
+++ b/docs/self-managed/zeebe-deployment/configuration/broker.md
@@ -36,16 +36,16 @@ We provide tables with environment variables, application properties, a descript
 Configuration names are noted as the **header** of each documented section, while the **field** values represent properties to set the configuration.
 
 :::note
-The Zeebe Broker is a Spring Boot application. As such, [many common Spring Boot properties will simply work out of the box](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html).
+The Zeebe Broker is a Spring Boot application. As such, [many common Spring Boot properties will work out of the box](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html).
 
-Additionally, its REST server is a reactive Spring Boot server (powered by WebFlux), and can be configured using the standard `server.*` properties, as well as the usual WebFlux properties. Its management server (e.g. where actuator endpoints live) is configured as a child application context, and is also a reactive, WebFlux server. It can be configured via `management.server.*` properties.
+Additionally, its REST server is a reactive Spring Boot server (powered by WebFlux), and can be configured using the standard `server.*` properties, as well as the usual WebFlux properties. Its management server (for example, where actuator endpoints live) is configured as a child application context, and is also a reactive WebFlux server. It can be configured via `management.server.*` properties.
 
 Finally, the REST server is only serving requests _if, and only if, the embedded gateway is enabled via_ `zeebe.broker.gateway.enable: true`.
 :::
 
 ### server
 
-The `server` configuration allows you to configure the main REST server. Below are a few common ones, [but you can find a more exhaustive list here.](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server)
+The `server` configuration allows you to configure the main REST server. Below are a few common ones, but you can find a more exhaustive list [in the official Spring documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server).
 
 | Field | Description                                                                                                               | Example value |
 | ----- | ------------------------------------------------------------------------------------------------------------------------- | ------------- |
@@ -60,7 +60,7 @@ The `server` configuration allows you to configure the main REST server. Below a
 
 #### server.ssl
 
-Allows you configure the SSL security for the REST server.
+Allows you to configure the SSL security for the REST server.
 
 | Field                   | Description                                                                                                                                                                     | Example value |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
@@ -84,9 +84,9 @@ server:
 
 ### spring.webflux
 
-| Field     | Description                                                                                                                                                                                                                                                 | Example value |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| base-path | The context path prefix for all REST API requests. For example, if you configure `/zeebe`, then client's REST address would be `http://localhost:8080/zeebe`. This setting can also be overridden using the environment variable `SPRING_WEBFLUX_BASEPATH`. | `/`           |
+| Field     | Description                                                                                                                                                                                                                                                     | Example value |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| base-path | The context path prefix for all REST API requests. For example, if you configure `/zeebe`, then the client's REST address would be `http://localhost:8080/zeebe`. This setting can also be overridden using the environment variable `SPRING_WEBFLUX_BASEPATH`. | `/`           |
 
 #### YAML snippet
 
@@ -99,11 +99,11 @@ spring.webflux:
 
 The `management.server` configuration allows you to configure the management server.
 
-| Field     | Description                                                                                                                                                                                                                                                                                | Example value |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| host      | Sets the host the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_HOST`.                                                                                                                                                 | 0.0.0.0       |
-| port      | Sets the port the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_PORT`.                                                                                                                                                 | 8080          |
-| base-path | The context path prefix for all management endpoints. For example, if you configure `/zeebe`, then your actuator endpoints will be at `http://localhost:9600/zeebe/actuator/configprops`. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_BASEPATH`. | `/`           |
+| Field     | Description                                                                                                                                                                                                                                                                           | Example value |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| host      | Sets the host the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_HOST`.                                                                                                                                            | 0.0.0.0       |
+| port      | Sets the port the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_PORT`.                                                                                                                                            | 8080          |
+| base-path | The context path prefix for all management endpoints. For example, if you configure `/zeebe`, your actuator endpoints will be at `http://localhost:9600/zeebe/actuator/configprops`. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_BASEPATH`. | `/`           |
 
 #### YAML snippet
 

--- a/docs/self-managed/zeebe-deployment/configuration/broker.md
+++ b/docs/self-managed/zeebe-deployment/configuration/broker.md
@@ -35,6 +35,85 @@ We provide tables with environment variables, application properties, a descript
 
 Configuration names are noted as the **header** of each documented section, while the **field** values represent properties to set the configuration.
 
+:::note
+The Zeebe Broker is a Spring Boot application. As such, [many common Spring Boot properties will simply work out of the box](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html).
+
+Additionally, its REST server is a reactive Spring Boot server (powered by WebFlux), and can be configured using the standard `server.*` properties, as well as the usual WebFlux properties. Its management server (e.g. where actuator endpoints live) is configured as a child application context, and is also a reactive, WebFlux server. It can be configured via `management.server.*` properties.
+
+Finally, the REST server is only serving requests _if, and only if, the embedded gateway is enabled via_ `zeebe.broker.gateway.enable: true`.
+:::
+
+### server
+
+The `server` configuration allows you to configure the main REST server. Below are a few common ones, [but you can find a more exhaustive list here.](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server)
+
+| Field | Description                                                                                                               | Example value |
+| ----- | ------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| host  | Sets the host the REST server binds to. This setting can also be overridden using the environment variable `SERVER_HOST`. | 0.0.0.0       |
+| port  | Sets the port the REST server binds to. This setting can also be overridden using the environment variable `SERVER_PORT`. | 8080          |
+
+#### server.compression
+
+| Field   | Description                                                                                                                                                 | Example value |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled | If true, enables compression of responses for the REST API. This setting can also be overridden using the environment variable `SERVER_COMPRESION_ENABLED`. | false         |
+
+#### server.ssl
+
+Allows you configure the SSL security for the REST server.
+
+| Field                   | Description                                                                                                                                                                     | Example value |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled                 | If true, enables TLS for the REST API. This setting can also be overridden using the environment variable `SERVER_SSL_ENABLED`.                                                 | false         |
+| certificate             | The path to a PEM encoded certificate. This setting can also be overridden using the environment variable `SERVER_SSL_CERTIFICATE`.                                             |               |
+| certificate-private-key | The path to a PKCS1 or PKCS8 private key for the configured certificate. This setting can also be overridden using the environment variable `SERVER_SSL_CERTIFICATEPRIVATEKEY`. |               |
+
+#### YAML snippet
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 8080
+  compression:
+    enabled: true
+  ssl:
+    enabled: true
+    certificate: /path/to/my/cert.pem
+    certificate-private-key: /path/to/my/private.key
+```
+
+### spring.webflux
+
+| Field     | Description                                                                                                                                                                                                                                                 | Example value |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| base-path | The context path prefix for all REST API requests. For example, if you configure `/zeebe`, then client's REST address would be `http://localhost:8080/zeebe`. This setting can also be overridden using the environment variable `SPRING_WEBFLUX_BASEPATH`. | `/`           |
+
+#### YAML snippet
+
+```yaml
+spring.webflux:
+  base-path: /
+```
+
+### management.server
+
+The `management.server` configuration allows you to configure the management server.
+
+| Field     | Description                                                                                                                                                                                                                                                                                | Example value |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| host      | Sets the host the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_HOST`.                                                                                                                                                 | 0.0.0.0       |
+| port      | Sets the port the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_PORT`.                                                                                                                                                 | 8080          |
+| base-path | The context path prefix for all management endpoints. For example, if you configure `/zeebe`, then your actuator endpoints will be at `http://localhost:9600/zeebe/actuator/configprops`. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_BASEPATH`. | `/`           |
+
+#### YAML snippet
+
+```yaml
+management.server:
+  host: 0.0.0.0
+  port: 9600
+  base-path: /
+```
+
 ### zeebe.broker.gateway
 
 To configure the embedded gateway, see [Gateway config docs](/self-managed/zeebe-deployment/configuration/gateway.md).

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -41,14 +41,14 @@ Configuration names are noted as the **header** of each documented section, whil
 For deploying purposes, it is easier to use environment variables. The following sections outline usage of these variables. As Helm is the recommended way to deploy Camunda 8, we will explain some configuration options here as well. Find more information about possible Zeebe Gateway Helm chart [configurations](https://artifacthub.io/packages/helm/camunda/camunda-platform#zeebe-gateway-parameters).
 
 :::note
-The Zeebe Gateway is a Spring Boot application. As such, [many common Spring Boot properties will simply work out of the box](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html).
+The Zeebe Gateway is a Spring Boot application. As such, [many common Spring Boot properties will work out of the box](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html).
 
-Additionally, its REST server is a reactive Spring Boot server (powered by WebFlux), and can be configured using the standard `server.*` properties, as well as the usual WebFlux properties. Its management server (e.g. where actuator endpoints live) is configured as a child application context, and is also a reactive, WebFlux server. It can be configured via `management.server.*` properties.
+Additionally, its REST server is a reactive Spring Boot server (powered by WebFlux), and can be configured using the standard `server.*` properties, as well as the usual WebFlux properties. Its management server (for example, where actuator endpoints live) is configured as a child application context, and is also a reactive WebFlux server. It can be configured via `management.server.*` properties.
 :::
 
 ### server
 
-The `server` configuration allows you to configure the main REST server. Below are a few common ones, [but you can find a more exhaustive list here.](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server)
+The `server` configuration allows you to configure the main REST server. Below are a few common ones, but you can find a more exhaustive list [in the official Spring documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server).
 
 | Field | Description                                                                                                               | Example value |
 | ----- | ------------------------------------------------------------------------------------------------------------------------- | ------------- |
@@ -63,7 +63,7 @@ The `server` configuration allows you to configure the main REST server. Below a
 
 #### server.ssl
 
-Allows you configure the SSL security for the REST server.
+Allows you to configure the SSL security for the REST server.
 
 | Field                   | Description                                                                                                                                                                     | Example value |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
@@ -87,9 +87,9 @@ server:
 
 ### spring.webflux
 
-| Field     | Description                                                                                                                                                                                                                                                 | Example value |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| base-path | The context path prefix for all REST API requests. For example, if you configure `/zeebe`, then client's REST address would be `http://localhost:8080/zeebe`. This setting can also be overridden using the environment variable `SPRING_WEBFLUX_BASEPATH`. | `/`           |
+| Field     | Description                                                                                                                                                                                                                                                     | Example value |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| base-path | The context path prefix for all REST API requests. For example, if you configure `/zeebe`, then the client's REST address would be `http://localhost:8080/zeebe`. This setting can also be overridden using the environment variable `SPRING_WEBFLUX_BASEPATH`. | `/`           |
 
 #### YAML snippet
 
@@ -102,11 +102,11 @@ spring.webflux:
 
 The `management.server` configuration allows you to configure the management server.
 
-| Field     | Description                                                                                                                                                                                                                                                                                | Example value |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| host      | Sets the host the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_HOST`.                                                                                                                                                 | 0.0.0.0       |
-| port      | Sets the port the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_PORT`.                                                                                                                                                 | 8080          |
-| base-path | The context path prefix for all management endpoints. For example, if you configure `/zeebe`, then your actuator endpoints will be at `http://localhost:9600/zeebe/actuator/configprops`. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_BASEPATH`. | `/`           |
+| Field     | Description                                                                                                                                                                                                                                                                           | Example value |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| host      | Sets the host the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_HOST`.                                                                                                                                            | 0.0.0.0       |
+| port      | Sets the port the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_PORT`.                                                                                                                                            | 8080          |
+| base-path | The context path prefix for all management endpoints. For example, if you configure `/zeebe`, your actuator endpoints will be at `http://localhost:9600/zeebe/actuator/configprops`. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_BASEPATH`. | `/`           |
 
 #### YAML snippet
 

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -40,6 +40,83 @@ Configuration names are noted as the **header** of each documented section, whil
 
 For deploying purposes, it is easier to use environment variables. The following sections outline usage of these variables. As Helm is the recommended way to deploy Camunda 8, we will explain some configuration options here as well. Find more information about possible Zeebe Gateway Helm chart [configurations](https://artifacthub.io/packages/helm/camunda/camunda-platform#zeebe-gateway-parameters).
 
+:::note
+The Zeebe Gateway is a Spring Boot application. As such, [many common Spring Boot properties will simply work out of the box](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html).
+
+Additionally, its REST server is a reactive Spring Boot server (powered by WebFlux), and can be configured using the standard `server.*` properties, as well as the usual WebFlux properties. Its management server (e.g. where actuator endpoints live) is configured as a child application context, and is also a reactive, WebFlux server. It can be configured via `management.server.*` properties.
+:::
+
+### server
+
+The `server` configuration allows you to configure the main REST server. Below are a few common ones, [but you can find a more exhaustive list here.](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server)
+
+| Field | Description                                                                                                               | Example value |
+| ----- | ------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| host  | Sets the host the REST server binds to. This setting can also be overridden using the environment variable `SERVER_HOST`. | 0.0.0.0       |
+| port  | Sets the port the REST server binds to. This setting can also be overridden using the environment variable `SERVER_PORT`. | 8080          |
+
+#### server.compression
+
+| Field   | Description                                                                                                                                                 | Example value |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled | If true, enables compression of responses for the REST API. This setting can also be overridden using the environment variable `SERVER_COMPRESION_ENABLED`. | false         |
+
+#### server.ssl
+
+Allows you configure the SSL security for the REST server.
+
+| Field                   | Description                                                                                                                                                                     | Example value |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled                 | If true, enables TLS for the REST API. This setting can also be overridden using the environment variable `SERVER_SSL_ENABLED`.                                                 | false         |
+| certificate             | The path to a PEM encoded certificate. This setting can also be overridden using the environment variable `SERVER_SSL_CERTIFICATE`.                                             |               |
+| certificate-private-key | The path to a PKCS1 or PKCS8 private key for the configured certificate. This setting can also be overridden using the environment variable `SERVER_SSL_CERTIFICATEPRIVATEKEY`. |               |
+
+#### YAML snippet
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 8080
+  compression:
+    enabled: true
+  ssl:
+    enabled: true
+    certificate: /path/to/my/cert.pem
+    certificate-private-key: /path/to/my/private.key
+```
+
+### spring.webflux
+
+| Field     | Description                                                                                                                                                                                                                                                 | Example value |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| base-path | The context path prefix for all REST API requests. For example, if you configure `/zeebe`, then client's REST address would be `http://localhost:8080/zeebe`. This setting can also be overridden using the environment variable `SPRING_WEBFLUX_BASEPATH`. | `/`           |
+
+#### YAML snippet
+
+```yaml
+spring.webflux:
+  base-path: /
+```
+
+### management.server
+
+The `management.server` configuration allows you to configure the management server.
+
+| Field     | Description                                                                                                                                                                                                                                                                                | Example value |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| host      | Sets the host the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_HOST`.                                                                                                                                                 | 0.0.0.0       |
+| port      | Sets the port the management server binds to. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_PORT`.                                                                                                                                                 | 8080          |
+| base-path | The context path prefix for all management endpoints. For example, if you configure `/zeebe`, then your actuator endpoints will be at `http://localhost:9600/zeebe/actuator/configprops`. This setting can also be overridden using the environment variable `MANAGEMENT_SERVER_BASEPATH`. | `/`           |
+
+#### YAML snippet
+
+```yaml
+management.server:
+  host: 0.0.0.0
+  port: 9600
+  base-path: /
+```
+
 ### zeebe.gateway.network
 
 The network configuration allows configuration of the host and port details for the gateway.

--- a/docs/self-managed/zeebe-deployment/operations/health.md
+++ b/docs/self-managed/zeebe-deployment/operations/health.md
@@ -58,7 +58,7 @@ If it is unhealthy, it may mean three things:
 [Metrics](metrics.md) give more insight into which partition is healthy or unhealthy.
 When a broker becomes unhealthy, it's recommended to check the logs to see what went wrong.
 
-(The default broker port can be configured using environment variables - respectively `SERVER_PORT` and `SERVER_ADDRESS` - or system properties - respectively `-Dserver.port=` or `-Dserver.address=` - to configure them)
+(The default broker port can be configured using environment variables - respectively `MANAGEMENT_SERVER_PORT` and `MANAGEMENT_SERVER_ADDRESS` - or system properties - respectively `-Dmanagement.server.port=` or `-Dmanagement.server.address=` - to configure them)
 
 ## Gateway
 

--- a/docs/self-managed/zeebe-deployment/operations/management-api.md
+++ b/docs/self-managed/zeebe-deployment/operations/management-api.md
@@ -7,7 +7,7 @@ description: "Zeebe Gateway also exposes an HTTP endpoint for cluster management
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-Besides the [REST](api-tools/zeebe-api-rest/zeebe-api-rest-overview.md) and [gRPC API](/apis-tools/zeebe-api/grpc.md) for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This API is not expected to be used by a typical user, but by a privileged user such as a cluster administrator. It is exposed via a different port and configured using configuration `management.server.port` (or via environment variable `MANAGEMENT_SERVER_PORT`). By default, this is set to `9600`.
+Besides the [REST](/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md) and [gRPC API](/apis-tools/zeebe-api/grpc.md) for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This API is not expected to be used by a typical user, but by a privileged user such as a cluster administrator. It is exposed via a different port and configured using configuration `management.server.port` (or via environment variable `MANAGEMENT_SERVER_PORT`). By default, this is set to `9600`.
 
 The API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints). For additional configurations such as security, refer to the Spring Boot documentation.
 

--- a/docs/self-managed/zeebe-deployment/operations/management-api.md
+++ b/docs/self-managed/zeebe-deployment/operations/management-api.md
@@ -7,9 +7,9 @@ description: "Zeebe Gateway also exposes an HTTP endpoint for cluster management
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-Besides the [gRPC API](/apis-tools/zeebe-api/grpc.md) for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This API is not expected to be used by a typical user, but by a privileged user such as a cluster administrator. It is exposed via a different port and configured using configuration `server.port` (or via environment variable SERVER_PORT). By default, this is set to `9600`.
+Besides the [REST](api-tools/zeebe-api-rest/zeebe-api-rest-overview.md) and [gRPC API](/apis-tools/zeebe-api/grpc.md) for process instance execution, Zeebe Gateway also exposes an HTTP endpoint for cluster management operations. This API is not expected to be used by a typical user, but by a privileged user such as a cluster administrator. It is exposed via a different port and configured using configuration `management.server.port` (or via environment variable `MANAGEMENT_SERVER_PORT`). By default, this is set to `9600`.
 
-The API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/production-ready-endpoints.html). For additional configurations such as security, refer to the Spring Boot documentation.
+The API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints). For additional configurations such as security, refer to the Spring Boot documentation.
 
 The following operations are currently available:
 

--- a/docs/self-managed/zeebe-deployment/operations/network-ports.md
+++ b/docs/self-managed/zeebe-deployment/operations/network-ports.md
@@ -6,13 +6,17 @@ title: "Network ports"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-The broker cluster sits behind the gRPC Gateway, which handles all requests from clients/workers and forwards events to brokers.
+The broker cluster sits behind the gateway, which handles all requests (via REST and gRPC servers) from clients/workers and forwards events to brokers.
 
 <Tabs groupId="networkPorts" defaultValue="gateway" queryString values={[{label: 'Gateway', value: 'gateway' },{label: 'Broker', value: 'broker' }]} >
 
 <TabItem value="gateway">
 
-The gateway needs to receive communication via `zeebe.gateway.network.port: 26500` from clients/workers, and `zeebe.gateway.cluster.initialContactPoints: [127.0.0.1:26502]` from brokers.
+In order to communicate with clients/workers, the gateway will start two different ports to communicate via its REST API (default port 8080) and gRPC (default port 26500). These are respectively controlled via `server.port: 8080` (REST) and `zeebe.gateway.network.port: 26500` (gRPC).
+
+Additionally, it will need to communicate with other nodes (mostly brokers) in the cluster (default port 26502), configured via `zeebe.gateway.cluster.port: 26502`.
+
+In order to join the cluster, it will also need at least one initial contact point, typically a broker, configured via `zeebe.gateway.cluster.initialContactPoints: [127.0.0.1:26502]`.
 
 :::note
 You can use all broker connections instead of one to make the startup process of the Zeebe gateway more resilient.
@@ -22,16 +26,21 @@ The relevant [configuration](../configuration/configuration.md) settings are:
 
 ```
 Config file
+    server:
+      port: 8080 # REST
     zeebe:
       gateway:
         network:
-          port: 26500
+          port: 26500 # gRPC
         cluster:
+          port: 26502
           initialContactPoints: [127.0.0.1:26502]
 
 
 Environment Variables
-  ZEEBE_GATEWAY_CLUSTER_NETWORK_PORT = 26500
+  SERVER_PORT = 8080
+  ZEEBE_GATEWAY_NETWORK_PORT = 26500
+  ZEEBE_GATEWAY_CLUSTER_PORT = 26502
   ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS = 127.0.0.1:26502
 ```
 

--- a/docs/self-managed/zeebe-deployment/operations/network-ports.md
+++ b/docs/self-managed/zeebe-deployment/operations/network-ports.md
@@ -12,11 +12,11 @@ The broker cluster sits behind the gateway, which handles all requests (via REST
 
 <TabItem value="gateway">
 
-In order to communicate with clients/workers, the gateway will start two different ports to communicate via its REST API (default port 8080) and gRPC (default port 26500). These are respectively controlled via `server.port: 8080` (REST) and `zeebe.gateway.network.port: 26500` (gRPC).
+To communicate with clients/workers, the gateway will start two different ports to communicate via its REST API (default port 8080) and gRPC (default port 26500). These are respectively controlled via `server.port: 8080` (REST) and `zeebe.gateway.network.port: 26500` (gRPC).
 
 Additionally, it will need to communicate with other nodes (mostly brokers) in the cluster (default port 26502), configured via `zeebe.gateway.cluster.port: 26502`.
 
-In order to join the cluster, it will also need at least one initial contact point, typically a broker, configured via `zeebe.gateway.cluster.initialContactPoints: [127.0.0.1:26502]`.
+To join the cluster, it will also need at least one initial contact point, typically a broker, configured via `zeebe.gateway.cluster.initialContactPoints: [127.0.0.1:26502]`.
 
 :::note
 You can use all broker connections instead of one to make the startup process of the Zeebe gateway more resilient.

--- a/docs/self-managed/zeebe-deployment/zeebe-gateway/zeebe-gateway-overview.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-gateway/zeebe-gateway-overview.md
@@ -14,13 +14,13 @@ To summarize, the Zeebe broker is the main part of the Zeebe cluster, which does
 
 ![Zeebe gateway overview](assets/zeebe-gateway-overview.png)
 
-To interact with the Zeebe cluster, the Zeebe client sends a command as a gRPC message to the Zeebe Gateway (to port `26500` by default). Given the gateway supports gRPC, the user can use several clients in different languages to interact with the Zeebe cluster. For more information, read our [overview](../../../apis-tools/working-with-apis-tools.md).
+To interact with the Zeebe cluster, the Zeebe client sends a command to the gateway either as a gRPC message (to port `26500` by default), or a plain HTTP request to its REST API (to port `8080` by default). Given the gateway supports gRPC as well as an OpenAPI spec, the user can use several clients in different languages to interact with the Zeebe cluster. For more information, read our [overview](../../../apis-tools/working-with-apis-tools.md).
 
 :::note
 Be aware Zeebe brokers divide data into partitions (shards), and use RAFT for replication. Read more on RAFT [here](../../../components/zeebe/technical-concepts/clustering.md#raft-consensus-and-replication-protocol).
 :::
 
-When the Zeebe Gateway receives a valid gRPC message, it is translated to an internal binary format and forwarded to one of the partition leaders inside the Zeebe cluster. The command type and values can determine to which partition the command is forwarded.
+When the Zeebe Gateway receives a valid message, it is translated to an internal binary format and forwarded to one of the partition leaders inside the Zeebe cluster. The command type and values can determine to which partition the command is forwarded.
 
 For example, creating a new process instance is sent in a round-robin fashion to the different partitions. If the command relates to an existing process instance, the command must be sent to the same partition where it was first created (determined by the key).
 


### PR DESCRIPTION
## Description

This PR documents the new server side configuration options for the REST API. Since many of these properties were previously used to configure the management server, I've also added how to configure it explicitly as part of our configuration page, and added an update guide note about the possibly breaking change.

closes #3278

## When should this change go live?

With the release of 8.5.0.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
