### PR TITLE
draft feedback widget with pushfeedback

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,6 +46,9 @@ module.exports = {
       "docusaurus-pushfeedback",
       {
         project: "m6exeps3n1",
+        buttonStyle: "dark",
+        buttonPosition: "center-right",
+        modalPosition: "sidebar-right",
       },
     ],
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,6 +43,15 @@ module.exports = {
     ],
     "./static/plugins/bpmn-js",
     [
+      "docusaurus-pushfeedback",
+      {
+        project: "m6exeps3n1",
+        buttonPosition: "center-left",
+        modalPosition: "sidebar-left",
+        buttonStyle: "dark",
+      },
+    ],
+    [
       "@docusaurus/plugin-content-docs",
       {
         id: "optimize",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,9 +46,6 @@ module.exports = {
       "docusaurus-pushfeedback",
       {
         project: "m6exeps3n1",
-        buttonPosition: "center-left",
-        modalPosition: "sidebar-left",
-        buttonStyle: "dark",
       },
     ],
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "docusaurus": "^1.14.7",
         "docusaurus-gtm-plugin": "0.0.2",
         "docusaurus-plugin-openapi-docs": "^2.0.4",
+        "docusaurus-pushfeedback": "^0.1.7",
         "docusaurus-theme-openapi-docs": "^2.0.4",
         "mixpanel-browser": "^2.47.0",
         "react": "^17.0.2",
@@ -11207,6 +11208,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/docusaurus-pushfeedback": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/docusaurus-pushfeedback/-/docusaurus-pushfeedback-0.1.7.tgz",
+      "integrity": "sha512-JE6lsYVghdowMEH+kymnQliuFBpqLtQNoLFoS02+W7e7kqCb/dKB40+VBaGJ8HV7JOA5ATcdo40vAwx78udk9w==",
+      "peerDependencies": {
+        "@docusaurus/core": "2.x"
       }
     },
     "node_modules/docusaurus-theme-openapi-docs": {
@@ -40465,6 +40474,12 @@
           }
         }
       }
+    },
+    "docusaurus-pushfeedback": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/docusaurus-pushfeedback/-/docusaurus-pushfeedback-0.1.7.tgz",
+      "integrity": "sha512-JE6lsYVghdowMEH+kymnQliuFBpqLtQNoLFoS02+W7e7kqCb/dKB40+VBaGJ8HV7JOA5ATcdo40vAwx78udk9w==",
+      "requires": {}
     },
     "docusaurus-theme-openapi-docs": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "docusaurus": "^1.14.7",
     "docusaurus-gtm-plugin": "0.0.2",
     "docusaurus-plugin-openapi-docs": "^2.0.4",
+    "docusaurus-pushfeedback": "^0.1.7",
     "docusaurus-theme-openapi-docs": "^2.0.4",
     "mixpanel-browser": "^2.47.0",
     "react": "^17.0.2",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,6 +17,7 @@ See: https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
   --ifm-color-primary-light: #d94a02;
   --ifm-color-primary-lighter: #e34d02;
   --ifm-color-primary-lightest: #fc5806;
+  --feedback-primary-color: #000;
 }
 
 .docusaurus-highlight-code-line {
@@ -471,8 +472,4 @@ span.callout + p::after {
   white-space: nowrap;
   margin-left: 4px;
   color: transparent;
-}
-
-:root {
-  --feedback-primary-color: #fc5806;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -472,3 +472,7 @@ span.callout + p::after {
   margin-left: 4px;
   color: transparent;
 }
+
+:root {
+  --feedback-primary-color: #fc5806;
+}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/camunda-docs/issues/355.

PushFeedback is an integrated widget to obtain feedback from our users. See the right side of the page:

<img width="1532" alt="Screenshot 2024-05-23 at 11 36 48 AM" src="https://github.com/camunda/camunda-docs/assets/84338309/4433dfbd-494d-4af7-bd5a-50bb9c676062">

When clicked, you see:

<img width="1528" alt="Screenshot 2024-05-23 at 11 37 30 AM" src="https://github.com/camunda/camunda-docs/assets/84338309/115b0bf5-f9a9-4fd8-a76f-21e2130b58d4">

This scrolls along with the page, like Ask AI, and shows up on every page of our documentation.

The feedback is looped into the project, where you can review it at https://app.pushfeedback.com/:

<img width="684" alt="Screenshot 2024-05-16 at 1 27 41 PM" src="https://github.com/camunda/camunda-docs/assets/84338309/cbb183d5-8934-4eff-a93f-ac9425a0a87e">

I reached out to @dgarcia360, and PushFeedback has enabled the open-source tier for http://docs.camunda.io/, allowing us unlimited feedback entries on this project.

Opportunity for analytics, too:

<img width="1272" alt="Screenshot 2024-05-16 at 1 28 10 PM" src="https://github.com/camunda/camunda-docs/assets/84338309/59d4b843-15c5-45d6-806f-fe278c3ce6dc">

<img width="1246" alt="Screenshot 2024-05-16 at 1 51 08 PM" src="https://github.com/camunda/camunda-docs/assets/84338309/0b4b21ce-0a4a-421e-8773-047515e0ad91">

## Remaining questions and tasks

- [ ] I wasn't sure about the styling, though [there are TONS of options](https://docs.pushfeedback.com/configuration/styles). Would love to work with @pepopowitz on this, as it seems pretty simple, but Swizzling is not my forte.
- [ ] This is currently hooked up to my work email -- is this what we would want to use? I can invite team members, but as an FYI:

<img width="1245" alt="Screenshot 2024-05-16 at 1 24 45 PM" src="https://github.com/camunda/camunda-docs/assets/84338309/e86ab476-21e1-4de5-83d5-57e07951b8c0">

- [ ] I don't think we would need emails as a field, so could remove this. Should make comments optional too.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either and Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
