### PR TITLE
Spring Zeebe SDK - Getting Started - Removal of unnecessary identity repo setup

### DIFF
--- a/docs/apis-tools/spring-zeebe-sdk/getting-started.md
+++ b/docs/apis-tools/spring-zeebe-sdk/getting-started.md
@@ -15,29 +15,13 @@ This project allows you to leverage Zeebe APIs ([gRPC](/apis-tools/zeebe-api/grp
 
 ## Add the Spring Zeebe SDK to your project
 
-Add the following repository and Maven dependency to your Spring Boot Starter project:
-
-```xml
-<repositories>
-    <repository>
-        <releases>
-            <enabled>true</enabled>
-        </releases>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-        <id>identity</id>
-        <name>Camunda Identity</name>
-        <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-    </repository>
-</repositories>
-```
+Add the following Maven dependency to your Spring Boot Starter project, replacing `x` with the latest patch level available:
 
 ```xml
 <dependency>
     <groupId>io.camunda</groupId>
     <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-    <version>8.6.3</version>
+    <version>8.6.x</version>
 </dependency>
 ```
 

--- a/docs/guides/getting-started-java-spring.md
+++ b/docs/guides/getting-started-java-spring.md
@@ -113,33 +113,13 @@ To implement a service task, take the following steps:
 
 ### Configure Spring Boot Starter
 
-See our documentation on [adding the Spring Zeebe SDK to your project](/apis-tools/spring-zeebe-sdk/getting-started.md#add-the-spring-zeebe-sdk-to-your-project) for more details, also described below:
-
-1. Copy the following code snippet into the `pom.xml` file of your Spring project, below properties and above dependencies:
-
-```xml
-<repositories>
-   <repository>
-      <releases>
-         <enabled>true</enabled>
-      </releases>
-      <snapshots>
-         <enabled>false</enabled>
-      </snapshots>
-      <id>identity</id>
-      <name>Camunda Identity</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-   </repository>
-</repositories>
-```
-
-2. Add the following dependency to your `pom.xml` file, as a child of the `<dependencies>` element:
+Add the following Maven dependency to your Spring Boot Starter project, replacing `x` with the latest patch level available:
 
 ```xml
 <dependency>
-   <groupId>io.camunda</groupId>
-   <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-   <version>8.6.3</version>
+    <groupId>io.camunda</groupId>
+    <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+    <version>8.6.x</version>
 </dependency>
 ```
 

--- a/versioned_docs/version-8.5/apis-tools/spring-zeebe-sdk/getting-started.md
+++ b/versioned_docs/version-8.5/apis-tools/spring-zeebe-sdk/getting-started.md
@@ -14,29 +14,13 @@ This project allows you to leverage Zeebe APIs ([gRPC](/apis-tools/zeebe-api/grp
 
 ## Add the Spring Zeebe SDK to your project
 
-Add the following repository and Maven dependency to your Spring Boot Starter project:
-
-```xml
-<repositories>
-    <repository>
-        <releases>
-            <enabled>true</enabled>
-        </releases>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-        <id>identity</id>
-        <name>Camunda Identity</name>
-        <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-    </repository>
-</repositories>
-```
+Add the following Maven dependency to your Spring Boot Starter project, replacing `x` with the latest patch level available:
 
 ```xml
 <dependency>
-  <groupId>io.camunda</groupId>
-  <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-  <version>8.5.0</version>
+    <groupId>io.camunda</groupId>
+    <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+    <version>8.5.x</version>
 </dependency>
 ```
 

--- a/versioned_docs/version-8.5/guides/getting-started-java-spring.md
+++ b/versioned_docs/version-8.5/guides/getting-started-java-spring.md
@@ -116,33 +116,13 @@ To implement a service task, take the following steps:
 
 ### Configure Spring Boot Starter
 
-See our documentation on [adding the Spring Zeebe SDK to your project](/apis-tools/spring-zeebe-sdk/getting-started.md#add-the-spring-zeebe-sdk-to-your-project) for more details, also described below:
-
-1. Copy the following code snippet into the `pom.xml` file of your Spring project, below properties and above dependencies:
-
-```xml
-<repositories>
-   <repository>
-      <releases>
-         <enabled>true</enabled>
-      </releases>
-      <snapshots>
-         <enabled>false</enabled>
-      </snapshots>
-      <id>identity</id>
-      <name>Camunda Identity</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-   </repository>
-</repositories>
-```
-
-2. Add the following dependency to your `pom.xml` file, as a child of the `<dependencies>` element:
+Add the following Maven dependency to your Spring Boot Starter project, replacing `x` with the latest patch level available:
 
 ```xml
 <dependency>
-   <groupId>io.camunda</groupId>
-   <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-   <version>8.5.0</version>
+    <groupId>io.camunda</groupId>
+    <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+    <version>8.5.x</version>
 </dependency>
 ```
 

--- a/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/getting-started.md
+++ b/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/getting-started.md
@@ -15,29 +15,13 @@ This project allows you to leverage Zeebe APIs ([gRPC](/apis-tools/zeebe-api/grp
 
 ## Add the Spring Zeebe SDK to your project
 
-Add the following repository and Maven dependency to your Spring Boot Starter project:
-
-```xml
-<repositories>
-    <repository>
-        <releases>
-            <enabled>true</enabled>
-        </releases>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-        <id>identity</id>
-        <name>Camunda Identity</name>
-        <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-    </repository>
-</repositories>
-```
+Add the following Maven dependency to your Spring Boot Starter project, replacing `x` with the latest patch level available:
 
 ```xml
 <dependency>
     <groupId>io.camunda</groupId>
     <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-    <version>8.6.3</version>
+    <version>8.6.x</version>
 </dependency>
 ```
 

--- a/versioned_docs/version-8.6/guides/getting-started-java-spring.md
+++ b/versioned_docs/version-8.6/guides/getting-started-java-spring.md
@@ -113,33 +113,13 @@ To implement a service task, take the following steps:
 
 ### Configure Spring Boot Starter
 
-See our documentation on [adding the Spring Zeebe SDK to your project](/apis-tools/spring-zeebe-sdk/getting-started.md#add-the-spring-zeebe-sdk-to-your-project) for more details, also described below:
-
-1. Copy the following code snippet into the `pom.xml` file of your Spring project, below properties and above dependencies:
-
-```xml
-<repositories>
-   <repository>
-      <releases>
-         <enabled>true</enabled>
-      </releases>
-      <snapshots>
-         <enabled>false</enabled>
-      </snapshots>
-      <id>identity</id>
-      <name>Camunda Identity</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-   </repository>
-</repositories>
-```
-
-2. Add the following dependency to your `pom.xml` file, as a child of the `<dependencies>` element:
+Add the following Maven dependency to your Spring Boot Starter project, replacing `x` with the latest patch level available:
 
 ```xml
 <dependency>
-   <groupId>io.camunda</groupId>
-   <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-   <version>8.6.3</version>
+    <groupId>io.camunda</groupId>
+    <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+    <version>8.6.x</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description

This closes https://github.com/camunda/camunda-docs/issues/4495 with the following changes:
* removal of the identity repo setup for 8.5+ docs, it's not needed as the Spring Zeebe SDK has no dependency on identity artifacts
* inline of the maven setup for the sdk in the [Getting started with Spring](https://docs.camunda.io/docs/next/guides/getting-started-java-spring/#configure-spring-boot-starter) guide - alternative is to just link to the separate page but I figured this would just interrupt the user reading the guide and I went for inlining the dependency to add

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
