### PR TITLE
Support migration of call activity and called instances

### DIFF
--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -113,7 +113,7 @@ Afterward, the process instance will continue as expected:
 
 ![After migrating the process instance, the input mapping is corrected and the incident is resolved by retry. Afterward, the process instance will continue as expected:](assets/process-instance-migration/migration-process_instance_with_incident_resolved.png)
 
-## Migrating active elements inside embedded subprocesses
+## Migrating active elements inside subprocesses
 
 Active elements located inside subprocesses can be migrated as part of a process instance migration.
 
@@ -133,6 +133,13 @@ A mapping instruction must be provided from the process instance's subprocess ID
 You cannot migrate an active embedded subprocess to an event subprocess.
 Additionally, changing the scope of a subprocesses during migration is not possible.
 :::
+
+### Call activities and called process instances
+
+Active call activities can be migrated like any other element.
+The called process instance is not changed when migrating the call activity.
+
+You can migrate a called process instance in the same way as a regular process instance.
 
 ## Process definitions and versions
 
@@ -232,7 +239,6 @@ The following limitations exist that may be supported in future versions:
 - Elements with a boundary event in the source and/or target process definition can only be be migrated for boundary events of type:
   - Message
 - The following scenarios cannot be migrated:
-  - A process instance that is started from a call activity, i.e. a child process instance
   - A process instance that contains an event subprocess
   - A target process definition that contains an event subprocess
   - An element that becomes nested in a newly added subprocess


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Link to an associated epic when applicable. -->
<!-- Add an assignee and use `component:` or version labels for good hygiene! -->

With https://github.com/camunda/zeebe/pull/18328, Zeebe now supports the migration of active call activities. Note that child process instances cannot yet be migrated.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either and Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
