### PR TITLE
fix?: maybe fix these two api explorer redirects?

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -43,9 +43,9 @@ RewriteRule ^docs/self-managed/platform-deployment/helm-kubernetes/guides/?$ /do
 RewriteRule ^docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/?$ /docs/self-managed/setup/deploy/local/local-kubernetes-cluster/ [R=301,L]
 
 # Operate API Explorer migrated into versioned docs
-RewriteRule ^api/operate/docs/(.*)$ /docs/apis-tools/operate-api/specifications/$1
+RewriteRule ^api/operate/docs/(.*)$ /docs/apis-tools/operate-api/specifications/$1 [R=301,L]
 # Tasklist API Explorer migrated into versioned docs
-RewriteRule ^api/tasklist/docs/(.*)$ /docs/apis-tools/tasklist-api-rest/specifications/$1
+RewriteRule ^api/tasklist/docs/(.*)$ /docs/apis-tools/tasklist-api-rest/specifications/$1 [R=301,L]
 
 # Remove updating-operate pages
 RewriteRule ^docs/components/operate/userguide/updating-operate/?$ /docs/self-managed/operational-guides/update-guide/introduction/$1 [R=301,L]


### PR DESCRIPTION
## Description

For some reason, the old Operate & Tasklist API explorer URLs are not redirecting to their new homes. I'm not sure why this is. And it's actually even weirder, because you can _see_ the explorer on the screen for a second before it changes to a "Not found" screen. [Example](https://docs.camunda.io/api/operate/docs/operate-public-api/).

When investigating, I noticed the redirect rules for these explorers were missing the `[R=301,L]` options. I don't _think_ this would cause the URL to not redirect, because it still matches, and nothing matches after it....but it's the only thing I can see that looks funny about these two rules, so maybe?????

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
