### PR TITLE
chore(preview-envs): Add preview env workflows to camunda docs repo

### DIFF
--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Shorten commit SHA
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
 
-      - name: Upsert comment
+      - name: Upsert deployment comment
         uses: peter-evans/create-or-update-comment@v4
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -24,6 +24,15 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
+      - name: Find deployment comment
+        uses: peter-evans/find-comment@v1
+        id: find-deployment-comment
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+
       - name: Install Dependencies
         run: npm ci
 
@@ -51,6 +60,16 @@ jobs:
           env: ${{ github.event.repository.name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # If the deployment comment is found, remove the old static files from the bucket
+      # before uploading the new build
+      - name: Remove files from Google bucket from previous deployment
+        if: steps.find-deployment-comment.outputs.comment-id == ''
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        run: |
+          gcloud config set pass_credentials_to_gsutil true
+          gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
+
       - name: Upload files to google bucket
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
@@ -65,15 +84,6 @@ jobs:
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Find deployment comment
-        uses: peter-evans/find-comment@v1
-        id: find-deployment-comment
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
 
       - name: Find env tear down comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -86,7 +86,7 @@ jobs:
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
-          comment-id: ${{ steps.find-teardown-comment.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           body: |
             <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -63,7 +63,7 @@ jobs:
       # If the deployment comment is found, remove the old static files from the bucket
       # before uploading the new build
       - name: Remove files from Google bucket from previous deployment
-        if: steps.find-deployment-comment.outputs.comment-id == ''
+        if: steps.find-deployment-comment.outputs.comment-id != ''
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         run: |

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -100,9 +100,9 @@ jobs:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           issue-number: ${{ github.event.number }}
-          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+          body-includes: The preview environment relating to the commit
 
-      - name: Upsert deployment comment
+      - name: Add deployment comment
         if: steps.find-deployment-comment.outputs.comment-id == '' && steps.find-teardown-comment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -1,0 +1,103 @@
+name: preview-env-deploy
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy') || contains( github.event.pull_request.labels.*.name, 'deploy'))
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    name: deploy-preview-env
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Import secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
+          DOCS_SITE_URL: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+          DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
+        run: npm run build
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: "${{ github.token }}"
+          env: ${{ github.event.repository.name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upload files to google bucket
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        run: |
+          gcloud config set pass_credentials_to_gsutil true
+          gsutil -m cp -R build/* gs://$BUCKET_NAME/pr-${{ github.event.number }}
+
+      - uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: "${{ github.token }}"
+          status: ${{ job.status }}
+          env: ${{ steps.deployment.outputs.env }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Find deployment comment
+        uses: peter-evans/find-comment@v1
+        id: find-deployment-comment
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+
+      - name: Find env tear down comment
+        uses: peter-evans/find-comment@v1
+        id: find-teardown-comment
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Your preview env has been torn down.
+
+      - name: Update env tear down comment
+        if: steps.find-teardown-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-teardown-comment.outputs.comment-id }}
+          body: |
+            Your preview env has been torn down.
+          edit-mode: replace
+
+      - name: Create comment
+        if: steps.find-deployment-comment.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v4
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+          edit-mode: replace

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -38,15 +38,6 @@ jobs:
           DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
         run: npm run build
 
-      - name: Start Deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          step: start
-          token: ${{ github.token }}
-          env: ${{ github.event.repository.name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -59,8 +50,16 @@ jobs:
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         run: |
-          gcloud config set pass_credentials_to_gsutil true
           gsutil -m rsync -d -r build gs://$BUCKET_NAME/pr-${{ github.event.number }}
+
+      - name: Start Deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: ${{ github.event.repository.name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: bobheadxi/deployments@v1
         with:

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -96,8 +96,6 @@ jobs:
       - name: Find deployment comment
         uses: peter-evans/find-comment@v3
         id: find-deployment-comment
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           issue-number: ${{ github.event.number }}
           body-includes: The preview environment relating to the commit

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
   deploy-preview:

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           comment-id: ${{ steps.find-teardown-comment.outputs.comment-id }}
           body: |
-            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on <a> https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html </a>.
+            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace
 
       - name: Add deployment comment
@@ -99,5 +99,5 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on <a> https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html </a>.
+            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}
+
 jobs:
   deploy-preview:
     if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy') || contains( github.event.pull_request.labels.*.name, 'deploy'))
@@ -24,17 +28,17 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
-      - name: Find deployment comment
-        uses: peter-evans/find-comment@v1
-        id: find-deployment-comment
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
-
       - name: Install Dependencies
         run: npm ci
+
+      - name: start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: "${{ github.token }}"
+          env: ${{ github.event.repository.name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build
         env:
@@ -51,31 +55,12 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: start deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          step: start
-          token: "${{ github.token }}"
-          env: ${{ github.event.repository.name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      # If the deployment comment is found, remove the old static files from the bucket
-      # before uploading the new build
-      - name: Remove files from Google bucket from previous deployment
-        if: steps.find-deployment-comment.outputs.comment-id != ''
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
-        run: |
-          gcloud config set pass_credentials_to_gsutil true
-          gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
-
       - name: Upload files to google bucket
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         run: |
           gcloud config set pass_credentials_to_gsutil true
-          gsutil -m cp -R build/* gs://$BUCKET_NAME/pr-${{ github.event.number }}
+          gsutil -m rsync -d -r build gs://$BUCKET_NAME/pr-${{ github.event.number }}
 
       - uses: bobheadxi/deployments@v1
         with:
@@ -84,6 +69,11 @@ jobs:
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
+
+      - name: Short commit SHA
+        id: extract_sha
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-10)" >> $GITHUB_ENV
 
       - name: Find env tear down comment
         uses: peter-evans/find-comment@v1
@@ -95,19 +85,30 @@ jobs:
       - name: Update env tear down comment
         if: steps.find-teardown-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           comment-id: ${{ steps.find-teardown-comment.outputs.comment-id }}
           body: |
-            Your preview env has been torn down.
+            The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace
 
-      - name: Create comment
-        if: steps.find-deployment-comment.outputs.comment-id == ''
+      - name: Find deployment comment
+        uses: peter-evans/find-comment@v1
+        id: find-deployment-comment
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+
+      - name: Upsert deployment comment
+        if: steps.find-deployment-comment.outputs.comment-id == '' && steps.find-teardown-comment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+            The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -73,30 +73,12 @@ jobs:
       - name: Shorten commit SHA
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
 
-      - name: Find previous deployment or tear-down comment
-        uses: peter-evans/find-comment@v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: <!-- preview-env -->
-
-      - name: Update previous deployment or tear-down comment
-        if: steps.find-comment.outputs.comment-id != ''
+      - name: Upsert comment
         uses: peter-evans/create-or-update-comment@v4
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          body: |
-            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
-          edit-mode: replace
-
-      - name: Add deployment comment
-        if: steps.find-comment.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
-        with:
           issue-number: ${{ github.event.number }}
           body: |
             <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           comment-id: ${{ steps.find-teardown-comment.outputs.comment-id }}
           body: |
-            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on <a> https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html </a>.
           edit-mode: replace
 
       - name: Add deployment comment
@@ -99,5 +99,5 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on <a> https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html </a>.
           edit-mode: replace

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -73,15 +73,15 @@ jobs:
       - name: Shorten commit SHA
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
 
-      - name: Find tear-down comment
+      - name: Find previous deployment or tear-down comment
         uses: peter-evans/find-comment@v3
-        id: find-teardown-comment
+        id: find-comment
         with:
           issue-number: ${{ github.event.number }}
           body-includes: <!-- preview-env -->
 
-      - name: Update tear-down comment
-        if: steps.find-teardown-comment.outputs.comment-id != ''
+      - name: Update previous deployment or tear-down comment
+        if: steps.find-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
@@ -92,7 +92,7 @@ jobs:
           edit-mode: replace
 
       - name: Add deployment comment
-        if: steps.find-teardown-comment.outputs.comment-id == ''
+        if: steps.find-comment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -73,6 +73,13 @@ jobs:
       - name: Shorten commit SHA
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
 
+      - name: Find previous deployment or tear-down comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: <!-- preview-env -->
+
       - name: Upsert deployment comment
         uses: peter-evans/create-or-update-comment@v4
         env:

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Upload files to Google bucket
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
-        run: |
-          gsutil -m rsync -d -r build gs://$BUCKET_NAME/pr-${{ github.event.number }}
-
       - name: Start Deployment
         uses: bobheadxi/deployments@v1
         id: deployment
@@ -60,6 +54,12 @@ jobs:
           token: ${{ github.token }}
           env: ${{ github.event.repository.name }}
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Upload files to Google bucket
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        run: |
+          gsutil -m rsync -d -r build gs://$BUCKET_NAME/pr-${{ github.event.number }}
 
       - uses: bobheadxi/deployments@v1
         with:
@@ -78,7 +78,7 @@ jobs:
         id: find-teardown-comment
         with:
           issue-number: ${{ github.event.number }}
-          body-includes: Your preview env has been torn down.
+          body-includes: <!-- preview-env -->
 
       - name: Update tear-down comment
         if: steps.find-teardown-comment.outputs.comment-id != ''
@@ -91,15 +91,8 @@ jobs:
             The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace
 
-      - name: Find deployment comment
-        uses: peter-evans/find-comment@v3
-        id: find-deployment-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: The preview environment relating to the commit
-
       - name: Add deployment comment
-        if: steps.find-deployment-comment.outputs.comment-id == '' && steps.find-teardown-comment.outputs.comment-id == ''
+        if: steps.find-teardown-comment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   deploy-preview:
@@ -43,7 +43,7 @@ jobs:
         id: deployment
         with:
           step: start
-          token: "${{ github.token }}"
+          token: ${{ github.token }}
           env: ${{ github.event.repository.name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -65,14 +65,14 @@ jobs:
       - uses: bobheadxi/deployments@v1
         with:
           step: finish
-          token: "${{ github.token }}"
+          token: ${{ github.token }}
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
       - name: Shorten commit SHA
-        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-10)" >> $GITHUB_ENV
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_ENV
 
       - name: Find tear-down comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     name: deploy-preview-env
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Import secrets from Vault
         id: secrets
@@ -31,7 +31,14 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: start deployment
+      - name: Build Docs
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
+          DOCS_SITE_URL: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+          DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
+        run: npm run build
+
+      - name: Start Deployment
         uses: bobheadxi/deployments@v1
         id: deployment
         with:
@@ -39,13 +46,6 @@ jobs:
           token: "${{ github.token }}"
           env: ${{ github.event.repository.name }}
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Build
-        env:
-          NODE_OPTIONS: --max_old_space_size=8192
-          DOCS_SITE_URL: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
-          DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
-        run: npm run build
 
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Upload files to google bucket
+      - name: Upload files to Google bucket
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         run: |
@@ -71,18 +71,18 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
-      - name: Short commit SHA
+      - name: Shorten commit SHA
         id: extract_sha
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-10)" >> $GITHUB_ENV
 
-      - name: Find env tear down comment
-        uses: peter-evans/find-comment@v1
+      - name: Find tear-down comment
+        uses: peter-evans/find-comment@v3
         id: find-teardown-comment
         with:
           issue-number: ${{ github.event.number }}
           body-includes: Your preview env has been torn down.
 
-      - name: Update env tear down comment
+      - name: Update tear-down comment
         if: steps.find-teardown-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
         env:
@@ -94,7 +94,7 @@ jobs:
           edit-mode: replace
 
       - name: Find deployment comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v3
         id: find-deployment-comment
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -72,7 +72,6 @@ jobs:
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
       - name: Shorten commit SHA
-        id: extract_sha
         run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-10)" >> $GITHUB_ENV
 
       - name: Find tear-down comment

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           comment-id: ${{ steps.find-teardown-comment.outputs.comment-id }}
           body: |
-            The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace
 
       - name: Add deployment comment
@@ -99,5 +99,5 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+            <!-- preview-env --> The preview environment relating to the commit ${{ env.short_sha }} has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
           edit-mode: replace

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
     name: teardown-preview-env
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Import secrets
         id: secrets
@@ -39,8 +39,8 @@ jobs:
           gcloud config set pass_credentials_to_gsutil true
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v1
+      - name: Find Deployment Comment
+        uses: peter-evans/find-comment@v3
         id: find-comment
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
@@ -48,7 +48,7 @@ jobs:
           issue-number: ${{ github.event.number }}
           body-includes: The preview environment relating to the commit
 
-      - name: Update comment
+      - name: Update deployment comment
         if: steps.find-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
         env:

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -42,8 +42,6 @@ jobs:
       - name: Find deployment comment
         uses: peter-evans/find-comment@v3
         id: find-comment
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           issue-number: ${{ github.event.number }}
           body-includes: The preview environment relating to the commit
@@ -51,8 +49,6 @@ jobs:
       - name: Update deployment comment
         if: steps.find-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v4
-        env:
-          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           body: |

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -46,7 +46,7 @@ jobs:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
           issue-number: ${{ github.event.number }}
-          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+          body-includes: The preview environment relating to the commit
 
       - name: Update comment
         if: steps.find-comment.outputs.comment-id != ''

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -4,7 +4,7 @@ on:
     types: [unlabeled, closed]
 
 jobs:
-  tear-dowm-preview-env:
+  tear-down-preview-env:
     if: github.event.label.name == 'deploy' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy'))
     runs-on: ubuntu-22.04
     timeout-minutes: 20

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -42,7 +42,7 @@ jobs:
         if: always()
         name: Deactivate GitHub Deployment environment
         with:
-          step: delete-env
+          step: deactivate-env
           token: ${{ github.token }}
           env: ${{ github.event.repository.name }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -39,6 +39,15 @@ jobs:
           gcloud config set pass_credentials_to_gsutil true
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
+      - uses: bobheadxi/deployments@v1
+        if: always()
+        name: Deactivate GitHub Deployment environment
+        with:
+          step: delete-env
+          token: ${{ github.token }}
+          env: ${{ github.event.repository.name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Find deployment comment
         uses: peter-evans/find-comment@v3
         id: find-comment

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -39,7 +39,7 @@ jobs:
           gcloud config set pass_credentials_to_gsutil true
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
-      - name: Find Deployment Comment
+      - name: Find deployment comment
         uses: peter-evans/find-comment@v3
         id: find-comment
         env:

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -44,7 +44,7 @@ jobs:
         id: find-comment
         with:
           issue-number: ${{ github.event.number }}
-          body-includes: The preview environment relating to the commit
+          body-includes: <!-- preview-env -->
 
       - name: Update deployment comment
         if: steps.find-comment.outputs.comment-id != ''
@@ -52,5 +52,5 @@ jobs:
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           body: |
-            Your preview env has been torn down.
+            <!-- preview-env --> Your preview env has been torn down.
           edit-mode: replace

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -36,7 +36,6 @@ jobs:
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         run: |
-          gcloud config set pass_credentials_to_gsutil true
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
       - uses: bobheadxi/deployments@v1

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -1,0 +1,60 @@
+name: preview-env-teardown
+on:
+  pull_request:
+    types: [unlabeled, closed]
+
+jobs:
+  tear-dowm-preview-env:
+    if: github.event.label.name == 'deploy' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy') )
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    name: teardown-preview-env
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Remove files from Google bucket
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        run: |
+          gcloud config set pass_credentials_to_gsutil true
+          gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Preview environment has successfully been deployed. You can access it on https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html.
+
+      - name: Update comment
+        if: steps.find-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        env:
+          BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          body: |
+            Your preview env has been torn down.
+          edit-mode: replace

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   tear-dowm-preview-env:
-    if: github.event.label.name == 'deploy' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy') )
+    if: github.event.label.name == 'deploy' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy'))
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     name: teardown-preview-env

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,9 +7,9 @@ module.exports = {
   title: "Camunda 8 Docs",
   tagline: "Documentation for all components of Camunda 8",
   // url: "https://camunda-cloud.github.io",
-  url: "https://docs.camunda.io",
+  url: process.env.DOCS_SITE_URL || "https://docs.camunda.io",
   // baseUrl: "/camunda-cloud-documentation/",
-  baseUrl: "/",
+  baseUrl: process.env.DOCS_SITE_BASE_URL || "/",
   customFields: {
     canonicalUrlRoot: "https://docs.camunda.io",
   },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,6 @@ const { unsupportedVersions } = require("./src/versions");
 
 const latestVersion = require("./src/versions").versionMappings[0].docsVersion;
 
-// test changes
 module.exports = {
   title: "Camunda 8 Docs",
   tagline: "Documentation for all components of Camunda 8",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,7 @@ const { unsupportedVersions } = require("./src/versions");
 
 const latestVersion = require("./src/versions").versionMappings[0].docsVersion;
 
+// test changes
 module.exports = {
   title: "Camunda 8 Docs",
   tagline: "Documentation for all components of Camunda 8",


### PR DESCRIPTION
## Description       
  
This pr adds two workflows which aim to assist in deploying the `camunda-docs` preview environments as well as tearing the environments down:

[preview-env-deploy.yml](https://github.com/camunda/camunda-docs/pull/3960/files#diff-3ba2b32605d5a9a991f461a7ac4e2f013808e2caddea0b241022c98702e4a526):
  - `Deployment Trigger:` Activates on labeled pull requests.
  - `Build:` Installs dependencies, builds the project
  - `Deployment`: Syncs the content of the path in the bucket to the local folder `build`. I did a test and using the gsutil command with the  `rsync -d -r` option does the following:
      a. Files which don’t exist in the bucket but exist locally in the build folder will get uploaded
      b. Files which exist in the bucket but not in the local folder will get deleted from the bucket
      c. File which exist in both the local directory and the bucket but they have different content will be synced (the content of the local files will override the content of the files in the bucket) 
  - `Comment Handling:` Updates or creates comments on the pull request about deployment status 
      a. If no comments exist then a comment indicating the deployment url will be shown 
      b. If a comment is found which indicates that the environment was previously teared down, it will be replaced by a comment indicating the preview env url. 
     c. If there is subsequent deployments then the comment indicating that the preview env has been deployed will remain intact
 - `Deployment status`: The deployment status will start showing in the pr just before the build step. Once the deployment has been concluded the url will be shown at the status
      
[preview-env-teardown.yml ](https://github.com/camunda/camunda-docs/blob/aabf94ee4951b3aa9ddd0ec1957c7e5f47ac16c1/.github/workflows/preview-env-teardown.yml)
 
 - `Deployment Trigger:` Runs on pull request unlabeled or closed events if the 'deploy' label is present or was present.
-  `Deletes Bucket Files:` Removes files from the Google Cloud Storage bucket associated with the pull request.
- `Updates Comment:` Finds and updates a specific comment on the pull request to indicate the preview environment has been torn down.

## Testing

### Test1: Teardown workflow gets triggered when closing pr
PR https://github.com/camunda/camunda-docs/pull/3961
Run triggered: https://github.com/camunda/camunda-docs/actions/runs/9576897550/job/26404161568

### Test 2: When pushing multiple times in the same pr: the deploy comment won’t get posted multiple times and the preview environment will be build from scratch
An example of this can be found in this pr as the deploy label is active and there are multiple pushes which have happened. The latest run of the `deploy-preview-env` workflow wiped out all files from the bucket `pr-3960` before pushing the built changes again
https://github.com/camunda/camunda-docs/actions/runs/9577037637/job/26404564930?pr=3960

### Test 3: Adding and removing the deploy label multiple times results in only one comment in the pr indicating the current status of the preview env.
You can have a look at the history of this pr. The label has been removed and added multiple times and there is one comment which constantly get updated. The comment gets created/updated in the following ways:

- When a deployment was successful a comment gets created.
- The comment doesnt get updated when there are subsequent pushes to the pr even if there have been subsequent deployments.
- The comment gets updated when the preview env gets teared down (on label removal for instance) indicating that action.
- The comment which previously was indicating that the preview env has been teared down will have to be updated again to indicate that the preview env has been deployed in case the label was added again to the pr and the deployment was successful.

After env was torn down:
<img width="1049" alt="Screenshot 2024-06-20 at 10 50 46" src="https://github.com/camunda/camunda-docs/assets/42938116/d382bda8-3e8c-4587-88e1-589dc7012dc9">

### Test 4: The url in the posted comment leads to a working preview environment
Following [this](https://github.com/camunda/camunda-docs/pull/3960#issuecomment-2180372126) comment on this pr 
the url posted there should prompt us to a working preview environment. The link is  https://preview.docs.camunda.cloud/pr-3960/index.html.

### Test 5: Test concurency in deploy preview env workflow
PR: https://github.com/camunda/camunda-docs/pull/3965

Initial run triggered: https://github.com/camunda/camunda-docs/actions/runs/9595842471/job/26461440032?pr=3965
Second run triggered: https://github.com/camunda/camunda-docs/actions/runs/9595856162/job/26461487867?pr=3965
The initial run got cancelled after the first run got triggered

## Test 6: Preview env has been torn down

PR: https://github.com/camunda/camunda-docs/pull/3972
I deployed the preview env and then removed the label to tear it down.

Since the deployment is only deactivated and not removed, this is how it is deployment after the environment has been torn down (notice the url not been apparent anymore):

<img width="775" alt="Screenshot 2024-06-24 at 14 41 22" src="https://github.com/camunda/camunda-docs/assets/42938116/74c4e57c-d9d5-404c-bbe0-4446a5b4e28c">

An explanation as to why the deployment has not been removed can be found in this comment https://github.com/camunda/camunda-docs/pull/3960#discussion_r1648617453

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
