### PR TITLE
console: why do we have scopes on cluster clients?

### DIFF
--- a/docs/components/console/manage-clusters/manage-api-clients.md
+++ b/docs/components/console/manage-clusters/manage-api-clients.md
@@ -40,6 +40,14 @@ When the rate limit is triggered, the client will receive an HTTP 429 response. 
 
 ## Create a client
 
+Currently, C8 SaaS is supporting the following Scopes:
+
+- Zeebe - Access to the Zeebe gRPC+REST API
+- Tasklist - Access to the Tasklist GraphQL API
+- Operate - Access to the Operate REST API
+- Optimize - Access to the Optimize REST API
+- Secrets - Access cluster secrets in a [hybrid setup](../../../guides/use-connectors-in-hybrid-mode.md)
+
 To create a client, take the following steps:
 
 1. Navigate into the **API** tab.

--- a/docs/guides/setup-client-connection-credentials.md
+++ b/docs/guides/setup-client-connection-credentials.md
@@ -9,6 +9,14 @@ description: "Set up client connection credentials to create, name, and connect 
 
 Here, we'll set up client connection credentials to create, name, and connect your client.
 
+Currently, C8 SaaS is supporting the following Scopes:
+
+- Zeebe - Access to the Zeebe gRPC+REST API
+- Tasklist - Access to the Tasklist GraphQL API
+- Operate - Access to the Operate REST API
+- Optimize - Access to the Optimize REST API
+- Secrets - Access cluster secrets in a [hybrid setup](use-connectors-in-hybrid-mode.md)
+
 To create a new client, take the following steps:
 
 1. Navigate to the API tab [in Camunda Console](https://console.cloud.camunda.io/) by clicking **Clusters > Cluster name > API**.


### PR DESCRIPTION
## Description

related [slack convo](https://camunda.slack.com/archives/CKZK2E7RP/p1713276261176009)

bottom line: the idea is to give at least a hint what those scopes are for. bonus points for references to doc-pages that actually describe what they can be used for (and TBH i have no idea if content like this even exists)



<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
