### PR TITLE
feat(vale): add rule for upper lower case titles

### DIFF
--- a/styles/camunda/all/titleUpperLowerCase.yml
+++ b/styles/camunda/all/titleUpperLowerCase.yml
@@ -1,0 +1,33 @@
+extends: capitalization
+message: "'%s' title should be uppercase followed by lowercase"
+level: error
+scope: heading
+match: '^(?:[A-Z\d][^\s]* ?)(?:[a-z\d][^\s]* ?)*$'
+exceptions:
+  - Amazon
+  - API
+  - AWS
+  - BPMN
+  - Camunda
+  - CLI
+  - Cloud
+  - CMMN
+  - Cockpit
+  - Community
+  - DMN
+  - EKS
+  - Elasticsearch
+  - Engine
+  - Enterprise
+  - IAM
+  - Modeler
+  - Open Source
+  - Optimize
+  - Platform
+  - PostgreSQL
+  - REST
+  - SDK
+  - Tasklist
+  - XOR
+  - YAML
+  - Zeebe


### PR DESCRIPTION
## Description

Just a proposal, we don't have to follow through with it, something I noticed that could be helpful to automate.

We are not following vale supported AP or Chicago styles for titles but rather `uppercase` followed by `lowercase`.

The following introduces a simple regex rule to filter out unsupported titles.

There are of course, a lot of proper nouns, I excluded some but stopped to hear whether this idea has any value for DevEx before putting work into it.

Additionally, there are maybe cases that we don't want to exclude that could simply be wrapped in the following to not trigger.
```
<!-- vale all.titleUpperLowerCase = NO -->
# Some Random Title We Want Hower We Want
<!-- vale all.titleUpperLowerCase = YES -->
```

Let me know what you think.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
