### PR TITLE
fix: revert zeebe-api-rest sidebar removal

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -716,6 +716,7 @@ module.exports = {
         require("./docs/apis-tools/tasklist-api-rest/sidebar-schema"),
         require("./docs/apis-tools/web-modeler-api/sidebar-schema"),
         require("./docs/apis-tools/zeebe-api/sidebar-schema"),
+        require("./docs/apis-tools/zeebe-api-rest/sidebar-schema"),
         {
           Deprecated: [
             require("./docs/apis-tools/tasklist-api/sidebar-schema"),


### PR DESCRIPTION
## Description

#3507 [accidentally removed the Zeebe REST API Explorer from the sidebar nav](https://github.com/camunda/camunda-docs/pull/3507/files#diff-9a6a0fdafefb0eecffb77784bc94f5ad984062167b8bcb7c4a899c90f6f567e8L720). This was resulting in no sidebar appearing on the Zeebe REST API Explorer pages ([as described](https://github.com/camunda/camunda-docs/pull/3597#issuecomment-2037428039) in #3597). 

This PR reverts that removal, so that the Zeebe REST API docs appear in the sidebar again. 

(Note that there were no issues with the optimize_sidebars.js, because I was lazy and was waiting to add the Zeebe REST API docs to that sidebar during my bulk sidebar synchronization tomorrow 😅 )

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
