### PR TITLE
fix(self-managed): deprecation notice for helm multiregion options

### DIFF
--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -108,9 +108,9 @@ An example of how to use the new `CorrelationResult` can be found in the [Connec
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. Only the combined Ingress configuration is officially supported. See the [Ingress guide](/self-managed/setup/guides/ingress-setup.md) for more information on configuring a combined Ingress setup.
 
-#### Helm chart - MultiRegion Failover / Failback mode deprecation
+#### Helm chart - global.multiregion.installationType deprecation
 
-The MultiRegion configuration in the helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. This will be replaced with a set of API actuator endpoints that you would call while following the ([Dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
+The `global.multiregion.installationType` option is used in failover and failback scenarios. This option in the helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. `global.multiregion.installationType` will be replaced with a set of API endpoints that you would call while following the ([Dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
 
 #### Helm chart - Elasticsearch nodes number
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -108,9 +108,9 @@ An example of how to use the new `CorrelationResult` can be found in the [Connec
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. Only the combined Ingress configuration is officially supported. See the [Ingress guide](/self-managed/setup/guides/ingress-setup.md) for more information on configuring a combined Ingress setup.
 
-#### Helm chart - global.multiregion.installationType deprecation
+#### Helm chart - `global.multiregion.installationType` deprecation
 
-The `global.multiregion.installationType` option is used in failover and failback scenarios. This option in the helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. `global.multiregion.installationType` will be replaced with a set of API endpoints that you would call while following the ([Dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
+The `global.multiregion.installationType` option is used in failover and failback scenarios. This option in the Helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. `global.multiregion.installationType` will be replaced with a set of API endpoints called while following the ([dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
 
 #### Helm chart - Elasticsearch nodes number
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -108,6 +108,10 @@ An example of how to use the new `CorrelationResult` can be found in the [Connec
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. Only the combined Ingress configuration is officially supported. See the [Ingress guide](/self-managed/setup/guides/ingress-setup.md) for more information on configuring a combined Ingress setup.
 
+#### Helm chart - MultiRegion Failover / Failback mode deprecation
+
+The MultiRegion configuration in the helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. This will be replaced with a set of API actuator endpoints that you would call while following the ([Dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
+
 #### Helm chart - Elasticsearch nodes number
 
 The default value of Elasticsearch deployment pods has changed from 2 to 3, and an affinity setting has been added to avoid scheduling Elasticsearch pods on the same Kubernetes worker.

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -110,7 +110,7 @@ The separated Ingress Helm configuration for Camunda 8 Self-Managed has been dep
 
 #### Helm chart - `global.multiregion.installationType` deprecation
 
-The `global.multiregion.installationType` option is used in failover and failback scenarios. This option in the Helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. `global.multiregion.installationType` will be replaced with a set of API endpoints called while following the ([dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
+The `global.multiregion.installationType` option is used in failover and failback scenarios. This option in the Helm chart has been deprecated in 8.6, and will be removed from the Helm chart in 8.7. `global.multiregion.installationType` was replaced with a set of API endpoints called while following the ([dual-region operational procdure](/self-managed/operational-guides/multi-region/dual-region-ops.md))
 
 #### Helm chart - Elasticsearch nodes number
 


### PR DESCRIPTION
## Description

As part of https://github.com/camunda/camunda-platform-helm/issues/2286, we want to announce the deprecation of the failover / failback options in the helm chart for multi-region enabled deployments. These helm variables were difficult to work around and instead, there are application-specific changes to zeebe to make this process easier. That process involves using API endpoints on the actuator to trigger certain events in zeebe, and is already documented here:

https://docs.camunda.io/docs/next/self-managed/operational-guides/multi-region/dual-region-operational-procedure/?lost-region=region-0-lost&failback=step1&failover=step1#introduction

This PR is a notice that for 8.6,  the options will remain in the helm chart, but for 8.7, they will be dropped. Users must migrate to using the new dual-region procedure.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Link to an associated epic when applicable. -->
<!-- Add an assignee and use `component:` or version labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
