### PR TITLE
JDK version for spring-zeebe-sdk should be >= 21

### DIFF
--- a/versioned_docs/version-8.5/apis-tools/spring-zeebe-sdk/getting-started.md
+++ b/versioned_docs/version-8.5/apis-tools/spring-zeebe-sdk/getting-started.md
@@ -10,7 +10,7 @@ This project allows you to leverage Zeebe APIs ([gRPC](/apis-tools/zeebe-api/grp
 
 | Camunda Spring SDK version | JDK    | Camunda version | Bundled Spring Boot version |
 | -------------------------- | ------ | --------------- | --------------------------- |
-| 8.5.x                      | \>= 17 | 8.5.x           | 3.2.x                       |
+| 8.5.x                      | \>= 21 | 8.5.x           | 3.2.x                       |
 
 ## Add the Spring Zeebe SDK to your project
 


### PR DESCRIPTION
Using JDK 17 causes the following error which indicates wrong version of the JDK: 

```
[ERROR]   bad class file: /home/user/.m2/repository/io/camunda/spring-boot-starter-camunda-sdk/8.5.3/spring-boot-starter-camunda-sdk-8.5.3.jar(/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.class)
[ERROR]     class file has wrong version 65.0, should be 61.0
```
