### PR TITLE
document rest api long polling limitation

### DIFF
--- a/docs/apis-tools/java-client/job-worker.md
+++ b/docs/apis-tools/java-client/job-worker.md
@@ -13,6 +13,13 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 The Java client provides a job worker that handles polling for available jobs. This allows you to focus on writing code to handle the activated jobs.
 
+:::caution REST API limitation
+The 8.6.0 Java client cannot maintain the long-lived polling connections required for job polling via the REST API. For example, this applies to performing long-polling job activation when activating jobs larger than the maximum message size, or receiving additional job activation requests while the long-polling connection is still open.
+
+If you encounter this issue, consider switching to the Zeebe gRPC protocol for job activation, or use job
+activation via the REST API with long polling disabled.
+:::
+
 On `open`, the job worker waits `pollInterval` milliseconds and then polls for `maxJobsActive` jobs. It then continues with the following schedule:
 
 1. If a poll did not activate any jobs, it waits for `pollInterval` milliseconds and then polls for more jobs.

--- a/versioned_docs/version-8.6/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.6/apis-tools/java-client/job-worker.md
@@ -13,6 +13,13 @@ keywords: ["backpressure", "back-pressure", "back pressure"]
 
 The Java client provides a job worker that handles polling for available jobs. This allows you to focus on writing code to handle the activated jobs.
 
+:::caution REST API limitation
+The 8.6.0 Java client cannot maintain the long-lived polling connections required for job polling via the REST API. For example, this applies to performing long-polling job activation when activating jobs larger than the maximum message size, or receiving additional job activation requests while the long-polling connection is still open.
+
+If you encounter this issue, consider switching to the Zeebe gRPC protocol for job activation, or use job
+activation via the REST API with long polling disabled.
+:::
+
 On `open`, the job worker waits `pollInterval` milliseconds and then polls for `maxJobsActive` jobs. It then continues with the following schedule:
 
 1. If a poll did not activate any jobs, it waits for `pollInterval` milliseconds and then polls for more jobs.


### PR DESCRIPTION
## Description

Backporting https://github.com/camunda/camunda-docs/pull/4376. Note that this is sufficient to merge for the `8.6` release, but there are lingering comments in the original PR to refine this content.

CC @koevskinikola 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
