### PR TITLE
docs(self-managed): add section about helm cli in the upgrade page

### DIFF
--- a/docs/self-managed/setup/upgrade.md
+++ b/docs/self-managed/setup/upgrade.md
@@ -113,6 +113,10 @@ helm search repo camunda/camunda-platform --versions
 
 **After applying the instructions for each Helm chart, get back to the top of this page and start the upgrade process. **
 
+## Helm CLI version
+
+For a smooth upgrade, always use the same Helm CLI version corresponding with the chart version that shows in the [chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/).
+
 ## From Camunda 8.4 to 8.5
 
 ### Helm chart 10.0.2+
@@ -120,6 +124,10 @@ helm search repo camunda/camunda-platform --versions
 The upgrade path for Camunda Helm Chart v9.x.x is v10.0.2+.
 
 The Camunda Helm chart v10.0.2 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
+
+#### Helm CLI version
+
+Ensure to use Helm CLI with version `3.14.3` or more. The upgrade could fail to work with the 10.0.2+ Camunda Helm chart version due to some bugs in the older Helm CLI itself.
 
 #### Deprecation notes
 

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -91,6 +91,10 @@ If you have specified on the first installation certain values, you have to spec
 
 For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).
 
+## Helm CLI version
+
+For a smooth upgrade, always use the same Helm CLI version corresponding with the chart version that shows in the [chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/).
+
 ## Version update instructions
 
 ### v8.2.9

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -91,6 +91,10 @@ If you have specified on the first installation certain values, you have to spec
 
 For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).
 
+## Helm CLI version
+
+For a smooth upgrade, always use the same Helm CLI version corresponding with the chart version that shows in the [chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/).
+
 ## Version update instructions
 
 ### v8.3.1

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -91,6 +91,10 @@ If you have specified on the first installation certain values, you have to spec
 
 For more details on the Keycloak upgrade path, you can also read the [Bitnami Keycloak upgrade guide](https://docs.bitnami.com/kubernetes/apps/keycloak/administration/upgrade/).
 
+## Helm CLI version
+
+For a smooth upgrade, always use the same Helm CLI version corresponding with the chart version that shows in the [chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/).
+
 ## Version update instructions
 
 ### v9.3.0

--- a/versioned_docs/version-8.5/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.5/self-managed/setup/upgrade.md
@@ -113,6 +113,10 @@ helm search repo camunda/camunda-platform --versions
 
 **After applying the instructions for each Helm chart, get back to the top of this page and start the upgrade process. **
 
+## Helm CLI version
+
+For a smooth upgrade, always use the same Helm CLI version corresponding with the chart version that shows in the [chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/).
+
 ## From Camunda 8.4 to 8.5
 
 ### Helm chart 10.0.2+
@@ -120,6 +124,10 @@ helm search repo camunda/camunda-platform --versions
 The upgrade path for Camunda Helm Chart v9.x.x is v10.0.2+.
 
 The Camunda Helm chart v10.0.2 has major changes in the values file structure. Follow the upgrade steps for each component before starting the chart upgrade.
+
+#### Helm CLI version
+
+Ensure to use Helm CLI with version `3.14.3` or more. The upgrade could fail to work with the 10.0.2+ Camunda Helm chart version due to some bugs in the older Helm CLI itself.
 
 #### Deprecation notes
 


### PR DESCRIPTION
## Description

For smooth operations and upgrades, we need to ensure that the Helm CLI version we used in the tests and release is visible to the end user.

## When should this change go live?

- [ ] This change is not yet live and should not be merged until {ADD_DATE} (apply `hold` label or convert to draft PR)?
- [ ] There is no urgency with this change.
- [ ] This change or page is part of a marketing blog, conference talk, or something else on a schedule.
- [ ] This functionality is already available but undocumented.
- [x] This is a bug fix or security concern.

## PR Checklist

- [x] I have added changes to the relevant `/versioned_docs` directory.
- [x] I have added changes to the main `/docs` directory (aka `/next/`).
- [x] My changes do not require an Engineering review.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
