### PR TITLE
feat(modeler): document boolean and number template types

### DIFF
--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -205,17 +205,17 @@ As an alternative to static `value`, you can use a generated value. The value is
 
 ### Types
 
-The input types `String`, `Text`, `Number`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.
+The input types `String`, `Text`, `Number`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above, `String` maps to a single-line input, while `Text` maps to a multi-line input.
 
 #### Number type
 
-The `Number` type maps to a number input field. By default, this will be persisted as a string in the BPMN. Refer to the [FEEL](#feel) section to use Numbers as expressions.
+The `Number` type maps to a number input field. By default, this will be persisted as a string in the BPMN. Refer to the [FEEL](#feel) section to use `Numbers` as expressions.
 
 #### Boolean / checkbox type
 
 The `Boolean` type maps to a checkbox that can be toggled by the user.
 
-When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)). Refer to the [FEEL](#feel) section to use Booleans as expressions.
+When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)). Additionally, refer to the [FEEL](#feel) section to use `Booleans` as expressions.
 
 #### Dropdown type
 
@@ -260,7 +260,7 @@ The following input types support the `feel` property:
 
 ##### FEEL required
 
-The field will be displayed as a FEEL editor and a visual indication that a FEEL expression is required will be shown.
+The field will be displayed as a FEEL editor and a visual indication that a FEEL expression is required will be shown:
 
 ```json
   "properties": [
@@ -274,7 +274,7 @@ The field will be displayed as a FEEL editor and a visual indication that a FEEL
 
 ##### FEEL optional
 
-An indicator to switch to a FEEL expression is shown. When activated, the field will be displayed as a FEEL editor.
+An indicator to switch to a FEEL expression is shown. When activated, the field will be displayed as a FEEL editor:
 
 ```json
   "properties": [
@@ -290,7 +290,7 @@ For `Boolean` and `Number` fields, the value will always be persisted as a FEEL 
 
 ##### FEEL static
 
-The value of `feel: static` is only valid for `Boolean` and `Number` fields. Similar to [FEEL optional](#feel-optional), the value of the field will be persisted as a FEEL expression. However, there is no toggle to switch to a FEEL editor and ensures only a static value can be entered.
+The value of `feel: static` is only valid for `Boolean` and `Number` fields. Similar to [FEEL optional](#feel-optional), the value of the field will be persisted as a FEEL expression. However, there is no toggle to switch to a FEEL editor and ensures only a static value can be entered:
 
 ```json
   "properties": [

--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -279,7 +279,7 @@ An indicator to switch to a FEEL expression is shown. When activated, the field 
 ```json
   "properties": [
     {
-      "label": "Required FEEL Expression",
+      "label": "Optional FEEL Expression",
       "type": "String",
       "feel": "optional"
     }

--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -205,13 +205,17 @@ As an alternative to static `value`, you can use a generated value. The value is
 
 ### Types
 
-The input types `String`, `Text`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.
+The input types `String`, `Text`, `Number`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.
+
+#### Number type
+
+The `Number` type maps to a number input field. By default, this will be persisted as a string in the BPMN. Refer to the [FEEL](#feel) section to use Numbers as expressions.
 
 #### Boolean / checkbox type
 
 The `Boolean` type maps to a checkbox that can be toggled by the user.
 
-When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)).
+When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)). Refer to the [FEEL](#feel) section to use Booleans as expressions.
 
 #### Dropdown type
 
@@ -247,30 +251,56 @@ The resulting properties panel control looks like this:
 
 #### FEEL
 
-We support the feel properties `optional` and `required`.
-When set, the input field offers visual indications that a FEEL expression is expected.
+The following input types support the `feel` property:
+
+- `String`
+- `Text`
+- `Number`
+- `Boolean`
+
+##### FEEL required
+
+The field will be displayed as a FEEL editor and a visual indication that a FEEL expression is required will be shown.
 
 ```json
   "properties": [
     {
-      "label": "Optional FEEL Expression",
-      "type": "String",
-      "feel": "optional"
-    },
-    {
       "label": "Required FEEL Expression",
-      "type": "Text",
+      "type": "String",
       "feel": "required"
     }
   ]
 ```
 
-##### Supported types
+##### FEEL optional
 
-The property `feel` is supported on the following input types:
+An indicator to switch to a FEEL expression is shown. When activated, the field will be displayed as a FEEL editor.
 
-- `String`
-- `Text`
+```json
+  "properties": [
+    {
+      "label": "Required FEEL Expression",
+      "type": "String",
+      "feel": "optional"
+    }
+  ]
+```
+
+For `Boolean` and `Number` fields, the value will always be persisted as a FEEL expression. This ensures that the value will not be interpreted as a string when evaluated in the engine.
+
+##### FEEL static
+
+The value of `feel: static` is only valid for `Boolean` and `Number` fields. Similar to [FEEL optional](#feel-optional), the value of the field will be persisted as a FEEL expression. However, there is no toggle to switch to a FEEL editor and ensures only a static value can be entered.
+
+```json
+  "properties": [
+    {
+      "label": "Static FEEL value",
+      "type": "Number",
+      "feel": "static"
+    }
+  ]
+```
 
 ### Bindings
 

--- a/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -205,17 +205,17 @@ As an alternative to static `value`, you can use a generated value. The value is
 
 ### Types
 
-The input types `String`, `Text`, `Number`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.
+The input types `String`, `Text`, `Number`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above, `String` maps to a single-line input, while `Text` maps to a multi-line input.
 
 #### Number type
 
-The `Number` type maps to a number input field. By default, this will be persisted as a string in the BPMN. Refer to the [FEEL](#feel) section to use Numbers as expressions.
+The `Number` type maps to a number input field. By default, this will be persisted as a string in the BPMN. Refer to the [FEEL](#feel) section to use `Numbers` as expressions.
 
 #### Boolean / checkbox type
 
 The `Boolean` type maps to a checkbox that can be toggled by the user.
 
-When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)). Refer to the [FEEL](#feel) section to use Booleans as expressions.
+When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)). Additionally, refer to the [FEEL](#feel) section to use `Booleans` as expressions.
 
 #### Dropdown type
 
@@ -260,7 +260,7 @@ The following input types support the `feel` property:
 
 ##### FEEL required
 
-The field will be displayed as a FEEL editor and a visual indication that a FEEL expression is required will be shown.
+The field will be displayed as a FEEL editor and a visual indication that a FEEL expression is required will be shown:
 
 ```json
   "properties": [
@@ -274,7 +274,7 @@ The field will be displayed as a FEEL editor and a visual indication that a FEEL
 
 ##### FEEL optional
 
-An indicator to switch to a FEEL expression is shown. When activated, the field will be displayed as a FEEL editor.
+An indicator to switch to a FEEL expression is shown. When activated, the field will be displayed as a FEEL editor:
 
 ```json
   "properties": [
@@ -290,7 +290,7 @@ For `Boolean` and `Number` fields, the value will always be persisted as a FEEL 
 
 ##### FEEL static
 
-The value of `feel: static` is only valid for `Boolean` and `Number` fields. Similar to [FEEL optional](#feel-optional), the value of the field will be persisted as a FEEL expression. However, there is no toggle to switch to a FEEL editor and ensures only a static value can be entered.
+The value of `feel: static` is only valid for `Boolean` and `Number` fields. Similar to [FEEL optional](#feel-optional), the value of the field will be persisted as a FEEL expression. However, there is no toggle to switch to a FEEL editor and ensures only a static value can be entered:
 
 ```json
   "properties": [

--- a/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -279,7 +279,7 @@ An indicator to switch to a FEEL expression is shown. When activated, the field 
 ```json
   "properties": [
     {
-      "label": "Required FEEL Expression",
+      "label": "Optional FEEL Expression",
       "type": "String",
       "feel": "optional"
     }

--- a/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -205,13 +205,17 @@ As an alternative to static `value`, you can use a generated value. The value is
 
 ### Types
 
-The input types `String`, `Text`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.
+The input types `String`, `Text`, `Number`, `Boolean`, `Dropdown`, and `Hidden` are available. As seen above `String` maps to a single-line input, while `Text` maps to a multi-line input.
+
+#### Number type
+
+The `Number` type maps to a number input field. By default, this will be persisted as a string in the BPMN. Refer to the [FEEL](#feel) section to use Numbers as expressions.
 
 #### Boolean / checkbox type
 
 The `Boolean` type maps to a checkbox that can be toggled by the user.
 
-When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)).
+When checked, it maps to `true` in the respective field (refer to [bindings](#bindings)). Refer to the [FEEL](#feel) section to use Booleans as expressions.
 
 #### Dropdown type
 
@@ -247,30 +251,56 @@ The resulting properties panel control looks like this:
 
 #### FEEL
 
-We support the feel properties `optional` and `required`.
-When set, the input field offers visual indications that a FEEL expression is expected.
+The following input types support the `feel` property:
+
+- `String`
+- `Text`
+- `Number`
+- `Boolean`
+
+##### FEEL required
+
+The field will be displayed as a FEEL editor and a visual indication that a FEEL expression is required will be shown.
 
 ```json
   "properties": [
     {
-      "label": "Optional FEEL Expression",
-      "type": "String",
-      "feel": "optional"
-    },
-    {
       "label": "Required FEEL Expression",
-      "type": "Text",
+      "type": "String",
       "feel": "required"
     }
   ]
 ```
 
-##### Supported types
+##### FEEL optional
 
-The property `feel` is supported on the following input types:
+An indicator to switch to a FEEL expression is shown. When activated, the field will be displayed as a FEEL editor.
 
-- `String`
-- `Text`
+```json
+  "properties": [
+    {
+      "label": "Required FEEL Expression",
+      "type": "String",
+      "feel": "optional"
+    }
+  ]
+```
+
+For `Boolean` and `Number` fields, the value will always be persisted as a FEEL expression. This ensures that the value will not be interpreted as a string when evaluated in the engine.
+
+##### FEEL static
+
+The value of `feel: static` is only valid for `Boolean` and `Number` fields. Similar to [FEEL optional](#feel-optional), the value of the field will be persisted as a FEEL expression. However, there is no toggle to switch to a FEEL editor and ensures only a static value can be entered.
+
+```json
+  "properties": [
+    {
+      "label": "Static FEEL value",
+      "type": "Number",
+      "feel": "static"
+    }
+  ]
+```
 
 ### Bindings
 


### PR DESCRIPTION
## Description

This PR adds documentation for new element template features: number and boolean types as well as the `feel: static` option.
This was released with 8.5 but not documented.

related to https://github.com/bpmn-io/internal-docs/issues/919

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory
- [x] I have added changes to the main `/docs` directory (aka `/next/`)
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
