### PR TITLE
docs(self-managed): Helm chart Elasticsearch nodes number changed

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -115,9 +115,15 @@ The `CorrelationResult` record has been changed compared to the previous version
 
 An example of how to use the new `CorrelationResult` can be found in the [Connector SDK documentation](/components/connectors/custom-built-connectors/connector-sdk.md#inbound-connector-runtime-logic).
 
-### Separated Ingress deprecation warning
+### Camunda 8 Self-Managed
+
+#### Helm chart - Separated Ingress deprecation
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. Only the combined Ingress configuration is officially supported. See the [Ingress guide](/self-managed/setup/guides/ingress-setup.md) for more information on configuring a combined Ingress setup.
+
+#### Helm chart - Elasticsearch nodes number
+
+The default value of Elasticsearch deployment Pods has changed from 2 to 3 with an affinity setting to avoid scheduling Elasticsearch Pods on the same Kubernetes worker.
 
 ## Camunda 8.5
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -123,7 +123,7 @@ The separated Ingress Helm configuration for Camunda 8 Self-Managed has been dep
 
 #### Helm chart - Elasticsearch nodes number
 
-The default value of Elasticsearch deployment pods has changed from 2 to 3 with an affinity setting. This avoids scheduling Elasticsearch pods on the same Kubernetes worker.
+The default value of Elasticsearch deployment pods has changed from 2 to 3, and an affinity setting has been added to avoid scheduling Elasticsearch pods on the same Kubernetes worker.
 
 ## Camunda 8.5
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -123,7 +123,7 @@ The separated Ingress Helm configuration for Camunda 8 Self-Managed has been dep
 
 #### Helm chart - Elasticsearch nodes number
 
-The default value of Elasticsearch deployment Pods has changed from 2 to 3 with an affinity setting to avoid scheduling Elasticsearch Pods on the same Kubernetes worker.
+The default value of Elasticsearch deployment pods has changed from 2 to 3 with an affinity setting. This avoids scheduling Elasticsearch pods on the same Kubernetes worker.
 
 ## Camunda 8.5
 

--- a/docs/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/docs/self-managed/operational-guides/update-guide/850-to-860.md
@@ -14,4 +14,4 @@ The separated Ingress Helm configuration for Camunda 8 Self-Managed has been dep
 
 ### Elasticsearch nodes number
 
-The default value of Elasticsearch deployment Pods has changed from 2 to 3 with an affinity setting to avoid scheduling Elasticsearch Pods on the same Kubernetes worker.
+The default value of Elasticsearch deployment pods has changed from 2 to 3 with an affinity setting. This avoids scheduling Elasticsearch pods on the same Kubernetes worker.

--- a/docs/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/docs/self-managed/operational-guides/update-guide/850-to-860.md
@@ -6,4 +6,12 @@ description: "Review which adjustments must be made to migrate from Camunda 8.5.
 
 The following sections explain which adjustments must be made to migrate from Camunda 8.5.x to 8.6.x for each component.
 
-TBD
+## Helm chart
+
+### Separated Ingress deprecation
+
+The separated Ingress Helm configuration for Camunda 8 Self-Managed has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. Only the combined Ingress configuration is officially supported. See the [Ingress guide](/self-managed/setup/guides/ingress-setup.md) for more information on configuring a combined Ingress setup.
+
+### Elasticsearch nodes number
+
+The default value of Elasticsearch deployment Pods has changed from 2 to 3 with an affinity setting to avoid scheduling Elasticsearch Pods on the same Kubernetes worker.

--- a/docs/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/docs/self-managed/operational-guides/update-guide/850-to-860.md
@@ -14,4 +14,4 @@ The separated Ingress Helm configuration for Camunda 8 Self-Managed has been dep
 
 ### Elasticsearch nodes number
 
-The default value of Elasticsearch deployment pods has changed from 2 to 3 with an affinity setting. This avoids scheduling Elasticsearch pods on the same Kubernetes worker.
+The default value of Elasticsearch deployment pods has changed from 2 to 3, and an affinity setting has been added to avoid scheduling Elasticsearch pods on the same Kubernetes worker.


### PR DESCRIPTION
## Description

The ideal setup for Elasticseaech is 3 nodes, so we set it to 3 by default in the Helm chart for Camunda Self-Managed 8.6.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
