### PR TITLE
docs(self-managed): tidy up sidebar names and add openshift version

### DIFF
--- a/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -12,9 +12,9 @@ We test against the following OpenShift versions and guarantee compatibility wit
 
 | OpenShift version | Supported          |
 | ----------------- | ------------------ |
-| 4.11.x            | :white_check_mark: |
 | 4.12.x            | :white_check_mark: |
 | 4.13.x            | :white_check_mark: |
+| 4.14.x            | :white_check_mark: |
 
 Any version not explicitly marked in the table above is not tested, and we cannot guarantee compatibility.
 

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -2139,7 +2139,7 @@ module.exports = {
             },
 
             {
-              "Microsoft Azure": [
+              "Microsoft (Azure)": [
                 docsLink(
                   "Microsoft AKS",
                   "self-managed/setup/deploy/azure/microsoft-aks/"
@@ -2148,7 +2148,7 @@ module.exports = {
             },
 
             {
-              "Google Cloud Platform": [
+              "Google (GCP)": [
                 docsLink(
                   "Google GKE",
                   "self-managed/setup/deploy/gcp/google-gke/"
@@ -2157,7 +2157,7 @@ module.exports = {
             },
 
             {
-              OpenShift: [
+              "Red Hat (OpenShift)": [
                 docsLink(
                   "Red Hat OpenShift",
                   "self-managed/setup/deploy/openshift/redhat-openshift/"

--- a/optimize_versioned_sidebars/version-3.13.0-sidebars.json
+++ b/optimize_versioned_sidebars/version-3.13.0-sidebars.json
@@ -2660,7 +2660,7 @@
               ]
             },
             {
-              "Microsoft Azure": [
+              "Microsoft (Azure)": [
                 {
                   "type": "link",
                   "label": "Microsoft AKS",
@@ -2669,7 +2669,7 @@
               ]
             },
             {
-              "Google Cloud Platform": [
+              "Google (GCP)": [
                 {
                   "type": "link",
                   "label": "Google GKE",
@@ -2678,7 +2678,7 @@
               ]
             },
             {
-              "OpenShift": [
+              "Red Hat (OpenShift)": [
                 {
                   "type": "link",
                   "label": "Red Hat OpenShift",

--- a/sidebars.js
+++ b/sidebars.js
@@ -873,13 +873,11 @@ module.exports = {
                 },
                 "self-managed/setup/deploy/amazon/aws-marketplace",
               ],
-              "Microsoft Azure": [
+              "Microsoft (Azure)": [
                 "self-managed/setup/deploy/azure/microsoft-aks",
               ],
-              "Google Cloud Platform": [
-                "self-managed/setup/deploy/gcp/google-gke",
-              ],
-              OpenShift: [
+              "Google (GCP)": ["self-managed/setup/deploy/gcp/google-gke"],
+              "Red Hat (OpenShift)": [
                 "self-managed/setup/deploy/openshift/redhat-openshift",
               ],
               Other: [

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -12,9 +12,9 @@ We test against the following OpenShift versions and guarantee compatibility wit
 
 | OpenShift version | Supported          |
 | ----------------- | ------------------ |
-| 4.11.x            | :white_check_mark: |
 | 4.12.x            | :white_check_mark: |
 | 4.13.x            | :white_check_mark: |
+| 4.14.x            | :white_check_mark: |
 
 Any version not explicitly marked in the table above is not tested, and we cannot guarantee compatibility.
 

--- a/versioned_sidebars/version-8.5-sidebars.json
+++ b/versioned_sidebars/version-8.5-sidebars.json
@@ -1397,13 +1397,11 @@
                 },
                 "self-managed/setup/deploy/amazon/aws-marketplace"
               ],
-              "Microsoft Azure": [
+              "Microsoft (Azure)": [
                 "self-managed/setup/deploy/azure/microsoft-aks"
               ],
-              "Google Cloud Platform": [
-                "self-managed/setup/deploy/gcp/google-gke"
-              ],
-              "OpenShift": [
+              "Google (GCP)": ["self-managed/setup/deploy/gcp/google-gke"],
+              "Red Hat (OpenShift)": [
                 "self-managed/setup/deploy/openshift/redhat-openshift"
               ],
               "Other": [


### PR DESCRIPTION
## Description

Keep the names in the sidebar consistent and add the OpenShift version (already supported for 8.5).

## When should this change go live?

ASAP.

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [x] My changes do not require a technical writer review.
