### PR TITLE
docs: simplify API Explorer docs

### DIFF
--- a/howtos/interactive-api-explorers.md
+++ b/howtos/interactive-api-explorers.md
@@ -2,53 +2,29 @@
 
 The docs include an interactive explorer for some of the Camunda APIs. These explorers are generated with [a Docusaurus plugin](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/), based on an OpenAPI specification file.
 
-Each explorer is configured in `docusaurus.config.js`.
+Each explorer is configured in `docusaurus.config.js` ([example](https://github.com/camunda/camunda-docs/blob/f71d68e0fa6681d334e4fd1bf86a077f456f35f0/docusaurus.config.js#L151-L169)). The docs for these APIs are generated directly into the main docs instance, in the Next version only. As minor versions are released, the docs for the Next version are copied to the current version of the docs. In this way, these APIs have versioned documentation.
 
-Some API Explorers are configured for both the `docusaurus-plugin-openapi-docs` generator plugin ([example](https://github.com/camunda/camunda-docs/blob/511cf0c26b93bb3076834d87a216609bd8f28548/docusaurus.config.js#L87-L101)) and a standalone docs instance ([example](https://github.com/camunda/camunda-docs/blob/511cf0c26b93bb3076834d87a216609bd8f28548/docusaurus.config.js#L68-L84). The docs for these APIs are generated into a subfolder of the `api` folder. These explorers only emit docs for one version for the API.
-
-Other APIs are configured only for the generator ([example](https://github.com/camunda/camunda-docs/blob/f71d68e0fa6681d334e4fd1bf86a077f456f35f0/docusaurus.config.js#L151-L169)). The docs for these APIs are generated directly in the main docs instance, in the Next version. As minor versions are released, the docs for the Next version are copied to the current version of the docs. In this way, these APIs have versioned documentation.
-
-## Explorers with standalone docs instances
-
-### Source files
+## Source files
 
 The source for each API's instance lives in an identifying folder within the `/api` folder. Following is a description of the contents of these folders.
 
 - `/api/[apiName]/`: Home to the API Explorer source/configuration.
 - `/api/[apiName]/[apiName]-openapi.yaml`: OpenAPI spec for the API.
-- `/api/[apiName]/[apiName]_sidebars.js`: Sidebars for the API's interactive explorer.
-- `/api/[apiName]/docs/`: Generated interactive explorer for the API.
-
-### Updating an OpenAPI spec
-
-When the OpenAPI spec for a standalone API explorer changes, the docs for the associated interactive explorer should be fully re-generated.
-
-1. Replace the OpenAPI spec file.
-2. Replace the hard-coded `servers[].url` in the spec file with something more generic, like `SERVER-URL`.
-3. Regenerate the explorer with this command:
-   `npm run api:generate:[apiName]`: Generate docs for the API Explorer.
-
-## Explorers without standalone docs instances (which are generated into the main docs)
-
-### Source files
-
-The source for each API's instance lives in an identifying folder within the `/api` folder. Following is a description of the contents of these folders.
-
-- `/api/[apiName]/`: Home to the API Explorer source/configuration.
-- `/api/[apiName]/[apiName]-openapi.yaml`: OpenAPI spec for the API.
-- `/api/[apiName]/generation-strategy.js`: A JavaScript file that describes custom steps required to generate this API's explorer.
+- `/api/[apiName]/generation-strategy.js`: A JavaScript file that describes custom steps required to standardize this API's explorer.
   See `api/generate-api-docs` for details on how this file is used during the generation process.
 
-### Updating an OpenAPI spec
+## Updating an OpenAPI spec
 
-The OpenAPI spec is only used to generate the API Explorer for the Next version of versioned explorers. For non-Next versions, the previously-generated documentation is copied into the versioned doc folder, and changes should be made directly to the markdown files.
+The OpenAPI spec is only used to generate the API Explorer for the Next version of versioned explorers. This can be done in synchrony with alpha releases, to give users a preview of the new API features.
+
+For non-Next versions, the previously-generated documentation is copied into the versioned doc folder, and changes can and should be made directly to the markdown files.
 
 To re-generate the Next version:
 
-1. Replace the OpenAPI spec file.
+1. Replace the OpenAPI spec file at `/api/[apiName]/[apiName]-openapi.yaml`.
 2. Regenerate the explorer with this command:
-   `npm run api:generate [apiName]`: Generate docs for the API Explorer.
-   Note the space between `generate` and `[apiName]`. This differs from the command for standalone docs instances, intentionally.
+   `npm run api:generate:[apiName]`.
+3. Commit changes, and open a PR.
 
 ## Code languages
 


### PR DESCRIPTION
## Description

Now that all API Explorers have been migrated to the main docs, we can remove documentation describing the old approach.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
