### PR TITLE
typo for update endpoint

### DIFF
--- a/docs/apis-tools/frontend-development/01-task-applications/02-user-task-lifecycle.md
+++ b/docs/apis-tools/frontend-development/01-task-applications/02-user-task-lifecycle.md
@@ -85,7 +85,7 @@ Make sure that you create your own validation logic that matches your use case.
 To implement task life cycle operations with the Zeebe task API, call the respective endpoints:
 
 - `POST /user-tasks/:taskKey/assignment` or `DELETE /user-tasks/:taskKey/assignee` to change task assignment.
-- `PATCH /user-tasks/:taskKey/update` to update a task.
+- `PATCH /user-tasks/:taskKey` to update a task.
 - `POST /user-tasks/:taskKey/completion` to complete a task.
 
 All these endpoints (except `DELETE`) allow you to send a custom `action` attribute via the payload. The `action` attribute carries any arbitrary string and can be used to track any life cycle event, including those mentioned above.


### PR DESCRIPTION
## Description

Follow up to https://github.com/camunda/camunda-docs/pull/3549.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
