### PR TITLE
feat: Clarify terms in Zeebe-Process-Test

### DIFF
--- a/docs/apis-tools/java-client/zeebe-process-test.md
+++ b/docs/apis-tools/java-client/zeebe-process-test.md
@@ -22,11 +22,7 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
-a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
-version is that your code can be implemented independently of the Java version that is used by
-the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
-is also the extra requirement that Docker must be running to execute the tests.
+If you are building your project with a JDK lower than 17, use the `testcontainer` dependency. This starts a `testcontainer` where a Zeebe engine is running. It is beneficial to use this version instead of the embedded version so your code can be implemented independently of the Java version used by the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. Additionally, Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -39,12 +35,8 @@ is also the extra requirement that Docker must be running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
-instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
-running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
-Whenever this Java version changes, you'd either have
-to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
-match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'll either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to match the Zeebe engine.
 
 ```xml
 <dependency>

--- a/docs/apis-tools/java-client/zeebe-process-test.md
+++ b/docs/apis-tools/java-client/zeebe-process-test.md
@@ -4,8 +4,8 @@ title: "Zeebe Process Test"
 ---
 
 [Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda 8 BPMN
-processes. It will start a Zeebe test engine and provide you with a set of assertions you can use to verify your process
-behaves as expected.
+processes. It will start a lightweight in-memory Zeebe engine and provide you with a set of assertions you can use to
+verify your process behaves as expected.
 
 ## Prerequisites
 
@@ -22,12 +22,11 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It
-starts a `testcontainer` in which a Zeebe test engine is running. The advantage of using this version
-instead of the embedded version is that your code can be implemented independently of the Java
-version that is used by the Zeebe engine. The downside is that `testcontainers` provide some
-overhead, which means tests will be slower. There is also the extra requirement that Docker must be
-running to execute the tests.
+If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
+a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
+version is that your code can be implemented independently of the Java version that is used by
+the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
+is also the extra requirement that Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -40,12 +39,12 @@ running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe test engine. The
-advantage of using this instead of the `testcontainer` version is that this is the faster solution.
-This also does not require Docker to be running. The downside to this solution is that the JDK
-requirement is bound to the Java version of the Zeebe engine. Whenever this Java version changes,
-you'd either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded),
-or update your own JDK to match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
+instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
+running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'd either have
+to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
+match the Zeebe engine.
 
 ```xml
 <dependency>
@@ -60,7 +59,7 @@ or update your own JDK to match the Zeebe engine.
 
 Annotate your test class with the `@ZeebeProcessTest` annotation. This annotation will do a couple of things:
 
-1. It will manage the lifecycle of the testcontainer/embedded test engine.
+1. It will manage the lifecycle of the testcontainer/embedded Zeebe engine.
 2. It will create a client which can be used to interact with the engine.
 3. It will (optionally) inject three fields in your test class:
    1. `ZeebeTestEngine` - This is the engine that will run your process. It will provide some basic functionality
@@ -72,7 +71,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
       Assertions use the records for verifying expectations. This grants you the freedom to create your own assertions.
 
 ```java
-// When using the embedded test engine (Java 17+)
+// When using the embedded Zeebe engine (Java 17+)
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 
 // When using testcontainers (Java 8+)

--- a/versioned_docs/version-8.1/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.1/apis-tools/java-client/zeebe-process-test.md
@@ -22,11 +22,7 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
-a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
-version is that your code can be implemented independently of the Java version that is used by
-the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
-is also the extra requirement that Docker must be running to execute the tests.
+If you are building your project with a JDK lower than 17, use the `testcontainer` dependency. This starts a `testcontainer` where a Zeebe engine is running. It is beneficial to use this version instead of the embedded version so your code can be implemented independently of the Java version used by the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. Additionally, Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -39,12 +35,8 @@ is also the extra requirement that Docker must be running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
-instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
-running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
-Whenever this Java version changes, you'd either have
-to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
-match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'll either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to match the Zeebe engine.
 
 ```xml
 <dependency>

--- a/versioned_docs/version-8.1/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.1/apis-tools/java-client/zeebe-process-test.md
@@ -4,8 +4,8 @@ title: "Zeebe Process Test"
 ---
 
 [Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda 8 BPMN
-processes. It will start a Zeebe test engine and provide you with a set of assertions you can use to verify your process
-behaves as expected.
+processes. It will start a lightweight in-memory Zeebe engine and provide you with a set of assertions you can use to
+verify your process behaves as expected.
 
 ## Prerequisites
 
@@ -22,12 +22,11 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It
-starts a `testcontainer` in which a Zeebe test engine is running. The advantage of using this version
-instead of the embedded version is that your code can be implemented independently of the Java
-version that is used by the Zeebe engine. The downside is that `testcontainers` provide some
-overhead, which means tests will be slower. There is also the extra requirement that Docker must be
-running to execute the tests.
+If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
+a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
+version is that your code can be implemented independently of the Java version that is used by
+the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
+is also the extra requirement that Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -40,12 +39,12 @@ running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe test engine. The
-advantage of using this instead of the `testcontainer` version is that this is the faster solution.
-This also does not require Docker to be running. The downside to this solution is that the JDK
-requirement is bound to the Java version of the Zeebe engine. Whenever this Java version changes,
-you'd either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded),
-or update your own JDK to match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
+instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
+running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'd either have
+to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
+match the Zeebe engine.
 
 ```xml
 <dependency>
@@ -60,7 +59,7 @@ or update your own JDK to match the Zeebe engine.
 
 Annotate your test class with the `@ZeebeProcessTest` annotation. This annotation will do a couple of things:
 
-1. It will manage the lifecycle of the testcontainer/embedded test engine.
+1. It will manage the lifecycle of the testcontainer/embedded Zeebe engine.
 2. It will create a client which can be used to interact with the engine.
 3. It will (optionally) inject three fields in your test class:
    1. `ZeebeTestEngine` - This is the engine that will run your process. It will provide some basic functionality
@@ -72,7 +71,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
       Assertions use the records for verifying expectations. This grants you the freedom to create your own assertions.
 
 ```java
-// When using the embedded test engine (Java 17+)
+// When using the embedded Zeebe engine (Java 17+)
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 
 // When using testcontainers (Java 8+)

--- a/versioned_docs/version-8.2/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.2/apis-tools/java-client/zeebe-process-test.md
@@ -22,11 +22,7 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
-a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
-version is that your code can be implemented independently of the Java version that is used by
-the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
-is also the extra requirement that Docker must be running to execute the tests.
+If you are building your project with a JDK lower than 17, use the `testcontainer` dependency. This starts a `testcontainer` where a Zeebe engine is running. It is beneficial to use this version instead of the embedded version so your code can be implemented independently of the Java version used by the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. Additionally, Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -39,12 +35,8 @@ is also the extra requirement that Docker must be running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
-instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
-running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
-Whenever this Java version changes, you'd either have
-to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
-match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'll either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to match the Zeebe engine.
 
 ```xml
 <dependency>

--- a/versioned_docs/version-8.2/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.2/apis-tools/java-client/zeebe-process-test.md
@@ -4,8 +4,8 @@ title: "Zeebe Process Test"
 ---
 
 [Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda 8 BPMN
-processes. It will start a Zeebe test engine and provide you with a set of assertions you can use to verify your process
-behaves as expected.
+processes. It will start a lightweight in-memory Zeebe engine and provide you with a set of assertions you can use to
+verify your process behaves as expected.
 
 ## Prerequisites
 
@@ -22,12 +22,11 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It
-starts a `testcontainer` in which a Zeebe test engine is running. The advantage of using this version
-instead of the embedded version is that your code can be implemented independently of the Java
-version that is used by the Zeebe engine. The downside is that `testcontainers` provide some
-overhead, which means tests will be slower. There is also the extra requirement that Docker must be
-running to execute the tests.
+If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
+a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
+version is that your code can be implemented independently of the Java version that is used by
+the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
+is also the extra requirement that Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -40,12 +39,12 @@ running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe test engine. The
-advantage of using this instead of the `testcontainer` version is that this is the faster solution.
-This also does not require Docker to be running. The downside to this solution is that the JDK
-requirement is bound to the Java version of the Zeebe engine. Whenever this Java version changes,
-you'd either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded),
-or update your own JDK to match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
+instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
+running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'd either have
+to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
+match the Zeebe engine.
 
 ```xml
 <dependency>
@@ -60,7 +59,7 @@ or update your own JDK to match the Zeebe engine.
 
 Annotate your test class with the `@ZeebeProcessTest` annotation. This annotation will do a couple of things:
 
-1. It will manage the lifecycle of the testcontainer/embedded test engine.
+1. It will manage the lifecycle of the testcontainer/embedded Zeebe engine.
 2. It will create a client which can be used to interact with the engine.
 3. It will (optionally) inject three fields in your test class:
    1. `ZeebeTestEngine` - This is the engine that will run your process. It will provide some basic functionality
@@ -72,7 +71,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
       Assertions use the records for verifying expectations. This grants you the freedom to create your own assertions.
 
 ```java
-// When using the embedded test engine (Java 17+)
+// When using the embedded Zeebe engine (Java 17+)
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 
 // When using testcontainers (Java 8+)

--- a/versioned_docs/version-8.3/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/zeebe-process-test.md
@@ -22,11 +22,7 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
-a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
-version is that your code can be implemented independently of the Java version that is used by
-the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
-is also the extra requirement that Docker must be running to execute the tests.
+If you are building your project with a JDK lower than 17, use the `testcontainer` dependency. This starts a `testcontainer` where a Zeebe engine is running. It is beneficial to use this version instead of the embedded version so your code can be implemented independently of the Java version used by the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. Additionally, Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -39,12 +35,8 @@ is also the extra requirement that Docker must be running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
-instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
-running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
-Whenever this Java version changes, you'd either have
-to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
-match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'll either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to match the Zeebe engine.
 
 ```xml
 <dependency>

--- a/versioned_docs/version-8.3/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/zeebe-process-test.md
@@ -4,8 +4,8 @@ title: "Zeebe Process Test"
 ---
 
 [Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda 8 BPMN
-processes. It will start a Zeebe test engine and provide you with a set of assertions you can use to verify your process
-behaves as expected.
+processes. It will start a lightweight in-memory Zeebe engine and provide you with a set of assertions you can use to
+verify your process behaves as expected.
 
 ## Prerequisites
 
@@ -22,12 +22,11 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It
-starts a `testcontainer` in which a Zeebe test engine is running. The advantage of using this version
-instead of the embedded version is that your code can be implemented independently of the Java
-version that is used by the Zeebe engine. The downside is that `testcontainers` provide some
-overhead, which means tests will be slower. There is also the extra requirement that Docker must be
-running to execute the tests.
+If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
+a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
+version is that your code can be implemented independently of the Java version that is used by
+the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
+is also the extra requirement that Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -40,12 +39,12 @@ running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe test engine. The
-advantage of using this instead of the `testcontainer` version is that this is the faster solution.
-This also does not require Docker to be running. The downside to this solution is that the JDK
-requirement is bound to the Java version of the Zeebe engine. Whenever this Java version changes,
-you'd either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded),
-or update your own JDK to match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
+instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
+running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'd either have
+to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
+match the Zeebe engine.
 
 ```xml
 <dependency>
@@ -60,7 +59,7 @@ or update your own JDK to match the Zeebe engine.
 
 Annotate your test class with the `@ZeebeProcessTest` annotation. This annotation will do a couple of things:
 
-1. It will manage the lifecycle of the testcontainer/embedded test engine.
+1. It will manage the lifecycle of the testcontainer/embedded Zeebe engine.
 2. It will create a client which can be used to interact with the engine.
 3. It will (optionally) inject three fields in your test class:
    1. `ZeebeTestEngine` - This is the engine that will run your process. It will provide some basic functionality
@@ -72,7 +71,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
       Assertions use the records for verifying expectations. This grants you the freedom to create your own assertions.
 
 ```java
-// When using the embedded test engine (Java 17+)
+// When using the embedded Zeebe engine (Java 17+)
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 
 // When using testcontainers (Java 8+)

--- a/versioned_docs/version-8.4/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.4/apis-tools/java-client/zeebe-process-test.md
@@ -22,11 +22,7 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
-a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
-version is that your code can be implemented independently of the Java version that is used by
-the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
-is also the extra requirement that Docker must be running to execute the tests.
+If you are building your project with a JDK lower than 17, use the `testcontainer` dependency. This starts a `testcontainer` where a Zeebe engine is running. It is beneficial to use this version instead of the embedded version so your code can be implemented independently of the Java version used by the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. Additionally, Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -39,12 +35,8 @@ is also the extra requirement that Docker must be running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
-instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
-running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
-Whenever this Java version changes, you'd either have
-to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
-match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'll either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to match the Zeebe engine.
 
 ```xml
 <dependency>

--- a/versioned_docs/version-8.4/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.4/apis-tools/java-client/zeebe-process-test.md
@@ -4,8 +4,8 @@ title: "Zeebe Process Test"
 ---
 
 [Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda 8 BPMN
-processes. It will start a Zeebe test engine and provide you with a set of assertions you can use to verify your process
-behaves as expected.
+processes. It will start a lightweight in-memory Zeebe engine and provide you with a set of assertions you can use to
+verify your process behaves as expected.
 
 ## Prerequisites
 
@@ -22,12 +22,11 @@ Java version you are using.
 
 #### Testcontainers (JDK 8+)
 
-If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It
-starts a `testcontainer` in which a Zeebe test engine is running. The advantage of using this version
-instead of the embedded version is that your code can be implemented independently of the Java
-version that is used by the Zeebe engine. The downside is that `testcontainers` provide some
-overhead, which means tests will be slower. There is also the extra requirement that Docker must be
-running to execute the tests.
+If you are building your project with a JDK lower than 17, you need to use the `testcontainer` dependency. It starts
+a `testcontainer` in which a Zeebe engine is running. The advantage of using this version instead of the embedded
+version is that your code can be implemented independently of the Java version that is used by
+the Zeebe engine. The downside is that `testcontainers` provide some overhead, which means tests will be slower. There
+is also the extra requirement that Docker must be running to execute the tests.
 
 ```xml
 <dependency>
@@ -40,12 +39,12 @@ running to execute the tests.
 
 #### Embedded (JDK 17+)
 
-If you are building your project with JDK 17+, you can make use of an embedded Zeebe test engine. The
-advantage of using this instead of the `testcontainer` version is that this is the faster solution.
-This also does not require Docker to be running. The downside to this solution is that the JDK
-requirement is bound to the Java version of the Zeebe engine. Whenever this Java version changes,
-you'd either have to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded),
-or update your own JDK to match the Zeebe engine.
+If you are building your project with JDK 17+, you can make use of an embedded Zeebe engine. The advantage of using this
+instead of the `testcontainer` version is that this is the faster solution. This also does not require Docker to be
+running. The downside to this solution is that the JDK requirement is bound to the Java version of the Zeebe engine.
+Whenever this Java version changes, you'd either have
+to [switch to the testcontainer version](#switching-between-testcontainers-and-embedded), or update your own JDK to
+match the Zeebe engine.
 
 ```xml
 <dependency>
@@ -60,7 +59,7 @@ or update your own JDK to match the Zeebe engine.
 
 Annotate your test class with the `@ZeebeProcessTest` annotation. This annotation will do a couple of things:
 
-1. It will manage the lifecycle of the testcontainer/embedded test engine.
+1. It will manage the lifecycle of the testcontainer/embedded Zeebe engine.
 2. It will create a client which can be used to interact with the engine.
 3. It will (optionally) inject three fields in your test class:
    1. `ZeebeTestEngine` - This is the engine that will run your process. It will provide some basic functionality
@@ -72,7 +71,7 @@ Annotate your test class with the `@ZeebeProcessTest` annotation. This annotatio
       Assertions use the records for verifying expectations. This grants you the freedom to create your own assertions.
 
 ```java
-// When using the embedded test engine (Java 17+)
+// When using the embedded Zeebe engine (Java 17+)
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
 
 // When using testcontainers (Java 8+)


### PR DESCRIPTION
## Description

The term "Zeebe test engine" confuses users because they are unsure if the test engine is the same as the production engine.

Replace the term "test engine" by just "Zeebe engine" and describe it as a lightweight in-memory Zeebe engine.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
