### PR TITLE
docs(various): rephrase volume performance from cluster nodes to pers…

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -70,7 +70,7 @@ The [sizing of a Camunda 8 installation](/components/best-practices/architecture
 
 #### Volume performance
 
-As a minimum requirement the cluster nodes should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
+As a minimum requirement, the persistent volumes for Zeebe should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
 
 To ensure an appropriate sizing, [determine your influencing factors](../components/best-practices/architecture/sizing-your-environment.md#understanding-influencing-factors) (e.g., throughput), and conduct [benchmarking to validate an appropriate environment sizing](../components/best-practices/architecture/sizing-your-environment.md#running-experiments-and-benchmarks).
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/amazon-eks.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/amazon-eks.md
@@ -87,10 +87,9 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](/s
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the EKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. The `gp2` volumes could also be used, but `gp2` volume type performance
 [varies based on volume size](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance).
 
-It's recommended to use `gp3` volumes, but if only `gp2` type is available, EKS cluster nodes
+It's recommended to use `gp3` volumes, but if only `gp2` type is available, persistent volumes
 should use `gp2` volumes of at least 334 GB.

--- a/docs/self-managed/setup/deploy/azure/microsoft-aks.md
+++ b/docs/self-managed/setup/deploy/azure/microsoft-aks.md
@@ -24,13 +24,12 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](/s
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the AKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. However, it has some [limitations](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-limitations), including [lack of support in Azure Backup](https://learn.microsoft.com/en-us/azure/backup/disk-backup-support-matrix#limitations). Therefore, using `Premium SSD` could be the only option in many cases.
 The `Premium SSD` volume could also be used, but its performance
 [varies based on volume size](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds).
 
-It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; AKS cluster nodes
+It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; persistent volumes
 should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress

--- a/docs/self-managed/setup/deploy/gcp/google-gke.md
+++ b/docs/self-managed/setup/deploy/gcp/google-gke.md
@@ -24,7 +24,7 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](/s
 
 ### Volume performance
 
-To have a proper performance in Camunda 8, the GKE cluster nodes should use volumes with around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
+To have a proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
 
 It's recommended to use `Performance (SSD) persistent disks` volume type with at least `100 GB` per volume to have 3,000 IOPS.
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
@@ -79,10 +79,9 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the EKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. The `gp2` volumes could also be used, but `gp2` volume type performance
 [varies based on volume size](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance).
 
-It's recommended to use `gp3` volumes, but if only `gp2` type is available, EKS cluster nodes
+It's recommended to use `gp3` volumes, but if only `gp2` type is available, persistent volumes
 should use `gp2` volumes of at least 334 GB.

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -24,7 +24,7 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have a proper performance in Camunda 8, the GKE cluster nodes should use volumes with around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
+To have a proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
 
 It's recommended to use `Performance (SSD) persistent disks` volume type with at least `100 GB` per volume to have 3,000 IOPS.
 

--- a/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.1/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -24,13 +24,12 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the AKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. However, it has some [limitations](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-limitations), including [lack of support in Azure Backup](https://learn.microsoft.com/en-us/azure/backup/disk-backup-support-matrix#limitations). Therefore, using `Premium SSD` could be the only option in many cases.
 The `Premium SSD` volume could also be used, but its performance
 [varies based on volume size](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds).
 
-It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; AKS cluster nodes
+It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; persistent volumes
 should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks.md
@@ -81,10 +81,9 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the EKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. The `gp2` volumes could also be used, but `gp2` volume type performance
 [varies based on volume size](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance).
 
-It's recommended to use `gp3` volumes, but if only `gp2` type is available, EKS cluster nodes
+It's recommended to use `gp3` volumes, but if only `gp2` type is available, persistent volumes
 should use `gp2` volumes of at least 334 GB.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -24,7 +24,7 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have a proper performance in Camunda 8, the GKE cluster nodes should use volumes with around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
+To have a proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
 
 It's recommended to use `Performance (SSD) persistent disks` volume type with at least `100 GB` per volume to have 3,000 IOPS.
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -24,13 +24,12 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the AKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. However, it has some [limitations](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-limitations), including [lack of support in Azure Backup](https://learn.microsoft.com/en-us/azure/backup/disk-backup-support-matrix#limitations). Therefore, using `Premium SSD` could be the only option in many cases.
 The `Premium SSD` volume could also be used, but its performance
 [varies based on volume size](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds).
 
-It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; AKS cluster nodes
+It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; persistent volumes
 should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress

--- a/versioned_docs/version-8.3/reference/supported-environments.md
+++ b/versioned_docs/version-8.3/reference/supported-environments.md
@@ -69,7 +69,7 @@ The [sizing of a Camunda 8 installation](/components/best-practices/architecture
 
 #### Volume performance
 
-As a minimum requirement the cluster nodes should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
+As a minimum requirement, the persistent volumes for Zeebe should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
 
 To ensure an appropriate sizing, [determine your influencing factors](../components/best-practices/architecture/sizing-your-environment.md#understanding-influencing-factors) (e.g., throughput), and conduct [benchmarking to validate an appropriate environment sizing](../components/best-practices/architecture/sizing-your-environment.md#running-experiments-and-benchmarks).
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/amazon-eks.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/amazon-eks.md
@@ -81,10 +81,9 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the EKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. The `gp2` volumes could also be used, but `gp2` volume type performance
 [varies based on volume size](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance).
 
-It's recommended to use `gp3` volumes, but if only `gp2` type is available, EKS cluster nodes
+It's recommended to use `gp3` volumes, but if only `gp2` type is available, persistent volumes
 should use `gp2` volumes of at least 334 GB.

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -24,7 +24,7 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have a proper performance in Camunda 8, the GKE cluster nodes should use volumes with around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
+To have a proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
 
 It's recommended to use `Performance (SSD) persistent disks` volume type with at least `100 GB` per volume to have 3,000 IOPS.
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -24,13 +24,12 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the AKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. However, it has some [limitations](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-limitations), including [lack of support in Azure Backup](https://learn.microsoft.com/en-us/azure/backup/disk-backup-support-matrix#limitations). Therefore, using `Premium SSD` could be the only option in many cases.
 The `Premium SSD` volume could also be used, but its performance
 [varies based on volume size](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds).
 
-It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; AKS cluster nodes
+It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; persistent volumes
 should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress

--- a/versioned_docs/version-8.4/reference/supported-environments.md
+++ b/versioned_docs/version-8.4/reference/supported-environments.md
@@ -69,7 +69,7 @@ The [sizing of a Camunda 8 installation](/components/best-practices/architecture
 
 #### Volume performance
 
-As a minimum requirement the cluster nodes should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
+As a minimum requirement, the persistent volumes for Zeebe should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
 
 To ensure an appropriate sizing, [determine your influencing factors](../components/best-practices/architecture/sizing-your-environment.md#understanding-influencing-factors) (e.g., throughput), and conduct [benchmarking to validate an appropriate environment sizing](../components/best-practices/architecture/sizing-your-environment.md#running-experiments-and-benchmarks).
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/amazon-eks.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/amazon-eks.md
@@ -87,10 +87,9 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the EKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. The `gp2` volumes could also be used, but `gp2` volume type performance
 [varies based on volume size](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance).
 
-It's recommended to use `gp3` volumes, but if only `gp2` type is available, EKS cluster nodes
+It's recommended to use `gp3` volumes, but if only `gp2` type is available, persistent volumes
 should use `gp2` volumes of at least 334 GB.

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/google-gke.md
@@ -24,7 +24,7 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have a proper performance in Camunda 8, the GKE cluster nodes should use volumes with around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
+To have a proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
 
 It's recommended to use `Performance (SSD) persistent disks` volume type with at least `100 GB` per volume to have 3,000 IOPS.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/microsoft-aks.md
@@ -24,13 +24,12 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](..
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the AKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. However, it has some [limitations](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-limitations), including [lack of support in Azure Backup](https://learn.microsoft.com/en-us/azure/backup/disk-backup-support-matrix#limitations). Therefore, using `Premium SSD` could be the only option in many cases.
 The `Premium SSD` volume could also be used, but its performance
 [varies based on volume size](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds).
 
-It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; AKS cluster nodes
+It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; persistent volumes
 should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress

--- a/versioned_docs/version-8.5/reference/supported-environments.md
+++ b/versioned_docs/version-8.5/reference/supported-environments.md
@@ -70,7 +70,7 @@ The [sizing of a Camunda 8 installation](/components/best-practices/architecture
 
 #### Volume performance
 
-As a minimum requirement the cluster nodes should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
+As a minimum requirement, the persistent volumes for Zeebe should use volumes with an absolute minimum of 1,000 IOPS. **NFS or other types of network storage volumes are not supported.**
 
 To ensure an appropriate sizing, [determine your influencing factors](../components/best-practices/architecture/sizing-your-environment.md#understanding-influencing-factors) (e.g., throughput), and conduct [benchmarking to validate an appropriate environment sizing](../components/best-practices/architecture/sizing-your-environment.md#running-experiments-and-benchmarks).
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/amazon-eks.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/amazon-eks.md
@@ -87,10 +87,9 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](/s
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the EKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `gp3` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. The `gp2` volumes could also be used, but `gp2` volume type performance
 [varies based on volume size](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp2-performance).
 
-It's recommended to use `gp3` volumes, but if only `gp2` type is available, EKS cluster nodes
+It's recommended to use `gp3` volumes, but if only `gp2` type is available, persistent volumes
 should use `gp2` volumes of at least 334 GB.

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/azure/microsoft-aks.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/azure/microsoft-aks.md
@@ -24,13 +24,12 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](/s
 
 ### Volume performance
 
-To have proper performance in Camunda 8, the AKS cluster nodes should use volumes
-with around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
+To have proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Premium SSD v2` volumes deliver a consistent baseline IOPS performance
 of 3,000 IOPS. However, it has some [limitations](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd-v2-limitations), including [lack of support in Azure Backup](https://learn.microsoft.com/en-us/azure/backup/disk-backup-support-matrix#limitations). Therefore, using `Premium SSD` could be the only option in many cases.
 The `Premium SSD` volume could also be used, but its performance
 [varies based on volume size](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssds).
 
-It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; AKS cluster nodes
+It's recommended to use `Premium SSD v2` volume type, but only if `Premium SSD` type is available; persistent volumes
 should use `Premium SSD` volumes of at least `256 GB` (P15).
 
 ### Zeebe Ingress

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/gcp/google-gke.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/gcp/google-gke.md
@@ -24,7 +24,7 @@ For general deployment pitfalls, visit the [deployment troubleshooting guide](/s
 
 ### Volume performance
 
-To have a proper performance in Camunda 8, the GKE cluster nodes should use volumes with around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
+To have a proper performance in Camunda 8, the persistent volumes attached to Zeebe should have around 1,000-3,000 IOPS. The `Performance (SSD) persistent disks` volumes deliver a consistent baseline IOPS performance but it [varies based on volume size](https://cloud.google.com/compute/docs/disks/performance#performance_factors).
 
 It's recommended to use `Performance (SSD) persistent disks` volume type with at least `100 GB` per volume to have 3,000 IOPS.
 


### PR DESCRIPTION
…itent volumes

## Description

<!-- This helps the reviewers by providing an overview of what to expect in the PR. Linking to an issue is preferred but not required. -->
<!-- Add an assignee and use component: labels for good hygiene! -->

related to https://github.com/camunda/team-infrastructure-experience/issues/198

The change proposes a rephrasing concerning volume performances.
The docs are very fixated on cluster nodes for scaling Zeebe, which implicitly is true but what you scale is the pods and the nodes are scaled due to tains and tolerations.
That's probably where the focus stems from also for the volume performances, as Zeebe doesn't scale based on the cluster node volumes but from the attached persistent volumes.
If a customer tried scaling their cluster volumes, they would not notice any benefits since it's a different entity to what is attached to Zeebe that needs the performance change.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->
<!-- Help the DevEx team prioritize our work (reviews, merges, etc.) by opening PRs sooner. -->

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [ ] This is a bug fix or security concern.

## PR Checklist

<!-- Keep in mind, Camunda maintains 18 months of versions. Backporting your change or including it in multiple versions is common. -->

- [x] I have added changes to the relevant `/versioned_docs` directory, or they are not for an **already released version**.
- [x] I have added changes to the main `/docs` directory (aka `/next/`), or they are not for **future versions**.
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned an engineering manager or tech lead as a reviewer, or my changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer, or my changes do not require a technical writer review.
