### PR TITLE
feat(concepts): update backup docs

### DIFF
--- a/docs/components/concepts/backups.md
+++ b/docs/components/concepts/backups.md
@@ -20,12 +20,6 @@ Exercise caution when deleting clusters to avoid unintended loss of backups.
 
 > Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
 
-## Backup types
-
-### Manual backup
-
-Manual backups refer to the user-initiated process of creating a consistent snapshot of the state of all system components, including Zeebe, Operate, Tasklist, and Optimize. These backups are managed on a per-cluster basis and are primarily designed for disaster recovery purposes.
-
 ## Backup location
 
 When you create a cluster in Camunda 8 SaaS, you must specify a region for that cluster.
@@ -35,23 +29,24 @@ You also need to specify where the backups for that cluster will be located:
 - By default, the backups will be located in the same region as the cluster.
 - For disaster recovery reasons, you can select a "dual region" backup location. Backups will be automatically replicated in the secondary region to give you better protection in case the primary region experiences disruption. Dual region backup is offered at no additional cost.
 
-#### Backup limits and rate limits
+## Manual backup
 
-Each cluster has a limit of three manual backups. To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours.
+Manual backups refer to the user-initiated process of creating a consistent snapshot of the state of all system components, including Zeebe, Operate, Tasklist, and Optimize. These backups are managed on a per-cluster basis and are primarily designed for disaster recovery purposes.
+
+### Retention and rate limits
+
+To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours.
 However, users can delete an existing backup to create a new one before the rate limit period ends.
 
 The system retains the three most recent completed backups per cluster. Failed backup attempts do not count towards the retention count. When a new backup is successful and the retention count is reached, the oldest backup is automatically deleted.
 
-### Scheduled backups
+## Scheduled backups
 
 Scheduled backups are created periodically (e.g daily, weekly). They are configured to run automatically on the scheduled time.
 
-#### Backup limits and rate limits
+### Retention
 
-A backup schedule retains the last three successful and failed backups. Failed backups are retained to allow further root-causing why the backup failed.
-
-The system retains the three most recent successful/failed backups per cluster.
-If a backup fails, it's not retried immediately as the system waits for the next backup attempt.
+A backup schedule retains the last three successful and failed backups. Failed backups are retained to allow further root-causing why the backup failed. If a backup fails, it is not retried immediately as the failure can lead to instability.
 
 :::note
 If you require more retained backups or more frequent backups, contact your Customer Success Manager to discuss your specific needs.

--- a/versioned_docs/version-8.2/components/concepts/backups.md
+++ b/versioned_docs/version-8.2/components/concepts/backups.md
@@ -8,39 +8,56 @@ description: "Learn more about Backups in Camunda 8 SaaS."
 
 You can use the backup feature of Camunda 8 SaaS to regularly back up the state of all of its components (Zeebe, Operate, Tasklist, and Optimize) with _zero downtime_. In case of failures that lead to data loss, you can request to restore the backup.
 
-A backup of Camunda 8 SaaS consists of a backup of Zeebe, Operate, Tasklist, Optimize, and the backup of exported Zeebe records in Elasticsearch. Since the data of these applications are dependent on each other, it is important that the backup is consistent across all components. Therefore, the backup of a Camunda 8 Cluster is taken as a whole.
+A Camunda 8 SaaS backup consists of a data backup of Zeebe, Operate, Tasklist, Optimize, and the backup of exported Zeebe records in Elasticsearch. Since the data of these applications depend on each other, the backup must be consistent across all components. Therefore, the backup of a Camunda 8 cluster is taken as a whole.
 
-With backups, you can capture snapshots of your data and applications while they are actively in use, resulting in zero downtime or disruption to your operations. Backups are designed specifically for disaster recovery purposes. Backups should not be used for archival of process data.
-
-## Backup and cluster relationship
-
-Backups are created and managed on a per-cluster basis. It is important to be aware that deleting a cluster will also delete all associated backups.
+With backups, you can capture snapshots of your data and applications while they are actively in use, resulting in zero downtime or disruption to your operations. Backups are designed specifically for disaster recovery purposes, and should not be used for archival of process data.
 
 :::caution
+Backups are created and managed on a per-cluster basis. It is important to be aware that deleting a cluster will also delete all associated backups.
+
 Exercise caution when deleting clusters to avoid unintended loss of backups.
 :::
 
-Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
+> Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
 
-## Rate limits
+## Backup location
 
-Each cluster has a limit of three backups. To ensure system stability backup operations are subject to rate limits. Specifically, you can perform a backup operation every 5 hours. However, it is possible to delete a backup and create a new one before the 5-hour rate limit expires.
+When you create a cluster in Camunda 8 SaaS, you must specify a region for that cluster.
 
-The system retains the three most recent completed backups per cluster. Failed backup attempts do not count towards the retention count. When a new backup is successful and the retention count is reached, the oldest backup will be automatically deleted.
+You also need to specify where the backups for that cluster will be located:
+
+- By default, the backups will be located in the same region as the cluster.
+- For disaster recovery reasons, you can select a "dual region" backup location. Backups will be automatically replicated in the secondary region to give you better protection in case the primary region experiences disruption. Dual region backup is offered at no additional cost.
+
+## Manual backup
+
+Manual backups refer to the user-initiated process of creating a consistent snapshot of the state of all system components, including Zeebe, Operate, Tasklist, and Optimize. These backups are managed on a per-cluster basis and are primarily designed for disaster recovery purposes.
+
+### Retention and rate limits
+
+To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours.
+However, users can delete an existing backup to create a new one before the rate limit period ends.
+
+The system retains the three most recent completed backups per cluster. Failed backup attempts do not count towards the retention count. When a new backup is successful and the retention count is reached, the oldest backup is automatically deleted.
+
+## Scheduled backups
+
+Scheduled backups are created periodically (e.g daily, weekly). They are configured to run automatically on the scheduled time.
+
+### Retention
+
+A backup schedule retains the last three successful and failed backups. Failed backups are retained to allow further root-causing why the backup failed. If a backup fails, it is not retried immediately as the failure can lead to instability.
 
 :::note
-If you require more retained backups or more frequent backups, get in touch with your Customer Success Manager to discuss your specific needs.
+If you require more retained backups or more frequent backups, contact your Customer Success Manager to discuss your specific needs.
 :::
 
 ## Programmatic access
 
-The backup operations can be performed programmatically using the Administration API. This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows. For detailed information on using the API, please refer to the [Administration API reference](/apis-tools/administration-api-reference.md/).
+The backup operations can be performed programmatically using the Administration API.
+This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows.
+For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
 
 ## Restore
 
-If you need to restore your Camunda 8 cluster from a backup, please follow these steps:
-
-1. [Contact Camunda support](https://camunda.com/services/support/) to request a restore for your backup.
-2. Our support team will assist you with the restoration process and guide you through the necessary steps to recover your cluster from the backup.
-
-For any further assistance or questions related to backups or restorations, please feel free to reach out to our support team.
+To restore your Camunda 8 cluster from a backup (and for any further assistance in general), [contact Camunda support](https://camunda.com/services/support/) to request a restore for your backup. Our support team will assist you with the restoration process and guide you through the necessary steps to recover your cluster from the backup.

--- a/versioned_docs/version-8.2/components/concepts/backups.md
+++ b/versioned_docs/version-8.2/components/concepts/backups.md
@@ -56,7 +56,7 @@ If you require more retained backups or more frequent backups, contact your Cust
 
 The backup operations can be performed programmatically using the Administration API.
 This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows.
-For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
+For detailed information on using the API, refer to the [Administration API reference](/docs/apis-tools/administration-api/administration-api-reference.md).
 
 ## Restore
 

--- a/versioned_docs/version-8.3/components/concepts/backups.md
+++ b/versioned_docs/version-8.3/components/concepts/backups.md
@@ -12,21 +12,41 @@ A Camunda 8 SaaS backup consists of a data backup of Zeebe, Operate, Tasklist, O
 
 With backups, you can capture snapshots of your data and applications while they are actively in use, resulting in zero downtime or disruption to your operations. Backups are designed specifically for disaster recovery purposes, and should not be used for archival of process data.
 
-## Backup and cluster relationship
-
+:::caution
 Backups are created and managed on a per-cluster basis. It is important to be aware that deleting a cluster will also delete all associated backups.
 
-:::caution
 Exercise caution when deleting clusters to avoid unintended loss of backups.
 :::
 
-Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
+> Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
 
-## Rate limits
+## Backup location
 
-Each cluster has a limit of three backups. To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours. However, it is possible to delete a backup and create a new one before the 5-hour rate limit expires.
+When you create a cluster in Camunda 8 SaaS, you must specify a region for that cluster.
+
+You also need to specify where the backups for that cluster will be located:
+
+- By default, the backups will be located in the same region as the cluster.
+- For disaster recovery reasons, you can select a "dual region" backup location. Backups will be automatically replicated in the secondary region to give you better protection in case the primary region experiences disruption. Dual region backup is offered at no additional cost.
+
+## Manual backup
+
+Manual backups refer to the user-initiated process of creating a consistent snapshot of the state of all system components, including Zeebe, Operate, Tasklist, and Optimize. These backups are managed on a per-cluster basis and are primarily designed for disaster recovery purposes.
+
+### Retention and rate limits
+
+To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours.
+However, users can delete an existing backup to create a new one before the rate limit period ends.
 
 The system retains the three most recent completed backups per cluster. Failed backup attempts do not count towards the retention count. When a new backup is successful and the retention count is reached, the oldest backup is automatically deleted.
+
+## Scheduled backups
+
+Scheduled backups are created periodically (e.g daily, weekly). They are configured to run automatically on the scheduled time.
+
+### Retention
+
+A backup schedule retains the last three successful and failed backups. Failed backups are retained to allow further root-causing why the backup failed. If a backup fails, it is not retried immediately as the failure can lead to instability.
 
 :::note
 If you require more retained backups or more frequent backups, contact your Customer Success Manager to discuss your specific needs.
@@ -34,7 +54,9 @@ If you require more retained backups or more frequent backups, contact your Cust
 
 ## Programmatic access
 
-The backup operations can be performed programmatically using the Administration API. This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows. For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api-reference.md).
+The backup operations can be performed programmatically using the Administration API.
+This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows.
+For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
 
 ## Restore
 

--- a/versioned_docs/version-8.3/components/concepts/backups.md
+++ b/versioned_docs/version-8.3/components/concepts/backups.md
@@ -56,7 +56,7 @@ If you require more retained backups or more frequent backups, contact your Cust
 
 The backup operations can be performed programmatically using the Administration API.
 This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows.
-For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
+For detailed information on using the API, refer to the [Administration API reference](/docs/apis-tools/administration-api/administration-api-reference.md).
 
 ## Restore
 

--- a/versioned_docs/version-8.4/components/concepts/backups.md
+++ b/versioned_docs/version-8.4/components/concepts/backups.md
@@ -12,21 +12,41 @@ A Camunda 8 SaaS backup consists of a data backup of Zeebe, Operate, Tasklist, O
 
 With backups, you can capture snapshots of your data and applications while they are actively in use, resulting in zero downtime or disruption to your operations. Backups are designed specifically for disaster recovery purposes, and should not be used for archival of process data.
 
-## Backup and cluster relationship
-
+:::caution
 Backups are created and managed on a per-cluster basis. It is important to be aware that deleting a cluster will also delete all associated backups.
 
-:::caution
 Exercise caution when deleting clusters to avoid unintended loss of backups.
 :::
 
-Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
+> Your cluster generation needs to be greater or equal to `8.2.4` to support backups.
 
-## Rate limits
+## Backup location
 
-Each cluster has a limit of three backups. To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours. However, it is possible to delete a backup and create a new one before the 5-hour rate limit expires.
+When you create a cluster in Camunda 8 SaaS, you must specify a region for that cluster.
+
+You also need to specify where the backups for that cluster will be located:
+
+- By default, the backups will be located in the same region as the cluster.
+- For disaster recovery reasons, you can select a "dual region" backup location. Backups will be automatically replicated in the secondary region to give you better protection in case the primary region experiences disruption. Dual region backup is offered at no additional cost.
+
+## Manual backup
+
+Manual backups refer to the user-initiated process of creating a consistent snapshot of the state of all system components, including Zeebe, Operate, Tasklist, and Optimize. These backups are managed on a per-cluster basis and are primarily designed for disaster recovery purposes.
+
+### Retention and rate limits
+
+To ensure system stability, backup operations are subject to rate limits. Specifically, you can perform a backup operation every five hours.
+However, users can delete an existing backup to create a new one before the rate limit period ends.
 
 The system retains the three most recent completed backups per cluster. Failed backup attempts do not count towards the retention count. When a new backup is successful and the retention count is reached, the oldest backup is automatically deleted.
+
+## Scheduled backups
+
+Scheduled backups are created periodically (e.g daily, weekly). They are configured to run automatically on the scheduled time.
+
+### Retention
+
+A backup schedule retains the last three successful and failed backups. Failed backups are retained to allow further root-causing why the backup failed. If a backup fails, it is not retried immediately as the failure can lead to instability.
 
 :::note
 If you require more retained backups or more frequent backups, contact your Customer Success Manager to discuss your specific needs.
@@ -34,7 +54,9 @@ If you require more retained backups or more frequent backups, contact your Cust
 
 ## Programmatic access
 
-The backup operations can be performed programmatically using the Administration API. This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows. For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
+The backup operations can be performed programmatically using the Administration API.
+This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows.
+For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
 
 ## Restore
 

--- a/versioned_docs/version-8.4/components/concepts/backups.md
+++ b/versioned_docs/version-8.4/components/concepts/backups.md
@@ -56,7 +56,7 @@ If you require more retained backups or more frequent backups, contact your Cust
 
 The backup operations can be performed programmatically using the Administration API.
 This provides the flexibility to seamlessly integrate backup-related tasks with your existing systems and automation workflows.
-For detailed information on using the API, refer to the [Administration API reference](/apis-tools/administration-api/administration-api-reference.md).
+For detailed information on using the API, refer to the [Administration API reference](/docs/apis-tools/administration-api/administration-api-reference.md).
 
 ## Restore
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

This back ports the new backup documentation to all versions above 8.2. The new feature of backup schedule is supported in all these versions. I tried to improve the wording and removed some redundancies. 


Relates to:
https://github.com/camunda-cloud/camunda-operator/issues/2543
PDP: https://github.com/camunda/product-hub/issues/1355

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.

Note for the checklist: I was a bit unsure whether I should check the last two. The `or` sentence is accurate in both cases. 😅 .
