### PR TITLE
docs(web-modeler): remove "saas only" limitation for process applications

### DIFF
--- a/docs/components/modeler/web-modeler/process-applications.md
+++ b/docs/components/modeler/web-modeler/process-applications.md
@@ -11,8 +11,6 @@ import DeployProcessApplicationImg from './img/process-applications/deploy-proce
 import RunProcessApplicationImg from './img/process-applications/run-process-application.png'
 import DeployErrorImg from './img/process-applications/deploy-error.png'
 
-<span class="badge badge--cloud">Camunda 8 SaaS only</span>
-
 ## Idea and purpose
 
 A process application is a special type of folder in Web Modeler that allows you to work on a set of related files and
@@ -108,11 +106,9 @@ Note that when you deploy the process application:
 - Linked external forms will be deployed together with the process application.
 - Linked external BPMN and DMN diagrams are _not_ deployed together. They must be deployed separately.
 
-## Limitations and availability
+## Limitations
 
-Process applications are available in SaaS only. They are not yet available in Web Modeler Self-Managed.
-
-Also be aware of the following limitations when working with process applications:
+Be aware of the following limitations when working with process applications:
 
 - You cannot create subfolders inside a process application.
 - Process applications can only be deployed to a Zeebe cluster in version 8.4.0 or higher.


### PR DESCRIPTION
## Description
Process applications will also be available in Web Modeler Self-Managed with the 8.6.0-alpha2 release.

## When should this change go live?
- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist
- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.