### PR TITLE
chore(optimize): move usertask sidebars to correct location

### DIFF
--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1173,6 +1173,7 @@ module.exports = {
                 "components/userguide/process-analysis/process-analysis-overview",
                 "components/userguide/process-analysis/task-analysis",
                 "components/userguide/process-analysis/branch-analysis",
+                "components/userguide/process-analysis/user-task-analytics",
                 {
                   "Report analysis": [
                     "components/userguide/process-analysis/report-analysis/overview",
@@ -1200,7 +1201,6 @@ module.exports = {
                     "components/userguide/process-analysis/flow-node-filters",
                     "components/userguide/process-analysis/process-instance-filters",
                     "components/userguide/process-analysis/variable-filters",
-                    "components/userguide/process-analysis/user-task-analytics",
                   ],
                 },
               ],

--- a/optimize_versioned_sidebars/version-3.13.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.13.0-sidebars.json
@@ -1469,6 +1469,7 @@
                 "components/userguide/process-analysis/process-analysis-overview",
                 "components/userguide/process-analysis/task-analysis",
                 "components/userguide/process-analysis/branch-analysis",
+                "components/userguide/process-analysis/user-task-analytics",
                 {
                   "Report analysis": [
                     "components/userguide/process-analysis/report-analysis/overview",
@@ -1493,8 +1494,7 @@
                     "components/userguide/process-analysis/instance-state-filters",
                     "components/userguide/process-analysis/flow-node-filters",
                     "components/userguide/process-analysis/process-instance-filters",
-                    "components/userguide/process-analysis/variable-filters",
-                    "components/userguide/process-analysis/user-task-analytics"
+                    "components/userguide/process-analysis/variable-filters"
                   ]
                 }
               ]

--- a/sidebars.js
+++ b/sidebars.js
@@ -460,7 +460,10 @@ module.exports = {
                   "Branch analysis",
                   "components/userguide/process-analysis/branch-analysis/"
                 ),
-
+                optimizeLink(
+                  "User task analytics",
+                  "components/userguide/process-analysis/user-task-analytics/"
+                ),
                 {
                   "Report analysis": [
                     optimizeLink(
@@ -533,10 +536,6 @@ module.exports = {
                     optimizeLink(
                       "Variable filters",
                       "components/userguide/process-analysis/variable-filters/"
-                    ),
-                    optimizeLink(
-                      "User task analytics",
-                      "components/userguide/process-analysis/user-task-analytics/"
                     ),
                   ],
                 },

--- a/versioned_sidebars/version-8.5-sidebars.json
+++ b/versioned_sidebars/version-8.5-sidebars.json
@@ -585,6 +585,11 @@
                   "href": "/optimize/components/userguide/process-analysis/branch-analysis/"
                 },
                 {
+                  "type": "link",
+                  "label": "User task analytics",
+                  "href": "/optimize/components/userguide/process-analysis/user-task-analytics/"
+                },
+                {
                   "Report analysis": [
                     {
                       "type": "link",
@@ -668,11 +673,6 @@
                       "type": "link",
                       "label": "Variable filters",
                       "href": "/optimize/components/userguide/process-analysis/variable-filters/"
-                    },
-                    {
-                      "type": "link",
-                      "label": "User task analytics",
-                      "href": "/optimize/components/userguide/process-analysis/user-task-analytics/"
                     }
                   ]
                 }


### PR DESCRIPTION
## Description

The optimize usertask link seems to have slipped into the filters section erroneously. 

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
