### PR TITLE
fix: use proper properties for assign team reviews

### DIFF
--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -60,6 +60,7 @@ jobs:
           commit-message: "docs: update REST API spec"
           branch: update-rest-doc
           delete-branch: true
-          reviewers: camunda/tech-writers,pepopowitz
+          team-reviewers: camunda/tech-writers
+          reviewers: pepopowitz
           base: main
           labels: deploy


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Link to an associated epic when applicable. -->
<!-- Add an assignee and use `component:` or version labels for good hygiene! -->

Looking at the generated [PR](https://github.com/camunda/camunda-docs/pull/4217) there is a problem with adding @camunda/tech-writers as reviewers, this PR fix this.
