### PR TITLE
Add backpressure sources, error messaging, to backpressure docs

### DIFF
--- a/docs/components/react-components/backpressure-export.md
+++ b/docs/components/react-components/backpressure-export.md
@@ -1,0 +1,6 @@
+---
+---
+
+:::note
+A backlog may also occur when Elasticsearch (or other seconday storage instance) is under high load, reducing the rate at which records can be exported.
+:::

--- a/docs/components/zeebe/technical-concepts/internal-processing.md
+++ b/docs/components/zeebe/technical-concepts/internal-processing.md
@@ -57,17 +57,23 @@ This command can in turn be processed, completing the service task and driving t
 
 ## Handling backpressure
 
+import BackpressureWarning from '../../../components/react-components/backpressure-warning.md'
+import BackpressureExport from '../../../components/react-components/backpressure-export.md'
+
 When a broker receives a client request, it is written to the **event stream** first, and processed later by the stream processor. If the processing is slow or if there are many client requests in the stream, it might take too long for the processor to start processing the command. If the broker keeps accepting new requests from the client, the backlog increases and the processing latency can grow beyond an acceptable time.
 
-To avoid such problems, Zeebe employs a [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) mechanism.
-When the broker receives more requests than it can process with an acceptable latency, it rejects some requests.
+<BackpressureExport/>
 
-Backpressure is indicated to the client by throwing a **resource exhausted** exception. If a client sees this exception, it can retry the requests with an appropriate retry strategy. If the rejection rate is high, it indicates the broker is constantly under high load and you need to reduce the rate of requests. Alternatively, you can also increase broker resources to adjust to your needs. In high-load scenarios, it is recommended to [benchmark](https://camunda.com/blog/2022/05/how-to-benchmark-your-camunda-platform-8-cluster/) your Zeebe broker up front to size it correctly.
+To avoid such problems, Zeebe employs a [backpressure](/self-managed/zeebe-deployment/operations/backpressure.md) mechanism. When the broker receives more requests than it can process with an acceptable latency, it rejects some requests.
+
+### Resource exhausted
+
+Backpressure is indicated to the client by throwing a **resource exhausted** exception, which indicates whether the write limit or request limit has been reached.
+
+If a client sees this exception, it can retry the requests with an appropriate retry strategy. If the rejection rate is high, it indicates the broker is constantly under high load and you need to reduce the rate of requests. Alternatively, you can also increase broker resources to adjust to your needs. In high-load scenarios, it is recommended to [benchmark](https://camunda.com/blog/2022/05/how-to-benchmark-your-camunda-platform-8-cluster/) your Zeebe broker up front to size it correctly.
 
 The maximum rate of requests that can be processed by a broker depends on the processing capacity of the machine, the network latency, current load of the system, etc. There is no fixed limit configured in Zeebe for the maximum rate of requests it accepts. Instead, Zeebe uses an adaptive algorithm to dynamically determine the limit of the number of in-flight requests (the requests that are accepted by the broker, but not yet processed).
 
 The in-flight request count is incremented when a request is accepted, and decremented when a response is sent back to the client. The broker rejects requests when the in-flight request count reaches the limit.
-
-import BackpressureWarning from '../../../components/react-components/backpressure-warning.md'
 
 <BackpressureWarning/>

--- a/docs/self-managed/zeebe-deployment/operations/backpressure.md
+++ b/docs/self-managed/zeebe-deployment/operations/backpressure.md
@@ -5,10 +5,14 @@ description: "This document outlines an overview of backpressure and its accompa
 keywords: [back-pressure, backpressure, back pressure]
 ---
 
+import BackpressureExport from '../../../components/react-components/backpressure-export.md'
+
 When a broker receives a client request, it is written to the **event stream** first (see section [internal processing](/components/zeebe/technical-concepts/internal-processing.md) for details), and processed later by the stream processor.
 
 If the processing is slow or if there are many client requests in the stream, it might take too long for the processor to start processing the command.
 If the broker keeps accepting new requests from the client, the backlog increases and the processing latency can grow beyond an acceptable time.
+
+<BackpressureExport/>
 
 To avoid such problems, Zeebe employs a backpressure mechanism. When the broker receives more requests than it can process with an acceptable latency, it rejects some requests (see [technical error handling](/apis-tools/zeebe-api/technical-error-handling.md)).
 


### PR DESCRIPTION
## Description

Relates to https://github.com/camunda/product-hub/issues/1426, https://github.com/camunda/camunda/issues/17547

Adding in information to the backpressure concept docs to reference new sources of backpressure (backlog created by export lag/elasticsearch load), and that `resource exhausted` error messaging now differentiates between write and request limits.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
