### PR TITLE
docs(self-managed): set web-modeler postgresql helm key back

### DIFF
--- a/docs/self-managed/setup/guides/air-gapped-installation.md
+++ b/docs/self-managed/setup/guides/air-gapped-installation.md
@@ -77,7 +77,7 @@ camunda-platform
     |_ tasklist
     |_ connectors
     |_ webModeler
-    |_ webModelerPostgresql
+    |_ postgresql
 ```
 
 - Keycloak is a dependency for Camunda Identity and PostgreSQL is a dependency for Keycloak.
@@ -189,7 +189,7 @@ webModeler:
     image:
       repository: camunda/modeler-websockets
   ...
-webModelerPostgresql:
+postgresql:
   image:
     repository: example.jfrog.io/bitnami/postgres
   ...

--- a/docs/self-managed/setup/guides/multi-namespace-deployment.md
+++ b/docs/self-managed/setup/guides/multi-namespace-deployment.md
@@ -94,7 +94,7 @@ identity:
   enabled: false
 webModeler:
   enabled: false
-webModelerPostgresql:
+postgresql:
   enabled: false
 ```
 
@@ -139,7 +139,7 @@ identity:
   enabled: false
 webModeler:
   enabled: false
-webModelerPostgresql:
+postgresql:
   enabled: false
 ```
 

--- a/docs/self-managed/setup/install.md
+++ b/docs/self-managed/setup/install.md
@@ -233,8 +233,8 @@ To set up Web Modeler, you need to provide the following required configuration 
   - Web Modeler requires an SMTP server to send notification emails to users.
 - Configure the database connection
   - Web Modeler requires a PostgreSQL database as persistent data storage (other database systems are currently not supported).
-  - _Option 1_: Set `webModelerPostgresql.enabled: true`. This will install a new PostgreSQL instance as part of the Helm release (using the [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by Bitnami as a dependency).
-  - _Option 2_: Set `webModelerPostgresql.enabled: false` and configure a [connection to an external database](#optional-configure-external-database).
+  - _Option 1_: Set `postgresql.enabled: true`. This will install a new PostgreSQL instance as part of the Helm release (using the [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by Bitnami as a dependency).
+  - _Option 2_: Set `postgresql.enabled: false` and configure a [connection to an external database](#optional-configure-external-database).
 
 We recommend specifying these values in a YAML file that you pass to the `helm install` command. A minimum configuration file would look as follows:
 
@@ -253,11 +253,11 @@ webModeler:
       smtpPassword: secret
       # Email address to be displayed as sender of emails from Web Modeler
       fromAddress: no-reply@example.com
-webModelerPostgresql:
+postgresql:
   enabled: true
 ```
 
-If you don't want to install a new PostgreSQL instance with Helm, but connect Web Modeler to an existing external database, set `webModelerPostgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
+If you don't want to install a new PostgreSQL instance with Helm, but connect Web Modeler to an existing external database, set `postgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
 
 ```yaml
 webModeler:
@@ -266,7 +266,7 @@ webModeler:
       url: jdbc:postgresql://postgres.example.com:5432/modeler-db
       user: modeler-user
       password: secret
-webModelerPostgresql:
+postgresql:
   # disables the PostgreSQL chart dependency
   enabled: false
 ```

--- a/docs/self-managed/setup/upgrade.md
+++ b/docs/self-managed/setup/upgrade.md
@@ -9,7 +9,7 @@ To upgrade to a more recent version of the Camunda Helm charts, there are certai
 
 :::caution
 
-Ensure to review the [instructions for a specific version](#version-update-instructions) before staring the actual upgrade.
+Ensure to review the [instructions for a specific version](#version-update-instructions) before starting the actual upgrade.
 
 :::
 
@@ -55,7 +55,9 @@ In the error message, Bitnami links to their [troubleshooting guide](https://doc
 For a successful upgrade, you first need to extract all secrets that were previously generated.
 
 :::note
+
 You also need to extract all secrets that were generated for Keycloak, since Keycloak is a dependency of Identity.
+
 :::
 
 To extract the secrets, use the following code snippet. Make sure to replace `camunda` with your actual Helm release name.
@@ -90,7 +92,9 @@ helm upgrade camunda camunda/camunda-platform \
 ```
 
 :::note
+
 If you have specified on the first installation certain values, you have to specify them again on the upgrade either via `--set` or the values file and the `-f` flag.
+
 :::
 
 For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).
@@ -107,12 +111,17 @@ You can also view all chart versions and application versions via Helm CLI as fo
 helm search repo camunda/camunda-platform --versions
 ```
 
+**After applying the instructions for each Helm chart, get back to the top of this page and start the upgrade process. **
+
 ## From Camunda 8.4 to 8.5
 
 ### Helm Chart 10.0.0
 
 :::caution Breaking changes
-The Camunda Helm chart v10.0.0 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
+
+- The Camunda Helm chart v10.0.0 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
+- It's not possible to upgrade from v9.x.x to v10.0.0, instead upgrade directly to v10.0.1 or above.
+
 :::
 
 #### Deprecation Notes
@@ -126,8 +135,6 @@ We highly recommend updating the keys in your values file and don't wait till th
 | Identity      |
 |               | `identity.keycloak`                | `identityKeycloak`                  |
 |               | `identity.postgresql`              | `identityPostgresql`                |
-| Web Modeler   |
-|               | `postgresql`                       | `webModelerPostgresql`              |
 | Zeebe Gateway |
 |               | `global.zeebePort`                 | `zeebeGateway.service.grpcPort`     |
 |               | `zeebe-gateway`                    | `zeebeGateway`                      |
@@ -140,6 +147,13 @@ We highly recommend updating the keys in your values file and don't wait till th
 |               | `global.elasticsearch.protocol`    | `global.elasticsearch.url.protocol` |
 |               | `global.elasticsearch.host`        | `global.elasticsearch.url.host`     |
 |               | `global.elasticsearch.port`        | `global.elasticsearch.url.port`     |
+
+Also, the Web Modeler PostgreSQL key will be changed in the 8.6 release (the new key `webModelerPostgresql` will not work in any chart using Camunda 8.5).
+
+| Component   | Old Key      | New Key                |
+| ----------- | ------------ | ---------------------- |
+| Web Modeler |
+|             | `postgresql` | `webModelerPostgresql` |
 
 #### Identity
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -9,7 +9,7 @@ To upgrade to a more recent version of the Camunda Helm charts, there are certai
 
 :::caution
 
-Ensure to review the [instructions for specific version](#version-update-instructions) before staring the actual upgrade.
+Ensure to review the [instructions for specific version](#version-update-instructions) before starting the actual upgrade.
 
 :::
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -9,7 +9,7 @@ To upgrade to a more recent version of the Camunda Helm charts, there are certai
 
 :::caution
 
-Ensure to review the [instructions for specific version](#version-update-instructions) before staring the actual upgrade.
+Ensure to review the [instructions for specific version](#version-update-instructions) before starting the actual upgrade.
 
 :::
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -9,7 +9,7 @@ To upgrade to a more recent version of the Camunda Helm charts, there are certai
 
 :::caution
 
-Ensure to review the [instructions for a specific version](#version-update-instructions) before staring the actual upgrade.
+Ensure to review the [instructions for a specific version](#version-update-instructions) before starting the actual upgrade.
 
 :::
 

--- a/versioned_docs/version-8.5/self-managed/setup/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/air-gapped-installation.md
@@ -77,7 +77,7 @@ camunda-platform
     |_ tasklist
     |_ connectors
     |_ webModeler
-    |_ webModelerPostgresql
+    |_ postgresql
 ```
 
 - Keycloak is a dependency for Camunda Identity and PostgreSQL is a dependency for Keycloak.
@@ -189,7 +189,7 @@ webModeler:
     image:
       repository: camunda/modeler-websockets
   ...
-webModelerPostgresql:
+postgresql:
   image:
     repository: example.jfrog.io/bitnami/postgres
   ...

--- a/versioned_docs/version-8.5/self-managed/setup/guides/multi-namespace-deployment.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/multi-namespace-deployment.md
@@ -94,7 +94,7 @@ identity:
   enabled: false
 webModeler:
   enabled: false
-webModelerPostgresql:
+postgresql:
   enabled: false
 ```
 
@@ -139,7 +139,7 @@ identity:
   enabled: false
 webModeler:
   enabled: false
-webModelerPostgresql:
+postgresql:
   enabled: false
 ```
 

--- a/versioned_docs/version-8.5/self-managed/setup/install.md
+++ b/versioned_docs/version-8.5/self-managed/setup/install.md
@@ -233,8 +233,8 @@ To set up Web Modeler, you need to provide the following required configuration 
   - Web Modeler requires an SMTP server to send notification emails to users.
 - Configure the database connection
   - Web Modeler requires a PostgreSQL database as persistent data storage (other database systems are currently not supported).
-  - _Option 1_: Set `webModelerPostgresql.enabled: true`. This will install a new PostgreSQL instance as part of the Helm release (using the [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by Bitnami as a dependency).
-  - _Option 2_: Set `webModelerPostgresql.enabled: false` and configure a [connection to an external database](#optional-configure-external-database).
+  - _Option 1_: Set `postgresql.enabled: true`. This will install a new PostgreSQL instance as part of the Helm release (using the [PostgreSQL Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by Bitnami as a dependency).
+  - _Option 2_: Set `postgresql.enabled: false` and configure a [connection to an external database](#optional-configure-external-database).
 
 We recommend specifying these values in a YAML file that you pass to the `helm install` command. A minimum configuration file would look as follows:
 
@@ -253,11 +253,11 @@ webModeler:
       smtpPassword: secret
       # Email address to be displayed as sender of emails from Web Modeler
       fromAddress: no-reply@example.com
-webModelerPostgresql:
+postgresql:
   enabled: true
 ```
 
-If you don't want to install a new PostgreSQL instance with Helm, but connect Web Modeler to an existing external database, set `webModelerPostgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
+If you don't want to install a new PostgreSQL instance with Helm, but connect Web Modeler to an existing external database, set `postgresql.enabled: false` and provide the values under `webModeler.restapi.externalDatabase`:
 
 ```yaml
 webModeler:
@@ -266,7 +266,7 @@ webModeler:
       url: jdbc:postgresql://postgres.example.com:5432/modeler-db
       user: modeler-user
       password: secret
-webModelerPostgresql:
+postgresql:
   # disables the PostgreSQL chart dependency
   enabled: false
 ```

--- a/versioned_docs/version-8.5/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.5/self-managed/setup/upgrade.md
@@ -9,7 +9,7 @@ To upgrade to a more recent version of the Camunda Helm charts, there are certai
 
 :::caution
 
-Ensure to review the [instructions for a specific version](#version-update-instructions) before staring the actual upgrade.
+Ensure to review the [instructions for a specific version](#version-update-instructions) before starting the actual upgrade.
 
 :::
 
@@ -55,7 +55,9 @@ In the error message, Bitnami links to their [troubleshooting guide](https://doc
 For a successful upgrade, you first need to extract all secrets that were previously generated.
 
 :::note
+
 You also need to extract all secrets that were generated for Keycloak, since Keycloak is a dependency of Identity.
+
 :::
 
 To extract the secrets, use the following code snippet. Make sure to replace `camunda` with your actual Helm release name.
@@ -90,7 +92,9 @@ helm upgrade camunda camunda/camunda-platform \
 ```
 
 :::note
+
 If you have specified on the first installation certain values, you have to specify them again on the upgrade either via `--set` or the values file and the `-f` flag.
+
 :::
 
 For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).
@@ -107,12 +111,17 @@ You can also view all chart versions and application versions via Helm CLI as fo
 helm search repo camunda/camunda-platform --versions
 ```
 
+**After applying the instructions for each Helm chart, get back to the top of this page and start the upgrade process. **
+
 ## From Camunda 8.4 to 8.5
 
 ### Helm Chart 10.0.0
 
 :::caution Breaking changes
-The Camunda Helm chart v10.0.0 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
+
+- The Camunda Helm chart v10.0.0 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
+- It's not possible to upgrade from v9.x.x to v10.0.0, instead upgrade directly to v10.0.1 or above.
+
 :::
 
 #### Deprecation Notes
@@ -126,8 +135,6 @@ We highly recommend updating the keys in your values file and don't wait till th
 | Identity      |
 |               | `identity.keycloak`                | `identityKeycloak`                  |
 |               | `identity.postgresql`              | `identityPostgresql`                |
-| Web Modeler   |
-|               | `postgresql`                       | `webModelerPostgresql`              |
 | Zeebe Gateway |
 |               | `global.zeebePort`                 | `zeebeGateway.service.grpcPort`     |
 |               | `zeebe-gateway`                    | `zeebeGateway`                      |
@@ -140,6 +147,13 @@ We highly recommend updating the keys in your values file and don't wait till th
 |               | `global.elasticsearch.protocol`    | `global.elasticsearch.url.protocol` |
 |               | `global.elasticsearch.host`        | `global.elasticsearch.url.host`     |
 |               | `global.elasticsearch.port`        | `global.elasticsearch.url.port`     |
+
+Also, the Web Modeler PostgreSQL key will be changed in the 8.6 release (the new key `webModelerPostgresql` will not work in any chart using Camunda 8.5).
+
+| Component   | Old Key      | New Key                |
+| ----------- | ------------ | ---------------------- |
+| Web Modeler |
+|             | `postgresql` | `webModelerPostgresql` |
 
 #### Identity
 


### PR DESCRIPTION
## Description

Using Web Modeler PostgreSQL helm key `webModelerPostgresql` is not possible until the 8.6 release.

## When should this change go live?

ASAP.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
