### PR TITLE
feat: support fully-qualified absolute canonical URLs

### DIFF
--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -66,6 +66,11 @@ function determineCanonical(currentDoc, currentPlugin) {
  * @returns string
  */
 function determineCanonicalFromUrl(canonicalUrl, currentPlugin) {
+  // If it's absolutely qualified, just trust it.
+  if (/^https?:\/\/.*/i.test(canonicalUrl)) {
+    return canonicalUrl;
+  }
+
   const match = currentPlugin.versions
     .flatMap((version) => version.docs)
     .find((doc) => doc.path === canonicalUrl);

--- a/src/theme/DocItem/Metadata/determineCanonical.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.js
@@ -51,8 +51,13 @@ function determineCanonical(currentDoc, currentPlugin) {
     result = determineCanonicalFromDoc(currentDoc, currentPlugin);
   }
 
-  // Trim trailing slashes. Most docs don't contain them, but occasionally we specify a slug that ends in a slash.
-  return result?.replace(/\/+$/, "");
+  if (!result) {
+    return result;
+  }
+
+  // Every canonical URL should end in exactly one slash.
+  //   Trim what's there, in case it was specified, then append exactly one.
+  return result.replace(/\/+$/, "") + "/";
 }
 
 /**

--- a/src/theme/DocItem/Metadata/determineCanonical.spec.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.spec.js
@@ -36,6 +36,28 @@ describe("determineCanonical", () => {
       });
     });
 
+    describe("when the URL is fully qualified", () => {
+      beforeEach(() => {
+        currentDoc = aCurrentDoc({
+          frontMatter: {
+            canonicalUrl: "https://docs.camunda.io/docs/welcome/",
+          },
+        });
+      });
+
+      it("returns the value of the canonicalUrl", () => {
+        // since we know it's a valid URL, it's a safe canonical
+
+        const result = determineCanonical(currentDoc, currentPlugin);
+
+        expect(result).toEqual("https://docs.camunda.io/docs/welcome/");
+      });
+
+      describe("when the URL does not include a trailing slash", () => {
+        it("does not append a trailing slash because it might be a non-camunda-docs URL", () => {});
+      });
+    });
+
     describe("when that URL exists in the newest version", () => {
       beforeEach(() => {
         currentPlugin.versions = [

--- a/src/theme/DocItem/Metadata/determineCanonical.spec.js
+++ b/src/theme/DocItem/Metadata/determineCanonical.spec.js
@@ -52,12 +52,12 @@ describe("determineCanonical", () => {
         ];
       });
 
-      it("returns the value of the canonicalUrl", () => {
+      it("returns the value of the canonicalUrl, terminating in a slash", () => {
         // since we know it's a valid URL, it's a safe canonical
 
         const result = determineCanonical(currentDoc, currentPlugin);
 
-        expect(result).toEqual("/docs/welcome");
+        expect(result).toEqual("/docs/welcome/");
       });
     });
 
@@ -77,12 +77,12 @@ describe("determineCanonical", () => {
         ];
       });
 
-      it("returns the value of the canonicalUrl", () => {
+      it("returns the value of the canonicalUrl, terminating in a slash", () => {
         // since we know it's a valid URL, it's a safe canonical
 
         const result = determineCanonical(currentDoc, currentPlugin);
 
-        expect(result).toEqual("/docs/welcome");
+        expect(result).toEqual("/docs/welcome/");
       });
     });
 
@@ -134,10 +134,10 @@ describe("determineCanonical", () => {
         ];
       });
 
-      it("returns the URL of the matching latest version doc", () => {
+      it("returns the URL of the matching latest version doc, terminating in a slash", () => {
         const result = determineCanonical(currentDoc, currentPlugin);
 
-        expect(result).toEqual("/docs/components");
+        expect(result).toEqual("/docs/components/");
       });
     });
 
@@ -194,10 +194,10 @@ describe("determineCanonical", () => {
         ];
       });
 
-      it("returns the URL of the newest doc with the same id", () => {
+      it("returns the URL of the newest doc with the same id, terminating in a slash", () => {
         const result = determineCanonical(currentDoc, currentPlugin);
 
-        expect(result).toEqual("/components");
+        expect(result).toEqual("/components/");
       });
 
       describe("when the path of the matching doc ends in a slash", () => {
@@ -206,10 +206,10 @@ describe("determineCanonical", () => {
           currentPlugin.versions[0].docs[0].path += "/";
         });
 
-        it("removes the trailing slash", () => {
+        it("includes the terminating slash", () => {
           const result = determineCanonical(currentDoc, currentPlugin);
 
-          expect(result).toEqual("/components");
+          expect(result).toEqual("/components/");
         });
       });
 
@@ -232,7 +232,7 @@ describe("determineCanonical", () => {
         it("chooses the newest version", () => {
           const result = determineCanonical(currentDoc, currentPlugin);
 
-          expect(result).toEqual("/components");
+          expect(result).toEqual("/components/");
         });
       });
 
@@ -257,7 +257,7 @@ describe("determineCanonical", () => {
         it("is not selected as canonical", () => {
           const result = determineCanonical(currentDoc, currentPlugin);
 
-          expect(result).toEqual("/components");
+          expect(result).toEqual("/components/");
         });
       });
     });
@@ -277,7 +277,7 @@ describe("determineCanonical", () => {
         it("returns the URL of the current page", () => {
           const result = determineCanonical(currentDoc, currentPlugin);
 
-          expect(result).toEqual("/docs/next/components");
+          expect(result).toEqual("/docs/next/components/");
         });
       });
     });

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -27,7 +27,8 @@ export default function MetadataWrapper(props) {
   // Canonical URLs should always:
   //   1. be fully qualified (Google's recommendation)
   //   2. end with a trailing slash (to avoid default-document redirects, e.g. /welcome -> /welcome/)
-  const fullCanonicalUrl = `${customFields.canonicalUrlRoot}${canonicalPath}/`;
+  //      The required trailing slash is handled by `determineCanonical`.
+  const fullCanonicalUrl = `${customFields.canonicalUrlRoot}${canonicalPath}`;
 
   return (
     <>

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -24,11 +24,17 @@ export default function MetadataWrapper(props) {
   // From the context, identify the proper canonical
   const canonicalPath = determineCanonical(currentDoc, currentPlugin);
 
-  // Canonical URLs should always:
-  //   1. be fully qualified (Google's recommendation)
-  //   2. end with a trailing slash (to avoid default-document redirects, e.g. /welcome -> /welcome/)
-  //      The required trailing slash is handled by `determineCanonical`.
-  const fullCanonicalUrl = `${customFields.canonicalUrlRoot}${canonicalPath}`;
+  let fullCanonicalUrl;
+  if (/^https?:\/\/.*/i.test(canonicalPath)) {
+    // The canonicalPath set in frontmatter is absolutely qualified. Trust it and use it as-is.
+    fullCanonicalUrl = canonicalPath;
+  } else {
+    // Canonical URLs should always:
+    //   1. be fully qualified (Google's recommendation)
+    //   2. end with a trailing slash (to avoid default-document redirects, e.g. /welcome -> /welcome/)
+    //      The required trailing slash is handled by `determineCanonical`.
+    fullCanonicalUrl = `${customFields.canonicalUrlRoot}${canonicalPath}`;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Description

Part of #3731.

Ports https://github.com/camunda/camunda-docs/pull/3760/commits/d00a54d1bb2fbdc42bcbd743232129faeee7ec7f, which was required during the 8.1 archival, to the main docs. This allows us to specify canonical URLs which include `https://docs.camunda.io`, which is necessary when archiving a version to `https://unsupported.docs.camunda.io`. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either and Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context. -->
- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process).
