### PR TITLE
docs(self-managed): remove deprecation note about helm global.image.tag

### DIFF
--- a/docs/self-managed/setup/upgrade.md
+++ b/docs/self-managed/setup/upgrade.md
@@ -92,8 +92,6 @@ As of this Helm chart version, the image tags for all components are independent
 
 With this change, Camunda applications no longer require a unified patch version. For example, a given installation may use Zeebe version 8.5.1, and Operate version 8.5.2. Note that only the patch version can differ between components.
 
-The key `global.image.tag` is deprecated and it will be removed in the Camunda 8.6 release.
-
 <h3>Helm chart 10.0.2+</h3>
 
 The upgrade path for Camunda Helm Chart v9.x.x is v10.0.2+.

--- a/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.2/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -103,8 +103,6 @@ As of this Helm chart version, the image tags for all components are independent
 
 With this change, Camunda applications no longer require a unified patch version. For example, a given installation may use Zeebe version 8.2.1, and Operate version 8.2.2. Note that only the patch version can differ between components.
 
-The key `global.image.tag` is deprecated and it will be removed in the Camunda 8.6 release.
-
 ### v8.2.9
 
 #### Optimize

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -103,8 +103,6 @@ As of this Helm chart version, the image tags for all components are independent
 
 With this change, Camunda applications no longer require a unified patch version. For example, a given installation may use Zeebe version 8.3.1, and Operate version 8.3.2. Note that only the patch version can differ between components.
 
-The key `global.image.tag` is deprecated and it will be removed in the Camunda 8.6 release.
-
 ### v8.3.1
 
 :::caution

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -103,8 +103,6 @@ As of this Helm chart version, the image tags for all components are independent
 
 With this change, Camunda applications no longer require a unified patch version. For example, a given installation may use Zeebe version 8.4.1, and Operate version 8.4.2. Note that only the patch version can differ between components.
 
-The key `global.image.tag` is deprecated and it will be removed in the Camunda 8.6 release.
-
 ### v9.3.0
 
 #### Enabling Console

--- a/versioned_docs/version-8.5/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.5/self-managed/setup/upgrade.md
@@ -54,8 +54,6 @@ As of this Helm chart version, the image tags for all components are independent
 
 With this change, Camunda applications no longer require a unified patch version. For example, a given installation may use Zeebe version 8.5.1, and Operate version 8.5.2. Note that only the patch version can differ between components.
 
-The key `global.image.tag` is deprecated and it will be removed in the Camunda 8.6 release.
-
 <h3>Helm chart 10.0.2+</h3>
 
 The upgrade path for Camunda Helm Chart v9.x.x is v10.0.2+.


### PR DESCRIPTION
## Description

After diving more into mono jar topics, we found the key `global.image.tag` could be useful in the future, so we will keep it for now and rethink it again in the 8.8 cycle.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.