### PR TITLE
docs(web-modeler): remove migration guide from next

### DIFF
--- a/docs/apis-tools/web-modeler-api/index.md
+++ b/docs/apis-tools/web-modeler-api/index.md
@@ -52,18 +52,3 @@ The API gives you access to the names, as well as the ids. For example, when req
 - **canonicalPath** contains the unique path. It is a list of **PathElementDto** objects which contain the id and the name of the element.
 
 Internally, the ids are what matters. You can rename files or move files between folders and projects and the id will stay the same.
-
-### How do I migrate from the `beta` API to the `v1` API? {#migrating-from-beta-to-v1}
-
-Web Modeler's beta API was removed in this release.
-To migrate to `v1`, change the base URL from `/api/beta` to `/api/v1`.
-
-:::caution Breaking changes
-
-- `GET /api/beta/projects/{projectId}/files` was removed. Use `POST /api/v1/files/search` instead.
-- `GET /api/beta/files/{fileId}/milestones` was removed. Use `POST /api/v1/milestones/search` instead.
-- `GET /api/beta/projects` was removed. Use `POST /api/v1/projects/search` instead.
-
-:::
-
-Refer to the [OpenAPI documentation](#openapi-documentation) for details.


### PR DESCRIPTION
## Description

Removes the migration guide for the public-api for all versions > 8.5 and finally closes https://github.com/camunda/web-modeler/issues/8250.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
