### PR TITLE
chore(optimize): add 3.13 migration notes to sidebars

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1230,6 +1230,10 @@ module.exports = {
                   "self-managed/optimize-deployment/migration-update/instructions/"
                 ),
                 optimizeLink(
+                  "Update notes (8.4/3.12 to 8.5/3.13)",
+                  "self-managed/optimize-deployment/migration-update/3.12_8.4-to-3.13_8.5/"
+                ),
+                optimizeLink(
                   "Update notes (8.3/3.11 to 8.4/3.12)",
                   "self-managed/optimize-deployment/migration-update/3.11_8.3-to-3.12_8.4/"
                 ),

--- a/versioned_sidebars/version-8.5-sidebars.json
+++ b/versioned_sidebars/version-8.5-sidebars.json
@@ -1779,6 +1779,11 @@
                 },
                 {
                   "type": "link",
+                  "label": "Update notes (8.4/3.12 to 8.5/3.13)",
+                  "href": "/optimize/self-managed/optimize-deployment/migration-update/3.12_8.4-to-3.13_8.5/"
+                },
+                {
+                  "type": "link",
                   "label": "Update notes (8.3/3.11 to 8.4/3.12)",
                   "href": "/optimize/self-managed/optimize-deployment/migration-update/3.11_8.3-to-3.12_8.4/"
                 },


### PR DESCRIPTION
## Description

Noticed that the 3.13. migration notes for Optimize were not added to the sidebars

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
