### PR TITLE
sync sidebars for next

### DIFF
--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -1578,6 +1578,7 @@ module.exports = {
                 "apis-tools/optimize-api/configuration/disable-sharing",
               ],
             },
+
             {
               Dashboard: [
                 "apis-tools/optimize-api/dashboard/get-dashboard-ids",
@@ -1585,6 +1586,7 @@ module.exports = {
                 "apis-tools/optimize-api/dashboard/export-dashboard-definitions",
               ],
             },
+
             {
               Report: [
                 "apis-tools/optimize-api/report/get-report-ids",
@@ -1675,6 +1677,10 @@ module.exports = {
             docsLink(
               "Migrate to Zeebe user tasks",
               "apis-tools/tasklist-api-rest/migrate-to-zeebe-user-tasks/"
+            ),
+            docsLink(
+              "Tutorial",
+              "apis-tools/tasklist-api-rest/tasklist-api-rest-tutorial/"
             ),
           ],
         },
@@ -2017,6 +2023,7 @@ module.exports = {
     {
       SDKs: [
         docsLink("Node.js", "apis-tools/node-js-sdk/"),
+
         {
           "Spring Zeebe": [
             docsLink(
@@ -2043,6 +2050,10 @@ module.exports = {
             docsLink(
               "User task life cycle",
               "apis-tools/frontend-development/task-applications/user-task-lifecycle/"
+            ),
+            docsLink(
+              "Task application architecture",
+              "apis-tools/frontend-development/task-applications/task-application-architecture/"
             ),
           ],
         },

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -2137,6 +2137,10 @@ module.exports = {
                       "self-managed/setup/deploy/amazon/amazon-eks/eks-helm/"
                     ),
                     docsLink(
+                      "Dual-region setup",
+                      "self-managed/setup/deploy/amazon/amazon-eks/dual-region/"
+                    ),
+                    docsLink(
                       "IAM roles for service accounts",
                       "self-managed/setup/deploy/amazon/amazon-eks/irsa/"
                     ),
@@ -2225,7 +2229,7 @@ module.exports = {
               "self-managed/setup/guides/multi-namespace-deployment/"
             ),
             docsLink(
-              "Verifying Camunda 8 Installation",
+              "Verifying Camunda 8 installation with a demo app",
               "self-managed/setup/guides/installing-payment-app-example/"
             ),
           ],
@@ -2237,6 +2241,10 @@ module.exports = {
       "Operational guides": [
         {
           "Update guide": [
+            docsLink(
+              "Update 8.5 to 8.6",
+              "self-managed/operational-guides/update-guide/850-to-860/"
+            ),
             docsLink(
               "Update 8.4 to 8.5",
               "self-managed/operational-guides/update-guide/840-to-850/"
@@ -2323,15 +2331,6 @@ module.exports = {
         },
 
         {
-          "Multi-region": [
-            docsLink(
-              "Dual-region operational procedure",
-              "self-managed/operational-guides/multi-region/dual-region-operational-procedure/"
-            ),
-          ],
-        },
-
-        {
           Troubleshooting: [
             docsLink(
               "Troubleshooting",
@@ -2381,6 +2380,10 @@ module.exports = {
         docsLink(
           "Elasticsearch privileges",
           "self-managed/concepts/elasticsearch-privileges/"
+        ),
+        docsLink(
+          "OpenSearch privileges",
+          "self-managed/concepts/opensearch-privileges/"
         ),
       ],
     },
@@ -2661,6 +2664,7 @@ module.exports = {
                 "self-managed/optimize-deployment/configuration/common-problems",
               ],
             },
+
             {
               Plugins: [
                 "self-managed/optimize-deployment/plugins/plugin-system",
@@ -2698,6 +2702,7 @@ module.exports = {
                 "self-managed/optimize-deployment/migration-update/2.1-to-2.2",
               ],
             },
+
             {
               "Advanced features": [
                 "self-managed/optimize-deployment/advanced-features/engine-data-deletion",

--- a/optimize_sidebars.js
+++ b/optimize_sidebars.js
@@ -290,6 +290,10 @@ module.exports = {
                   "Publish processes via a form",
                   "components/modeler/web-modeler/advanced-modeling/publish-public-processes/"
                 ),
+                docsLink(
+                  "Refactoring suggestions",
+                  "components/modeler/web-modeler/advanced-modeling/refactoring-suggestions/"
+                ),
               ],
             },
 
@@ -463,6 +467,10 @@ module.exports = {
                   "components/modeler/bpmn/terminate-events/"
                 ),
                 docsLink("Link events", "components/modeler/bpmn/link-events/"),
+                docsLink(
+                  "Compensation events",
+                  "components/modeler/bpmn/compensation-events/"
+                ),
               ],
             },
 
@@ -490,6 +498,10 @@ module.exports = {
                 docsLink(
                   "Multi-instance",
                   "components/modeler/bpmn/multi-instance/"
+                ),
+                docsLink(
+                  "Compensation",
+                  "components/modeler/bpmn/compensation-handler/"
                 ),
               ],
             },

--- a/sidebars.js
+++ b/sidebars.js
@@ -446,6 +446,7 @@ module.exports = {
               "components/userguide/combined-process-reports/"
             ),
             optimizeLink("Process KPIs", "components/userguide/process-KPIs/"),
+
             {
               "Process analysis": [
                 optimizeLink(

--- a/sidebars.js
+++ b/sidebars.js
@@ -1133,7 +1133,7 @@ module.exports = {
                   "self-managed/optimize-deployment/configuration/security-instructions/"
                 ),
                 optimizeLink(
-                  "Shared Elasticsearch cluster",
+                  "Shared Elasticsearch/OpenSearch cluster",
                   "self-managed/optimize-deployment/configuration/shared-elasticsearch-cluster/"
                 ),
                 optimizeLink(


### PR DESCRIPTION
## Description

Syncing sidebars for `next`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [x] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
