### PR TITLE
feat: replace raw alpha warnings with admonitions when generating C8 REST API docs

### DIFF
--- a/api/camunda/generation-strategy.js
+++ b/api/camunda/generation-strategy.js
@@ -13,6 +13,7 @@ function preGenerateDocs() {
     ...addDisclaimer(originalSpec),
     ...redefineCreateProcessInstanceRequest(originalSpec),
     ...redefineEvaluateDecisionRequest(originalSpec),
+    ...addAlphaAdmonition(), // needs to go before addFrequentlyLinkedDocs
     ...addFrequentlyLinkedDocs(),
   ];
 
@@ -217,6 +218,23 @@ function redefineEvaluateDecisionRequest(originalSpec) {
     EvaluateDecisionRequestBase:
       type: object
       properties:`,
+    },
+  ];
+}
+
+function addAlphaAdmonition() {
+  // This task is inherently repeatable, because the `match` is replaced by something that won't match again.
+
+  return [
+    {
+      // Matches an empty line, followed by an alpha warning, with these capture groups:
+      //  $1: the blank line before the warning
+      //  $2: the indentation before the warning
+      //  $3: the warning text
+      from: /^([^\S\n]*\n)([^\S\n]*)(This endpoint is an alpha feature and may be subject to change\n[\s]*in future releases.\n)/gm,
+
+      // Surrounds the warning with `:::note` and `:::`, creating an admonition.
+      to: "$1$2:::note\n$2$3$2:::\n",
     },
   ];
 }


### PR DESCRIPTION
## Description

In https://github.com/camunda/camunda/pull/24340, we removed all docs-specific formatting from the upstream spec. We'd already accounted for adding links in #4541, but we also need to add admonitions for alpha warnings.

This PR turns a text-only alpha warning into a `:::note` admonition.

This injection has no effect on the _current_ docs spec, because the admonitions are already there -- this is why there are no files changed other than the generation strategy. However, when https://github.com/camunda/camunda/pull/24340 makes it to this project via the weekly spec sync, our spec will be missing admonitions, and we'll want to regenerate with this new step. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process).
