### PR TITLE
fix(dual-region): Rephrase the release notes on supported components for clarity

### DIFF
--- a/docs/reference/release-notes/850.md
+++ b/docs/reference/release-notes/850.md
@@ -97,7 +97,7 @@ You are now able to consume the secrets from the console in your own custom Conn
 You can now run Zeebe, Operate, and Tasklist across two geographical regions. This allows Camunda 8 to run in a mix of active-active and active-passive setups, resulting in an overall **active-passive** setup. You will find installation and failover guides to help you recover quickly and safely from whole region failures.
 
 :::note
-There is no dedicated guide on setting up Optimize, Identity, and Connectors across regions yet.
+Optimize, Identity, and Connectors are not supported in dual-region setups yet.
 :::
 
 ### REST Postman collection to Connector template converter

--- a/versioned_docs/version-8.5/reference/release-notes/850.md
+++ b/versioned_docs/version-8.5/reference/release-notes/850.md
@@ -97,7 +97,7 @@ You are now able to consume the secrets from the console in your own custom Conn
 You can now run Zeebe, Operate, and Tasklist across two geographical regions. This allows Camunda 8 to run in a mix of active-active and active-passive setups, resulting in an overall **active-passive** setup. You will find installation and failover guides to help you recover quickly and safely from whole region failures.
 
 :::note
-There is no dedicated guide on setting up Optimize, Identity, and Connectors across regions yet.
+Optimize, Identity, and Connectors are not supported in dual-region setups yet.
 :::
 
 ### REST Postman collection to Connector template converter


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Emphasize on Optimize, Identity and Connectors not supported yet.

The former wording in the release notes was not aligned with the [documentation](https://docs.camunda.io/docs/self-managed/concepts/multi-region/dual-region/#limitations), where we clearly state these 3 components are not supported in the dual-region setups.

Context: https://camunda.slack.com/archives/C0486FPV076/p1713534628804619?thread_ts=1713370090.038159&cid=C0486FPV076 (conversation with @ManuelDittmar)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
