### PR TITLE
docs(zeebe): document rolling updates

### DIFF
--- a/docs/self-managed/zeebe-deployment/operations/update-zeebe.md
+++ b/docs/self-managed/zeebe-deployment/operations/update-zeebe.md
@@ -4,9 +4,189 @@ title: "Update Zeebe"
 description: "This section describes how to update Zeebe to a new version."
 ---
 
-## Update
+Zeebe versions can be updated from any patch version to a newer patch of the same minor version or to any patch of the next minor version.
+It is recommended but not required to first update to the latest patch of the current minor version before updating to the next minor version.
+In other words, Zeebe can always be updated to a higher version but skipping minor versions is not allowed.
+For example, an update from 8.5.0 to 8.5.3 or from 8.5.3 to 8.6.1 is possible
 
-See the [update guide](/self-managed/operational-guides/update-guide/introduction.md) for specific instructions per Zeebe version.
+Since Zeebe 8.5, updates to a newer version can be rolling or offline.
+Zeebe 8.4 and older don't contain necessary safety checks that make rolling updates safe, and we recommend offline updates instead to ensure processing behaves correctly.
+
+Please refer to the [update guide] to check if there are known issues for the specific update you are planning.
+
+## Rolling update
+
+A rolling update ensures that the Zeebe cluster stays available by updating brokers and gateways one by one instead of all at once.
+
+There are three parties to a rolling update, the Zeebe brokers, Zeebe gateways, and the clients.
+We recommend to update brokers first, then gateways and finally clients.
+This ensures that clients don't use new APIs that are not yet supported by the brokers or gateways.
+Because Zeebe is backwards compatible with the previous minor version, updating gateways and clients is not strictly necessary and can happen any time after updating the brokers.
+
+While updating brokers, leadership for partitions will rotate which may cause brief unavailability or loss of performance on the affected partitions.
+
+The procedure to do a rolling update of Zeebe brokers is the following:
+
+1. Pick the broker with the highest id that runs the old version
+2. Shut down the broker
+3. Update the broker software to the new version
+4. Start the broker and wait for it to become ready and healthy
+5. Repeat until all brokers are updated.
+
+Gateways are updated with the same procedure, updating each replica one by one.
+
+Clients can be updated according to your requirements and environment, for example by simply deploying a new version of your worker applications.
+
+For disaster recovery, you may want to take [backups] before the update.
+
+If you plan to immediately update again, you should ensure to wait to give all brokers a chance to take new snapshots.
+The snapshot period is 5 minutes by default but is [configurable via `snapshotPeriod`](../configuration/broker.md#zeebebrokerdata).
+
+### Using Helm
+
+If your Zeebe deployment is managed by our [Helm charts](../../platform-deployment/helm-kubernetes/deploy.md) the rolling update procedure is already automated[^1].
+
+#### Updating brokers
+
+Ensure that the `StatefulSet` for brokers is ready to do a rolling update by checking that
+
+1. The update strategy is `RollingUpdate`
+2. All replicas are ready
+3. The version is at least 8.5.0
+
+The following is an example how to verify these properties.
+Depending on your environment, you may have to adjust these commands slightly.
+
+```
+$ kubectl get statefulsets -l app.kubernetes.io/component=zeebe-broker -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.updateStrategy.type}{"\n"}{end}'
+camunda-platform-zeebe  RollingUpdate
+$ kubectl rollout status statefulset -l app.kubernetes.io/component=zeebe-broker
+statefulset rolling update complete 3 pods at revision camunda-platform-zeebe-d69689fbc...
+$ kubectl get services -l app.kubernetes.io/component=zeebe-gateway
+NAME                             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                       AGE
+camunda-platform-zeebe-gateway   ClusterIP   10.96.227.153   <none>        9600/TCP,26500/TCP,8080/TCP   21m
+$ kubectl port-forward services/camunda-platform-zeebe-gateway -p 8080:8080 &
+$ curl localhost:8080/api/v1/topology | jq .brokers[].version && kill %1
+8.5.0
+8.5.0
+8.5.0
+```
+
+To start the rolling update, you need to update the Helm deployment to use a new version of Zeebe.
+Set `$NEW_ZEEBE_VERSION` to the version you want to update to, for example "8.5.2".
+Remember to read the [update guide] to check for known issues.
+Then start the rolling update with `helm upgrade`.
+
+```
+$ export $NEW_ZEEBE_VERSION=8.5.2
+$ helm upgrade camunda-platform camunda/camunda-platform --reuse-values --set zeebe.image.tag=$NEW_ZEEBE_VERSION
+```
+
+Then wait for the rolling update to complete:
+
+```
+$ kubectl rollout status statefulset -l app.kubernetes.io/component=zeebe-broker
+Waiting for 3 pods to be ready...
+Waiting for 2 pods to be ready...
+Waiting for 1 pods to be ready...
+statefulset rolling update complete 3 pods at revision camunda-platform-zeebe-5b7f7d6477...
+```
+
+When the command finishes, all Zeebe brokers are updated to the new version and should be ready.
+We can verify this by running the command to check versions again:
+
+```shell
+$ kubectl port-forward services/camunda-platform-zeebe-gateway -p 8080:8080 &
+$ curl localhost:8080/api/v1/topology | jq .brokers[].version && kill %1
+8.5.2
+8.5.2
+8.5.2
+```
+
+#### Updating gateways
+
+Ensure that the deployment of gateways is ready to do a rolling update by checking that:
+
+1. All replicas are ready
+2. The version is at least 8.5
+
+You can use the following command to verify this:
+
+```
+$ kubectl rollout status statefulset -l app.kubernetes.io/component=zeebe-gateway
+NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
+camunda-platform-zeebe-gateway   2/2     2            2           4h25m
+```
+
+Then update the version via helm:
+
+```
+$ helm upgrade camunda-platform camunda/camunda-platform --reuse-values --set zeebe-gateway.image.tag=$NEW_ZEEBE_VERSION
+```
+
+And wait for the update to complete:
+
+```
+$ kubectl rollout status -l app.kubernetes.io/component=zeebe-gateway
+```
+
+At this point, both brokers and gateways are updated.
+Your client applications are ready to be updated as well and can start using features added in the new version.
+
+### Troubleshooting
+
+#### Rolling update is not completing
+
+A rolling update can become stuck due to outside interference such as failing Kubernetes pods.
+
+To recover from this, the update can be forced by not waiting on each broker to become ready and instead directly updating all brokers at once.
+Assuming you use our helm charts, this can be done via the following command:
+
+```
+$ kubectl delete pod -l app.kubernetes.io/component=zeebe-broker
+```
+
+This will recreate all broker pods from scratch, running the new version.
+Because the update is no longer rolling and all brokers are shut down at the same time, a short downtime is to be expected.
+
+#### Failed to install partition
+
+If updated brokers log the error message "Failed to install partition" and do not become healthy, you should look for more details to understand if this is caused by the rolling update.
+
+If the error is caused by "Cannot upgrade to or from a pre-release version", Zeebe detected that either the version you started from or the version you updated to is a pre-release version.
+This is not permitted because pre-release versions such as alpha releases are considered unstable and do not guarantee compatibility with any other version.
+If you attempted to update from a normal version to a pre-release version, you can roll back to the previous normal version.
+
+If the log message includes "Snapshot is not compatible with current version", the rolling update failed and manual recovery is required.
+Note that this message can also be logged by not yet updated brokers, in which case it should resolve itself automatically as soon as the [rolling update completes](#rolling-update-is-not-completing)
+
+The exact scenario is further described in the log message and can be one of the following.
+
+##### Snapshot is not compatible with current version: `SkippedMinorVersion`
+
+This normally occurs when attempting an update from one minor version to a newer one while skipping minor version in between.
+For example, updating from 8.5 to 8.7 directly without first updating to 8.6.
+This is not supported and Zeebe refuses to run when detecting this.
+To recover, you may be able to roll back to the previous version and then updating to the next minor version first.
+
+Another much more unlikely cause may be that you updated multiple times before Zeebe brokers could take snapshots.
+For example, if you first update from 8.5 to 8.6 and then immediately to 8.7, the updated brokers running 8.7 may find snapshots taken by 8.5 and refuse to run.
+You can recover from this manually
+
+##### Snapshot is not compatible with current version: `PatchDowngrade` or `MinorDowngrade`
+
+These indicate a deliberate version downgrade which Zeebe does not support.
+If you mistakenly tried to downgrade either the patch or minor version, you can restore by switching to the original version again.
+
+Note that this his message may show up during a rolling update on not yet updated broker.
+In that case it is caused by updated brokers sharing snapshots with not yet updated brokers.
+This should resolve automatically once the broker is updated.
+
+If this persists, you may want to [force the update](#rolling-update-is-not-completing).
+
+## Offline update
+
+See the [update guide] for specific instructions per Zeebe version.
 
 To update a Zeebe cluster, take the following steps:
 
@@ -55,3 +235,9 @@ The response contains all partitions of the broker mapped to the partition-id.
 
   </p>
 </details>
+
+[update guide]: ../../operational-guides/update-guide/introduction.md
+[Helm charts]: ../../platform-deployment/helm-kubernetes/deploy.md
+[backups]: ../../operational-guides/backup-restore/backup-and-restore.md
+
+[^1]: Zeebe brokers are managed by a `StatefulSet`: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies. Zeebe gateways are managed by a `Deployment`: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment

--- a/docs/self-managed/zeebe-deployment/operations/update-zeebe.md
+++ b/docs/self-managed/zeebe-deployment/operations/update-zeebe.md
@@ -4,55 +4,61 @@ title: "Update Zeebe"
 description: "This section describes how to update Zeebe to a new version."
 ---
 
-Zeebe versions can be updated from any patch version to a newer patch of the same minor version or to any patch of the next minor version.
-It is recommended but not required to first update to the latest patch of the current minor version before updating to the next minor version.
-In other words, Zeebe can always be updated to a higher version but skipping minor versions is not allowed.
-For example, an update from 8.5.0 to 8.5.3 or from 8.5.3 to 8.6.1 is possible
+Zeebe versions can be updated:
 
-Since Zeebe 8.5, updates to a newer version can be rolling or offline.
-Zeebe 8.4 and older don't contain necessary safety checks that make rolling updates safe, and we recommend offline updates instead to ensure processing behaves correctly.
+- From any patch version to a newer patch of the same minor version
+- To any patch of the next minor version.
 
-Please refer to the [update guide] to check if there are known issues for the specific update you are planning.
+It is recommended but not required to first update to the latest patch of the current minor version before updating to the next minor version. In other words, Zeebe can always be updated to a higher version but skipping minor versions is not allowed. For example, an update from `8.5.0` to `8.5.3` or from `8.5.3` to `8.6.1` is possible.
+
+Since Zeebe 8.5, updates to a newer version can be rolling or offline. Zeebe 8.4 and older don't contain necessary safety checks that make rolling updates safe, and we recommend offline updates instead to ensure processing behaves correctly.
+
+Refer to the [update guide](/docs/self-managed/operational-guides/update-guide/introduction.md) to check if there are known issues for the specific update you are planning.
 
 ## Rolling update
 
-A rolling update ensures that the Zeebe cluster stays available by updating brokers and gateways one by one instead of all at once.
+A **rolling update** ensures the Zeebe cluster stays available by updating brokers and gateways one by one instead of all at once.
 
-There are three parties to a rolling update, the Zeebe brokers, Zeebe gateways, and the clients.
-We recommend to update brokers first, then gateways and finally clients.
-This ensures that clients don't use new APIs that are not yet supported by the brokers or gateways.
+There are three parties to a rolling update: the Zeebe brokers, Zeebe gateways, and the clients.
+
+We recommend updating brokers first, then gateways, and finally clients. This ensures clients don't use new APIs that are not yet supported by the brokers or gateways.
+
 Because Zeebe is backwards compatible with the previous minor version, updating gateways and clients is not strictly necessary and can happen any time after updating the brokers.
 
 While updating brokers, leadership for partitions will rotate which may cause brief unavailability or loss of performance on the affected partitions.
 
 The procedure to do a rolling update of Zeebe brokers is the following:
 
-1. Pick the broker with the highest id that runs the old version
-2. Shut down the broker
-3. Update the broker software to the new version
-4. Start the broker and wait for it to become ready and healthy
+1. Pick the broker with the highest id that runs the old version.
+2. Shut down the broker.
+3. Update the broker software to the new version.
+4. Start the broker and wait for it to become ready and healthy.
 5. Repeat until all brokers are updated.
 
 Gateways are updated with the same procedure, updating each replica one by one.
 
 Clients can be updated according to your requirements and environment, for example by simply deploying a new version of your worker applications.
 
-For disaster recovery, you may want to take [backups] before the update.
+For disaster recovery, you may want to take [backups](/docs/self-managed/operational-guides/backup-restore/backup-and-restore.md) before the update.
 
-If you plan to immediately update again, you should ensure to wait to give all brokers a chance to take new snapshots.
-The snapshot period is 5 minutes by default but is [configurable via `snapshotPeriod`](../configuration/broker.md#zeebebrokerdata).
+If you plan to immediately update again, wait to give all brokers a chance to take new snapshots.
+The snapshot period is five minutes by default but is [configurable via `snapshotPeriod`](../configuration/broker.md#zeebebrokerdata).
 
 ### Using Helm
 
-If your Zeebe deployment is managed by our [Helm charts](../../platform-deployment/helm-kubernetes/deploy.md) the rolling update procedure is already automated[^1].
+If your Zeebe deployment is managed by our [Helm charts](../../platform-deployment/helm-kubernetes/deploy.md), the rolling update procedure is already automated.
+
+:::note
+Zeebe brokers are managed by a [`StatefulSet`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies). Zeebe gateways are managed by a []`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment).
+:::
 
 #### Updating brokers
 
-Ensure that the `StatefulSet` for brokers is ready to do a rolling update by checking that
+Ensure the `StatefulSet` for brokers is ready to do a rolling update by checking that:
 
-1. The update strategy is `RollingUpdate`
-2. All replicas are ready
-3. The version is at least 8.5.0
+- The update strategy is `RollingUpdate`.
+- All replicas are ready.
+- The version is at least 8.5.0.
 
 The following is an example how to verify these properties.
 Depending on your environment, you may have to adjust these commands slightly.
@@ -72,17 +78,17 @@ $ curl localhost:8080/api/v1/topology | jq .brokers[].version && kill %1
 8.5.0
 ```
 
-To start the rolling update, you need to update the Helm deployment to use a new version of Zeebe.
-Set `$NEW_ZEEBE_VERSION` to the version you want to update to, for example "8.5.2".
-Remember to read the [update guide] to check for known issues.
-Then start the rolling update with `helm upgrade`.
+To start the rolling update, update the Helm deployment to use a new version of Zeebe.
+Set `$NEW_ZEEBE_VERSION` to the version you want to update to, for example `8.5.2`.
+Remember to read the [update guide](/docs/self-managed/operational-guides/update-guide/introduction.md) to check for known issues.
+Then, start the rolling update with `helm upgrade`.
 
 ```
 $ export $NEW_ZEEBE_VERSION=8.5.2
 $ helm upgrade camunda-platform camunda/camunda-platform --reuse-values --set zeebe.image.tag=$NEW_ZEEBE_VERSION
 ```
 
-Then wait for the rolling update to complete:
+Then, wait for the rolling update to complete:
 
 ```
 $ kubectl rollout status statefulset -l app.kubernetes.io/component=zeebe-broker
@@ -105,10 +111,10 @@ $ curl localhost:8080/api/v1/topology | jq .brokers[].version && kill %1
 
 #### Updating gateways
 
-Ensure that the deployment of gateways is ready to do a rolling update by checking that:
+Ensure the deployment of gateways is ready to do a rolling update by checking that:
 
-1. All replicas are ready
-2. The version is at least 8.5
+- All replicas are ready.
+- The version is at least 8.5.
 
 You can use the following command to verify this:
 
@@ -118,13 +124,13 @@ NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
 camunda-platform-zeebe-gateway   2/2     2            2           4h25m
 ```
 
-Then update the version via helm:
+Then, update the version via Helm:
 
 ```
 $ helm upgrade camunda-platform camunda/camunda-platform --reuse-values --set zeebe-gateway.image.tag=$NEW_ZEEBE_VERSION
 ```
 
-And wait for the update to complete:
+Wait for the update to complete:
 
 ```
 $ kubectl rollout status -l app.kubernetes.io/component=zeebe-gateway
@@ -140,7 +146,7 @@ Your client applications are ready to be updated as well and can start using fea
 A rolling update can become stuck due to outside interference such as failing Kubernetes pods.
 
 To recover from this, the update can be forced by not waiting on each broker to become ready and instead directly updating all brokers at once.
-Assuming you use our helm charts, this can be done via the following command:
+Assuming you use our Helm charts, this can be done via the following command:
 
 ```
 $ kubectl delete pod -l app.kubernetes.io/component=zeebe-broker
@@ -151,42 +157,46 @@ Because the update is no longer rolling and all brokers are shut down at the sam
 
 #### Failed to install partition
 
-If updated brokers log the error message "Failed to install partition" and do not become healthy, you should look for more details to understand if this is caused by the rolling update.
+If updated brokers log the error message `Failed to install partition` and do not become healthy, look for more details to understand if this is caused by the rolling update.
 
-If the error is caused by "Cannot upgrade to or from a pre-release version", Zeebe detected that either the version you started from or the version you updated to is a pre-release version.
+If the error is caused by `Cannot upgrade to or from a pre-release version`, Zeebe detected that either the version you started from or the version you updated to is a pre-release version.
 This is not permitted because pre-release versions such as alpha releases are considered unstable and do not guarantee compatibility with any other version.
 If you attempted to update from a normal version to a pre-release version, you can roll back to the previous normal version.
 
-If the log message includes "Snapshot is not compatible with current version", the rolling update failed and manual recovery is required.
-Note that this message can also be logged by not yet updated brokers, in which case it should resolve itself automatically as soon as the [rolling update completes](#rolling-update-is-not-completing)
+If the log message includes `Snapshot is not compatible with current version`, the rolling update failed and manual recovery is required.
 
-The exact scenario is further described in the log message and can be one of the following.
+:::note
+This message can also be logged by not yet updated brokers, in which case it should resolve itself automatically as soon as the [rolling update completes](#rolling-update-is-not-completing).
+:::
+
+The exact scenario is further described in the log message and can be one of the following:
 
 ##### Snapshot is not compatible with current version: `SkippedMinorVersion`
 
-This normally occurs when attempting an update from one minor version to a newer one while skipping minor version in between.
-For example, updating from 8.5 to 8.7 directly without first updating to 8.6.
-This is not supported and Zeebe refuses to run when detecting this.
-To recover, you may be able to roll back to the previous version and then updating to the next minor version first.
+This normally occurs when attempting an update from one minor version to a newer one while skipping minor versions in between. For example, updating from 8.5 to 8.7 directly without first updating to 8.6.
+
+This is not supported and Zeebe refuses to run when detecting this. To recover, you may be able to roll back to the previous version and then update to the next minor version first.
 
 Another much more unlikely cause may be that you updated multiple times before Zeebe brokers could take snapshots.
-For example, if you first update from 8.5 to 8.6 and then immediately to 8.7, the updated brokers running 8.7 may find snapshots taken by 8.5 and refuse to run.
-You can recover from this manually
+
+For example, if you first update from 8.5 to 8.6 and then immediately to 8.7, the updated brokers running 8.7 may find snapshots taken by 8.5 and refuse to run. You can recover from this manually.
 
 ##### Snapshot is not compatible with current version: `PatchDowngrade` or `MinorDowngrade`
 
 These indicate a deliberate version downgrade which Zeebe does not support.
 If you mistakenly tried to downgrade either the patch or minor version, you can restore by switching to the original version again.
 
-Note that this his message may show up during a rolling update on not yet updated broker.
-In that case it is caused by updated brokers sharing snapshots with not yet updated brokers.
+:::note
+This message may show up during a rolling update on not yet updated broker.
+In that case, it is caused by updated brokers sharing snapshots with not yet updated brokers.
 This should resolve automatically once the broker is updated.
+:::
 
 If this persists, you may want to [force the update](#rolling-update-is-not-completing).
 
 ## Offline update
 
-See the [update guide] for specific instructions per Zeebe version.
+See the [update guide](/docs/self-managed/operational-guides/update-guide/introduction.md) for specific instructions per Zeebe version.
 
 To update a Zeebe cluster, take the following steps:
 
@@ -235,9 +245,3 @@ The response contains all partitions of the broker mapped to the partition-id.
 
   </p>
 </details>
-
-[update guide]: ../../operational-guides/update-guide/introduction.md
-[Helm charts]: ../../platform-deployment/helm-kubernetes/deploy.md
-[backups]: ../../operational-guides/backup-restore/backup-and-restore.md
-
-[^1]: Zeebe brokers are managed by a `StatefulSet`: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies. Zeebe gateways are managed by a `Deployment`: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment


### PR DESCRIPTION
## Description

Documents that Zeebe 8.5.0 now supports rolling updates and how to execute them using our helm charts.
I've also added a troubleshooting section to catch common problems.

Part of https://github.com/camunda/zeebe/issues/15879

## When should this change go live?

This documents a new ability of Zeebe 8.5.0, ideally it should be released as part of 8.5.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
