### PR TITLE
chore(preview-envs): Build workflows to deploy and tear down preview …

### DIFF
--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         env:
           NODE_OPTIONS: --max_old_space_size=8192
-          DOCS_SITE_URL: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+          DOCS_SITE_URL: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
           DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
         run: npm run build
 

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -1,0 +1,77 @@
+name: preview-env-deploy
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy') || contains( github.event.pull_request.labels.*.name, 'deploy'))
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    name: deploy-preview-env
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Import secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
+          DOCS_SITE_URL: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+          DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
+        run: npm run build
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: "${{ github.token }}"
+          env: ${{ github.event.repository.name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upload files to google bucket
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        run: |
+          gcloud config set pass_credentials_to_gsutil true
+          gsutil -m cp -R build/* gs://$BUCKET_NAME/pr-${{ github.event.number }}
+
+      - uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: "${{ github.token }}"
+          status: ${{ job.status }}
+          env: ${{ steps.deployment.outputs.env }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v4
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+          edit-mode: replace

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -1,0 +1,60 @@
+name: preview-env-teardown
+on:
+  pull_request:
+    types: [unlabeled, closed]
+
+jobs:
+  tear-dowm-preview-env:
+    if: github.event.label.name == 'deploy' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy') )
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    name: teardown-preview-env
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Remove files from Google bucket
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        run: |
+          gcloud config set pass_credentials_to_gsutil true
+          gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+
+      - name: Update comment
+        if: steps.find-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          body: |
+            Your preview env has been teared down.
+          edit-mode: replace

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -56,5 +56,5 @@ jobs:
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           body: |
-            Your preview env has been teared down.
+            Your preview env has been torn down.
           edit-mode: replace

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,20 +2,14 @@ const versionedLinks = require("./src/mdx/versionedLinks");
 const { unsupportedVersions } = require("./src/versions");
 
 const latestVersion = require("./src/versions").versionMappings[0].docsVersion;
-// Read url and baseUrl from environment variables
-const siteUrlEnv = process.env.DOCS_SITE_URL || "https://docs.camunda.io";
-const siteUrl = siteUrlEnv.startsWith("https://")
-  ? siteUrlEnv
-  : `https://${siteUrlEnv}`;
-const siteBaseUrl = process.env.DOCS_SITE_BASE_URL || "/";
 
 module.exports = {
   title: "Camunda 8 Docs",
   tagline: "Documentation for all components of Camunda 8",
   // url: "https://camunda-cloud.github.io",
-  url: siteUrl,
+  url: process.env.DOCS_SITE_URL || "https://docs.camunda.io",
   // baseUrl: "/camunda-cloud-documentation/",
-  baseUrl: siteBaseUrl,
+  baseUrl: process.env.DOCS_SITE_BASE_URL || "/",
   customFields: {
     canonicalUrlRoot: "https://docs.camunda.io",
   },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,14 +2,20 @@ const versionedLinks = require("./src/mdx/versionedLinks");
 const { unsupportedVersions } = require("./src/versions");
 
 const latestVersion = require("./src/versions").versionMappings[0].docsVersion;
+// Read url and baseUrl from environment variables
+const siteUrlEnv = process.env.DOCS_SITE_URL || "https://docs.camunda.io";
+const siteUrl = siteUrlEnv.startsWith("https://")
+  ? siteUrlEnv
+  : `https://${siteUrlEnv}`;
+const siteBaseUrl = process.env.DOCS_SITE_BASE_URL || "/";
 
 module.exports = {
   title: "Camunda 8 Docs",
   tagline: "Documentation for all components of Camunda 8",
   // url: "https://camunda-cloud.github.io",
-  url: "https://docs.camunda.io",
+  url: siteUrl,
   // baseUrl: "/camunda-cloud-documentation/",
-  baseUrl: "/",
+  baseUrl: siteBaseUrl,
   customFields: {
     canonicalUrlRoot: "https://docs.camunda.io",
   },


### PR DESCRIPTION
…envs 

## Description

This pr aims to add the following functionality:
- create a workflow to deploy preview envs
- creates a workflow to tear down preview envs
- modify the url & baseurl of docusaurus

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->

## NOTES:
- The `preview-env-deploy`workflow is set to timeout in 30 mins because some builds took a bit more than 20 mins. I thought it might make sense to not have the timeout too tight
- In the `preview-env-deploy` in the `Build` step, I tried passing the bucket name prepended by https:// to node but node couldnt read it for some reason:
`          DOCS_SITE_URL: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}`
The only logical explanation I could think of is that there might an issue when one concatenates a string to a secret so I therefore did the processing in the `docausaurus.config.js` file 

## TESTING:
### Test 1: Test that the preview env can be deployed and the link works when adding a label
- I did this test with the help of [this](https://github.com/camunda/camunda-docs/pull/3945) pr. When removing the label the comment gets replaced and the preview env gets cleaned up so I wouldnt be able to do it in the same pr. The files has been uploaded in [this](https://console.cloud.google.com/storage/browser/preview.docs.camunda.cloud/pr-3945?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&authuser=1&project=ci-30-162810) path of the google bucket.
<img width="911" alt="Screenshot 2024-06-14 at 13 58 28" src="https://github.com/camunda/camunda-docs/assets/42938116/09987e07-f649-4c00-a514-18c777fbf52b">

### Test 2: Test that the preview env gets cleaned up when removing the label 
See the [comment](https://github.com/camunda/camunda-docs/pull/3947#issuecomment-2167866105) below which replaces the original comment with a new one indicating that the deployment has been cleaned up
