### PR TITLE
Add context path info to component REST APIs

### DIFF
--- a/docs/apis-tools/operate-api/overview.md
+++ b/docs/apis-tools/operate-api/overview.md
@@ -14,6 +14,16 @@ In case of errors, Operate API returns an error object.
 Work with this API in our [Postman collection](https://www.postman.com/camundateam/workspace/camunda-8-postman/collection/20317927-9d9314a2-4cff-40ab-90ea-98e28ca1f81c?action=share&creator=11465105), and check it out in [GitHub](https://github.com/camunda-community-hub/camunda-8-api-postman-collection).
 :::
 
+## Context paths
+
+For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
+:::
+
 ## API Explorer
 
 See [the interactive Operate API Explorer][operate-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Operate API.

--- a/docs/apis-tools/operate-api/overview.md
+++ b/docs/apis-tools/operate-api/overview.md
@@ -19,7 +19,7 @@ Work with this API in our [Postman collection](https://www.postman.com/camundate
 For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
 :::
@@ -35,7 +35,7 @@ A Swagger UI is also available within a running instance of Operate, at `https:/
 For SaaS: `https://${REGION}.operate.camunda.io/${CLUSTER_ID}/swagger-ui.html`, and for Self-Managed installations: `http://localhost:8080/swagger-ui.html`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Multi-tenancy

--- a/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -13,6 +13,16 @@ The Tasklist API is a REST API designed to build task applications for human-cen
 Ensure you [authenticate](./tasklist-api-rest-authentication.md) before accessing the Tasklist API.
 :::
 
+## Context paths
+
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
+:::
+
 ## API Explorer
 
 See [the interactive Tasklist REST API Explorer][tasklist-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Tasklist REST API.

--- a/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -18,7 +18,7 @@ Ensure you [authenticate](./tasklist-api-rest-authentication.md) before accessin
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
 :::
@@ -34,7 +34,7 @@ A detailed API description is also available as a Swagger UI at `https://${base-
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`, and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## API in Postman

--- a/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -17,7 +17,7 @@ Ensure you [authenticate](./zeebe-api-rest-authentication.md) before accessing t
 For SaaS: `https://${REGION}.zeebe.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Zeebe component.
 :::

--- a/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -11,3 +11,19 @@ The Zeebe REST API is a REST API designed to interact with the Zeebe process aut
 :::note
 Ensure you [authenticate](./zeebe-api-rest-authentication.md) before accessing the Zeebe REST API.
 :::
+
+## Context paths
+
+For SaaS: `https://${REGION}.zeebe.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Zeebe component.
+:::
+
+## API Explorer
+
+See [the interactive Zeebe REST API Explorer][zeebe-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Tasklist REST API.
+
+[zeebe-api-explorer]: ./specifications/zeebe-rest-api.info.mdx

--- a/versioned_docs/version-8.2/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.2/apis-tools/operate-api/overview.md
@@ -12,6 +12,16 @@ Requests and responses are in JSON notation. Some objects have additional endpoi
 For example, `process-definitions` has an endpoint to get the process-definition as XML representation.
 In case of errors, Operate API returns an error object.
 
+## Context paths
+
+For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
+:::
+
 ## API documentation as Swagger
 
 A detailed API description is also available as Swagger UI at `${base-url}/swagger-ui.html`.

--- a/versioned_docs/version-8.2/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.2/apis-tools/operate-api/overview.md
@@ -17,7 +17,7 @@ In case of errors, Operate API returns an error object.
 For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
 :::
@@ -29,7 +29,7 @@ A detailed API description is also available as Swagger UI at `${base-url}/swagg
 For SaaS: `https://${REGION}.operate.camunda.io/${CLUSTER_ID}/swagger-ui.html`, and for Self-Managed installations: `http://localhost:8080/swagger-ui.html`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Authentication

--- a/versioned_docs/version-8.2/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.2/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -15,7 +15,7 @@ Requests and responses are in JSON notation. Some objects have additional endpoi
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
 :::
@@ -27,7 +27,7 @@ A detailed API description is also available as Swagger UI at `https://${base-ur
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`, and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Endpoints

--- a/versioned_docs/version-8.2/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.2/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -10,6 +10,16 @@ description: "Tasklist API is a REST API and provides searching, getting, and ch
 Tasklist API is a REST API and provides searching, getting, and changing Tasklist data.
 Requests and responses are in JSON notation. Some objects have additional endpoints.
 
+## Context paths
+
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
+:::
+
 ## API documentation as Swagger
 
 A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`.

--- a/versioned_docs/version-8.3/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.3/apis-tools/operate-api/overview.md
@@ -12,6 +12,16 @@ Requests and responses are in JSON notation. Some objects have additional endpoi
 For example, `process-definitions` has an endpoint to get the process-definition as XML representation.
 In case of errors, Operate API returns an error object.
 
+## Context paths
+
+For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
+:::
+
 ## API documentation as Swagger
 
 A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`.

--- a/versioned_docs/version-8.3/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.3/apis-tools/operate-api/overview.md
@@ -17,7 +17,7 @@ In case of errors, Operate API returns an error object.
 For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
 :::
@@ -29,7 +29,7 @@ A detailed API description is also available as Swagger UI at `https://${base-ur
 For SaaS: `https://${REGION}.operate.camunda.io/${CLUSTER_ID}/swagger-ui.html`, and for Self-Managed installations: `http://localhost:8080/swagger-ui.html`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Authentication

--- a/versioned_docs/version-8.3/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.3/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -15,7 +15,7 @@ Requests and responses are in JSON notation. Some objects have additional endpoi
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
 :::
@@ -27,7 +27,7 @@ A detailed API description is also available as Swagger UI at `https://${base-ur
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`, and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Endpoints

--- a/versioned_docs/version-8.3/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.3/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -10,6 +10,16 @@ description: "Tasklist API is a REST API and provides searching, getting, and ch
 Tasklist API is a REST API and provides searching, getting, and changing Tasklist data.
 Requests and responses are in JSON notation. Some objects have additional endpoints.
 
+## Context paths
+
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
+:::
+
 ## API documentation as Swagger
 
 A detailed API description is also available as Swagger UI at `https://${base-url}/swagger-ui/index.html`.

--- a/versioned_docs/version-8.4/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.4/apis-tools/operate-api/overview.md
@@ -14,6 +14,16 @@ In case of errors, Operate API returns an error object.
 Work with this API in our [Postman collection](https://www.postman.com/camundateam/workspace/camunda-8-postman/collection/20317927-9d9314a2-4cff-40ab-90ea-98e28ca1f81c?action=share&creator=11465105), and check it out in [GitHub](https://github.com/camunda-community-hub/camunda-8-api-postman-collection).
 :::
 
+## Context paths
+
+For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
+:::
+
 ## API explorer
 
 See [the interactive Operate API Explorer][operate-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Operate API.

--- a/versioned_docs/version-8.4/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.4/apis-tools/operate-api/overview.md
@@ -19,7 +19,7 @@ Work with this API in our [Postman collection](https://www.postman.com/camundate
 For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
 :::
@@ -35,7 +35,7 @@ A Swagger UI is also available within a running instance of Operate, at `https:/
 For SaaS: `https://${REGION}.operate.camunda.io/${CLUSTER_ID}/swagger-ui.html`, and for Self-Managed installations: `http://localhost:8080/swagger-ui.html`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Multi-tenancy

--- a/versioned_docs/version-8.4/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.4/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -13,6 +13,16 @@ The Tasklist API is a REST API designed to build task applications for human-cen
 Ensure you [authenticate](./tasklist-api-rest-authentication.md) before accessing the Tasklist API.
 :::
 
+## Context paths
+
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
+:::
+
 ## API Explorer
 
 See [the interactive Tasklist REST API Explorer][tasklist-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Tasklist REST API.

--- a/versioned_docs/version-8.4/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.4/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -18,7 +18,7 @@ Ensure you [authenticate](./tasklist-api-rest-authentication.md) before accessin
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
 :::
@@ -34,7 +34,7 @@ A detailed API description is also available as a Swagger UI at `https://${base-
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`, and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## API in Postman

--- a/versioned_docs/version-8.5/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.5/apis-tools/operate-api/overview.md
@@ -14,6 +14,16 @@ In case of errors, Operate API returns an error object.
 Work with this API in our [Postman collection](https://www.postman.com/camundateam/workspace/camunda-8-postman/collection/20317927-9d9314a2-4cff-40ab-90ea-98e28ca1f81c?action=share&creator=11465105), and check it out in [GitHub](https://github.com/camunda-community-hub/camunda-8-api-postman-collection).
 :::
 
+## Context paths
+
+For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
+:::
+
 ## API Explorer
 
 See [the interactive Operate API Explorer][operate-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Operate API.

--- a/versioned_docs/version-8.5/apis-tools/operate-api/overview.md
+++ b/versioned_docs/version-8.5/apis-tools/operate-api/overview.md
@@ -19,7 +19,7 @@ Work with this API in our [Postman collection](https://www.postman.com/camundate
 For SaaS: `https://${REGION}.operate.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Operate component.
 :::
@@ -35,7 +35,7 @@ A Swagger UI is also available within a running instance of Operate, at `https:/
 For SaaS: `https://${REGION}.operate.camunda.io/${CLUSTER_ID}/swagger-ui.html`, and for Self-Managed installations: `http://localhost:8080/swagger-ui.html`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## Multi-tenancy

--- a/versioned_docs/version-8.5/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.5/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -13,6 +13,16 @@ The Tasklist API is a REST API designed to build task applications for human-cen
 Ensure you [authenticate](./tasklist-api-rest-authentication.md) before accessing the Tasklist API.
 :::
 
+## Context paths
+
+For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
+:::
+
 ## API Explorer
 
 See [the interactive Tasklist REST API Explorer][tasklist-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Tasklist REST API.

--- a/versioned_docs/version-8.5/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
+++ b/versioned_docs/version-8.5/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md
@@ -18,7 +18,7 @@ Ensure you [authenticate](./tasklist-api-rest-authentication.md) before accessin
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Tasklist component.
 :::
@@ -34,7 +34,7 @@ A detailed API description is also available as a Swagger UI at `https://${base-
 For SaaS: `https://${REGION}.tasklist.camunda.io:443/${CLUSTER_ID}/swagger-ui/index.html`, and for Self-Managed installations: [`http://localhost:8080/swagger-ui/index.html`](http://localhost:8080/swagger-ui/index.html).
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 :::
 
 ## API in Postman

--- a/versioned_docs/version-8.5/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/versioned_docs/version-8.5/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -17,7 +17,7 @@ Ensure you [authenticate](./zeebe-api-rest-authentication.md) before accessing t
 For SaaS: `https://${REGION}.zeebe.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
 
 :::note
-Find your region and cluster id under connection information in your client credentials.
+Find your region and cluster id under **Connection information** in your client credentials (revealed when you click on your client under the **API** tab within your cluster).
 
 For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Zeebe component.
 :::

--- a/versioned_docs/version-8.5/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/versioned_docs/version-8.5/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -11,3 +11,19 @@ The Zeebe REST API is a REST API designed to interact with the Zeebe process aut
 :::note
 Ensure you [authenticate](./zeebe-api-rest-authentication.md) before accessing the Zeebe REST API.
 :::
+
+## Context paths
+
+For SaaS: `https://${REGION}.zeebe.camunda.io:443/${CLUSTER_ID}/v1/`, and for Self-Managed installations: `http://localhost:8080/v1/`.
+
+:::note
+Find your region and cluster id under connection information in your client credentials.
+
+For Self-Managed, the host and port depend on your configuration. The context path mentioned here is the default for the Zeebe component.
+:::
+
+## API Explorer
+
+See [the interactive Zeebe REST API Explorer][zeebe-api-explorer] for specifications, example requests and responses, and code samples of interacting with the Tasklist REST API.
+
+[zeebe-api-explorer]: ./specifications/zeebe-rest-api.info.mdx


### PR DESCRIPTION
## Description

Adds details on where to find the Zeebe, Tasklist, and Operate REST API endpoints.
Backported until version 8.2 where applicable.

closes #3698 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [x] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
