### PR TITLE
docs(spring-zeebe-sdk): remove references to old annotation

### DIFF
--- a/docs/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/docs/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -136,7 +136,7 @@ You can also use integrations in certain programming frameworks, like [Spring Ze
 **A subscription for your glue code is opened automatically by the Spring integration:**
 
 ```java
-@ZeebeWorker(type = "serviceA", autoComplete = true)
+@JobWorker(type = "serviceA")
 public void handleJobFoo(final JobClient client, final ActivatedJob job) {
   // here: business logic that is executed with every job
   // you do not need to call "complete" on the job, as autoComplete is turned on above

--- a/docs/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/docs/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -64,7 +64,7 @@ Using the [`FailJob `](/apis-tools/zeebe-api/gateway-service.md#failjob-rpc) API
 This number is typically decremented with every attempt to execute the service task. Note that you need to do that in your worker code. Example in Java:
 
 ```java
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     try {
         // your code

--- a/docs/components/best-practices/development/routing-events-to-processes.md
+++ b/docs/components/best-practices/development/routing-events-to-processes.md
@@ -213,8 +213,8 @@ If messages are exchanged between different processes deployed in the workflow e
 Use some simple code on the sending side to route the message to a new process instance, e.g. by starting a new process instance by the BPMN id in Java:
 
 ```java
-@ZeebeWorker(type="routeInput", autoComplete=true)
-public void routeInput(@ZeebeVariable String invoiceId) {
+@JobWorker(type="routeInput")
+public void routeInput(@Variable String invoiceId) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("invoiceId", execution.getVariable("invoiceId"));
   zeebeClient.newCreateInstanceCommand()
@@ -230,8 +230,8 @@ public void routeInput(@ZeebeVariable String invoiceId) {
 Use some simple code on the sending side to correlate the message to a running process instance, for example in Java:
 
 ```java
-@ZeebeWorker(type="notifyOrder", autoComplete=true)
-public void notifyOrder(@ZeebeVariable String orderId, @ZeebeVariable String paymentInformation) {
+@JobWorker(type="notifyOrder")
+public void notifyOrder(@Variable String orderId, @Variable String paymentInformation) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("paymentInformation", paymentInformation);
 

--- a/docs/components/best-practices/development/testing-process-definitions.md
+++ b/docs/components/best-practices/development/testing-process-definitions.md
@@ -134,8 +134,8 @@ The `PublishTweetWorker` is executed as part of the test. It does input data map
 @Autowired
 private TwitterService twitterService;
 
-@ZeebeWorker( type = "publish-tweet", autoComplete = true)
-public void handleTweet(@ZeebeVariablesAsType TwitterProcessVariables variables) throws Exception {
+@JobWorker( type = "publish-tweet")
+public void handleTweet(@VariableAsType TwitterProcessVariables variables) throws Exception {
     try {
         twitterService.tweet(
           variables.getTweet() // 1

--- a/docs/components/best-practices/development/writing-good-workers.md
+++ b/docs/components/best-practices/development/writing-good-workers.md
@@ -26,7 +26,7 @@ Thinking of Java, the three REST invocations might live in three classes within 
 
 ```java
 public class RetrieveMoneyWorker {
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -35,7 +35,7 @@ public class RetrieveMoneyWorker {
 
 ```java
 public class FetchGoodsWorker {
-  @ZeebeWorker(type = "fetchGoods")
+  @JobWorker(type = "fetchGoods", autoComplete = false)
   public void fetchGoods(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -112,7 +112,7 @@ client.newWorker().jobType("retrieveMoney")
 The [Spring integration](https://github.com/zeebe-io/spring-zeebe/) provides a more elegant way of writing this, but also [uses a normal worker from the Java client](https://github.com/zeebe-io/spring-zeebe/blob/master/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/config/processor/ZeebeWorkerPostProcessor.java#L56) underneath. In this case, your code might look like this:
 
 ```java
-@ZeebeWorker(type = "retrieveMoney")
+@JobWorker(type = "retrieveMoney", autoComplete = false)
 public void retrieveMoney(final JobClient client, final ActivatedJob job) {
   //...
 }
@@ -135,7 +135,7 @@ zeebe.client.worker.threads=5
 Now, you can **leverage blocking code** for your REST call, for example, the `RestTemplate` inside Spring:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void blockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   String response = restTemplate.getForObject( // <-- blocking call
@@ -164,7 +164,7 @@ Doing so **limits** the degree of parallelism to the number of threads you have 
 If you experience a large number of jobs, and these jobs are waiting for IO the whole time — as REST calls do — you should think about using **reactive programming**. For the REST call, this means for example the Spring WebClient:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void nonBlockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   Flux<String> paymentResponseFlux = WebClient.create()

--- a/docs/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/docs/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -95,7 +95,7 @@ The programming models of Camunda 7 and Camunda 8 are very similar if you progra
 For example, a worker in Camunda 8 can be implemented like this (using [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe)):
 
 ```java
-@ZeebeWorker(type = "payment", autoComplete = true)
+@JobWorker(type = "payment")
 public void retrievePayment(ActivatedJob job) {
   // Do whatever you need to, e.g. invoke a remote service:
   String orderId = job.getVariablesMap().get("orderId");

--- a/versioned_docs/version-8.1/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -136,7 +136,7 @@ You can also use integrations in certain programming frameworks, like [Spring Ze
 **A subscription for your glue code is opened automatically by the Spring integration:**
 
 ```java
-@ZeebeWorker(type = "serviceA", autoComplete = true)
+@JobWorker(type = "serviceA")
 public void handleJobFoo(final JobClient client, final ActivatedJob job) {
   // here: business logic that is executed with every job
   // you do not need to call "complete" on the job, as autoComplete is turned on above

--- a/versioned_docs/version-8.1/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -64,7 +64,7 @@ Using the [`FailJob `](/apis-tools/grpc.md#failjob-rpc) API is pretty handy to l
 This number is typically decremented with every attempt to execute the service task. Note that you need to do that in your worker code. Example in Java:
 
 ```java
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     try {
         // your code

--- a/versioned_docs/version-8.1/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/routing-events-to-processes.md
@@ -482,7 +482,7 @@ If messages are exchanged between different processes deployed in the workflow e
 Use some simple code on the sending side to route the message to a new process instance, e.g. by starting a new process instance by the BPMN id in Java:
 
 ```java
-@ZeebeWorker(type="routeInput", autoComplete=true)
+@JobWorker(type="routeInput")
 public void routeInput(@ZeebeVariable String invoiceId) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("invoiceId", execution.getVariable("invoiceId"));
@@ -499,7 +499,7 @@ public void routeInput(@ZeebeVariable String invoiceId) {
 Use some simple code on the sending side to correlate the message to a running process instance, for example in Java:
 
 ```java
-@ZeebeWorker(type="notifyOrder", autoComplete=true)
+@JobWorker(type="notifyOrder")
 public void notifyOrder(@ZeebeVariable String orderId, @ZeebeVariable String paymentInformation) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("paymentInformation", paymentInformation);

--- a/versioned_docs/version-8.1/components/best-practices/development/testing-process-definitions.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/testing-process-definitions.md
@@ -134,8 +134,8 @@ The `PublishTweetWorker` is executed as part of the test. It does input data map
 @Autowired
 private TwitterService twitterService;
 
-@ZeebeWorker( type = "publish-tweet", autoComplete = true)
-public void handleTweet(@ZeebeVariablesAsType TwitterProcessVariables variables) throws Exception {
+@JobWorker( type = "publish-tweet")
+public void handleTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     try {
         twitterService.tweet(
           variables.getTweet() // 1

--- a/versioned_docs/version-8.1/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.1/components/best-practices/development/writing-good-workers.md
@@ -26,7 +26,7 @@ Thinking of Java, the three REST invocations might live in three classes within 
 
 ```java
 public class RetrieveMoneyWorker {
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -35,7 +35,7 @@ public class RetrieveMoneyWorker {
 
 ```java
 public class FetchGoodsWorker {
-  @ZeebeWorker(type = "fetchGoods")
+  @JobWorker(type = "fetchGoods", autoComplete = false)
   public void fetchGoods(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -112,7 +112,7 @@ client.newWorker().jobType("retrieveMoney")
 The [Spring integration](https://github.com/zeebe-io/spring-zeebe/) provides a more elegant way of writing this, but also [uses a normal worker from the Java client](https://github.com/zeebe-io/spring-zeebe/blob/master/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/config/processor/ZeebeWorkerPostProcessor.java#L56) underneath. In this case, your code might look like this:
 
 ```java
-@ZeebeWorker(type = "retrieveMoney")
+@JobWorker(type = "retrieveMoney", autoComplete = false)
 public void retrieveMoney(final JobClient client, final ActivatedJob job) {
   //...
 }
@@ -135,7 +135,7 @@ zeebe.client.worker.threads=5
 Now, you can **leverage blocking code** for your REST call, for example, the `RestTemplate` inside Spring:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void blockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   String response = restTemplate.getForObject( // <-- blocking call
@@ -164,7 +164,7 @@ Doing so **limits** the degree of parallelism to the number of threads you have 
 If you experience a large number of jobs, and these jobs are waiting for IO the whole time — as REST calls do — you should think about using **reactive programming**. For the REST call, this means for example the Spring WebClient:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void nonBlockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   Flux<String> paymentResponseFlux = WebClient.create()

--- a/versioned_docs/version-8.1/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.1/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -81,7 +81,7 @@ The programming models of Camunda 7 and Camunda 8 are very similar if you progra
 For example, a worker in Camunda 8 can be implemented like this (using [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe)):
 
 ```java
-@ZeebeWorker(type = "payment", autoComplete = true)
+@JobWorker(type = "payment")
 public void retrievePayment(ActivatedJob job) {
   // Do whatever you need to, e.g. invoke a remote service:
   String orderId = job.getVariablesMap().get("orderId");

--- a/versioned_docs/version-8.2/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -136,7 +136,7 @@ You can also use integrations in certain programming frameworks, like [Spring Ze
 **A subscription for your glue code is opened automatically by the Spring integration:**
 
 ```java
-@ZeebeWorker(type = "serviceA", autoComplete = true)
+@JobWorker(type = "serviceA")
 public void handleJobFoo(final JobClient client, final ActivatedJob job) {
   // here: business logic that is executed with every job
   // you do not need to call "complete" on the job, as autoComplete is turned on above

--- a/versioned_docs/version-8.2/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -64,7 +64,7 @@ Using the [`FailJob `](../../../apis-tools/grpc.md#failjob-rpc) API is pretty ha
 This number is typically decremented with every attempt to execute the service task. Note that you need to do that in your worker code. Example in Java:
 
 ```java
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     try {
         // your code

--- a/versioned_docs/version-8.2/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/routing-events-to-processes.md
@@ -482,7 +482,7 @@ If messages are exchanged between different processes deployed in the workflow e
 Use some simple code on the sending side to route the message to a new process instance, e.g. by starting a new process instance by the BPMN id in Java:
 
 ```java
-@ZeebeWorker(type="routeInput", autoComplete=true)
+@JobWorker(type="routeInput")
 public void routeInput(@ZeebeVariable String invoiceId) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("invoiceId", execution.getVariable("invoiceId"));
@@ -499,7 +499,7 @@ public void routeInput(@ZeebeVariable String invoiceId) {
 Use some simple code on the sending side to correlate the message to a running process instance, for example in Java:
 
 ```java
-@ZeebeWorker(type="notifyOrder", autoComplete=true)
+@JobWorker(type="notifyOrder")
 public void notifyOrder(@ZeebeVariable String orderId, @ZeebeVariable String paymentInformation) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("paymentInformation", paymentInformation);

--- a/versioned_docs/version-8.2/components/best-practices/development/testing-process-definitions.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/testing-process-definitions.md
@@ -134,8 +134,8 @@ The `PublishTweetWorker` is executed as part of the test. It does input data map
 @Autowired
 private TwitterService twitterService;
 
-@ZeebeWorker( type = "publish-tweet", autoComplete = true)
-public void handleTweet(@ZeebeVariablesAsType TwitterProcessVariables variables) throws Exception {
+@JobWorker( type = "publish-tweet")
+public void handleTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     try {
         twitterService.tweet(
           variables.getTweet() // 1

--- a/versioned_docs/version-8.2/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.2/components/best-practices/development/writing-good-workers.md
@@ -26,7 +26,7 @@ Thinking of Java, the three REST invocations might live in three classes within 
 
 ```java
 public class RetrieveMoneyWorker {
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -35,7 +35,7 @@ public class RetrieveMoneyWorker {
 
 ```java
 public class FetchGoodsWorker {
-  @ZeebeWorker(type = "fetchGoods")
+  @JobWorker(type = "fetchGoods", autoComplete = false)
   public void fetchGoods(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -112,7 +112,7 @@ client.newWorker().jobType("retrieveMoney")
 The [Spring integration](https://github.com/zeebe-io/spring-zeebe/) provides a more elegant way of writing this, but also [uses a normal worker from the Java client](https://github.com/zeebe-io/spring-zeebe/blob/master/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/config/processor/ZeebeWorkerPostProcessor.java#L56) underneath. In this case, your code might look like this:
 
 ```java
-@ZeebeWorker(type = "retrieveMoney")
+@JobWorker(type = "retrieveMoney", autoComplete = false)
 public void retrieveMoney(final JobClient client, final ActivatedJob job) {
   //...
 }
@@ -135,7 +135,7 @@ zeebe.client.worker.threads=5
 Now, you can **leverage blocking code** for your REST call, for example, the `RestTemplate` inside Spring:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void blockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   String response = restTemplate.getForObject( // <-- blocking call
@@ -164,7 +164,7 @@ Doing so **limits** the degree of parallelism to the number of threads you have 
 If you experience a large number of jobs, and these jobs are waiting for IO the whole time — as REST calls do — you should think about using **reactive programming**. For the REST call, this means for example the Spring WebClient:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void nonBlockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   Flux<String> paymentResponseFlux = WebClient.create()

--- a/versioned_docs/version-8.2/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.2/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -81,7 +81,7 @@ The programming models of Camunda 7 and Camunda 8 are very similar if you progra
 For example, a worker in Camunda 8 can be implemented like this (using [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe)):
 
 ```java
-@ZeebeWorker(type = "payment", autoComplete = true)
+@JobWorker(type = "payment")
 public void retrievePayment(ActivatedJob job) {
   // Do whatever you need to, e.g. invoke a remote service:
   String orderId = job.getVariablesMap().get("orderId");

--- a/versioned_docs/version-8.3/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -136,7 +136,7 @@ You can also use integrations in certain programming frameworks, like [Spring Ze
 **A subscription for your glue code is opened automatically by the Spring integration:**
 
 ```java
-@ZeebeWorker(type = "serviceA", autoComplete = true)
+@JobWorker(type = "serviceA")
 public void handleJobFoo(final JobClient client, final ActivatedJob job) {
   // here: business logic that is executed with every job
   // you do not need to call "complete" on the job, as autoComplete is turned on above

--- a/versioned_docs/version-8.3/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -64,7 +64,7 @@ Using the [`FailJob `](../../../apis-tools/grpc.md#failjob-rpc) API is pretty ha
 This number is typically decremented with every attempt to execute the service task. Note that you need to do that in your worker code. Example in Java:
 
 ```java
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     try {
         // your code

--- a/versioned_docs/version-8.3/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/routing-events-to-processes.md
@@ -482,7 +482,7 @@ If messages are exchanged between different processes deployed in the workflow e
 Use some simple code on the sending side to route the message to a new process instance, e.g. by starting a new process instance by the BPMN id in Java:
 
 ```java
-@ZeebeWorker(type="routeInput", autoComplete=true)
+@JobWorker(type="routeInput")
 public void routeInput(@ZeebeVariable String invoiceId) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("invoiceId", execution.getVariable("invoiceId"));
@@ -499,7 +499,7 @@ public void routeInput(@ZeebeVariable String invoiceId) {
 Use some simple code on the sending side to correlate the message to a running process instance, for example in Java:
 
 ```java
-@ZeebeWorker(type="notifyOrder", autoComplete=true)
+@JobWorker(type="notifyOrder")
 public void notifyOrder(@ZeebeVariable String orderId, @ZeebeVariable String paymentInformation) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("paymentInformation", paymentInformation);

--- a/versioned_docs/version-8.3/components/best-practices/development/testing-process-definitions.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/testing-process-definitions.md
@@ -134,8 +134,8 @@ The `PublishTweetWorker` is executed as part of the test. It does input data map
 @Autowired
 private TwitterService twitterService;
 
-@ZeebeWorker( type = "publish-tweet", autoComplete = true)
-public void handleTweet(@ZeebeVariablesAsType TwitterProcessVariables variables) throws Exception {
+@JobWorker( type = "publish-tweet")
+public void handleTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     try {
         twitterService.tweet(
           variables.getTweet() // 1

--- a/versioned_docs/version-8.3/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.3/components/best-practices/development/writing-good-workers.md
@@ -26,7 +26,7 @@ Thinking of Java, the three REST invocations might live in three classes within 
 
 ```java
 public class RetrieveMoneyWorker {
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -35,7 +35,7 @@ public class RetrieveMoneyWorker {
 
 ```java
 public class FetchGoodsWorker {
-  @ZeebeWorker(type = "fetchGoods")
+  @JobWorker(type = "fetchGoods", autoComplete = false)
   public void fetchGoods(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -112,7 +112,7 @@ client.newWorker().jobType("retrieveMoney")
 The [Spring integration](https://github.com/zeebe-io/spring-zeebe/) provides a more elegant way of writing this, but also [uses a normal worker from the Java client](https://github.com/zeebe-io/spring-zeebe/blob/master/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/config/processor/ZeebeWorkerPostProcessor.java#L56) underneath. In this case, your code might look like this:
 
 ```java
-@ZeebeWorker(type = "retrieveMoney")
+@JobWorker(type = "retrieveMoney", autoComplete = false)
 public void retrieveMoney(final JobClient client, final ActivatedJob job) {
   //...
 }
@@ -135,7 +135,7 @@ zeebe.client.worker.threads=5
 Now, you can **leverage blocking code** for your REST call, for example, the `RestTemplate` inside Spring:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void blockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   String response = restTemplate.getForObject( // <-- blocking call
@@ -164,7 +164,7 @@ Doing so **limits** the degree of parallelism to the number of threads you have 
 If you experience a large number of jobs, and these jobs are waiting for IO the whole time — as REST calls do — you should think about using **reactive programming**. For the REST call, this means for example the Spring WebClient:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void nonBlockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   Flux<String> paymentResponseFlux = WebClient.create()

--- a/versioned_docs/version-8.3/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.3/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -95,7 +95,7 @@ The programming models of Camunda 7 and Camunda 8 are very similar if you progra
 For example, a worker in Camunda 8 can be implemented like this (using [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe)):
 
 ```java
-@ZeebeWorker(type = "payment", autoComplete = true)
+@JobWorker(type = "payment")
 public void retrievePayment(ActivatedJob job) {
   // Do whatever you need to, e.g. invoke a remote service:
   String orderId = job.getVariablesMap().get("orderId");

--- a/versioned_docs/version-8.4/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -136,7 +136,7 @@ You can also use integrations in certain programming frameworks, like [Spring Ze
 **A subscription for your glue code is opened automatically by the Spring integration:**
 
 ```java
-@ZeebeWorker(type = "serviceA", autoComplete = true)
+@JobWorker(type = "serviceA")
 public void handleJobFoo(final JobClient client, final ActivatedJob job) {
   // here: business logic that is executed with every job
   // you do not need to call "complete" on the job, as autoComplete is turned on above

--- a/versioned_docs/version-8.4/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -64,7 +64,7 @@ Using the [`FailJob `](/apis-tools/zeebe-api/gateway-service.md#failjob-rpc) API
 This number is typically decremented with every attempt to execute the service task. Note that you need to do that in your worker code. Example in Java:
 
 ```java
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     try {
         // your code

--- a/versioned_docs/version-8.4/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/routing-events-to-processes.md
@@ -484,7 +484,7 @@ If messages are exchanged between different processes deployed in the workflow e
 Use some simple code on the sending side to route the message to a new process instance, e.g. by starting a new process instance by the BPMN id in Java:
 
 ```java
-@ZeebeWorker(type="routeInput", autoComplete=true)
+@JobWorker(type="routeInput")
 public void routeInput(@ZeebeVariable String invoiceId) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("invoiceId", execution.getVariable("invoiceId"));
@@ -501,7 +501,7 @@ public void routeInput(@ZeebeVariable String invoiceId) {
 Use some simple code on the sending side to correlate the message to a running process instance, for example in Java:
 
 ```java
-@ZeebeWorker(type="notifyOrder", autoComplete=true)
+@JobWorker(type="notifyOrder")
 public void notifyOrder(@ZeebeVariable String orderId, @ZeebeVariable String paymentInformation) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("paymentInformation", paymentInformation);

--- a/versioned_docs/version-8.4/components/best-practices/development/testing-process-definitions.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/testing-process-definitions.md
@@ -134,8 +134,8 @@ The `PublishTweetWorker` is executed as part of the test. It does input data map
 @Autowired
 private TwitterService twitterService;
 
-@ZeebeWorker( type = "publish-tweet", autoComplete = true)
-public void handleTweet(@ZeebeVariablesAsType TwitterProcessVariables variables) throws Exception {
+@JobWorker( type = "publish-tweet")
+public void handleTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     try {
         twitterService.tweet(
           variables.getTweet() // 1

--- a/versioned_docs/version-8.4/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.4/components/best-practices/development/writing-good-workers.md
@@ -26,7 +26,7 @@ Thinking of Java, the three REST invocations might live in three classes within 
 
 ```java
 public class RetrieveMoneyWorker {
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -35,7 +35,7 @@ public class RetrieveMoneyWorker {
 
 ```java
 public class FetchGoodsWorker {
-  @ZeebeWorker(type = "fetchGoods")
+  @JobWorker(type = "fetchGoods", autoComplete = false)
   public void fetchGoods(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -112,7 +112,7 @@ client.newWorker().jobType("retrieveMoney")
 The [Spring integration](https://github.com/zeebe-io/spring-zeebe/) provides a more elegant way of writing this, but also [uses a normal worker from the Java client](https://github.com/zeebe-io/spring-zeebe/blob/master/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/config/processor/ZeebeWorkerPostProcessor.java#L56) underneath. In this case, your code might look like this:
 
 ```java
-@ZeebeWorker(type = "retrieveMoney")
+@JobWorker(type = "retrieveMoney", autoComplete = false)
 public void retrieveMoney(final JobClient client, final ActivatedJob job) {
   //...
 }
@@ -135,7 +135,7 @@ zeebe.client.worker.threads=5
 Now, you can **leverage blocking code** for your REST call, for example, the `RestTemplate` inside Spring:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void blockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   String response = restTemplate.getForObject( // <-- blocking call
@@ -164,7 +164,7 @@ Doing so **limits** the degree of parallelism to the number of threads you have 
 If you experience a large number of jobs, and these jobs are waiting for IO the whole time — as REST calls do — you should think about using **reactive programming**. For the REST call, this means for example the Spring WebClient:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void nonBlockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   Flux<String> paymentResponseFlux = WebClient.create()

--- a/versioned_docs/version-8.4/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.4/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -95,7 +95,7 @@ The programming models of Camunda 7 and Camunda 8 are very similar if you progra
 For example, a worker in Camunda 8 can be implemented like this (using [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe)):
 
 ```java
-@ZeebeWorker(type = "payment", autoComplete = true)
+@JobWorker(type = "payment")
 public void retrievePayment(ActivatedJob job) {
   // Do whatever you need to, e.g. invoke a remote service:
   String orderId = job.getVariablesMap().get("orderId");

--- a/versioned_docs/version-8.5/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/versioned_docs/version-8.5/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -136,7 +136,7 @@ You can also use integrations in certain programming frameworks, like [Spring Ze
 **A subscription for your glue code is opened automatically by the Spring integration:**
 
 ```java
-@ZeebeWorker(type = "serviceA", autoComplete = true)
+@JobWorker(type = "serviceA")
 public void handleJobFoo(final JobClient client, final ActivatedJob job) {
   // here: business logic that is executed with every job
   // you do not need to call "complete" on the job, as autoComplete is turned on above

--- a/versioned_docs/version-8.5/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.5/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -64,7 +64,7 @@ Using the [`FailJob `](/apis-tools/zeebe-api/gateway-service.md#failjob-rpc) API
 This number is typically decremented with every attempt to execute the service task. Note that you need to do that in your worker code. Example in Java:
 
 ```java
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     try {
         // your code

--- a/versioned_docs/version-8.5/components/best-practices/development/routing-events-to-processes.md
+++ b/versioned_docs/version-8.5/components/best-practices/development/routing-events-to-processes.md
@@ -213,7 +213,7 @@ If messages are exchanged between different processes deployed in the workflow e
 Use some simple code on the sending side to route the message to a new process instance, e.g. by starting a new process instance by the BPMN id in Java:
 
 ```java
-@ZeebeWorker(type="routeInput", autoComplete=true)
+@JobWorker(type="routeInput")
 public void routeInput(@ZeebeVariable String invoiceId) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("invoiceId", execution.getVariable("invoiceId"));
@@ -230,7 +230,7 @@ public void routeInput(@ZeebeVariable String invoiceId) {
 Use some simple code on the sending side to correlate the message to a running process instance, for example in Java:
 
 ```java
-@ZeebeWorker(type="notifyOrder", autoComplete=true)
+@JobWorker(type="notifyOrder")
 public void notifyOrder(@ZeebeVariable String orderId, @ZeebeVariable String paymentInformation) {
   Map<String, Object> variables = new HashMap<String, Object>();
   variables.put("paymentInformation", paymentInformation);

--- a/versioned_docs/version-8.5/components/best-practices/development/testing-process-definitions.md
+++ b/versioned_docs/version-8.5/components/best-practices/development/testing-process-definitions.md
@@ -134,8 +134,8 @@ The `PublishTweetWorker` is executed as part of the test. It does input data map
 @Autowired
 private TwitterService twitterService;
 
-@ZeebeWorker( type = "publish-tweet", autoComplete = true)
-public void handleTweet(@ZeebeVariablesAsType TwitterProcessVariables variables) throws Exception {
+@JobWorker( type = "publish-tweet")
+public void handleTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     try {
         twitterService.tweet(
           variables.getTweet() // 1

--- a/versioned_docs/version-8.5/components/best-practices/development/writing-good-workers.md
+++ b/versioned_docs/version-8.5/components/best-practices/development/writing-good-workers.md
@@ -26,7 +26,7 @@ Thinking of Java, the three REST invocations might live in three classes within 
 
 ```java
 public class RetrieveMoneyWorker {
-  @ZeebeWorker(type = "retrieveMoney")
+  @JobWorker(type = "retrieveMoney", autoComplete = false)
   public void retrieveMoney(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -35,7 +35,7 @@ public class RetrieveMoneyWorker {
 
 ```java
 public class FetchGoodsWorker {
-  @ZeebeWorker(type = "fetchGoods")
+  @JobWorker(type = "fetchGoods", autoComplete = false)
   public void fetchGoods(final JobClient client, final ActivatedJob job) {
     // ... code
   }
@@ -112,7 +112,7 @@ client.newWorker().jobType("retrieveMoney")
 The [Spring integration](https://github.com/zeebe-io/spring-zeebe/) provides a more elegant way of writing this, but also [uses a normal worker from the Java client](https://github.com/zeebe-io/spring-zeebe/blob/master/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/config/processor/ZeebeWorkerPostProcessor.java#L56) underneath. In this case, your code might look like this:
 
 ```java
-@ZeebeWorker(type = "retrieveMoney")
+@JobWorker(type = "retrieveMoney", autoComplete = false)
 public void retrieveMoney(final JobClient client, final ActivatedJob job) {
   //...
 }
@@ -135,7 +135,7 @@ zeebe.client.worker.threads=5
 Now, you can **leverage blocking code** for your REST call, for example, the `RestTemplate` inside Spring:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void blockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   String response = restTemplate.getForObject( // <-- blocking call
@@ -164,7 +164,7 @@ Doing so **limits** the degree of parallelism to the number of threads you have 
 If you experience a large number of jobs, and these jobs are waiting for IO the whole time — as REST calls do — you should think about using **reactive programming**. For the REST call, this means for example the Spring WebClient:
 
 ```java
-@ZeebeWorker(type = "rest")
+@JobWorker(type = "rest", autoComplete = false)
 public void nonBlockingRestCall(final JobClient client, final ActivatedJob job) {
   LOGGER.info("Invoke REST call...");
   Flux<String> paymentResponseFlux = WebClient.create()

--- a/versioned_docs/version-8.5/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.5/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -95,7 +95,7 @@ The programming models of Camunda 7 and Camunda 8 are very similar if you progra
 For example, a worker in Camunda 8 can be implemented like this (using [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe)):
 
 ```java
-@ZeebeWorker(type = "payment", autoComplete = true)
+@JobWorker(type = "payment")
 public void retrievePayment(ActivatedJob job) {
   // Do whatever you need to, e.g. invoke a remote service:
   String orderId = job.getVariablesMap().get("orderId");


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Removed references to old @ZeebeWorker annotation, deprecated since 8.1.
Replaced with @JobWorker annotation

closes: #3699 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
