### PR TITLE
fix: allow accessing Desktop Modeler landing page

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -696,9 +696,6 @@ RewriteRule ^docs/self-managed/iam/deployment/configuration-variables/(.*)$  /do
 RewriteRule ^docs/self-managed/iam/deployment/making-iam-production-ready/(.*)$  /docs/self-managed/identity/user-guide/making-identity-production-ready/ [R=301,L]
 RewriteRule ^docs/self-managed/iam/getting-started(.*)$ /docs/self-managed/identity/getting-started/ [R=301,L]
 
-# Static resource page for the camunda desktop modeler
-RewriteRule ^docs/components/modeler/desktop-modeler/?$ /docs/components/modeler/desktop-modeler/install-the-modeler/ [R=301,L]
-
 # workaround for 404 with trailing slashes https://github.com/camunda-cloud/camunda-cloud-documentation/issues/403
 RewriteRule ^(.*\.(yaml|bpmn|xml|png|jpeg|jpg|yml|svg|graphqls|diff))/$ /$1 [R=301,L]
 


### PR DESCRIPTION
## Description

The [Desktop Modeler landing page](https://docs.camunda.io/docs/components/modeler/desktop-modeler) works well on `next` but is redirected to the now nearly obsolete ("just for SEO purposes") [install page](https://docs.camunda.io/docs/components/modeler/desktop-modeler/install-the-modeler/) on `latest`. This hopefully fixes the issue.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
