### PR TITLE
chore(preview-envs): Look into improving commenting of preview enviro…

### DIFF
--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -99,4 +99,4 @@ jobs:
           message-id: preview-env-status
           refresh-message-position: true
           message: |
-            The preview environment relating to the commit ${{ github.sha }} has successfully been deployed. You can access it at [https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html](https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html).
+            The preview environment relating to the commit ${{ github.sha }} has successfully been deployed. You can access it at [https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html](https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html)

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Upsert comment with build status
         uses: mshick/add-pr-comment@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: preview-env-status
           refresh-message-position: true
           message: |
@@ -69,7 +68,6 @@ jobs:
       - name: Update comment with upload status
         uses: mshick/add-pr-comment@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: preview-env-status
           refresh-message-position: true
           message: |
@@ -95,7 +93,6 @@ jobs:
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: preview-env-status
           refresh-message-position: true
           message: |

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -28,21 +28,14 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
-      - name: Find previous deployment or tear-down comment
-        uses: peter-evans/find-comment@v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: <!-- preview-env -->
-
       - name: Upsert comment with build status
-        uses: peter-evans/create-or-update-comment@v4
+        uses: mshick/add-pr-comment@v2
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          body: |
-            :construction: The preview environment for the commit ${{ github.sha }} is being built. This usually takes 15-20 minutes. <!-- preview-env -->
-          edit-mode: replace
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: preview-env-status
+          refresh-message-position: true
+          message: |
+            :construction: The preview environment for the commit ${{ github.sha }} is being built. This usually takes 15-20 minutes.
 
       - name: Install Dependencies
         run: npm ci
@@ -73,21 +66,14 @@ jobs:
           env: ${{ github.event.repository.name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Find build status comment
-        uses: peter-evans/find-comment@v3
-        id: find-build-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: <!-- preview-env -->
-
       - name: Update comment with upload status
-        uses: peter-evans/create-or-update-comment@v4
+        uses: mshick/add-pr-comment@v2
         with:
-          comment-id: ${{ steps.find-build-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          body: |
-            :arrow_up: The preview environment build results for commit ${{ github.sha }} is being uploaded. This usually takes 3-4 minutes. <!-- preview-env -->
-          edit-mode: replace
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: preview-env-status
+          refresh-message-position: true
+          message: |
+            :arrow_up: The preview environment build results for commit ${{ github.sha }} are being uploaded. This usually takes 3-4 minutes.
 
       - name: Upload files to Google bucket
         env:
@@ -105,12 +91,12 @@ jobs:
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
       - name: Update comment with deployment status
-        uses: peter-evans/create-or-update-comment@v4
+        uses: mshick/add-pr-comment@v2
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
-          comment-id: ${{ steps.find-build-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          body: |
-            The preview environment relating to the commit ${{ github.sha }} has successfully been deployed. You can access it at [https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html](https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html) <!-- preview-env -->
-          edit-mode: replace
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: preview-env-status
+          refresh-message-position: true
+          message: |
+            The preview environment relating to the commit ${{ github.sha }} has successfully been deployed. You can access it at [https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html](https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html).

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Upsert comment with build status
         uses: mshick/add-pr-comment@v2
         with:
-          message-id: preview-env-status
           refresh-message-position: true
           message: |
             :construction: The preview environment for the commit ${{ github.sha }} is being built. This usually takes 15-20 minutes.
@@ -68,7 +67,6 @@ jobs:
       - name: Update comment with upload status
         uses: mshick/add-pr-comment@v2
         with:
-          message-id: preview-env-status
           refresh-message-position: true
           message: |
             :arrow_up: The preview environment build results for commit ${{ github.sha }} are being uploaded. This usually takes 3-4 minutes.
@@ -93,7 +91,6 @@ jobs:
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
-          message-id: preview-env-status
           refresh-message-position: true
           message: |
             The preview environment relating to the commit ${{ github.sha }} has successfully been deployed. You can access it at [https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html](https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/index.html)

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Update comment with tear-down warning
         uses: mshick/add-pr-comment@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: preview-env-status
           refresh-message-position: true
           message: |
@@ -59,7 +58,6 @@ jobs:
       - name: Update comment with tear-down status
         uses: mshick/add-pr-comment@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-id: preview-env-status
           refresh-message-position: true
           message: |

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Update comment with tear-down warning
         uses: mshick/add-pr-comment@v2
         with:
-          message-id: preview-env-status
           refresh-message-position: true
           message: |
             :warning: Preview environment for commit ${{ github.sha }} is being deleted. This usually takes 2-3 minutes.
@@ -58,7 +57,6 @@ jobs:
       - name: Update comment with tear-down status
         uses: mshick/add-pr-comment@v2
         with:
-          message-id: preview-env-status
           refresh-message-position: true
           message: |
             :broom: Preview environment for this PR has been torn down.

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -29,21 +29,14 @@ jobs:
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
-      - name: Find deployment status comment
-        uses: peter-evans/find-comment@v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          body-includes: <!-- preview-env -->
-
       - name: Update comment with tear-down warning
-        if: steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: mshick/add-pr-comment@v2
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          body: |
-            :warning: Preview environment for commit ${{ github.sha }} is being deleted. This usually takes 2-3 minutes. <!-- preview-env -->
-          edit-mode: replace
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: preview-env-status
+          refresh-message-position: true
+          message: |
+            :warning: Preview environment for commit ${{ github.sha }} is being deleted. This usually takes 2-3 minutes.
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -64,10 +57,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with tear-down status
-        if: steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: mshick/add-pr-comment@v2
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          body: |
-            :broom: Preview environment for this PR has been torn down. <!-- preview-env -->
-          edit-mode: replace
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: preview-env-status
+          refresh-message-position: true
+          message: |
+            :broom: Preview environment for this PR has been torn down.


### PR DESCRIPTION
…nments

## Description
This pr aims to switch to a different action in order to post comments in prs called `mshick/add-pr-comment`. The newly 
used action has the capability of always positioning the newly created comment in the latest comment position and requires very minimal configuration in order to find old comments.


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->


## TEST

### Test 1: Sequential deployments dont create a new group of messages
Tested with [this](https://github.com/camunda/camunda-docs/pull/4060/commits/9bf63c0c2baeac9d313263659d4293c56d4da0a4) commit by making a new push after there had already been a comment for the previous deployment

### Test 2: Triggering the teardown workflow updates the preview-env-status comments
Tested with [this](https://github.com/camunda/camunda-docs/pull/4060/commits/d7537838df43d0ba6683d855028a8b18ce398825) commit by adding and removing the deploy label 
