### PR TITLE
chore(sidebars): sync sidebars in v8.4

### DIFF
--- a/optimize_versioned_sidebars/version-3.12.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.12.0-sidebars.json
@@ -5,6 +5,7 @@
       "label": "Introduction to Components",
       "href": "/docs/components/"
     },
+
     {
       "Concepts": [
         {
@@ -99,6 +100,7 @@
         }
       ]
     },
+
     {
       "Console": [
         {
@@ -106,6 +108,7 @@
           "label": "Introduction to Camunda Console",
           "href": "/docs/components/console/introduction-to-console/"
         },
+
         {
           "Manage your organization": [
             {
@@ -160,6 +163,7 @@
             }
           ]
         },
+
         {
           "Manage clusters": [
             {
@@ -171,6 +175,16 @@
               "type": "link",
               "label": "Rename your cluster",
               "href": "/docs/components/console/manage-clusters/rename-cluster/"
+            },
+            {
+              "type": "link",
+              "label": "Resume your cluster",
+              "href": "/docs/components/console/manage-clusters/resume-cluster/"
+            },
+            {
+              "type": "link",
+              "label": "Update your cluster",
+              "href": "/docs/components/console/manage-clusters/update-cluster/"
             },
             {
               "type": "link",
@@ -204,6 +218,7 @@
             }
           ]
         },
+
         {
           "Manage your plan": [
             {
@@ -243,6 +258,7 @@
             }
           ]
         },
+
         {
           "Troubleshooting": [
             {
@@ -254,6 +270,7 @@
         }
       ]
     },
+
     {
       "Modeler": [
         {
@@ -293,6 +310,7 @@
               "label": "Visit the Camunda Marketplace",
               "href": "/docs/components/modeler/web-modeler/camunda-marketplace/"
             },
+
             {
               "Collaboration": [
                 {
@@ -322,6 +340,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Milestones",
@@ -332,6 +351,7 @@
               "label": "Token simulation",
               "href": "/docs/components/modeler/web-modeler/token-simulation/"
             },
+
             {
               "Advanced modeling": [
                 {
@@ -358,6 +378,7 @@
             }
           ]
         },
+
         {
           "Desktop Modeler": [
             {
@@ -380,6 +401,7 @@
               "label": "Start a new process instance",
               "href": "/docs/components/modeler/desktop-modeler/start-instance/"
             },
+
             {
               "Element templates": [
                 {
@@ -409,6 +431,7 @@
                 }
               ]
             },
+
             {
               "Additional configuration": [
                 {
@@ -438,6 +461,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Troubleshooting",
@@ -445,6 +469,7 @@
             }
           ]
         },
+
         {
           "BPMN": [
             {
@@ -467,6 +492,7 @@
               "label": "Data flow",
               "href": "/docs/components/modeler/bpmn/data-flow/"
             },
+
             {
               "Tasks": [
                 {
@@ -516,6 +542,7 @@
                 }
               ]
             },
+
             {
               "Gateways": [
                 {
@@ -545,6 +572,7 @@
                 }
               ]
             },
+
             {
               "Events": [
                 {
@@ -594,6 +622,7 @@
                 }
               ]
             },
+
             {
               "Subprocesses": [
                 {
@@ -618,6 +647,7 @@
                 }
               ]
             },
+
             {
               "Markers": [
                 {
@@ -634,6 +664,7 @@
             }
           ]
         },
+
         {
           "DMN": [
             {
@@ -646,6 +677,7 @@
               "label": "Decision requirements graph",
               "href": "/docs/components/modeler/dmn/decision-requirements-graph/"
             },
+
             {
               "Decision table": [
                 {
@@ -675,6 +707,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Decision literal expression",
@@ -687,6 +720,7 @@
             }
           ]
         },
+
         {
           "FEEL expressions": [
             {
@@ -704,6 +738,7 @@
               "label": "Unary-tests",
               "href": "/docs/components/modeler/feel/language-guide/feel-unary-tests/"
             },
+
             {
               "Expressions": [
                 {
@@ -763,6 +798,7 @@
                 }
               ]
             },
+
             {
               "Built-in Functions": [
                 {
@@ -814,6 +850,7 @@
             }
           ]
         },
+
         {
           "Camunda Forms": [
             {
@@ -821,6 +858,7 @@
               "label": "What are Camunda Forms?",
               "href": "/docs/components/modeler/forms/camunda-forms-reference/"
             },
+
             {
               "Form Element Library": [
                 {
@@ -860,7 +898,7 @@
                 },
                 {
                   "type": "link",
-                  "label": "Radio",
+                  "label": "Radio group",
                   "href": "/docs/components/modeler/forms/form-element-library/forms-element-library-radio/"
                 },
                 {
@@ -870,8 +908,8 @@
                 },
                 {
                   "type": "link",
-                  "label": "Checklist",
-                  "href": "/docs/components/modeler/forms/form-element-library/forms-element-library-checklist/"
+                  "label": "Checkbox group",
+                  "href": "/docs/components/modeler/forms/form-element-library/forms-element-library-checkbox-group/"
                 },
                 {
                   "type": "link",
@@ -920,6 +958,7 @@
                 }
               ]
             },
+
             {
               "Configuration": [
                 {
@@ -946,11 +985,13 @@
             }
           ]
         },
+
         {
           "type": "link",
           "label": "Data handling",
           "href": "/docs/components/modeler/data-handling/"
         },
+
         {
           "Reference": [
             {
@@ -991,6 +1032,7 @@
         }
       ]
     },
+
     {
       "Connectors": [
         {
@@ -1003,6 +1045,7 @@
           "label": "Types of Connectors",
           "href": "/docs/components/connectors/connector-types/"
         },
+
         {
           "Use Connectors": [
             {
@@ -1022,6 +1065,7 @@
             }
           ]
         },
+
         {
           "Out-of-the-box Connectors": [
             {
@@ -1039,6 +1083,7 @@
               "label": "Automation Anywhere Connector",
               "href": "/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/"
             },
+
             {
               "AWS": [
                 {
@@ -1068,6 +1113,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Blue Prism Connector",
@@ -1088,6 +1134,7 @@
               "label": "GitLab Connector",
               "href": "/docs/components/connectors/out-of-the-box-connectors/gitlab/"
             },
+
             {
               "Google": [
                 {
@@ -1107,11 +1154,13 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Kafka Connector",
               "href": "/docs/components/connectors/out-of-the-box-connectors/kafka/"
             },
+
             {
               "Microsoft": [
                 {
@@ -1126,6 +1175,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "OpenAI Connector",
@@ -1173,6 +1223,7 @@
             }
           ]
         },
+
         {
           "Protocol Connectors": [
             {
@@ -1197,11 +1248,13 @@
             }
           ]
         },
+
         {
           "type": "link",
           "label": "Manage Connector templates",
           "href": "/docs/components/connectors/manage-connector-templates/"
         },
+
         {
           "Building custom Connectors": [
             {
@@ -1214,6 +1267,7 @@
               "label": "Connector templates",
               "href": "/docs/components/connectors/custom-built-connectors/connector-templates/"
             },
+
             {
               "Update guide": [
                 {
@@ -1277,6 +1331,7 @@
         }
       ]
     },
+
     {
       "Zeebe": [
         {
@@ -1284,6 +1339,7 @@
           "label": "Introduction",
           "href": "/docs/components/zeebe/zeebe-overview/"
         },
+
         {
           "Technical concepts": [
             {
@@ -1325,6 +1381,7 @@
         }
       ]
     },
+
     {
       "Operate": [
         {
@@ -1332,6 +1389,7 @@
           "label": "Introduction",
           "href": "/docs/components/operate/operate-introduction/"
         },
+
         {
           "User guide": [
             {
@@ -1368,16 +1426,12 @@
               "type": "link",
               "label": "Process instance migration",
               "href": "/docs/components/operate/userguide/process-instance-migration/"
-            },
-            {
-              "type": "link",
-              "label": "Giving feedback and asking questions",
-              "href": "/docs/components/operate/userguide/operate-feedback-and-questions/"
             }
           ]
         }
       ]
     },
+
     {
       "Tasklist": [
         {
@@ -1385,6 +1439,7 @@
           "label": "Introduction",
           "href": "/docs/components/tasklist/introduction-to-tasklist/"
         },
+
         {
           "User guide": [
             {
@@ -1401,6 +1456,7 @@
         }
       ]
     },
+
     {
       "Optimize": [
         "components/what-is-optimize",
@@ -1480,6 +1536,7 @@
         }
       ]
     },
+
     {
       "Best Practices": [
         {
@@ -1487,6 +1544,7 @@
           "label": "Overview",
           "href": "/docs/components/best-practices/best-practices-overview/"
         },
+
         {
           "Project management": [
             {
@@ -1501,6 +1559,7 @@
             }
           ]
         },
+
         {
           "Architecture": [
             {
@@ -1520,6 +1579,7 @@
             }
           ]
         },
+
         {
           "Development": [
             {
@@ -1559,6 +1619,7 @@
             }
           ]
         },
+
         {
           "Modeling": [
             {
@@ -1598,6 +1659,7 @@
             }
           ]
         },
+
         {
           "Operations": [
             {
@@ -1612,6 +1674,7 @@
             }
           ]
         },
+
         {
           "Camunda 7 specific": [
             {
@@ -1633,6 +1696,16 @@
               "type": "link",
               "label": "Understanding Camunda 7 transaction handling",
               "href": "/docs/components/best-practices/development/understanding-transaction-handling-c7/"
+            },
+            {
+              "type": "link",
+              "label": "Testing process definitions in Camunda 7",
+              "href": "/docs/components/best-practices/development/testing-process-definitions-c7/"
+            },
+            {
+              "type": "link",
+              "label": "Routing events to processes in Camunda 7",
+              "href": "/docs/components/best-practices/development/routing-events-to-processes-c7/"
             },
             {
               "type": "link",

--- a/optimize_versioned_sidebars/version-3.12.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.12.0-sidebars.json
@@ -1738,6 +1738,7 @@
       "label": "Working with APIs & tools",
       "href": "/docs/apis-tools/working-with-apis-tools/"
     },
+
     {
       "APIs": [
         {
@@ -1759,17 +1760,13 @@
             }
           ]
         },
+
         {
           "Operate API (REST)": [
             {
               "type": "link",
               "label": "Overview",
               "href": "/docs/apis-tools/operate-api/overview/"
-            },
-            {
-              "type": "link",
-              "label": "Operate API Explorer",
-              "href": "/api/operate/docs/operate-public-api/"
             },
             {
               "type": "link",
@@ -1780,9 +1777,165 @@
               "type": "link",
               "label": "Tutorial",
               "href": "/docs/apis-tools/operate-api/tutorial/"
+            },
+
+            {
+              "Specifications": [
+                {
+                  "type": "link",
+                  "label": "Introduction",
+                  "href": "/docs/apis-tools/operate-api/specifications/operate-public-api/"
+                },
+
+                {
+                  "ProcessDefinition": [
+                    {
+                      "type": "link",
+                      "label": "Search process definitions",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-2/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get process definition by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key-2/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get process definition as XML by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/xml-by-key/"
+                    }
+                  ]
+                },
+
+                {
+                  "DecisionDefinition": [
+                    {
+                      "type": "link",
+                      "label": "Search decision definitions",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-7/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get decision definition by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key-6/"
+                    }
+                  ]
+                },
+
+                {
+                  "DecisionInstance": [
+                    {
+                      "type": "link",
+                      "label": "Search decision instances",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-6/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get decision instance by id",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-id/"
+                    }
+                  ]
+                },
+
+                {
+                  "FlownodeInstance": [
+                    {
+                      "type": "link",
+                      "label": "Search flownode-instances",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-4/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get flow node instance by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key-4/"
+                    }
+                  ]
+                },
+
+                {
+                  "Variable": [
+                    {
+                      "type": "link",
+                      "label": "Search variables for process instances",
+                      "href": "/docs/apis-tools/operate-api/specifications/search/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get variable by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key/"
+                    }
+                  ]
+                },
+
+                {
+                  "ProcessInstance": [
+                    {
+                      "type": "link",
+                      "label": "Search process instances",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-1/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get process instance by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key-1/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Delete process instance and all dependant data by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/delete/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get flow node statistic by process instance id",
+                      "href": "/docs/apis-tools/operate-api/specifications/get-statistics/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get sequence flows of process instance by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/sequence-flows-by-key/"
+                    }
+                  ]
+                },
+
+                {
+                  "DecisionRequirements": [
+                    {
+                      "type": "link",
+                      "label": "Search decision requirements",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-5/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get decision requirements by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key-5/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get decision requirements as XML by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/xml-by-key-1/"
+                    }
+                  ]
+                },
+
+                {
+                  "Incident": [
+                    {
+                      "type": "link",
+                      "label": "Search incidents",
+                      "href": "/docs/apis-tools/operate-api/specifications/search-3/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get incident by key",
+                      "href": "/docs/apis-tools/operate-api/specifications/by-key-3/"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
+
         {
           "Optimize API (REST)": [
             "apis-tools/optimize-api/overview",
@@ -1815,6 +1968,7 @@
             "apis-tools/optimize-api/variable-labeling"
           ]
         },
+
         {
           "Tasklist API (GraphQL)": [
             {
@@ -1842,6 +1996,7 @@
               "label": "GraphQL to REST API migration",
               "href": "/docs/apis-tools/tasklist-api/tasklist-api-graphql-to-rest-migration/"
             },
+
             {
               "Directives": [
                 {
@@ -1866,6 +2021,7 @@
                 }
               ]
             },
+
             {
               "Enums": [
                 {
@@ -1885,6 +2041,7 @@
                 }
               ]
             },
+
             {
               "Inputs": [
                 {
@@ -1909,6 +2066,7 @@
                 }
               ]
             },
+
             {
               "Mutations": [
                 {
@@ -1933,6 +2091,7 @@
                 }
               ]
             },
+
             {
               "Objects": [
                 {
@@ -1957,6 +2116,7 @@
                 }
               ]
             },
+
             {
               "Queries": [
                 {
@@ -1991,6 +2151,7 @@
                 }
               ]
             },
+
             {
               "Scalars": [
                 {
@@ -2022,6 +2183,7 @@
             }
           ]
         },
+
         {
           "Tasklist API (REST)": [
             {
@@ -2031,16 +2193,82 @@
             },
             {
               "type": "link",
-              "label": "Tasklist API (REST) Explorer",
-              "href": "/api/tasklist/docs/tasklist-rest-api/"
-            },
-            {
-              "type": "link",
               "label": "Authentication",
               "href": "/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-authentication/"
+            },
+
+            {
+              "Specifications": [
+                {
+                  "type": "link",
+                  "label": "Introduction",
+                  "href": "/docs/apis-tools/tasklist-api-rest/specifications/tasklist-rest-api/"
+                },
+
+                {
+                  "Form": [
+                    {
+                      "type": "link",
+                      "label": "Get a form",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/get-form/"
+                    }
+                  ]
+                },
+
+                {
+                  "Variables": [
+                    {
+                      "type": "link",
+                      "label": "Get a variable",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/get-variable-by-id/"
+                    }
+                  ]
+                },
+
+                {
+                  "Task": [
+                    {
+                      "type": "link",
+                      "label": "Save draft variables",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/save-draft-task-variables/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Search task variables",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/search-task-variables/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Search tasks",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/search-tasks/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Unassign a task",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/unassign-task/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Complete a task",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/complete-task/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Assign a task",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/assign-task/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Get a task",
+                      "href": "/docs/apis-tools/tasklist-api-rest/specifications/get-task-by-id/"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
+
         {
           "Web Modeler API (REST)": [
             {
@@ -2055,6 +2283,7 @@
             }
           ]
         },
+
         {
           "Zeebe API (gRPC)": [
             {
@@ -2064,7 +2293,7 @@
             },
             {
               "type": "link",
-              "label": "Gateway service",
+              "label": "Zeebe API RPCs",
               "href": "/docs/apis-tools/zeebe-api/gateway-service/"
             },
             {
@@ -2081,6 +2310,7 @@
         }
       ]
     },
+
     {
       "Clients": [
         {
@@ -2097,6 +2327,7 @@
             }
           ]
         },
+
         {
           "Go client": [
             {
@@ -2116,6 +2347,7 @@
             }
           ]
         },
+
         {
           "Java client": [
             {
@@ -2138,6 +2370,7 @@
               "label": "Zeebe Process Test",
               "href": "/docs/apis-tools/java-client/zeebe-process-test/"
             },
+
             {
               "Examples": [
                 {
@@ -2189,6 +2422,7 @@
             }
           ]
         },
+
         {
           "Community clients": [
             {
@@ -2196,6 +2430,7 @@
               "label": "Component clients",
               "href": "/docs/apis-tools/community-clients/"
             },
+
             {
               "Zeebe clients": [
                 {
@@ -2242,6 +2477,7 @@
             }
           ]
         },
+
         {
           "type": "link",
           "label": "Build your own client",

--- a/optimize_versioned_sidebars/version-3.12.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.12.0-sidebars.json
@@ -2502,6 +2502,7 @@
       "label": "Camunda 8 Self-Managed",
       "href": "/docs/self-managed/about-self-managed/"
     },
+
     {
       "Architecture": [
         {
@@ -2511,6 +2512,7 @@
         }
       ]
     },
+
     {
       "Installation": [
         {
@@ -2518,6 +2520,7 @@
           "label": "Overview",
           "href": "/docs/self-managed/platform-deployment/overview/"
         },
+
         {
           "Helm/Kubernetes": [
             {
@@ -2535,6 +2538,7 @@
               "label": "Upgrade",
               "href": "/docs/self-managed/platform-deployment/helm-kubernetes/upgrade/"
             },
+
             {
               "Platforms": [
                 {
@@ -2561,6 +2565,7 @@
                     }
                   ]
                 },
+
                 {
                   "type": "link",
                   "label": "Microsoft AKS",
@@ -2578,6 +2583,7 @@
                 }
               ]
             },
+
             {
               "Guides": [
                 {
@@ -2617,11 +2623,6 @@
                 },
                 {
                   "type": "link",
-                  "label": "Install Zeebe exporters",
-                  "href": "/docs/self-managed/platform-deployment/helm-kubernetes/guides/install-zeebe-exporters/"
-                },
-                {
-                  "type": "link",
                   "label": "Running custom Connectors",
                   "href": "/docs/self-managed/platform-deployment/helm-kubernetes/guides/running-custom-connectors/"
                 },
@@ -2632,6 +2633,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Troubleshooting",
@@ -2639,6 +2641,7 @@
             }
           ]
         },
+
         {
           "type": "link",
           "label": "Docker",
@@ -2651,6 +2654,7 @@
         }
       ]
     },
+
     {
       "Operational guides": [
         {
@@ -2680,6 +2684,7 @@
               "label": "Update 1.3 to 8.0",
               "href": "/docs/self-managed/operational-guides/update-guide/130-to-800/"
             },
+
             {
               "Elasticsearch": [
                 {
@@ -2688,14 +2693,26 @@
                   "href": "/docs/self-managed/operational-guides/update-guide/elasticsearch/7-to-8/"
                 }
               ]
+            },
+
+            {
+              "Keycloak": [
+                {
+                  "type": "link",
+                  "label": "Update Keycloak",
+                  "href": "/docs/self-managed/operational-guides/update-guide/keycloak/keycloak-update/"
+                }
+              ]
             }
           ]
         },
+
         {
           "type": "link",
           "label": "Configure multi-tenancy",
           "href": "/docs/self-managed/operational-guides/configure-multi-tenancy/"
         },
+
         {
           "Backup and restore": [
             {
@@ -2712,9 +2729,15 @@
               "type": "link",
               "label": "Backup and restore Zeebe data",
               "href": "/docs/self-managed/operational-guides/backup-restore/zeebe-backup-and-restore/"
+            },
+            {
+              "type": "link",
+              "label": "Backup and restore Web Modeler data",
+              "href": "/docs/self-managed/operational-guides/backup-restore/modeler-backup-and-restore/"
             }
           ]
         },
+
         {
           "Troubleshooting": [
             {
@@ -2726,6 +2749,7 @@
         }
       ]
     },
+
     {
       "Concepts": [
         {
@@ -2747,6 +2771,7 @@
             }
           ]
         },
+
         {
           "type": "link",
           "label": "Exporters",
@@ -2756,549 +2781,586 @@
           "type": "link",
           "label": "Multi-tenancy",
           "href": "/docs/self-managed/concepts/multi-tenancy/"
+        },
+        {
+          "type": "link",
+          "label": "Elasticsearch privileges",
+          "href": "/docs/self-managed/concepts/elasticsearch-privileges/"
         }
       ]
     },
+
     {
-      "Zeebe": [
+      "Components": [
         {
-          "type": "link",
-          "label": "Overview",
-          "href": "/docs/self-managed/zeebe-deployment/zeebe-installation/"
-        },
-        {
-          "Zeebe Gateway": [
+          "Zeebe": [
             {
               "type": "link",
               "label": "Overview",
-              "href": "/docs/self-managed/zeebe-deployment/zeebe-gateway/overview/"
+              "href": "/docs/self-managed/zeebe-deployment/zeebe-installation/"
             },
+
             {
-              "type": "link",
-              "label": "Interceptors",
-              "href": "/docs/self-managed/zeebe-deployment/zeebe-gateway/interceptors/"
-            }
-          ]
-        },
-        {
-          "Configuration": [
-            {
-              "type": "link",
-              "label": "Overview",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/"
-            },
-            {
-              "type": "link",
-              "label": "Logging",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/logging/"
-            },
-            {
-              "type": "link",
-              "label": "Gateway health probes",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/gateway-health-probes/"
-            },
-            {
-              "type": "link",
-              "label": "Environment variables",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/environment-variables/"
-            },
-            {
-              "type": "link",
-              "label": "Fixed partitioning",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/fixed-partitioning/"
-            },
-            {
-              "type": "link",
-              "label": "Priority election",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/priority-election/"
-            },
-            {
-              "type": "link",
-              "label": "Broker configuration",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/broker-config/"
-            },
-            {
-              "type": "link",
-              "label": "Gateway configuration",
-              "href": "/docs/self-managed/zeebe-deployment/configuration/gateway-config/"
-            }
-          ]
-        },
-        {
-          "Security": [
-            {
-              "type": "link",
-              "label": "Overview",
-              "href": "/docs/self-managed/zeebe-deployment/security/"
-            },
-            {
-              "type": "link",
-              "label": "Client authorization",
-              "href": "/docs/self-managed/zeebe-deployment/security/client-authorization/"
-            },
-            {
-              "type": "link",
-              "label": "Secure client communication",
-              "href": "/docs/self-managed/zeebe-deployment/security/secure-client-communication/"
-            },
-            {
-              "type": "link",
-              "label": "Secure cluster communication",
-              "href": "/docs/self-managed/zeebe-deployment/security/secure-cluster-communication/"
-            }
-          ]
-        },
-        {
-          "Operation": [
-            {
-              "type": "link",
-              "label": "Overview",
-              "href": "/docs/self-managed/zeebe-deployment/operations/zeebe-in-production/"
-            },
-            {
-              "type": "link",
-              "label": "Resource planning",
-              "href": "/docs/self-managed/zeebe-deployment/operations/resource-planning/"
-            },
-            {
-              "type": "link",
-              "label": "Network ports",
-              "href": "/docs/self-managed/zeebe-deployment/operations/network-ports/"
-            },
-            {
-              "type": "link",
-              "label": "Setting up a Zeebe cluster",
-              "href": "/docs/self-managed/zeebe-deployment/operations/setting-up-a-cluster/"
-            },
-            {
-              "type": "link",
-              "label": "Metrics",
-              "href": "/docs/self-managed/zeebe-deployment/operations/metrics/"
-            },
-            {
-              "type": "link",
-              "label": "Health status",
-              "href": "/docs/self-managed/zeebe-deployment/operations/health/"
-            },
-            {
-              "type": "link",
-              "label": "Backpressure",
-              "href": "/docs/self-managed/zeebe-deployment/operations/backpressure/"
-            },
-            {
-              "type": "link",
-              "label": "Disk space",
-              "href": "/docs/self-managed/zeebe-deployment/operations/disk-space/"
-            },
-            {
-              "type": "link",
-              "label": "Update Zeebe",
-              "href": "/docs/self-managed/zeebe-deployment/operations/update-zeebe/"
-            },
-            {
-              "type": "link",
-              "label": "Rebalancing",
-              "href": "/docs/self-managed/zeebe-deployment/operations/rebalancing/"
-            },
-            {
-              "type": "link",
-              "label": "Management API",
-              "href": "/docs/self-managed/zeebe-deployment/operations/management-api/"
-            },
-            {
-              "type": "link",
-              "label": "Backups",
-              "href": "/docs/self-managed/zeebe-deployment/operations/backups/"
-            },
-            {
-              "type": "link",
-              "label": "Cluster scaling",
-              "href": "/docs/self-managed/zeebe-deployment/operations/cluster-scaling/"
-            }
-          ]
-        },
-        {
-          "Exporters": [
-            {
-              "type": "link",
-              "label": "Overview",
-              "href": "/docs/self-managed/zeebe-deployment/exporters/"
-            },
-            {
-              "type": "link",
-              "label": "Elasticsearch",
-              "href": "/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter/"
-            },
-            {
-              "type": "link",
-              "label": "OpenSearch",
-              "href": "/docs/self-managed/zeebe-deployment/exporters/opensearch-exporter/"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Operate": [
-        {
-          "type": "link",
-          "label": "Installation",
-          "href": "/docs/self-managed/operate-deployment/install-and-start/"
-        },
-        {
-          "type": "link",
-          "label": "Configuration",
-          "href": "/docs/self-managed/operate-deployment/operate-configuration/"
-        },
-        {
-          "type": "link",
-          "label": "Data retention",
-          "href": "/docs/self-managed/operate-deployment/data-retention/"
-        },
-        {
-          "type": "link",
-          "label": "Schema and migration",
-          "href": "/docs/self-managed/operate-deployment/schema-and-migration/"
-        },
-        {
-          "type": "link",
-          "label": "Importer and archiver",
-          "href": "/docs/self-managed/operate-deployment/importer-and-archiver/"
-        },
-        {
-          "type": "link",
-          "label": "Authentication and authorization",
-          "href": "/docs/self-managed/operate-deployment/operate-authentication/"
-        },
-        {
-          "type": "link",
-          "label": "Usage metrics",
-          "href": "/docs/self-managed/operate-deployment/usage-metrics/"
-        }
-      ]
-    },
-    {
-      "Tasklist": [
-        {
-          "type": "link",
-          "label": "Installation",
-          "href": "/docs/self-managed/tasklist-deployment/install-and-start/"
-        },
-        {
-          "type": "link",
-          "label": "Configuration",
-          "href": "/docs/self-managed/tasklist-deployment/tasklist-configuration/"
-        },
-        {
-          "type": "link",
-          "label": "Data retention",
-          "href": "/docs/self-managed/tasklist-deployment/data-retention/"
-        },
-        {
-          "type": "link",
-          "label": "Importer and archiver",
-          "href": "/docs/self-managed/tasklist-deployment/importer-and-archiver/"
-        },
-        {
-          "type": "link",
-          "label": "Authentication",
-          "href": "/docs/self-managed/tasklist-deployment/tasklist-authentication/"
-        },
-        {
-          "type": "link",
-          "label": "Usage metrics",
-          "href": "/docs/self-managed/tasklist-deployment/usage-metrics/"
-        }
-      ]
-    },
-    {
-      "Connectors": [
-        {
-          "type": "link",
-          "label": "Installation",
-          "href": "/docs/self-managed/connectors-deployment/install-and-start/"
-        },
-        {
-          "type": "link",
-          "label": "Configuration",
-          "href": "/docs/self-managed/connectors-deployment/connectors-configuration/"
-        }
-      ]
-    },
-    {
-      "Optimize": [
-        "self-managed/optimize-deployment/install-and-start",
-        "self-managed/optimize-deployment/version-policy",
-        {
-          "Configuration": [
-            "self-managed/optimize-deployment/configuration/getting-started",
-            {
-              "System configuration": [
-                "self-managed/optimize-deployment/configuration/system-configuration",
-                "self-managed/optimize-deployment/configuration/system-configuration-platform-8",
-                "self-managed/optimize-deployment/configuration/system-configuration-platform-7",
-                "self-managed/optimize-deployment/configuration/event-based-process-configuration"
-              ]
-            },
-            "self-managed/optimize-deployment/configuration/logging",
-            "self-managed/optimize-deployment/configuration/optimize-license",
-            "self-managed/optimize-deployment/configuration/security-instructions",
-            "self-managed/optimize-deployment/configuration/shared-elasticsearch-cluster",
-            "self-managed/optimize-deployment/configuration/history-cleanup",
-            "self-managed/optimize-deployment/configuration/localization",
-            "self-managed/optimize-deployment/configuration/object-variables",
-            "self-managed/optimize-deployment/configuration/clustering",
-            "self-managed/optimize-deployment/configuration/webhooks",
-            "self-managed/optimize-deployment/configuration/authorization-management",
-            "self-managed/optimize-deployment/configuration/user-management",
-            "self-managed/optimize-deployment/configuration/multi-tenancy",
-            "self-managed/optimize-deployment/configuration/multiple-engines",
-            "self-managed/optimize-deployment/configuration/setup-event-based-processes",
-            "self-managed/optimize-deployment/configuration/telemetry",
-            "self-managed/optimize-deployment/configuration/common-problems"
-          ]
-        },
-        {
-          "Plugins": [
-            "self-managed/optimize-deployment/plugins/plugin-system",
-            "self-managed/optimize-deployment/plugins/businesskey-import-plugin",
-            "self-managed/optimize-deployment/plugins/decision-import-plugin",
-            "self-managed/optimize-deployment/plugins/elasticsearch-header",
-            "self-managed/optimize-deployment/plugins/engine-rest-filter-plugin",
-            "self-managed/optimize-deployment/plugins/single-sign-on",
-            "self-managed/optimize-deployment/plugins/variable-import-plugin"
-          ]
-        },
-        "self-managed/optimize-deployment/reimport",
-        {
-          "Migration & update": [
-            "self-managed/optimize-deployment/migration-update/instructions",
-            "self-managed/optimize-deployment/migration-update/3.11_8.3-to-3.12_8.4",
-            "self-managed/optimize-deployment/migration-update/3.10-to-3.11_8.3",
-            "self-managed/optimize-deployment/migration-update/3.9-to-3.10",
-            "self-managed/optimize-deployment/migration-update/3.9-preview-1-to-3.9",
-            "self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1",
-            "self-managed/optimize-deployment/migration-update/3.7-to-3.8",
-            "self-managed/optimize-deployment/migration-update/3.6-to-3.7",
-            "self-managed/optimize-deployment/migration-update/3.5-to-3.6",
-            "self-managed/optimize-deployment/migration-update/3.4-to-3.5",
-            "self-managed/optimize-deployment/migration-update/3.3-to-3.4",
-            "self-managed/optimize-deployment/migration-update/3.2-to-3.3",
-            "self-managed/optimize-deployment/migration-update/3.1-to-3.2",
-            "self-managed/optimize-deployment/migration-update/3.0-to-3.1",
-            "self-managed/optimize-deployment/migration-update/2.7-to-3.0",
-            "self-managed/optimize-deployment/migration-update/2.6-to-2.7",
-            "self-managed/optimize-deployment/migration-update/2.5-to-2.6",
-            "self-managed/optimize-deployment/migration-update/2.4-to-2.5",
-            "self-managed/optimize-deployment/migration-update/2.3-to-2.4",
-            "self-managed/optimize-deployment/migration-update/2.2-to-2.3",
-            "self-managed/optimize-deployment/migration-update/2.1-to-2.2"
-          ]
-        },
-        {
-          "Advanced features": [
-            "self-managed/optimize-deployment/advanced-features/engine-data-deletion",
-            "self-managed/optimize-deployment/advanced-features/import-guide"
-          ]
-        }
-      ]
-    },
-    {
-      "Identity": [
-        {
-          "type": "link",
-          "label": "What is Identity?",
-          "href": "/docs/self-managed/identity/what-is-identity/"
-        },
-        {
-          "type": "link",
-          "label": "Installation and first steps",
-          "href": "/docs/self-managed/identity/getting-started/install-identity/"
-        },
-        {
-          "User guide": [
-            {
-              "Configuration": [
+              "Zeebe Gateway": [
                 {
                   "type": "link",
-                  "label": "Making Identity production ready",
-                  "href": "/docs/self-managed/identity/user-guide/configuration/making-identity-production-ready/"
+                  "label": "Overview",
+                  "href": "/docs/self-managed/zeebe-deployment/zeebe-gateway/overview/"
                 },
                 {
                   "type": "link",
-                  "label": "Configuring an external identity provider",
-                  "href": "/docs/self-managed/identity/user-guide/configuration/configure-external-identity-provider/"
-                },
-                {
-                  "type": "link",
-                  "label": "Configure logging",
-                  "href": "/docs/self-managed/identity/user-guide/configuration/configure-logging/"
-                },
-                {
-                  "type": "link",
-                  "label": "Connect to an existing Keycloak instance",
-                  "href": "/docs/self-managed/identity/user-guide/configuration/connect-to-an-existing-keycloak/"
+                  "label": "Interceptors",
+                  "href": "/docs/self-managed/zeebe-deployment/zeebe-gateway/interceptors/"
                 }
               ]
             },
-            {
-              "Roles": [
-                {
-                  "type": "link",
-                  "label": "Add and assign a role",
-                  "href": "/docs/self-managed/identity/user-guide/roles/add-assign-role/"
-                },
-                {
-                  "type": "link",
-                  "label": "Add and assign a permission",
-                  "href": "/docs/self-managed/identity/user-guide/roles/add-assign-permission/"
-                }
-              ]
-            },
-            {
-              "Groups": [
-                {
-                  "type": "link",
-                  "label": "Create a group",
-                  "href": "/docs/self-managed/identity/user-guide/groups/create-group/"
-                },
-                {
-                  "type": "link",
-                  "label": "Assign users and roles to a group",
-                  "href": "/docs/self-managed/identity/user-guide/groups/assign-users-roles-to-group/"
-                }
-              ]
-            },
-            {
-              "Authorizations": [
-                {
-                  "type": "link",
-                  "label": "Managing resource authorizations",
-                  "href": "/docs/self-managed/identity/user-guide/authorizations/managing-resource-authorizations/"
-                },
-                {
-                  "type": "link",
-                  "label": "Managing user access",
-                  "href": "/docs/self-managed/identity/user-guide/authorizations/managing-user-access/"
-                },
-                {
-                  "type": "link",
-                  "label": "Generating machine-to-machine (M2M) tokens",
-                  "href": "/docs/self-managed/identity/user-guide/authorizations/generating-m2m-tokens/"
-                }
-              ]
-            },
-            {
-              "Tenants": [
-                {
-                  "type": "link",
-                  "label": "Managing tenants",
-                  "href": "/docs/self-managed/identity/user-guide/tenants/managing-tenants/"
-                }
-              ]
-            },
-            {
-              "Additional features": [
-                {
-                  "type": "link",
-                  "label": "Adding an API",
-                  "href": "/docs/self-managed/identity/user-guide/additional-features/adding-an-api/"
-                },
-                {
-                  "type": "link",
-                  "label": "Incorporate applications",
-                  "href": "/docs/self-managed/identity/user-guide/additional-features/incorporate-applications/"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Deployment": [
-            {
-              "type": "link",
-              "label": "Configuration variables",
-              "href": "/docs/self-managed/identity/deployment/configuration-variables/"
-            },
-            {
-              "type": "link",
-              "label": "Application monitoring",
-              "href": "/docs/self-managed/identity/deployment/application-monitoring/"
-            },
-            {
-              "type": "link",
-              "label": "Starting configuration",
-              "href": "/docs/self-managed/identity/deployment/starting-configuration-for-identity/"
-            },
-            {
-              "type": "link",
-              "label": "Resource management",
-              "href": "/docs/self-managed/identity/deployment/resource-management/"
-            }
-          ]
-        },
-        {
-          "type": "link",
-          "label": "Troubleshoot Identity",
-          "href": "/docs/self-managed/identity/troubleshooting/troubleshoot-identity/"
-        }
-      ]
-    },
-    {
-      "Modeler": [
-        {
-          "Web Modeler": [
-            {
-              "type": "link",
-              "label": "Installation",
-              "href": "/docs/self-managed/modeler/web-modeler/installation/"
-            },
+
             {
               "Configuration": [
                 {
                   "type": "link",
                   "label": "Overview",
-                  "href": "/docs/self-managed/modeler/web-modeler/configuration/"
-                },
-                {
-                  "type": "link",
-                  "label": "Database",
-                  "href": "/docs/self-managed/modeler/web-modeler/configuration/database/"
-                },
-                {
-                  "type": "link",
-                  "label": "Identity",
-                  "href": "/docs/self-managed/modeler/web-modeler/configuration/identity/"
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/"
                 },
                 {
                   "type": "link",
                   "label": "Logging",
-                  "href": "/docs/self-managed/modeler/web-modeler/configuration/logging/"
-                }
-              ]
-            },
-            {
-              "Troubleshooting": [
-                {
-                  "type": "link",
-                  "label": "Database connection",
-                  "href": "/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-database-connection/"
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/logging/"
                 },
                 {
                   "type": "link",
-                  "label": "Zeebe connection",
-                  "href": "/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection/"
+                  "label": "Gateway health probes",
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/gateway-health-probes/"
+                },
+                {
+                  "type": "link",
+                  "label": "Environment variables",
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/environment-variables/"
+                },
+                {
+                  "type": "link",
+                  "label": "Fixed partitioning",
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/fixed-partitioning/"
+                },
+                {
+                  "type": "link",
+                  "label": "Priority election",
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/priority-election/"
+                },
+                {
+                  "type": "link",
+                  "label": "Broker configuration",
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/broker-config/"
+                },
+                {
+                  "type": "link",
+                  "label": "Gateway configuration",
+                  "href": "/docs/self-managed/zeebe-deployment/configuration/gateway-config/"
+                }
+              ]
+            },
+
+            {
+              "Security": [
+                {
+                  "type": "link",
+                  "label": "Overview",
+                  "href": "/docs/self-managed/zeebe-deployment/security/"
+                },
+                {
+                  "type": "link",
+                  "label": "Client authorization",
+                  "href": "/docs/self-managed/zeebe-deployment/security/client-authorization/"
+                },
+                {
+                  "type": "link",
+                  "label": "Secure client communication",
+                  "href": "/docs/self-managed/zeebe-deployment/security/secure-client-communication/"
+                },
+                {
+                  "type": "link",
+                  "label": "Secure cluster communication",
+                  "href": "/docs/self-managed/zeebe-deployment/security/secure-cluster-communication/"
+                }
+              ]
+            },
+
+            {
+              "Operation": [
+                {
+                  "type": "link",
+                  "label": "Overview",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/zeebe-in-production/"
+                },
+                {
+                  "type": "link",
+                  "label": "Resource planning",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/resource-planning/"
+                },
+                {
+                  "type": "link",
+                  "label": "Network ports",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/network-ports/"
+                },
+                {
+                  "type": "link",
+                  "label": "Setting up a Zeebe cluster",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/setting-up-a-cluster/"
+                },
+                {
+                  "type": "link",
+                  "label": "Metrics",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/metrics/"
+                },
+                {
+                  "type": "link",
+                  "label": "Health status",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/health/"
+                },
+                {
+                  "type": "link",
+                  "label": "Backpressure",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/backpressure/"
+                },
+                {
+                  "type": "link",
+                  "label": "Disk space",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/disk-space/"
+                },
+                {
+                  "type": "link",
+                  "label": "Update Zeebe",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/update-zeebe/"
+                },
+                {
+                  "type": "link",
+                  "label": "Rebalancing",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/rebalancing/"
+                },
+                {
+                  "type": "link",
+                  "label": "Management API",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/management-api/"
+                },
+                {
+                  "type": "link",
+                  "label": "Backups",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/backups/"
+                },
+                {
+                  "type": "link",
+                  "label": "Cluster scaling",
+                  "href": "/docs/self-managed/zeebe-deployment/operations/cluster-scaling/"
+                }
+              ]
+            },
+
+            {
+              "Exporters": [
+                {
+                  "type": "link",
+                  "label": "Install Zeebe exporters",
+                  "href": "/docs/self-managed/zeebe-deployment/exporters/install-zeebe-exporters/"
+                },
+                {
+                  "type": "link",
+                  "label": "Elasticsearch",
+                  "href": "/docs/self-managed/zeebe-deployment/exporters/elasticsearch-exporter/"
+                },
+                {
+                  "type": "link",
+                  "label": "OpenSearch",
+                  "href": "/docs/self-managed/zeebe-deployment/exporters/opensearch-exporter/"
                 }
               ]
             }
           ]
         },
+
         {
-          "Desktop Modeler": [
+          "Operate": [
             {
               "type": "link",
-              "label": "Deploy diagram",
-              "href": "/docs/self-managed/modeler/desktop-modeler/deploy-to-self-managed/"
+              "label": "Installation",
+              "href": "/docs/self-managed/operate-deployment/install-and-start/"
+            },
+            {
+              "type": "link",
+              "label": "Configuration",
+              "href": "/docs/self-managed/operate-deployment/operate-configuration/"
+            },
+            {
+              "type": "link",
+              "label": "Data retention",
+              "href": "/docs/self-managed/operate-deployment/data-retention/"
+            },
+            {
+              "type": "link",
+              "label": "Schema and migration",
+              "href": "/docs/self-managed/operate-deployment/schema-and-migration/"
+            },
+            {
+              "type": "link",
+              "label": "Importer and archiver",
+              "href": "/docs/self-managed/operate-deployment/importer-and-archiver/"
+            },
+            {
+              "type": "link",
+              "label": "Authentication and authorization",
+              "href": "/docs/self-managed/operate-deployment/operate-authentication/"
+            },
+            {
+              "type": "link",
+              "label": "Usage metrics",
+              "href": "/docs/self-managed/operate-deployment/usage-metrics/"
+            }
+          ]
+        },
+
+        {
+          "Tasklist": [
+            {
+              "type": "link",
+              "label": "Installation",
+              "href": "/docs/self-managed/tasklist-deployment/install-and-start/"
+            },
+            {
+              "type": "link",
+              "label": "Configuration",
+              "href": "/docs/self-managed/tasklist-deployment/tasklist-configuration/"
+            },
+            {
+              "type": "link",
+              "label": "Data retention",
+              "href": "/docs/self-managed/tasklist-deployment/data-retention/"
+            },
+            {
+              "type": "link",
+              "label": "Importer and archiver",
+              "href": "/docs/self-managed/tasklist-deployment/importer-and-archiver/"
+            },
+            {
+              "type": "link",
+              "label": "Authentication",
+              "href": "/docs/self-managed/tasklist-deployment/tasklist-authentication/"
+            },
+            {
+              "type": "link",
+              "label": "Usage metrics",
+              "href": "/docs/self-managed/tasklist-deployment/usage-metrics/"
+            }
+          ]
+        },
+
+        {
+          "Connectors": [
+            {
+              "type": "link",
+              "label": "Installation",
+              "href": "/docs/self-managed/connectors-deployment/install-and-start/"
+            },
+            {
+              "type": "link",
+              "label": "Configuration",
+              "href": "/docs/self-managed/connectors-deployment/connectors-configuration/"
+            }
+          ]
+        },
+
+        {
+          "Optimize": [
+            "self-managed/optimize-deployment/install-and-start",
+            "self-managed/optimize-deployment/version-policy",
+            {
+              "Configuration": [
+                "self-managed/optimize-deployment/configuration/getting-started",
+                {
+                  "System configuration": [
+                    "self-managed/optimize-deployment/configuration/system-configuration",
+                    "self-managed/optimize-deployment/configuration/system-configuration-platform-8",
+                    "self-managed/optimize-deployment/configuration/system-configuration-platform-7",
+                    "self-managed/optimize-deployment/configuration/event-based-process-configuration"
+                  ]
+                },
+                "self-managed/optimize-deployment/configuration/logging",
+                "self-managed/optimize-deployment/configuration/optimize-license",
+                "self-managed/optimize-deployment/configuration/security-instructions",
+                "self-managed/optimize-deployment/configuration/shared-elasticsearch-cluster",
+                "self-managed/optimize-deployment/configuration/history-cleanup",
+                "self-managed/optimize-deployment/configuration/localization",
+                "self-managed/optimize-deployment/configuration/object-variables",
+                "self-managed/optimize-deployment/configuration/clustering",
+                "self-managed/optimize-deployment/configuration/webhooks",
+                "self-managed/optimize-deployment/configuration/authorization-management",
+                "self-managed/optimize-deployment/configuration/user-management",
+                "self-managed/optimize-deployment/configuration/multi-tenancy",
+                "self-managed/optimize-deployment/configuration/multiple-engines",
+                "self-managed/optimize-deployment/configuration/setup-event-based-processes",
+                "self-managed/optimize-deployment/configuration/telemetry",
+                "self-managed/optimize-deployment/configuration/common-problems"
+              ]
+            },
+            {
+              "Plugins": [
+                "self-managed/optimize-deployment/plugins/plugin-system",
+                "self-managed/optimize-deployment/plugins/businesskey-import-plugin",
+                "self-managed/optimize-deployment/plugins/decision-import-plugin",
+                "self-managed/optimize-deployment/plugins/elasticsearch-header",
+                "self-managed/optimize-deployment/plugins/engine-rest-filter-plugin",
+                "self-managed/optimize-deployment/plugins/single-sign-on",
+                "self-managed/optimize-deployment/plugins/variable-import-plugin"
+              ]
+            },
+            "self-managed/optimize-deployment/reimport",
+            {
+              "Migration & update": [
+                "self-managed/optimize-deployment/migration-update/instructions",
+                "self-managed/optimize-deployment/migration-update/3.11_8.3-to-3.12_8.4",
+                "self-managed/optimize-deployment/migration-update/3.10-to-3.11_8.3",
+                "self-managed/optimize-deployment/migration-update/3.9-to-3.10",
+                "self-managed/optimize-deployment/migration-update/3.9-preview-1-to-3.9",
+                "self-managed/optimize-deployment/migration-update/3.8-to-3.9-preview-1",
+                "self-managed/optimize-deployment/migration-update/3.7-to-3.8",
+                "self-managed/optimize-deployment/migration-update/3.6-to-3.7",
+                "self-managed/optimize-deployment/migration-update/3.5-to-3.6",
+                "self-managed/optimize-deployment/migration-update/3.4-to-3.5",
+                "self-managed/optimize-deployment/migration-update/3.3-to-3.4",
+                "self-managed/optimize-deployment/migration-update/3.2-to-3.3",
+                "self-managed/optimize-deployment/migration-update/3.1-to-3.2",
+                "self-managed/optimize-deployment/migration-update/3.0-to-3.1",
+                "self-managed/optimize-deployment/migration-update/2.7-to-3.0",
+                "self-managed/optimize-deployment/migration-update/2.6-to-2.7",
+                "self-managed/optimize-deployment/migration-update/2.5-to-2.6",
+                "self-managed/optimize-deployment/migration-update/2.4-to-2.5",
+                "self-managed/optimize-deployment/migration-update/2.3-to-2.4",
+                "self-managed/optimize-deployment/migration-update/2.2-to-2.3",
+                "self-managed/optimize-deployment/migration-update/2.1-to-2.2"
+              ]
+            },
+            {
+              "Advanced features": [
+                "self-managed/optimize-deployment/advanced-features/engine-data-deletion",
+                "self-managed/optimize-deployment/advanced-features/import-guide"
+              ]
+            }
+          ]
+        },
+
+        {
+          "Identity": [
+            {
+              "type": "link",
+              "label": "What is Identity?",
+              "href": "/docs/self-managed/identity/what-is-identity/"
+            },
+            {
+              "type": "link",
+              "label": "Installation and first steps",
+              "href": "/docs/self-managed/identity/getting-started/install-identity/"
+            },
+
+            {
+              "User guide": [
+                {
+                  "Configuration": [
+                    {
+                      "type": "link",
+                      "label": "Making Identity production ready",
+                      "href": "/docs/self-managed/identity/user-guide/configuration/making-identity-production-ready/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Configuring an external identity provider",
+                      "href": "/docs/self-managed/identity/user-guide/configuration/configure-external-identity-provider/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Configure logging",
+                      "href": "/docs/self-managed/identity/user-guide/configuration/configure-logging/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Connect to an existing Keycloak instance",
+                      "href": "/docs/self-managed/identity/user-guide/configuration/connect-to-an-existing-keycloak/"
+                    }
+                  ]
+                },
+
+                {
+                  "Roles": [
+                    {
+                      "type": "link",
+                      "label": "Add and assign a role",
+                      "href": "/docs/self-managed/identity/user-guide/roles/add-assign-role/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Add and assign a permission",
+                      "href": "/docs/self-managed/identity/user-guide/roles/add-assign-permission/"
+                    }
+                  ]
+                },
+
+                {
+                  "Groups": [
+                    {
+                      "type": "link",
+                      "label": "Create a group",
+                      "href": "/docs/self-managed/identity/user-guide/groups/create-group/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Assign users and roles to a group",
+                      "href": "/docs/self-managed/identity/user-guide/groups/assign-users-roles-to-group/"
+                    }
+                  ]
+                },
+
+                {
+                  "Authorizations": [
+                    {
+                      "type": "link",
+                      "label": "Managing resource authorizations",
+                      "href": "/docs/self-managed/identity/user-guide/authorizations/managing-resource-authorizations/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Managing user access",
+                      "href": "/docs/self-managed/identity/user-guide/authorizations/managing-user-access/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Generating machine-to-machine (M2M) tokens",
+                      "href": "/docs/self-managed/identity/user-guide/authorizations/generating-m2m-tokens/"
+                    }
+                  ]
+                },
+
+                {
+                  "Tenants": [
+                    {
+                      "type": "link",
+                      "label": "Managing tenants",
+                      "href": "/docs/self-managed/identity/user-guide/tenants/managing-tenants/"
+                    }
+                  ]
+                },
+
+                {
+                  "Additional features": [
+                    {
+                      "type": "link",
+                      "label": "Adding an API",
+                      "href": "/docs/self-managed/identity/user-guide/additional-features/adding-an-api/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Incorporate applications",
+                      "href": "/docs/self-managed/identity/user-guide/additional-features/incorporate-applications/"
+                    }
+                  ]
+                }
+              ]
+            },
+
+            {
+              "Deployment": [
+                {
+                  "type": "link",
+                  "label": "Configuration variables",
+                  "href": "/docs/self-managed/identity/deployment/configuration-variables/"
+                },
+                {
+                  "type": "link",
+                  "label": "Application monitoring",
+                  "href": "/docs/self-managed/identity/deployment/application-monitoring/"
+                },
+                {
+                  "type": "link",
+                  "label": "Starting configuration",
+                  "href": "/docs/self-managed/identity/deployment/starting-configuration-for-identity/"
+                },
+                {
+                  "type": "link",
+                  "label": "Resource management",
+                  "href": "/docs/self-managed/identity/deployment/resource-management/"
+                }
+              ]
+            },
+
+            {
+              "type": "link",
+              "label": "Troubleshoot Identity",
+              "href": "/docs/self-managed/identity/troubleshooting/troubleshoot-identity/"
+            }
+          ]
+        },
+
+        {
+          "Modeler": [
+            {
+              "Web Modeler": [
+                {
+                  "type": "link",
+                  "label": "Installation",
+                  "href": "/docs/self-managed/modeler/web-modeler/installation/"
+                },
+
+                {
+                  "Configuration": [
+                    {
+                      "type": "link",
+                      "label": "Overview",
+                      "href": "/docs/self-managed/modeler/web-modeler/configuration/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Database",
+                      "href": "/docs/self-managed/modeler/web-modeler/configuration/database/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Identity",
+                      "href": "/docs/self-managed/modeler/web-modeler/configuration/identity/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Logging",
+                      "href": "/docs/self-managed/modeler/web-modeler/configuration/logging/"
+                    }
+                  ]
+                },
+
+                {
+                  "Troubleshooting": [
+                    {
+                      "type": "link",
+                      "label": "Database connection",
+                      "href": "/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-database-connection/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Zeebe connection",
+                      "href": "/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection/"
+                    },
+                    {
+                      "type": "link",
+                      "label": "Login issues",
+                      "href": "/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-login/"
+                    }
+                  ]
+                }
+              ]
+            },
+
+            {
+              "Desktop Modeler": [
+                {
+                  "type": "link",
+                  "label": "Deploy diagram",
+                  "href": "/docs/self-managed/modeler/desktop-modeler/deploy-to-self-managed/"
+                }
+              ]
             }
           ]
         }

--- a/versioned_sidebars/version-8.4-sidebars.json
+++ b/versioned_sidebars/version-8.4-sidebars.json
@@ -490,6 +490,7 @@
           "label": "What is Optimize?",
           "href": "/optimize/components/what-is-optimize/"
         },
+
         {
           "User guide": [
             {
@@ -507,6 +508,7 @@
               "label": "Data sources",
               "href": "/optimize/components/userguide/data-sources/"
             },
+
             {
               "Dashboards": [
                 {
@@ -526,6 +528,7 @@
                 }
               ]
             },
+
             {
               "Dashboards maintained by Camunda": [
                 {
@@ -540,6 +543,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Creating reports",
@@ -550,6 +554,7 @@
               "label": "Combined process reports",
               "href": "/optimize/components/userguide/combined-process-reports/"
             },
+
             {
               "Process analysis": [
                 {
@@ -567,6 +572,7 @@
                   "label": "Branch analysis",
                   "href": "/optimize/components/userguide/process-analysis/branch-analysis/"
                 },
+
                 {
                   "Report analysis": [
                     {
@@ -574,6 +580,7 @@
                       "label": "Report process analysis",
                       "href": "/optimize/components/userguide/process-analysis/report-analysis/overview/"
                     },
+
                     {
                       "Edit mode": [
                         {
@@ -613,6 +620,7 @@
                         }
                       ]
                     },
+
                     {
                       "type": "link",
                       "label": "View mode",
@@ -620,6 +628,7 @@
                     }
                   ]
                 },
+
                 {
                   "Filters": [
                     {
@@ -656,6 +665,7 @@
                 }
               ]
             },
+
             {
               "Decision analysis": [
                 {
@@ -675,6 +685,7 @@
                 }
               ]
             },
+
             {
               "Additional features": [
                 {

--- a/versioned_sidebars/version-8.4-sidebars.json
+++ b/versioned_sidebars/version-8.4-sidebars.json
@@ -1489,6 +1489,7 @@
               "label": "Version policy",
               "href": "/optimize/self-managed/optimize-deployment/version-policy/"
             },
+
             {
               "Configuration": [
                 {
@@ -1496,6 +1497,7 @@
                   "label": "Getting started",
                   "href": "/optimize/self-managed/optimize-deployment/configuration/getting-started/"
                 },
+
                 {
                   "System configuration": [
                     {
@@ -1520,6 +1522,7 @@
                     }
                   ]
                 },
+
                 {
                   "type": "link",
                   "label": "Logging",
@@ -1602,6 +1605,7 @@
                 }
               ]
             },
+
             {
               "Plugins": [
                 {
@@ -1641,11 +1645,13 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Camunda engine data reimport",
               "href": "/optimize/self-managed/optimize-deployment/reimport/"
             },
+
             {
               "Migration & update": [
                 {
@@ -1755,6 +1761,7 @@
                 }
               ]
             },
+
             {
               "Advanced features": [
                 {

--- a/versioned_sidebars/version-8.4-sidebars.json
+++ b/versioned_sidebars/version-8.4-sidebars.json
@@ -991,6 +991,7 @@
               "label": "Authentication",
               "href": "/optimize/apis-tools/optimize-api/optimize-api-authentication/"
             },
+
             {
               "Configuration": [
                 {
@@ -1005,6 +1006,7 @@
                 }
               ]
             },
+
             {
               "Dashboard": [
                 {
@@ -1024,6 +1026,7 @@
                 }
               ]
             },
+
             {
               "Report": [
                 {
@@ -1048,6 +1051,7 @@
                 }
               ]
             },
+
             {
               "type": "link",
               "label": "Event ingestion",


### PR DESCRIPTION
Part of #3250. 

## Description

Synchronizes sidebars for **v8.4**.

* There are many whitespace changes in this PR. In the past I've not included whitespace changes for sidebar synchronization, but since they are generated by the script consistently every time, we realized it makes more sense to commit them....so that in the future, all we see during synchronization are meaningful changes.
* There are no significant changes in the main instance's sidebars.json file! That means we did a great job of updating the main instance sidebars when we made structural changes to the Optimize documentation in v8.4. Yay, us!
* There are many significant changes in the Optimize instance's optimize_sidebars.json file. We introduced multiple API Explorers, and we also made a big folder for all the Components in the Self-Managed documentation. We didn't duplicate those changes into optimize_sidebars.json when we made those changes. Maybe this matters in v8.4 a little more than it matters in vNext, but I still think it's not that big a deal.


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [x] This change or page is part of a marketing blog, conference talk, or something else on a schedule. It'd be great to merge these before cutting docs on Monday.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
