### PR TITLE
feature: add csrf token to the tasklist docs

### DIFF
--- a/docs/apis-tools/tasklist-api/tasklist-api-authentication.md
+++ b/docs/apis-tools/tasklist-api/tasklist-api-authentication.md
@@ -74,7 +74,7 @@ The authentication is described in [Tasklist Configuration - Authentication](/se
 ### Authentication via cookie
 
 :::note
-When authenticating via cookie, it is necessary to note that Cross-Site Request Forgery (CSRF) protection must be disabled to allow this method of authentication. In a Self-Managed Camunda cluster, this can be done by setting the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`.
+When authenticating via cookie, note that Cross-Site Request Forgery (CSRF) protection must be disabled to allow this method of authentication. In a Camunda Self-Managed cluster, set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`.
 :::
 
 Another way to access the Tasklist API in a Self-Managed cluster is to send cookie headers in each request. The cookie can be obtained by using the API endpoint `/api/login`. Take the following steps:

--- a/docs/apis-tools/tasklist-api/tasklist-api-authentication.md
+++ b/docs/apis-tools/tasklist-api/tasklist-api-authentication.md
@@ -73,6 +73,10 @@ The authentication is described in [Tasklist Configuration - Authentication](/se
 
 ### Authentication via cookie
 
+:::note
+When authenticating via cookie, it is necessary to note that Cross-Site Request Forgery (CSRF) protection must be disabled to allow this method of authentication. In a Self-Managed Camunda cluster, this can be done by setting the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`.
+:::
+
 Another way to access the Tasklist API in a Self-Managed cluster is to send cookie headers in each request. The cookie can be obtained by using the API endpoint `/api/login`. Take the following steps:
 
 1. Log in as user 'demo' and store the cookie in the file `cookie.txt`:

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -337,11 +337,11 @@ camunda.tasklist:
     prefix: zeebe-record
 ```
 
-## Cross-Site Request Forgery Protection
+## Cross-site request forgery protection
 
-Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated. To mitigate this risk, Camunda provides CSRF protection that can be enabled in the Tasklist web application.
+Cross-site request forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated. To mitigate this risk, Camunda provides CSRF protection that can be enabled in the Tasklist web application.
 
-### Enabling CSRF Protection
+### Enabling CSRF protection
 
 CSRF protection is enabled by default on Camunda Self-Managed. To explicitly define this, set the configuration variable `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
 
@@ -351,9 +351,9 @@ camunda:
     csrfPreventionEnabled: true
 ```
 
-When CSRF protection is enabled, the Tasklist web application will require a valid `X-CSRF-Token` header to be present in all state-changing HTTP requests (POST, PUT, DELETE, etc.).
+When CSRF protection is enabled, the Tasklist web application requires a valid `X-CSRF-Token` header to be present in all state-changing HTTP requests (POST, PUT, DELETE, etc.)
 
-### Disabling CSRF Protection
+### Disabling CSRF protection
 
 To disable CSRF protection, set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
 

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -343,7 +343,7 @@ Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execut
 
 ### Enabling CSRF Protection
 
-CSRF protection is enabled by default on Self-managed, in case you wanna explicit define this, it is necessary to set the configuration variable: `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
+CSRF protection is enabled by default on Camunda Self-Managed. To explicitly define this, set the configuration variable `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
 
 ```yaml
 camunda:
@@ -355,7 +355,7 @@ When CSRF protection is enabled, the Tasklist web application will require a val
 
 ### Disabling CSRF Protection
 
-To disable CSRF protection, you must set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
+To disable CSRF protection, set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
 
 ```yaml
 camunda:

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -336,3 +336,29 @@ camunda.tasklist:
     # Index prefix, configured in Zeebe Elasticsearch exporter
     prefix: zeebe-record
 ```
+
+## Cross-Site Request Forgery Protection
+
+Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated. To mitigate this risk, Camunda provides CSRF protection that can be enabled in the Tasklist web application.
+
+### Enabling CSRF Protection
+
+CSRF protection is enabled by default on Self-managed, in case you wanna explicit define this, it is necessary to set the configuration variable: `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
+
+```yaml
+camunda:
+  tasklist:
+    csrfPreventionEnabled: true
+```
+
+When CSRF protection is enabled, the Tasklist web application will require a valid `X-CSRF-Token` header to be present in all state-changing HTTP requests (POST, PUT, DELETE, etc.).
+
+### Disabling CSRF Protection
+
+To disable CSRF protection, you must set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
+
+```yaml
+camunda:
+  tasklist:
+    csrfPreventionEnabled: false
+```

--- a/versioned_docs/version-8.5/apis-tools/tasklist-api/tasklist-api-authentication.md
+++ b/versioned_docs/version-8.5/apis-tools/tasklist-api/tasklist-api-authentication.md
@@ -74,7 +74,7 @@ The authentication is described in [Tasklist Configuration - Authentication](/se
 ### Authentication via cookie
 
 :::note
-When authenticating via cookie, it is necessary to note that Cross-Site Request Forgery (CSRF) protection must be disabled to allow this method of authentication. In a Self-Managed Camunda cluster, this can be done by setting the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`.
+When authenticating via cookie, note that Cross-Site Request Forgery (CSRF) protection must be disabled to allow this method of authentication. In a Camunda Self-Managed cluster, set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`.
 :::
 
 Another way to access the Tasklist API in a Self-Managed cluster is to send cookie headers in each request. The cookie can be obtained by using the API endpoint `/api/login`. Take the following steps:

--- a/versioned_docs/version-8.5/apis-tools/tasklist-api/tasklist-api-authentication.md
+++ b/versioned_docs/version-8.5/apis-tools/tasklist-api/tasklist-api-authentication.md
@@ -73,6 +73,10 @@ The authentication is described in [Tasklist Configuration - Authentication](/se
 
 ### Authentication via cookie
 
+:::note
+When authenticating via cookie, it is necessary to note that Cross-Site Request Forgery (CSRF) protection must be disabled to allow this method of authentication. In a Self-Managed Camunda cluster, this can be done by setting the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`.
+:::
+
 Another way to access the Tasklist API in a Self-Managed cluster is to send cookie headers in each request. The cookie can be obtained by using the API endpoint `/api/login`. Take the following steps:
 
 1. Log in as user 'demo' and store the cookie in the file `cookie.txt`:

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -337,11 +337,11 @@ camunda.tasklist:
     prefix: zeebe-record
 ```
 
-## Cross-Site Request Forgery Protection
+## Cross-site request forgery protection
 
-Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated. To mitigate this risk, Camunda provides CSRF protection that can be enabled in the Tasklist web application.
+Cross-site request forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated. To mitigate this risk, Camunda provides CSRF protection that can be enabled in the Tasklist web application.
 
-### Enabling CSRF Protection
+### Enabling CSRF protection
 
 CSRF protection is enabled by default on Camunda Self-Managed. To explicitly define this, set the configuration variable `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
 
@@ -351,9 +351,9 @@ camunda:
     csrfPreventionEnabled: true
 ```
 
-When CSRF protection is enabled, the Tasklist web application will require a valid `X-CSRF-Token` header to be present in all state-changing HTTP requests (POST, PUT, DELETE, etc.).
+When CSRF protection is enabled, the Tasklist web application requires a valid `X-CSRF-Token` header to be present in all state-changing HTTP requests (POST, PUT, DELETE, etc.)
 
-### Disabling CSRF Protection
+### Disabling CSRF protection
 
 To disable CSRF protection, set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
 

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -343,7 +343,7 @@ Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execut
 
 ### Enabling CSRF Protection
 
-CSRF protection is enabled by default on Self-managed, in case you wanna explicit define this, it is necessary to set the configuration variable: `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
+CSRF protection is enabled by default on Camunda Self-Managed. To explicitly define this, set the configuration variable `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
 
 ```yaml
 camunda:
@@ -355,7 +355,7 @@ When CSRF protection is enabled, the Tasklist web application will require a val
 
 ### Disabling CSRF Protection
 
-To disable CSRF protection, you must set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
+To disable CSRF protection, set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -336,3 +336,29 @@ camunda.tasklist:
     # Index prefix, configured in Zeebe Elasticsearch exporter
     prefix: zeebe-record
 ```
+
+## Cross-Site Request Forgery Protection
+
+Cross-Site Request Forgery (CSRF) is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated. To mitigate this risk, Camunda provides CSRF protection that can be enabled in the Tasklist web application.
+
+### Enabling CSRF Protection
+
+CSRF protection is enabled by default on Self-managed, in case you wanna explicit define this, it is necessary to set the configuration variable: `camunda.tasklist.csrfPreventionEnabled` to `true`. This is the recommended setting for production environments to enhance security.
+
+```yaml
+camunda:
+  tasklist:
+    csrfPreventionEnabled: true
+```
+
+When CSRF protection is enabled, the Tasklist web application will require a valid `X-CSRF-Token` header to be present in all state-changing HTTP requests (POST, PUT, DELETE, etc.).
+
+### Disabling CSRF Protection
+
+To disable CSRF protection, you must set the configuration property `camunda.tasklist.csrfPreventionEnabled` to `false`. This setting is not recommended for production environments as it may expose the application to CSRF attacks.
+
+```yaml
+camunda:
+  tasklist:
+    csrfPreventionEnabled: false
+```


### PR DESCRIPTION
## Description

We add the CSRF Token protections for the version: 8.5.1 and 8.6.0-alpha1. On the docs I am bringing a short explanation how to enabled/disabled this for self-managed. Also considering the cookies authentication on API, API developers should disable CSRF Protection in order to use the operations on API without blockers on POST operations.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [x] This change is not yet live and should not be merged until 07/05/2024 (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
