### PR TITLE
connectors-rm-redundant-var

### DIFF
--- a/docs/self-managed/connectors-deployment/connectors-configuration.md
+++ b/docs/self-managed/connectors-deployment/connectors-configuration.md
@@ -86,7 +86,6 @@ However, if you still wish to do so, you need to start your Connector runtime wi
 ```bash
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
-SPRING_MAIN_WEB-APPLICATION-TYPE=none
 OPERATE_CLIENT_ENABLED=false
 ```
 

--- a/docs/self-managed/setup/deploy/other/docker.md
+++ b/docs/self-managed/setup/deploy/other/docker.md
@@ -189,7 +189,6 @@ docker run --rm --name=MyConnectorsInstance \
   -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
   -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
   -e OPERATE_CLIENT_ENABLED=false \
-  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
     camunda/connectors-bundle:latest
 ```
 

--- a/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.1/self-managed/connectors-deployment/connectors-configuration.md
@@ -67,7 +67,6 @@ However, if you still wish to do so, you need to start your Connector runtime wi
 ```bash
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
-SPRING_MAIN_WEB-APPLICATION-TYPE=none
 OPERATE_CLIENT_ENABLED=false
 ```
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/docker.md
@@ -195,7 +195,6 @@ docker run --rm --name=MyConnectorsInstance \
   -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
   -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
   -e OPERATE_CLIENT_ENABLED=false \
-  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
     camunda/connectors-bundle:latest
 ```
 

--- a/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.2/self-managed/connectors-deployment/connectors-configuration.md
@@ -67,7 +67,6 @@ However, if you still wish to do so, you need to start your Connector runtime wi
 ```bash
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
-SPRING_MAIN_WEB-APPLICATION-TYPE=none
 OPERATE_CLIENT_ENABLED=false
 ```
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/docker.md
@@ -204,7 +204,6 @@ docker run --rm --name=MyConnectorsInstance \
   -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
   -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
   -e OPERATE_CLIENT_ENABLED=false \
-  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
     camunda/connectors-bundle:latest
 ```
 

--- a/versioned_docs/version-8.3/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.3/self-managed/connectors-deployment/connectors-configuration.md
@@ -67,7 +67,6 @@ However, if you still wish to do so, you need to start your Connector runtime wi
 ```bash
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
-SPRING_MAIN_WEB-APPLICATION-TYPE=none
 OPERATE_CLIENT_ENABLED=false
 ```
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/docker.md
@@ -204,7 +204,6 @@ docker run --rm --name=MyConnectorsInstance \
   -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
   -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
   -e OPERATE_CLIENT_ENABLED=false \
-  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
     camunda/connectors-bundle:latest
 ```
 

--- a/versioned_docs/version-8.4/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/connectors-deployment/connectors-configuration.md
@@ -86,7 +86,6 @@ However, if you still wish to do so, you need to start your Connector runtime wi
 ```bash
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
-SPRING_MAIN_WEB-APPLICATION-TYPE=none
 OPERATE_CLIENT_ENABLED=false
 ```
 

--- a/versioned_docs/version-8.5/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.5/self-managed/connectors-deployment/connectors-configuration.md
@@ -86,7 +86,6 @@ However, if you still wish to do so, you need to start your Connector runtime wi
 ```bash
 CAMUNDA_CONNECTOR_POLLING_ENABLED=false
 CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false
-SPRING_MAIN_WEB-APPLICATION-TYPE=none
 OPERATE_CLIENT_ENABLED=false
 ```
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/other/docker.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/other/docker.md
@@ -189,7 +189,6 @@ docker run --rm --name=MyConnectorsInstance \
   -e CAMUNDA_CONNECTOR_POLLING_ENABLED=false \
   -e CAMUNDA_CONNECTOR_WEBHOOK_ENABLED=false \
   -e OPERATE_CLIENT_ENABLED=false \
-  -e SPRING_MAIN_WEB-APPLICATION-TYPE=none \
     camunda/connectors-bundle:latest
 ```
 


### PR DESCRIPTION
## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

Removes the redundant variable `SPRING_MAIN_WEB-APPLICATION_TYPE` from examples. It's insignificant and its declaration conflits with default health indicators of the connector runtime in the newer connectors versions.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
