### PR TITLE
feat: [CPT] I can read how to write process tests

### DIFF
--- a/docs/apis-tools/testing/assertions.md
+++ b/docs/apis-tools/testing/assertions.md
@@ -57,7 +57,7 @@ Assert that the given BPMN elements of the process instance are active, complete
 ```java
 assertThat(processInstance).hasActiveElements("A", "B");
 
-assertThat(processInstance).hasComplatedElements("A", "B");
+assertThat(processInstance).hasCompletedElements("A", "B");
 
 assertThat(processInstance).hasTerminatedElements("A", "B");
 ```

--- a/docs/apis-tools/testing/assertions.md
+++ b/docs/apis-tools/testing/assertions.md
@@ -1,0 +1,76 @@
+---
+id: assertions
+title: Assertions
+description: "Use assertions to verify the process instance state."
+---
+
+The class `CamundaAssert` is the entry point for all assertions. It is based on [AssertJ](https://github.com/assertj/assertj) and [Awaitility](http://www.awaitility.org/).
+
+The assertions follow the style: `assertThat(object_to_test)` + expected property.
+
+Use the assertions by adding the following static import in your test class:
+
+```java
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
+```
+
+:::info Assertions are blocking
+Camunda executes BPMN processes asynchronously. For testing, this means that there might be a delay between creating a process instance and reaching the expected state.
+
+The assertions handle the asynchronous behavior and wait until the expected property is fulfilled. Only if the property is not fulfilled within the given time, the assertion fails.
+
+By default, the assertions wait 10 seconds. If needed, you can change the time using `CamundaAssert.setAssertionTimeout(Duration.ofMinutes(1))`.
+:::
+
+## Process instance assertions
+
+You can verify the process instance state using the creation event of the process instance.
+
+```java
+// given/when
+ProcessInstanceEvent processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId("my-process").latestVersion().send().join();
+// or
+ProcessInstanceResult processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId("my-process").latestVersion().withResult().send().join();
+
+// then
+assertThat(processInstance).isActive();
+```
+
+### Process instance state
+
+Assert that the process instance is active, completed, or terminated.
+
+```java
+assertThat(processInstance).isActive();
+
+assertThat(processInstance).isCompleted();
+
+assertThat(processInstance).isTerminated();
+```
+
+### Element instance state
+
+Assert that the given BPMN elements of the process instance are active, completed, or terminated. The elements are identified by their BPMN element name.
+
+```java
+assertThat(processInstance).hasActiveElements("A", "B");
+
+assertThat(processInstance).hasComplatedElements("A", "B");
+
+assertThat(processInstance).hasTerminatedElements("A", "B");
+```
+
+### Process instance variables
+
+Assert that the process instance has the given variables. Local variables of BPMN elements are ignored.
+
+```java
+assertThat(processInstance).hasVariableNames("var1", "var2");
+
+assertThat(processInstance).hasVariable("var1", 100);
+
+Map<String, Object> expectedVariables = //
+assertThat(processInstance).hasVariables(expectedVariables);
+```

--- a/docs/apis-tools/testing/connectors.md
+++ b/docs/apis-tools/testing/connectors.md
@@ -1,7 +1,7 @@
 ---
 id: connectors
 title: Connectors
-description: "Enable connectors for your process test."
+description: "Run your process test with Connectors to verify the integration with external systems or the configuration of the Connector tasks in your processes."
 ---
 
 import Tabs from "@theme/Tabs";
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 You can run your process test with [Connectors](/components/connectors/introduction.md) to verify the integration with external systems or the configuration of the Connector tasks in your processes.
 
-For more unit-focused tests, you don't want to run the Connectors but mock the interaction, for example, by completing Connector jobs with an expected result.
+For more unit-focused tests, mock the interaction; for example, by completing Connector jobs with an expected result.
 
 ## Enable Connectors
 
@@ -200,9 +200,9 @@ You might need to wrap the invocation of the Connector in a retry loop, for exam
 There can be a delay between verifying that the Connnectors event is active and opening the Connectors inbound subscription.
 :::
 
-## Custom connectors
+## Custom Connectors
 
-If you don't use the out-of-the-box Camunda Connectors but a custom Connectors bundle, you can replace the Connectors in the test runtime.
+To use a custom Connectors bundle, replace the Connectors in the test runtime.
 
 <Tabs groupId="client" defaultValue="spring-sdk" queryString values={
 [

--- a/docs/apis-tools/testing/connectors.md
+++ b/docs/apis-tools/testing/connectors.md
@@ -1,0 +1,249 @@
+---
+id: connectors
+title: Connectors
+description: "Enable connectors for your process test."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+You can run your process test with [Connectors](/components/connectors/introduction.md) to verify the integration with external systems or the configuration of the Connector tasks in your processes.
+
+For more unit-focused tests, you don't want to run the Connectors but mock the interaction, for example, by completing Connector jobs with an expected result.
+
+## Enable Connectors
+
+By default, the Connectors are disabled. You need to change the runtime configuration to enable them.
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+Set the following property in your `application.yml` (or `application.properties`):
+
+```yaml
+io:
+  camunda:
+    process:
+      test:
+        connectors-enabled: true
+```
+
+Or, set the property directly on your test class:
+
+```java
+@SpringBootTest(properties = {"io.camunda.process.test.connectors-enabled=true"})
+@CamundaSpringProcessTest
+public class MyProcessTest {
+    //
+}
+```
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+Register the JUnit extension in your test class with enabled Connectors:
+
+```java
+// No annotation: @CamundaProcessTest
+public class MyProcessTest {
+
+    @RegisterExtension
+    private final CamundaProcessTestExtension extension =
+            new CamundaProcessTestExtension().withConnectorsEnabled(true);
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+## Connector secrets
+
+If you use [Connectors secrets](/components/connectors/use-connectors/index.md#using-secrets) in your processes, you can define them in the test runtime.
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+Add your secrets under the following property in your `application.yml` (or `application.properties`):
+
+```yaml
+io:
+  camunda:
+    process:
+      test:
+        connectors-enabled: true
+        connectors-secrets:
+          GITHUB_TOKEN: ghp_secret
+          SLACK_TOKEN: xoxb-secret
+```
+
+Or, set the property directly on your test class:
+
+```java
+@SpringBootTest(
+        properties = {
+                "io.camunda.process.test.connectors-enabled=true",
+                "io.camunda.process.test.connectors-secrets.GITHUB_TOKEN=ghp_secret",
+                "io.camunda.process.test.connectors-secrets.SLACK_TOKEN=xoxb-secret"
+        }
+)
+@CamundaSpringProcessTest
+public class MyProcessTest {
+    //
+}
+```
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+Add your secrets when you register the JUnit extension:
+
+```java
+// No annotation: @CamundaProcessTest
+public class MyProcessTest {
+
+    @RegisterExtension
+    private final CamundaProcessTestExtension extension =
+            new CamundaProcessTestExtension()
+                    .withConnectorsEnabled(true)
+                    .withConnectorsSecret("GITHUB_TOKEN", "ghp_secret")
+                    .withConnectorsSecret("SLACK_TOKEN", "xoxb-secret");
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+## Invoke an inbound Connector
+
+You can retrieve the URL address to invoke an inbound Connector in your test from the `CamundaProcessTestContext`.
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+```java
+@SpringBootTest
+@CamundaSpringProcessTest
+public class MyProcessTest {
+
+    @Autowired private ZeebeClient client;
+    @Autowired private CamundaProcessTestContext processTestContext;
+
+    @Test
+    void shouldInvokeConnector() {
+        // given: a process instance waiting at a Connector event
+
+        // when
+        final String inboundConnectorAddress =
+                processTestContext.getConnectorsAddress() + "/inbound/" + CONNECTOR_ID;
+        // invoke the connector address, for example, via HTTP request
+
+        // then: verify that the Connector event is completed
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+```java
+@CamundaProcessTest
+public class MyProcessTest {
+
+    // to be injected
+    private ZeebeClient client;
+    private CamundaProcessTestContext processTestContext;
+
+    @Test
+    void shouldInvokeConnector() {
+        // given: a process instance waiting at a Connector event
+
+        // when
+        final String connectorInboundAddress =
+                processTestContext.getConnectorsAddress() + "/inbound/" + CONNECTOR_ID;
+        // invoke the connector address, for example, via HTTP request
+
+        // then: verify that the Connector event is completed
+    }
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+:::tip
+You might need to wrap the invocation of the Connector in a retry loop, for example, by using [Awaitility](http://www.awaitility.org/).
+
+There can be a delay between verifying that the Connnectors event is active and opening the Connectors inbound subscription.
+:::
+
+## Custom connectors
+
+If you don't use the out-of-the-box Camunda Connectors but a custom Connectors bundle, you can replace the Connectors in the test runtime.
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+Set the Docker image name and version of your custom Connector bundle under the following properties in your `application.yml` (or `application.properties`):
+
+```yaml
+io:
+  camunda:
+    process:
+      test:
+        connectors-enabled: true
+        connectors-docker-image-name: my-org/my-connectors
+        connectors-docker-image-version: 1.0.0
+```
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+Set the Docker image name and version of your custom Connector bundle when you register the JUnit extension:
+
+```java
+// No annotation: @CamundaProcessTest
+public class MyProcessTest {
+
+    @RegisterExtension
+    private final CamundaProcessTestExtension extension =
+            new CamundaProcessTestExtension()
+                    .withConnectorsEnabled(true)
+                    .withConnectorsDockerImageName("my-org/my-connectors")
+                    .withConnectorsDockerImageVersion("1.0.0");
+}
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 [Camunda Process Test](https://github.com/camunda/camunda/tree/main/testing/camunda-process-test-java) (CPT) is a Java library to test your BPMN processes and your process application.
 
-CPT is based on [JUnit 5](https://junit.org/junit5/) and [Testcontainers](https://java.testcontainers.org/). It provides a managed isolated runtime to execute your process tests on your local machine. The runtime uses the Camunda Docker Images and includes the following components:
+CPT is based on [JUnit 5](https://junit.org/junit5/) and [Testcontainers](https://java.testcontainers.org/). It provides a managed isolated runtime to execute your process tests on your local machine. The runtime uses the Camunda Docker images and includes the following components:
 
 - Zeebe
 - Operate
@@ -17,15 +17,15 @@ CPT is based on [JUnit 5](https://junit.org/junit5/) and [Testcontainers](https:
 - Connectors
 
 :::warning Disclaimer
-For Camunda 8.6, CPT is in an [alpha version](/reference/alpha-features.md#alpha) (i.e. preview).
+For Camunda 8.6, CPT is in an [alpha version](/reference/alpha-features.md#alpha), for preview, for example.
 
-If you need a full-featured testing library, take a look at [Zeebe Process Test](/apis-tools/java-client/zeebe-process-test.md).
+For a full-featured testing library, take a look at [Zeebe Process Test](/apis-tools/java-client/zeebe-process-test.md).
 :::
 
 :::note Limitations
-CPT is in an early stage. It doesn't contain all features, and it is not optimized yet. Please be aware of the following limitations:
+CPT is in an early stage. It doesn't contain all features, and it is not optimized yet. Be aware of the following limitations:
 
-- Slow test execution (~ 40 seconds per test case)
+- Slow test execution (~40 seconds per test case)
 - Only basic assertions
 
 :::
@@ -123,10 +123,10 @@ public class MyProcessTest {
 
 - `@SpringBootTest` is the standard Spring annotation for tests.
 - `@CamundaSpringProcessTest` registers the Camunda test execution listener that starts and stops the test runtime.
-- (optional) Inject a preconfigured `ZeebeClient` to interact with the Camunda runtime.
-- (optional) Inject a `CamundaProcessTestContext` to interact with the test runtime.
 - `@Test` is the standard JUnit 5 annotation for a test case.
-- (optional) Use `CamundaAssert` to verify the process instance state.
+- (_optional_) Inject a preconfigured `ZeebeClient` to interact with the Camunda runtime.
+- (_optional_) Inject a `CamundaProcessTestContext` to interact with the test runtime.
+- (_optional_) Use `CamundaAssert` to verify the process instance state.
 
 </TabItem>
 
@@ -165,10 +165,10 @@ public class MyProcessTest {
 ```
 
 - `@CamundaProcessTest` registers the Camunda JUnit extension that starts and stops the test runtime.
-- (optional) Get a preconfigured `ZeebeClient` injected to interact with the Camunda runtime.
-- (optional) Get a `CamundaProcessTestContext` injected to interact with the test runtime.
 - `@Test` is the standard JUnit 5 annotation for a test case.
-- (optional) Use `CamundaAssert` to verify the process instance state.
+- (_optional_) Get a preconfigured `ZeebeClient` injected to interact with the Camunda runtime.
+- (_optional_) Get a `CamundaProcessTestContext` injected to interact with the test runtime.
+- (_optional_) Use `CamundaAssert` to verify the process instance state.
 
 </TabItem>
 
@@ -286,4 +286,4 @@ For most cases, the log level `warn` (warning) is sufficient.
 
 ## Examples
 
-Take a look at the example project on [GitHub](https://github.com/camunda/camunda/tree/main/testing/camunda-process-test-example). It demonstrates the usage of the library for a demo Spring Boot process application.
+Take a look at the example project on [GitHub](https://github.com/camunda/camunda/tree/main/testing/camunda-process-test-example). This demonstrates the usage of the library for a demo Spring Boot process application.

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -1,0 +1,290 @@
+---
+id: getting-started
+title: Getting started
+description: "Integrate the Camunda Process Test library in your project."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+[Camunda Process Test](https://github.com/camunda/camunda/tree/main/testing/camunda-process-test-java) (CPT) is a Java library to test your BPMN processes and your process application.
+
+CPT is based on [JUnit 5](https://junit.org/junit5/) and [Testcontainers](https://java.testcontainers.org/). It provides a managed isolated runtime to execute your process tests on your local machine. The runtime uses the Camunda Docker Images and includes the following components:
+
+- Zeebe
+- Operate
+- Tasklist
+- Connectors
+
+:::warning Disclaimer
+For Camunda 8.6, CPT is in an [alpha version](/reference/alpha-features.md#alpha) (i.e. preview).
+
+If you need a full-featured testing library, take a look at [Zeebe Process Test](/apis-tools/java-client/zeebe-process-test.md).
+:::
+
+:::note Limitations
+CPT is in an early stage. It doesn't contain all features, and it is not optimized yet. Please be aware of the following limitations:
+
+- Slow test execution (~ 40 seconds per test case)
+- Only basic assertions
+
+:::
+
+## Prerequisites
+
+- Java 8+ / 17+ (for Spring SDK)
+- JUnit 5
+- A Docker-API compatible container runtime, such as Docker on Linux or Docker Desktop on Mac and Windows. If you have issues with your Docker runtime, have a look at the [Testcontainers documentation](https://java.testcontainers.org/supported_docker_environment/).
+
+## Install
+
+We have two variations of CPT: for the [Spring SDK](/apis-tools/spring-zeebe-sdk/getting-started.md) and the [Zeebe Java client](/apis-tools/java-client/index.md). Choose the one depending on which library you use in your process application.
+
+Add the following dependency to your Maven project:
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-process-test-spring</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-process-test-java</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+</TabItem>
+
+</Tabs>
+
+## Write a test
+
+Create a new Java class with the following structure:
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+```java
+package com.example;
+
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@CamundaSpringProcessTest
+public class MyProcessTest {
+
+    @Autowired private ZeebeClient client;
+    @Autowired private CamundaProcessTestContext processTestContext;
+
+    @Test
+    void shouldCompleteProcessInstance() {
+        // given
+        client.newDeployResourceCommand().addResourceFromClasspath("my-process.bpmn").send().join();
+
+        // when
+        final ProcessInstanceEvent processInstance =
+                client.newCreateInstanceCommand().bpmnProcessId("my-process").latestVersion().send().join();
+
+        // then
+        CamundaAssert.assertThat(processInstance).isCompleted();
+    }
+}
+```
+
+- `@SpringBootTest` is the standard Spring annotation for tests.
+- `@CamundaSpringProcessTest` registers the Camunda test execution listener that starts and stops the test runtime.
+- (optional) Inject a preconfigured `ZeebeClient` to interact with the Camunda runtime.
+- (optional) Inject a `CamundaProcessTestContext` to interact with the test runtime.
+- `@Test` is the standard JUnit 5 annotation for a test case.
+- (optional) Use `CamundaAssert` to verify the process instance state.
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+```java
+package com.example;
+
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaProcessTest;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class MyProcessTest {
+
+    // to be injected
+    private ZeebeClient client;
+    private CamundaProcessTestContext processTestContext;
+
+    @Test
+    void shouldCompleteProcessInstance() {
+        // given
+        client.newDeployResourceCommand().addResourceFromClasspath("my-process.bpmn").send().join();
+
+        // when
+        final ProcessInstanceEvent processInstance =
+                client.newCreateInstanceCommand().bpmnProcessId("my-process").latestVersion().send().join();
+
+        // then
+        CamundaAssert.assertThat(processInstance).isCompleted();
+    }
+}
+```
+
+- `@CamundaProcessTest` registers the Camunda JUnit extension that starts and stops the test runtime.
+- (optional) Get a preconfigured `ZeebeClient` injected to interact with the Camunda runtime.
+- (optional) Get a `CamundaProcessTestContext` injected to interact with the test runtime.
+- `@Test` is the standard JUnit 5 annotation for a test case.
+- (optional) Use `CamundaAssert` to verify the process instance state.
+
+</TabItem>
+
+</Tabs>
+
+Read more about `CamundaAssert` and the available assertions [here](assertions.md).
+
+## Configure the runtime
+
+By default, the test runtime uses the Camunda Docker images in the same version as the test library. You can change the version or customize the runtime to your needs.
+
+<Tabs groupId="client" defaultValue="spring-sdk" queryString values={
+[
+{label: 'Spring SDK', value: 'spring-sdk' },
+{label: 'Java client', value: 'java-client' }
+]
+}>
+
+<TabItem value='spring-sdk'>
+
+Set the following properties in your `application.yml` (or `application.properties`) to override the defaults:
+
+```yaml
+io:
+  camunda:
+    process:
+      test:
+        # Change the version of the Camunda Docker image
+        camundaVersion: 8.6.0
+        # Change the Zeebe Docker image
+        zeebe-docker-image-name: camunda/zeebe
+        # Set additional Zeebe environment variables
+        zeebe-env-vars:
+          env_1: value_1
+        # Expose addition Zeebe ports
+        zeebeExposedPorts:
+          - 4567
+        # Enable Connectors
+        connectors-enabled: true
+        # Change the Connectors Docker image
+        connectors-docker-image-name: camunda/connectors
+        # Change version of the Connectors Docker image
+        connectors-docker-image-version: 8.6.0
+        # Set additional Connectors environment variables
+        connectors-env-vars:
+          env_1: value_1
+        # Set Connectors secrets
+        connectors-secrets:
+          secret_1: value_1
+```
+
+</TabItem>
+
+<TabItem value='java-client'>
+
+You can change the version by setting the following properties in a `/camunda-container-runtime.properties` file:
+
+```properties
+camunda.version=8.6.0
+elasticsearch.version=8.13.4
+```
+
+For more configuration options, you can register the JUnit extension manually and use the fluent builder to override the default:
+
+```java
+package com.example;
+
+import io.camunda.process.test.api.CamundaProcessTestExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+// No annotation: @CamundaProcessTest
+public class MyProcessTest {
+
+    @RegisterExtension
+    private final CamundaProcessTestExtension extension =
+            new CamundaProcessTestExtension()
+                    // Change the version of the Camunda Docker image
+                    .withCamundaVersion("8.6.0")
+                    // Change the Zeebe Docker image
+                    .withZeebeDockerImageName("camunda/zeebe")
+                    // Set additional Zeebe environment variables
+                    .withZeebeEnv("env_1", "value_1")
+                    // Expose addition Zeebe ports
+                    .withZeebeExposedPort(4567)
+                    // Enable Connectors
+                    .withConnectorsEnabled(true)
+                    // Change the Connectors Docker image
+                    .withConnectorsDockerImageName("camunda/connectors")
+                    // Change version of the Connectors Docker image
+                    .withConnectorsDockerImageVersion("8.6.0")
+                    // Set additional Connectors environment variables
+                    .withConnectorsEnv("env_1", "value_1")
+                    // Set Connectors secrets
+                    .withConnectorsSecret("secret_1", "value_1");
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+## Logging
+
+The test runtime uses [SLF4J](https://www.slf4j.org/) as the logging framework. If needed, you can enable the logging for the following packages:
+
+- `io.camunda.process.test` - The test runtime
+- `tc.zeebe` - The Zeebe Docker container
+- `tc.operate` - The Operate Docker container
+- `tc.tasklist` - The Tasklist Docker container
+- `tc.connectors` - The Connectors Docker container
+- `tc.elasticsearch` - The Elasticsearch Docker container
+- `org.testcontainers` - The Testconainers framework
+
+For most cases, the log level `warn` (warning) is sufficient.
+
+## Examples
+
+Take a look at the example project on [GitHub](https://github.com/camunda/camunda/tree/main/testing/camunda-process-test-example). It demonstrates the usage of the library for a demo Spring Boot process application.

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -109,8 +109,7 @@ public class MyProcessTest {
 
     @Test
     void shouldCompleteProcessInstance() {
-        // given
-        client.newDeployResourceCommand().addResourceFromClasspath("my-process.bpmn").send().join();
+        // given: the processes are deployed
 
         // when
         final ProcessInstanceEvent processInstance =

--- a/docs/apis-tools/testing/utilities.md
+++ b/docs/apis-tools/testing/utilities.md
@@ -1,0 +1,31 @@
+---
+id: utilities
+title: Utilities
+description: "Use utilities to interact with the process instance."
+---
+
+There are different utilities that can help you to write your process test.
+
+## Manipulate the clock
+
+The Camunda runtime uses an internal clock to execute process instances and to calculate when a BPMN timer event is due. In a test, you can use `CamundaProcessTestContext` to manipulate the clock.
+
+When to use it:
+
+- Trigger an active BPMN timer event
+- Test scenarios that require a specific date or time, for example, a leap year
+
+```java
+@Test
+void shouldTriggerTimerEvent() {
+    // given: a process instance waiting at a BPMN timer event
+
+    // when
+    assertThat(processInstance).hasActiveElements("Wait 2 days");
+
+    processTestContext.increaseTime(Duration.ofDays(2));
+
+    // then
+    assertThat(processInstance).hasCompletedElements("Wait 2 days");
+}
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -859,6 +859,18 @@ module.exports = {
       ],
     },
     require("./docs/apis-tools/frontend-development/sidebar-schema"),
+    {
+      Testing: [
+        {
+          "Camunda Process Test": [
+            "apis-tools/testing/getting-started",
+            "apis-tools/testing/assertions",
+            "apis-tools/testing/utilities",
+            "apis-tools/testing/connectors",
+          ],
+        },
+      ],
+    },
   ],
 
   Reference: [


### PR DESCRIPTION
## Description

Adds a new reference documentation for the new Camunda Process Test Java library. It describes how to install and use the library to write process tests. Take inspiration from the [Zeebe Process Test](https://docs.camunda.io/docs/apis-tools/java-client/zeebe-process-test/) documentation.

The new documentation is added to the sidebar under: `API & Tools > Testing > Camunda Process Test`.

closes #3921 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [x] I included my new page in the sidebar file(s).

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

