### PR TITLE
docs: update Helm chart docs for REST API

### DIFF
--- a/docs/self-managed/setup/deploy/amazon/aws-marketplace.md
+++ b/docs/self-managed/setup/deploy/amazon/aws-marketplace.md
@@ -274,11 +274,12 @@ identity:
   contextPath: "/identity"
   fullURL: "https://$CAMUNDA_HOSTNAME/identity"
 
-zeebe-gateway:
+zeebeGateway:
+  contextPath: "/zeebe"
   ingress:
-    enabled: true
-    className: nginx
-    host: "$CAMUNDA_HOSTNAME"
+    grpc:
+      enabled: true
+      host: "$CAMUNDA_HOSTNAME"
 ```
 
 Then, run the following command to replace the template with the environment variables specified:
@@ -299,7 +300,7 @@ zeebe:
   image:
     repository: camunda/camunda8/zeebe
 
-zeebe-gateway:
+zeebeGateway:
   image:
     repository: camunda/camunda8/zeebe
 

--- a/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -303,14 +303,6 @@ zeebeGateway:
       tls:
         enabled: true
         secretName: <EXTERNAL_URL_CERTIFICATE_SECRET_NAME>
-    rest:
-      annotations:
-        route.openshift.io/termination: reencrypt
-        route.openshift.io/destination-ca-certificate-secret: <SERVICE_CERTIFICATE_SECRET_NAME>
-      className: openshift-default
-      tls:
-        enabled: true
-        secretName: <EXTERNAL_URL_CERTIFICATE_SECRET_NAME>
 ```
 
 3. Mount the **Service Certificate Secret** to the Zeebe Gateway Pod:
@@ -318,12 +310,6 @@ zeebeGateway:
 ```yaml
 zeebeGateway:
   env:
-    - name: SERVER_SSL_ENABLED
-      value: "true"
-    - name: SERVER_SSL_CERTIFICATE
-      value: /usr/local/zeebe/config/tls.crt
-    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
-      value: /usr/local/zeebe/config/tls.key
     - name: ZEEBE_GATEWAY_SECURITY_ENABLED
       value: "true"
     - name: ZEEBE_GATEWAY_SECURITY_CERTIFICATECHAINPATH

--- a/docs/self-managed/setup/deploy/other/docker.md
+++ b/docs/self-managed/setup/deploy/other/docker.md
@@ -27,12 +27,13 @@ The provided Docker images are supported for production usage only on Linux syst
 Zeebe is the only component that is often run on its own as a standalone component. In this scenario, it does not need anything else, so a simple `docker run` is sufficient:
 
 ```bash
-docker run --name zeebe -p 26500-26502:26500-26502 camunda/zeebe:latest
+docker run --name zeebe -p 8080:8080 -p 26500-26502:26500-26502 camunda/zeebe:latest
 ```
 
 This will give you a single broker node with the following ports exposed:
 
-- `26500`: Gateway API (this is the port clients need to use)
+- `8080`: Gateway REST API (this is one of the ports clients need to use)
+- `26500`: Gateway gRPC API (this is one of the ports clients need to use)
 - `26501`: Command API (internal, gateway-to-broker)
 - `26502`: Internal API (internal, broker-to-broker)
 

--- a/docs/self-managed/setup/guides/ingress-setup.md
+++ b/docs/self-managed/setup/guides/ingress-setup.md
@@ -75,11 +75,13 @@ webModeler:
 console:
   contextPath: "/console"
 
-zeebe-gateway:
+zeebeGateway:
+  contextPath: "/zeebe"
   ingress:
-    enabled: true
-    className: nginx
-    host: "zeebe.camunda.example.com"
+    grpc:
+      enabled: true
+      className: nginx
+      host: "zeebe.camunda.example.com"
 ```
 
 :::note Web Modeler
@@ -98,10 +100,10 @@ helm install demo camunda/camunda-platform -f values-combined-ingress.yaml
 
 Once deployed, you can access the Camunda 8 components on:
 
-- **Web applications:** `https://camunda.example.com/[identity|operate|optimize|tasklist|modeler|console]`
+- **Web applications:** `https://camunda.example.com/[identity|operate|optimize|tasklist|modeler|console|zeebe]`
   - _Note_: Web Modeler also exposes a WebSocket endpoint on `https://camunda.example.com/modeler-ws`. This is only used by the application itself and not supposed to be accessed by users directly.
 - **Keycloak authentication:** `https://camunda.example.com/auth`
-- **Zeebe Gateway:** `grpc://zeebe.camunda.example.com`
+- **Zeebe Gateway:** `https://zeebe.camunda.example.com`
 
 ## Separated Ingress setup
 
@@ -164,11 +166,16 @@ tasklist:
     className: nginx
     host: "tasklist.camunda.example.com"
 
-zeebe-gateway:
+zeebeGateway:
   ingress:
-    enabled: true
-    className: nginx
-    host: "zeebe.camunda.example.com"
+    rest:
+      enabled: true
+      className: nginx
+      host: "zeebe.camunda.example.com"
+    grpc:
+      enabled: true
+      className: nginx
+      host: "zeebe-grpc.camunda.example.com"
 
 webModeler:
   ingress:
@@ -203,9 +210,9 @@ helm install demo camunda/camunda-platform -f values-separated-ingress.yaml
 
 Once deployed, you can access the Camunda 8 components on:
 
-- **Web applications:** `https://[identity|operate|optimize|tasklist|modeler|console].camunda.example.com`
+- **Web applications:** `https://[identity|operate|optimize|tasklist|modeler|console|zeebe].camunda.example.com`
 - **Keycloak authentication:** `https://keycloak.camunda.example.com`
-- **Zeebe Gateway:** `grpc://zeebe.camunda.example.com`
+- **Zeebe Gateway:** `https://zeebe-grpc.camunda.example.com`
 
 ## Ingress controllers
 

--- a/docs/self-managed/setup/guides/multi-namespace-deployment.md
+++ b/docs/self-managed/setup/guides/multi-namespace-deployment.md
@@ -205,7 +205,9 @@ console:
               readiness: http://camunda-tasklist.camunda-team01:80/actuator/health/readiness
               metrics: http://camunda-tasklist.camunda-team01:80/actuator/prometheus
             - name: Zeebe Gateway
-              url: grpc://
+              url:
+                grpc: http://camunda-zeebe-gateway-grpc.camunda-team01:80
+                http: http://camunda-zeebe-gateway.camunda-team01:80
               readiness: http://camunda-zeebe-gateway.camunda-team01:9600/actuator/health/readiness
               metrics: http://camunda-zeebe-gateway.camunda-team01:9600/actuator/prometheus
             - name: Zeebe
@@ -227,7 +229,9 @@ console:
               readiness: http://camunda-tasklist.camunda-team02:80/actuator/health/readiness
               metrics: http://camunda-tasklist.camunda-team02:80/actuator/prometheus
             - name: Zeebe Gateway
-              url: grpc://
+              url:
+                grpc: http://camunda-zeebe-gateway.camunda-team02:80
+                http: http://camunda-team02.example.com:80
               readiness: http://camunda-zeebe-gateway.camunda-team02:9600/actuator/health/readiness
               metrics: http://camunda-zeebe-gateway.camunda-team02:9600/actuator/prometheus
             - name: Zeebe

--- a/docs/self-managed/setup/upgrade.md
+++ b/docs/self-managed/setup/upgrade.md
@@ -212,8 +212,10 @@ zeebeGateway:
       # more properties
 ```
 
-Note that the new `zeebeGateway.contextPath` is added to deployment path, both for
-management (i.e. port `9600`) and REST (i.e. port `8080`), _even if the ingress it not enabled_.
+:::note
+The new `zeebeGateway.contextPath` is added to the deployment path, both for
+management (for example, port `9600`) and REST (for example, `8080`), _even if the ingress it not enabled_.
+:::
 
 #### Enabling external Elasticsearch
 

--- a/docs/self-managed/setup/upgrade.md
+++ b/docs/self-managed/setup/upgrade.md
@@ -184,6 +184,37 @@ New:
 zeebeGateway:
 ```
 
+Additionally, with the introduction of the REST API, there are now two ingresses.
+Previously, there was only the old gRPC ingress at `zeebe-gateway.ingress`, which is now:
+
+Old:
+
+```yaml
+zeebe-gateway:
+  ingress:
+    enabled: false
+    # more properties
+```
+
+New:
+
+```yaml
+zeebeGateway:
+  ingress:
+    # Define and enable gRPC ingress; keep in mind it does not support context paths
+    grpc:
+      enabled: true
+      # more properties
+    # Define and enable the REST ingress; this one does support the zeebeGateway.contextPath
+    # parameter out of the box
+    rest:
+      enabled: true
+      # more properties
+```
+
+Note that the new `zeebeGateway.contextPath` is added to deployment path, both for
+management (i.e. port `9600`) and REST (i.e. port `8080`), _even if the ingress it not enabled_.
+
 #### Enabling external Elasticsearch
 
 It is possible to use external Elasticsearch. For more information on how to set up external Elasticsearch, refer to [using existing Elasticsearch](./guides/using-existing-elasticsearch.md).


### PR DESCRIPTION
## Description

This PR updates the Helm documentation to include the new Zeebe REST API, specifically references to the old Zeebe Gateway ingress and various use cases around that.

> [!Note]
> I did not update any images, as I don't know where the source images live.

I tried to update as much as it made sense to me, but some things (like the OpenShift route set up, and the managed console stuff) I know little about, so there may be some errors. Please review these more carefully.

## When should this change go live?

With the 8.5.0 release.

## PR Checklist

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
