### PR TITLE
Add 8.5 update guide to intro page

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/introduction.md
+++ b/docs/self-managed/operational-guides/update-guide/introduction.md
@@ -18,37 +18,44 @@ Versions prior to Camunda 8 are listed below and identified as Camunda Cloud ver
 
 There is a dedicated update guide for each version:
 
+### [Camunda 8.4 to Camunda 8.5](../840-to-850)
+
+Update from 8.4.x to 8.5.0
+
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.5.0) |
+[Release blog](https://camunda.com/blog/2024/04/camunda-8-5-release/)
+
 ### [Camunda 8.3 to Camunda 8.4](../830-to-840)
 
 Update from 8.3.x to 8.4.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.4.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.4.0) |
 [Release blog](https://camunda.com/blog/2024/01/camunda-8-4-simplifying-installation-enhancing-user-experience/)
 
 ### [Camunda 8.2 to Camunda 8.3](../820-to-830)
 
 Update from 8.2.x to 8.3.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.3.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.3.0) |
 [Release blog](https://camunda.com/blog/2023/10/camunda-8-3-scaling-automation-maximize-value/)
 
 ### [Camunda 8.1 to Camunda 8.2](../810-to-820)
 
 Update from 8.1.x to 8.2.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0) |
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
 ### [Camunda 8.0 to Camunda 8.1](../800-to-810)
 
 Update from 8.0.x to 8.1.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0) |
 [Release blog](https://camunda.com/blog/2022/10/camunda-platform-8-1-released-whats-new/)
 
 ### [Camunda Cloud 1.3 to Camunda 8.0](../130-to-800)
 
 Update from 1.3.x to 8.0.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.0.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.0.0) |
 [Release blog](https://camunda.com/blog/2022/04/camunda-platform-8-0-released-whats-new/)

--- a/versioned_docs/version-8.5/self-managed/operational-guides/update-guide/introduction.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/update-guide/introduction.md
@@ -18,37 +18,44 @@ Versions prior to Camunda 8 are listed below and identified as Camunda Cloud ver
 
 There is a dedicated update guide for each version:
 
+### [Camunda 8.4 to Camunda 8.5](../840-to-850)
+
+Update from 8.4.x to 8.5.0
+
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.5.0) |
+[Release blog](https://camunda.com/blog/2024/04/camunda-8-5-release/)
+
 ### [Camunda 8.3 to Camunda 8.4](../830-to-840)
 
 Update from 8.3.x to 8.4.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.4.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.4.0) |
 [Release blog](https://camunda.com/blog/2024/01/camunda-8-4-simplifying-installation-enhancing-user-experience/)
 
 ### [Camunda 8.2 to Camunda 8.3](../820-to-830)
 
 Update from 8.2.x to 8.3.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.3.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.3.0) |
 [Release blog](https://camunda.com/blog/2023/10/camunda-8-3-scaling-automation-maximize-value/)
 
 ### [Camunda 8.1 to Camunda 8.2](../810-to-820)
 
 Update from 8.1.x to 8.2.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.2.0) |
 [Release blog](https://camunda.com/blog/2023/04/camunda-platform-8-2-key-to-scaling-automation/)
 
 ### [Camunda 8.0 to Camunda 8.1](../800-to-810)
 
 Update from 8.0.x to 8.1.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.1.0) |
 [Release blog](https://camunda.com/blog/2022/10/camunda-platform-8-1-released-whats-new/)
 
 ### [Camunda Cloud 1.3 to Camunda 8.0](../130-to-800)
 
 Update from 1.3.x to 8.0.0
 
-[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.0.0)
+[Release notes](https://github.com/camunda/camunda-platform/releases/tag/8.0.0) |
 [Release blog](https://camunda.com/blog/2022/04/camunda-platform-8-0-released-whats-new/)


### PR DESCRIPTION
## Description

8.5 update guide link was missing from intro page.

I also added a | between the release notes and release blog, as that spacing has bothered me for years.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
