### PR TITLE
docs: Match text and code snippet

### DIFF
--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -53,7 +53,7 @@ Start the modeler without activating installed plug-ins. This is useful to debug
 
 ### BPMN-only Mode
 
-To disable the CMMN and DMN editing capabilities of the App, configure your `flags.json` like this:
+To disable the DMN and Form editing capabilities of the App, configure your `flags.json` like this:
 
 ```js
 {


### PR DESCRIPTION
## Description

Text and code snippets currently don't align, now they match again.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
