### PR TITLE
feat: Rename Zeebe gPRC page title (Gateway service)

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -6,7 +6,9 @@ sidebar_position: 2
 description: "The Zeebe client gRPC API is exposed through a single gateway service."
 ---
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file
+can be found in
+the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/zeebe/gateway-protocol/src/main/proto/gateway.proto).
 
 ## `ActivateJobs` RPC
 

--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -1,6 +1,6 @@
 ---
 id: gateway-service
-title: "Gateway service"
+title: "Zeebe API RPCs"
 slug: /apis-tools/zeebe-api/gateway-service
 sidebar_position: 2
 description: "The Zeebe client gRPC API is exposed through a single gateway service."

--- a/docs/apis-tools/zeebe-api/grpc.md
+++ b/docs/apis-tools/zeebe-api/grpc.md
@@ -7,6 +7,8 @@ description: "Zeebe clients use gRPC to communicate with the cluster. Activate j
 keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
-[Zeebe](/components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the cluster.
+[Zeebe](/components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the Zeebe cluster.
+See [Zeebe API RPCs](gateway-service.md) for all available operations.
 
-To authorize the Zeebe API (gRPC) in a [Self-Managed](/self-managed/about-self-managed.md) setup, see [client authorization](/self-managed/zeebe-deployment/security/client-authorization.md).
+To authorize the Zeebe API (gRPC) in a [Self-Managed](/self-managed/about-self-managed.md) setup,
+see [client authorization](/self-managed/zeebe-deployment/security/client-authorization.md).

--- a/versioned_docs/version-8.1/apis-tools/grpc.md
+++ b/versioned_docs/version-8.1/apis-tools/grpc.md
@@ -9,7 +9,9 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 ## Gateway service
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file
+can be found in
+the [Zeebe repository](https://github.com/camunda/zeebe/blob/stable/8.1/gateway-protocol/src/main/proto/gateway.proto).
 
 ### `ActivateJobs` RPC
 

--- a/versioned_docs/version-8.2/apis-tools/grpc.md
+++ b/versioned_docs/version-8.2/apis-tools/grpc.md
@@ -9,9 +9,9 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 ## Gateway service
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).
-
-To authorize the Zeebe API (gRPC) in a [Self-Managed](/self-managed/about-self-managed.md) setup, see [client authorization](/self-managed/zeebe-deployment/security/client-authorization.md).
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file
+can be found in
+the [Zeebe repository](https://github.com/camunda/zeebe/blob/stable/8.2/gateway-protocol/src/main/proto/gateway.proto).
 
 ### `ActivateJobs` RPC
 

--- a/versioned_docs/version-8.3/apis-tools/grpc.md
+++ b/versioned_docs/version-8.3/apis-tools/grpc.md
@@ -11,7 +11,9 @@ To authorize the Zeebe API (gRPC) in a [Self-Managed](/self-managed/about-self-m
 
 ## Gateway service
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file
+can be found in
+the [Zeebe repository](https://github.com/camunda/zeebe/blob/stable/8.3/gateway-protocol/src/main/proto/gateway.proto).
 
 ### `ActivateJobs` RPC
 

--- a/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
+++ b/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
@@ -6,7 +6,9 @@ sidebar_position: 2
 description: "The Zeebe client gRPC API is exposed through a single gateway service."
 ---
 
-The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file can be found in the [Zeebe repository](https://github.com/camunda/zeebe/blob/main/gateway-protocol/src/main/proto/gateway.proto).
+The Zeebe client gRPC API is exposed through a single gateway service. The current version of the protocol buffer file
+can be found in
+the [Zeebe repository](https://github.com/camunda/zeebe/blob/stable/8.4/gateway-protocol/src/main/proto/gateway.proto).
 
 ## `ActivateJobs` RPC
 

--- a/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
+++ b/versioned_docs/version-8.4/apis-tools/zeebe-api/gateway-service.md
@@ -1,6 +1,6 @@
 ---
 id: gateway-service
-title: "Gateway service"
+title: "Zeebe API RPCs"
 slug: /apis-tools/zeebe-api/gateway-service
 sidebar_position: 2
 description: "The Zeebe client gRPC API is exposed through a single gateway service."

--- a/versioned_docs/version-8.4/apis-tools/zeebe-api/grpc.md
+++ b/versioned_docs/version-8.4/apis-tools/zeebe-api/grpc.md
@@ -7,6 +7,8 @@ description: "Zeebe clients use gRPC to communicate with the cluster. Activate j
 keywords: ["backpressure", "back-pressure", "back pressure"]
 ---
 
-[Zeebe](/components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the cluster.
+[Zeebe](/components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the Zeebe cluster.
+See [Zeebe API RPCs](gateway-service.md) for all available operations.
 
-To authorize the Zeebe API (gRPC) in a [Self-Managed](/self-managed/about-self-managed.md) setup, see [client authorization](/self-managed/zeebe-deployment/security/client-authorization.md).
+To authorize the Zeebe API (gRPC) in a [Self-Managed](/self-managed/about-self-managed.md) setup,
+see [client authorization](/self-managed/zeebe-deployment/security/client-authorization.md).


### PR DESCRIPTION
## Description

The "Gateway service" page contains Zeebe's available RPCs. Technically, the name "Gateway service" is correct because the service is called "Gateway" in the protobuf file. However, users (like me) might not expect Zeebe's gRPC API under this name. Rename the page to "Zeebe API RPCs" and link it from the overview page.

The module of the protobuf file was moved. Change the link for the current version to the new directory. Change the link of previous versions to the correct branch.  

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
