### PR TITLE
docs(sidebar): resurrect aws dual-region setup

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -856,6 +856,7 @@ module.exports = {
                     "self-managed/setup/deploy/amazon/amazon-eks/eks-eksctl",
                     "self-managed/setup/deploy/amazon/amazon-eks/eks-terraform",
                     "self-managed/setup/deploy/amazon/amazon-eks/eks-helm",
+                    "self-managed/setup/deploy/amazon/amazon-eks/dual-region",
                     "self-managed/setup/deploy/amazon/amazon-eks/irsa",
                   ],
                 },


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

The self-managed installation restructuring https://github.com/camunda/camunda-docs/pull/3476 has accidentally lost a link in the sidebar.

This PR aims to fix that. The remaining dual-region topics are still present, only the AWS one is lost in the sidebar.

Doesn't require port back since 8.5 isn't cut yet.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
