### PR TITLE
chore(web-modeler): clarify target container for timeout increases

### DIFF
--- a/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
+++ b/docs/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
@@ -22,7 +22,7 @@ If that works, further debug your Zeebe connection with the help of the informat
 Web Modeler uses the [Zeebe Java client](/docs/apis-tools/java-client/index.md) to connect to Zeebe.
 Depending on your infrastructure, the default timeouts configured may be too short.
 
-You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client via three individual environment variables:
+You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client to `modeler-restapi` via three individual environment variables:
 
 ```shell
 ZEEBE_CLIENT_REQUESTTIMEOUT=30000 # limit the time to wait for a response from the Zeebe gateway

--- a/versioned_docs/version-8.2/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
+++ b/versioned_docs/version-8.2/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
@@ -22,7 +22,7 @@ If that works, further debug your Zeebe connection with the help of the informat
 Web Modeler uses the [Zeebe Java client](/versioned_docs/version-8.2/apis-tools/java-client/index.md) to connect to Zeebe.
 Depending on your infrastructure, the default timeouts configured may be too short.
 
-You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client via three individual environment variables:
+You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client to `modeler-restapi` via three individual environment variables:
 
 ```shell
 ZEEBE_CLIENT_REQUESTTIMEOUT=30000 # limit the time to wait for a response from the Zeebe gateway

--- a/versioned_docs/version-8.3/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
+++ b/versioned_docs/version-8.3/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
@@ -22,7 +22,7 @@ If that works, further debug your Zeebe connection with the help of the informat
 Web Modeler uses the [Zeebe Java client](/versioned_docs/version-8.3/apis-tools/java-client/index.md) to connect to Zeebe.
 Depending on your infrastructure, the default timeouts configured may be too short.
 
-You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client via three individual environment variables:
+You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client to `modeler-restapi` via three individual environment variables:
 
 ```shell
 ZEEBE_CLIENT_REQUESTTIMEOUT=30000 # limit the time to wait for a response from the Zeebe gateway

--- a/versioned_docs/version-8.4/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
+++ b/versioned_docs/version-8.4/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
@@ -22,7 +22,7 @@ If that works, further debug your Zeebe connection with the help of the informat
 Web Modeler uses the [Zeebe Java client](/docs/apis-tools/java-client/index.md) to connect to Zeebe.
 Depending on your infrastructure, the default timeouts configured may be too short.
 
-You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client via three individual environment variables:
+You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client to `modeler-restapi` via three individual environment variables:
 
 ```shell
 ZEEBE_CLIENT_REQUESTTIMEOUT=30000 # limit the time to wait for a response from the Zeebe gateway

--- a/versioned_docs/version-8.5/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
+++ b/versioned_docs/version-8.5/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
@@ -22,7 +22,7 @@ If that works, further debug your Zeebe connection with the help of the informat
 Web Modeler uses the [Zeebe Java client](/docs/apis-tools/java-client/index.md) to connect to Zeebe.
 Depending on your infrastructure, the default timeouts configured may be too short.
 
-You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client via three individual environment variables:
+You can pass custom timeouts in milliseconds for Web Modeler's Zeebe client to `modeler-restapi` via three individual environment variables:
 
 ```shell
 ZEEBE_CLIENT_REQUESTTIMEOUT=30000 # limit the time to wait for a response from the Zeebe gateway


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Closes https://github.com/camunda/web-modeler/issues/8999

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/doxcumentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
