### PR TITLE
docs(identity): fix identity docs

### DIFF
--- a/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -156,9 +156,9 @@ global:
       type: "MICROSOFT"
       publicIssuerUrl: https://login.microsoftonline.com/<Tenant ID>/v2.0
       identity:
-        clientId: <Client ID from Step 2>
-        existingSecret: <Client secret from Step 2>
-        audience: <Audience from Step 2>
+        clientId: <Client ID from Step 1>
+        existingSecret: <Client secret from Step 3>
+        audience: <Audience from Step 1>
         initialClaimName: <Initial claim name if not using the default "oid">
         initialClaimValue: <Initial claim value>
         redirectUrl: <See table below>

--- a/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -148,13 +148,13 @@ For authentication, the Camunda components use the scopes `email`, `openid`, `of
 global:
   identity:
     auth:
-      issuer: https://login.microsoftonline.com/<Client ID from Step 1>/v2.0
+      issuer: https://login.microsoftonline.com/<Tenant ID>/v2.0
       # this is used for container to container communication
       issuerBackendUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/v2.0
       tokenUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/oauth2/v2.0/token
       jwksUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/discovery/v2.0/keys
       type: "MICROSOFT"
-      publicIssuerUrl: https://login.microsoftonline.com/<Client ID from Step 1>/v2.0
+      publicIssuerUrl: https://login.microsoftonline.com/<Tenant ID>/v2.0
       identity:
         clientId: <Client ID from Step 2>
         existingSecret: <Client secret from Step 2>

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -175,7 +175,7 @@ global:
         publicApiAudience: <Audience for using Web Modeler's API. For security reasons, use a different value than for clientApiAudience>
         redirectUrl: <See table below>
       connectors:
-        clientId: <Client ID from Step 2>
+        clientId: <Client ID from Step 1>
         existingSecret: <Client secret from Step 3>
 ```
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -142,13 +142,13 @@ For authentication, the Camunda components use the scopes `email`, `openid`, `of
 global:
   identity:
     auth:
-      issuer: https://login.microsoftonline.com/<Client ID from Step 1>/v2.0
+      issuer: https://login.microsoftonline.com/<Tenant ID>/v2.0
       # this is used for container to container communication
       issuerBackendUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/v2.0
       tokenUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/oauth2/v2.0/token
       jwksUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/discovery/v2.0/keys
       type: "MICROSOFT"
-      publicIssuerUrl: https://login.microsoftonline.com/<Client ID from Step 1>/v2.0
+      publicIssuerUrl: https://login.microsoftonline.com/<Tenant ID>/v2.0
       operate:
         clientId: <Client ID from Step 1>
         audience: <Client ID from Step 1>

--- a/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -156,9 +156,9 @@ global:
       type: "MICROSOFT"
       publicIssuerUrl: https://login.microsoftonline.com/<Tenant ID>/v2.0
       identity:
-        clientId: <Client ID from Step 2>
-        existingSecret: <Client secret from Step 2>
-        audience: <Audience from Step 2>
+        clientId: <Client ID from Step 1>
+        existingSecret: <Client secret from Step 3>
+        audience: <Audience from Step 1>
         initialClaimName: <Initial claim name if not using the default "oid">
         initialClaimValue: <Initial claim value>
         redirectUrl: <See table below>

--- a/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -148,13 +148,13 @@ For authentication, the Camunda components use the scopes `email`, `openid`, `of
 global:
   identity:
     auth:
-      issuer: https://login.microsoftonline.com/<Client ID from Step 1>/v2.0
+      issuer: https://login.microsoftonline.com/<Tenant ID>/v2.0
       # this is used for container to container communication
       issuerBackendUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/v2.0
       tokenUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/oauth2/v2.0/token
       jwksUrl: https://login.microsoftonline.com/<Microsoft Entra tenant id>/discovery/v2.0/keys
       type: "MICROSOFT"
-      publicIssuerUrl: https://login.microsoftonline.com/<Client ID from Step 1>/v2.0
+      publicIssuerUrl: https://login.microsoftonline.com/<Tenant ID>/v2.0
       identity:
         clientId: <Client ID from Step 2>
         existingSecret: <Client secret from Step 2>


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/camunda-docs/issues/3676

A couple of inconsistencies were spotted in the OIDC documentation, this PR addresses those, namely:
1. Using the correct step reference numbers for Identity
2. Change the `client id` in the issuer based URLs to correctly reflect that its the tenant ID

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
