### PR TITLE
fix(connectors): invalid connectorData mapping examples

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/slack.md
+++ b/docs/components/connectors/out-of-the-box-connectors/slack.md
@@ -236,10 +236,10 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be a part of the Slack event subscription or slash command URL.
 2. In the **Webhook Configuration** section, configure the **Slack signing secret**. This value is unique to your Slack application and used to validate a Slack payload integrity. Read more about signing secrets in the [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
-3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(request.connectorData.command = "/test")`.
+3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(connectorData.command = "/test")`.
 4. In the **Variable mapping** section, fill the field **Result variable** to store the response in a process variable. For example, `myResultVariable`.
 5. In the **Variable expression** section, fill the field to map specific fields from the response into process variables using [FEEL](/components/modeler/feel/what-is-feel.md).
-   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: request.connectorData.user_id, text: request.connectorData.text}`.
+   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: connectorData.user_id, text: connectorData.text}`.
 
 When using the **Slack inbound Connector** with an **Intermediate Catch Event**, fill in the **Correlation key (process)** and **Correlation key (payload)**.
 
@@ -249,7 +249,7 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `text=hello}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.connectorData.text`
+- **Correlation key (payload)**: `=connectorData.text`
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 

--- a/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.1/components/connectors/out-of-the-box-connectors/slack.md
@@ -244,10 +244,10 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be a part of the Slack event subscription or slash command URL.
 2. In the **Webhook Configuration** section, configure the **Slack signing secret**. This value is unique to your Slack application and used to validate a Slack payload integrity. Read more about signing secrets in the [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
-3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(request.connectorData.command = "/test")`.
+3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(connectorData.command = "/test")`.
 4. In the **Variable mapping** section, fill the field **Result variable** to store the response in a process variable. For example, `myResultVariable`.
 5. In the **Variable expression** section, fill the field to map specific fields from the response into process variables using [FEEL](/components/modeler/feel/what-is-feel.md).
-   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: request.connectorData.user_id, text: request.connectorData.text}`.
+   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: connectorData.user_id, text: connectorData.text}`.
 
 When using the **Slack inbound Connector** with an **Intermediate Catch Event**, fill in the **Correlation key (process)** and **Correlation key (payload)**.
 
@@ -257,7 +257,7 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `text=hello}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.connectorData.text`
+- **Correlation key (payload)**: `=connectorData.text`
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 

--- a/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.2/components/connectors/out-of-the-box-connectors/slack.md
@@ -236,10 +236,10 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be a part of the Slack event subscription or slash command URL.
 2. In the **Webhook Configuration** section, configure the **Slack signing secret**. This value is unique to your Slack application and used to validate a Slack payload integrity. Read more about signing secrets in the [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
-3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(request.connectorData.command = "/test")`.
+3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(connectorData.command = "/test")`.
 4. In the **Variable mapping** section, fill the field **Result variable** to store the response in a process variable. For example, `myResultVariable`.
 5. In the **Variable expression** section, fill the field to map specific fields from the response into process variables using [FEEL](/components/modeler/feel/what-is-feel.md).
-   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: request.connectorData.user_id, text: request.connectorData.text}`.
+   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: connectorData.user_id, text: connectorData.text}`.
 
 When using the **Slack inbound Connector** with an **Intermediate Catch Event**, fill in the **Correlation key (process)** and **Correlation key (payload)**.
 
@@ -249,7 +249,7 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `text=hello}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.connectorData.text`
+- **Correlation key (payload)**: `=connectorData.text`
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/slack.md
@@ -230,10 +230,10 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be a part of the Slack event subscription or slash command URL.
 2. In the **Webhook Configuration** section, configure the **Slack signing secret**. This value is unique to your Slack application and used to validate a Slack payload integrity. Read more about signing secrets in the [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
-3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(request.connectorData.command = "/test")`.
+3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(connectorData.command = "/test")`.
 4. In the **Variable mapping** section, fill the field **Result variable** to store the response in a process variable. For example, `myResultVariable`.
 5. In the **Variable expression** section, fill the field to map specific fields from the response into process variables using [FEEL](/components/modeler/feel/what-is-feel.md).
-   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: request.connectorData.user_id, text: request.connectorData.text}`.
+   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: connectorData.user_id, text: connectorData.text}`.
 
 When using the **Slack inbound Connector** with an **Intermediate Catch Event**, fill in the **Correlation key (process)** and **Correlation key (payload)**.
 
@@ -243,7 +243,7 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `text=hello}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.connectorData.text`
+- **Correlation key (payload)**: `=connectorData.text`
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 

--- a/versioned_docs/version-8.4/components/connectors/out-of-the-box-connectors/slack.md
+++ b/versioned_docs/version-8.4/components/connectors/out-of-the-box-connectors/slack.md
@@ -236,10 +236,10 @@ Learn more about correlation keys in the [messages guide](../../../concepts/mess
 
 1. In the **Webhook Configuration** section, configure the **Webhook ID**. By default, **Webhook ID** is pre-filled with a random value. This value will be a part of the Slack event subscription or slash command URL.
 2. In the **Webhook Configuration** section, configure the **Slack signing secret**. This value is unique to your Slack application and used to validate a Slack payload integrity. Read more about signing secrets in the [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack).
-3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(request.connectorData.command = "/test")`.
+3. In the **Activation** section, configure **Condition** when the Slack event or command can trigger a new BPMN process. The following example will trigger a new BPMN process for every `/test` Slack command type: `=(connectorData.command = "/test")`.
 4. In the **Variable mapping** section, fill the field **Result variable** to store the response in a process variable. For example, `myResultVariable`.
 5. In the **Variable expression** section, fill the field to map specific fields from the response into process variables using [FEEL](/components/modeler/feel/what-is-feel.md).
-   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: request.connectorData.user_id, text: request.connectorData.text}`.
+   The following example will extract both Slack message sender ID and text from Slack `/test hello` command: `={senderId: connectorData.user_id, text: connectorData.text}`.
 
 When using the **Slack inbound Connector** with an **Intermediate Catch Event**, fill in the **Correlation key (process)** and **Correlation key (payload)**.
 
@@ -249,7 +249,7 @@ When using the **Slack inbound Connector** with an **Intermediate Catch Event**,
 For example, given that your correlation key is defined with `myCorrelationKey` process variable, and the request body contains `text=hello}`, your correlation key settings will look like this:
 
 - **Correlation key (process)**: `=myCorrelationKey`
-- **Correlation key (payload)**: `=request.connectorData.text`
+- **Correlation key (payload)**: `=connectorData.text`
 
 Learn more about correlation keys in the [messages guide](../../../concepts/messages).
 


### PR DESCRIPTION
## Description

Fixed the incorrect data mapping examples in the Slack connector guide.

The old version suggested that the `connectorData` object is part of the `request` wrapper and needs to be accessed like this `request.connectorData`. 

In reality it is a top-level object that can be accessed directly.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
