### PR TITLE
Document soft pause exporter.

### DIFF
--- a/docs/self-managed/zeebe-deployment/operations/management-api.md
+++ b/docs/self-managed/zeebe-deployment/operations/management-api.md
@@ -23,7 +23,7 @@ Exporting API is used:
 - As a debugging tool.
 - When taking a backup of Camunda 8 (see [backup and restore](/self-managed/operational-guides/backup-restore/backup-and-restore.md)).
 
-<Tabs groupId="exporting" defaultValue="pause" queryString values={[{label: 'Pause exporting', value: 'pause' },{label: 'Resume exporting', value: 'resume' }]} >
+<Tabs groupId="exporting" defaultValue="pause" queryString values={[{label: 'Pause exporting', value: 'pause' },{label: 'Resume exporting', value: 'resume' },{label: 'Soft pause exporting', value: 'softPause' }]} >
 
 <TabItem value="pause">
 
@@ -34,12 +34,6 @@ POST actuator/exporting/pause
 ```
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
-
-Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
-
-```
-POST actuator/exporting/pause?soft=true
-```
 
 </TabItem>
 
@@ -52,6 +46,18 @@ POST actuator/exporting/resume
 ```
 
 When all partitions have resumed exporting, a successful response is received. If the request fails, only some partitions may have resumed exporting. Therefore, it is important to retry until successful.
+
+</TabItem>
+
+<TabItem value="softPause">
+
+Soft pause feature can be used when you want to continue exporting records but do not want to delete those records (log compaction) from zeebe. This is particularly useful during hot backups. How to use this feature for hot backups is documented [here](/self-managed/operational-guides/backup-restore/backup-and-restore.md).
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
+When all partitions soft pause exporting, a successful response is received. If the request fails, some partitions may have soft paused exporting. Therefore, it is important to either retry until success or revert the partial soft pause by resuming exporting.
 
 </TabItem>
 </Tabs>

--- a/docs/self-managed/zeebe-deployment/operations/management-api.md
+++ b/docs/self-managed/zeebe-deployment/operations/management-api.md
@@ -35,6 +35,12 @@ POST actuator/exporting/pause
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
 
+Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
 </TabItem>
 
 <TabItem value="resume">

--- a/versioned_docs/version-8.2/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.2/self-managed/zeebe-deployment/operations/management-api.md
@@ -30,6 +30,16 @@ POST actuator/exporting/pause
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
 
+### Soft Pause exporting
+
+Soft pause feature can be used when you want to continue exporting records but do not want to delete those records (log compaction) from zeebe. This is particularly useful during hot backups. How to use this feature for hot backups is documented [here](/self-managed/backup-restore/backup-and-restore.md).
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
+When all partitions soft pause exporting, a successful response is received. If the request fails, some partitions may have soft paused exporting. Therefore, it is important to either retry until success or revert the partial soft pause by resuming exporting.
+
 ### Resume exporting
 
 After exporting is paused, it must eventually be resumed. Otherwise, the cluster could become unavailable. To resume exporting, send the following request to the gateway's management endpoint:

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/operations/management-api.md
@@ -30,11 +30,15 @@ POST actuator/exporting/pause
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
 
-Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
+### Soft Pause exporting
+
+Soft pause feature can be used when you want to continue exporting records but do not want to delete those records (log compaction) from zeebe. This is particularly useful during hot backups. How to use this feature for hot backups is documented [here](/self-managed/operational-guides/backup-restore/backup-and-restore.md).
 
 ```
 POST actuator/exporting/pause?soft=true
 ```
+
+When all partitions soft pause exporting, a successful response is received. If the request fails, some partitions may have soft paused exporting. Therefore, it is important to either retry until success or revert the partial soft pause by resuming exporting.
 
 ### Resume exporting
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/operations/management-api.md
@@ -30,6 +30,12 @@ POST actuator/exporting/pause
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
 
+Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
 ### Resume exporting
 
 After exporting is paused, it must eventually be resumed. Otherwise, the cluster could become unavailable. To resume exporting, send the following request to the gateway's management endpoint:

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/management-api.md
@@ -23,7 +23,7 @@ Exporting API is used:
 - As a debugging tool.
 - When taking a backup of Camunda 8 (see [backup and restore](/self-managed/operational-guides/backup-restore/backup-and-restore.md)).
 
-<Tabs groupId="exporting" defaultValue="pause" queryString values={[{label: 'Pause exporting', value: 'pause' },{label: 'Resume exporting', value: 'resume' }]} >
+<Tabs groupId="exporting" defaultValue="pause" queryString values={[{label: 'Pause exporting', value: 'pause' },{label: 'Resume exporting', value: 'resume' },{label: 'Soft pause exporting', value: 'softPause' }]} >
 
 <TabItem value="pause">
 
@@ -34,12 +34,6 @@ POST actuator/exporting/pause
 ```
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
-
-Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
-
-```
-POST actuator/exporting/pause?soft=true
-```
 
 </TabItem>
 
@@ -52,6 +46,18 @@ POST actuator/exporting/resume
 ```
 
 When all partitions have resumed exporting, a successful response is received. If the request fails, only some partitions may have resumed exporting. Therefore, it is important to retry until successful.
+
+</TabItem>
+
+<TabItem value="softPause">
+
+Soft pause feature can be used when you want to continue exporting records but do not want to delete those records (log compaction) from zeebe. This is particularly useful during hot backups. How to use this feature for hot backups is documented [here](/self-managed/operational-guides/backup-restore/backup-and-restore.md).
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
+When all partitions soft pause exporting, a successful response is received. If the request fails, some partitions may have soft paused exporting. Therefore, it is important to either retry until success or revert the partial soft pause by resuming exporting.
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/management-api.md
@@ -35,6 +35,12 @@ POST actuator/exporting/pause
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
 
+Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
 </TabItem>
 
 <TabItem value="resume">

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/management-api.md
@@ -23,7 +23,7 @@ Exporting API is used:
 - As a debugging tool.
 - When taking a backup of Camunda 8 (see [backup and restore](/self-managed/operational-guides/backup-restore/backup-and-restore.md)).
 
-<Tabs groupId="exporting" defaultValue="pause" queryString values={[{label: 'Pause exporting', value: 'pause' },{label: 'Resume exporting', value: 'resume' }]} >
+<Tabs groupId="exporting" defaultValue="pause" queryString values={[{label: 'Pause exporting', value: 'pause' },{label: 'Resume exporting', value: 'resume' },{label: 'Soft pause exporting', value: 'softPause' }]} >
 
 <TabItem value="pause">
 
@@ -34,12 +34,6 @@ POST actuator/exporting/pause
 ```
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
-
-Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
-
-```
-POST actuator/exporting/pause?soft=true
-```
 
 </TabItem>
 
@@ -52,6 +46,18 @@ POST actuator/exporting/resume
 ```
 
 When all partitions have resumed exporting, a successful response is received. If the request fails, only some partitions may have resumed exporting. Therefore, it is important to retry until successful.
+
+</TabItem>
+
+<TabItem value="softPause">
+
+Soft pause feature can be used when you want to continue exporting records but do not want to delete those records (log compaction) from zeebe. This is particularly useful during hot backups. How to use this feature for hot backups is documented [here](/self-managed/operational-guides/backup-restore/backup-and-restore.md).
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
+When all partitions soft pause exporting, a successful response is received. If the request fails, some partitions may have soft paused exporting. Therefore, it is important to either retry until success or revert the partial soft pause by resuming exporting.
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/management-api.md
@@ -35,6 +35,12 @@ POST actuator/exporting/pause
 
 When all partitions pause exporting, a successful response is received. If the request fails, some partitions may have paused exporting. Therefore, it is important to either retry until success or revert the partial pause by resuming exporting.
 
+Another option is to use the soft pause feature, which enables us to continue to export records without updating the last acknowledged record position. This allows us to continue to export data to ES without creating new snapshots while we do the backups.
+
+```
+POST actuator/exporting/pause?soft=true
+```
+
 </TabItem>
 
 <TabItem value="resume">


### PR DESCRIPTION
## Description

This PR adds documentation for the soft pause exporter: https://docs.camunda.io/docs/next/self-managed/zeebe-deployment/operations/management-api/#exporting-api
This also affects versions 8.3, 8.4, and 8.5.

closes https://github.com/camunda/zeebe/issues/17424

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [ ] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [ ] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
