### PR TITLE
Add tech-writers team to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,10 +26,10 @@
 - [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
 -->
 
-<!-- All changes require either and Engineering review or technical writer review. **Many require both!** -->
+<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->
 
 - [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
-- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.
+- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.
 
 <!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
 - [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->

--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -214,7 +214,7 @@ After the proposed change is finished open a GitHub PR and assign at least one r
 - Identity: @dlavrenuek
 - DevEx: @akeller
 - Product Management: @felix-mueller
-- Documentation: @christinaausley
+- Documentation: @camunda/tech-writers
 - Documentation infrastructure: @pepopowitz
 - Fallback: @akeller
 


### PR DESCRIPTION
## Description

We have more than one tech writer now! Yay! We should reflect this in the PR template so our writers can distribute work.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- All changes require either and Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @christinaausley as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
