### PR TITLE
test build for restructure

### DIFF
--- a/docs/components/components-overview.md
+++ b/docs/components/components-overview.md
@@ -1,18 +1,102 @@
 ---
 id: components-overview
-title: Introduction to Components
-sidebar_label: Introduction to Components
+title: What is Camunda 8?
+sidebar_label: What is Camunda 8?
 slug: /components/
 description: "This section contains product manual content for each component in Camunda 8, including conceptual content."
 keywords: ["process automation tools"]
 ---
 
-This section contains product manual content for each component in Camunda 8, including conceptual content. Together, these components comprise the Camunda 8 SaaS experience.
+[Camunda 8](https://camunda.io) orchestrates complex business processes that span people, systems, and devices. With Camunda, business users collaborate with developers to model and [automate end-to-end processes using BPMN-powered flowcharts](/guides/automating-a-process-using-bpmn.md), alongside DMN decision tables that promote speed, scale, and decision logic.
 
-See our [introduction to Camunda](/guides/introduction-to-camunda-8.md) if you are new to Camunda, or visiting the Camunda documentation for the first time.
+## What use cases does Camunda 8 have?
 
-:::note Looking for deployment guides?
+### Orchestrate, observe, and analyze microservices & human tasks
 
-Deployment guides for Camunda 8 components are available in the [Self-Managed section](/self-managed/about-self-managed.md).
+An end-to-end, automated business process typically requires multiple microservices to achieve an outcome. Software developers and architects often struggle to effectively communicate across multiple microservices, monitor their performance, and identify and resolve problems when they occur.
 
-:::
+Camunda enables organizations to overcome these issues without compromising autonomy and the coupling of microservices. Camunda offers speed, scale, and security when paired with [microservices](/guides/getting-started-orchestrate-microservices.md), without the overhead of building and maintaining a daunting infrastructure.
+
+In addition to microservices, many organizations have mission-critical processes that require people to perform tasks manually. An end-to-end business process often requires the combination of manual work with automated steps in a unified workflow.
+
+It’s important that workflows are properly orchestrated to achieve a desired outcome. For example, if a customer onboarding process is delayed because an employee doesn’t know they need to complete a task, the customer will have a poor experience. Camunda provides a lightweight, developer-friendly, easy-to-integrate solution with the [human task orchestration](/guides/getting-started-orchestrate-human-tasks.md) feature of Camunda 8 to help individuals and groups fix slow, inefficient, or broken human workflows.
+
+For a closer look at other use cases, refer to the [solutions page](https://camunda.com/solutions/) which outlines the following:
+
+- Modernize legacy IT systems
+- Orchestrate, monitor, and analyze RPA bots
+- Replace homegrown workflow automation software
+- Modernize legacy business process management systems (BPMS)
+- Build a centralized process automation platform
+
+## What are the core quality attributes of Camunda 8?
+
+Camunda 8 is designed to operate on a very large scale. To achieve this, it provides:
+
+- **Horizontal scalability** and no dependence on an external database; [Zeebe](/components/zeebe/zeebe-overview.md) (the workflow engine inside Camunda 8) writes data directly to the file system on the same servers where it is deployed. Zeebe enables distribution processing across a cluster of machines to deliver high throughput.
+- **High availability and fault tolerance** via a pre-configured replication mechanism, ensuring Camunda 8 can recover from machine or software failure with no data loss and minimal downtime. This ensures the system as a whole remains available without requiring manual action.
+- **Audit trail** as all process-relevant events are written to an append-only log, providing an audit trail and a history of the state of a process.
+- **Reactive publish-subscribe interaction model** which enables microservices that connect to Camunda 8 to maintain a high degree of control and autonomy, including control over processing rates. These properties make Camunda 8 resilient, scalable, and reactive.
+- **Visual processes modeled in ISO-standard BPMN 2.0** so technical and non-technical stakeholders can collaborate on process design in a widely-used modeling language.
+- **Language-agnostic client model** makes it possible to build a client in nearly any programming language an organization uses to build microservices.
+- **Operational ease-of-use** as a SaaS provider we take care of all operational details.
+
+## What are the Camunda 8 components?
+
+### Modeler
+
+Model and deploy business process diagrams with BPMN and DMN. By using industry-standard BPMN flowcharts to model and automate end-to-end processes, both developers and business stakeholders can collaborate and work on process diagrams and decision tables simultaneously, and use collaborative features such as comments to discuss. Available via [web and desktop app](/components/modeler/about-modeler.md).
+
+#### Connectors
+
+Connectors help you communicate with systems and technology, reducing the time required to automate and orchestrate business processes that span multiple systems. Connectors are inserted into BPMN diagrams directly from within the Camunda Modeler interface. Once added to your diagram, they are configured via an intuitive properties panel.
+
+#### Forms
+
+[Create and implement custom forms](/guides/utilizing-forms.md) that power workflows requiring human interaction.
+
+### Workflow engine & decision engine
+
+Powered by Zeebe, Camunda’s cloud-native workflow engine provides organizations with speed, scale, and security without the overhead of building and maintaining a complex infrastructure. Zeebe can scale throughput linearly by adding cluster nodes, allowing the processing of an unlimited amount of transactions at consistently low latencies. Zeebe also comes with a new fail-over architecture that also supports geo-replication across data centers to provide enterprise grade availability.
+
+### Tasklist
+
+With [Tasklist](/components/tasklist/introduction-to-tasklist.md), process owners can achieve end-to-end process automation by [orchestrating human tasks](/guides/getting-started-orchestrate-human-tasks.md). When a user needs to work on a task, they’ll observe it appear in Tasklist.
+
+### Operate
+
+[Operate](/components/operate/operate-introduction.md) provides transparency and real-time visibility to monitor, analyze, and resolve problems with processes running in Camunda 8.
+
+### Optimize
+
+[Optimize]($optimize$/components/what-is-optimize) leverages process execution data to continuously [provide actionable insights](/guides/improve-processes-with-optimize.md). Optimize specializes in BPMN-based analysis and can show users exactly what their process model needs for successful execution.
+
+### Console
+
+With [Console](/components/console/introduction-to-console.md), teams can create, configure, manage, and monitor clusters for all environments from development to production. Additionally, Console offers control over organizational settings such as user management, roles, and insights into usage metrics.
+
+## How does Camunda 8 compare to other solutions?
+
+### End-to-end orchestration
+
+Design, automate, and improve all components of the business process across different technologies, systems, infrastructures, people, and devices.
+
+### Open architecture
+
+Fit into diverse and complex enterprise environments and technology stacks with Camunda's open and scalable architecture based on open components that can be easily integrated with most common technical architectures and frameworks.
+
+### Standards-based business & IT collaboration
+
+Use BPMN and DMN standards as a common language for developers and business stakeholders alike throughout the entire process automation lifecycle.
+
+### Developer-friendly approach
+
+The platform and tools are usable in your environment right away, with full public access to all of Camunda's documentation, [open APIs for integration](/apis-tools/working-with-apis-tools.md), and a [community](https://camunda.com/developers/) comprised of around 100,000 developers.
+
+## Next steps
+
+- To request information about Camunda 8 performance and benchmarking, refer to our [Contact](/contact/) page.
+- [Introduction to Camunda 8](/guides/introduction-to-camunda-8.md)
+- [Create a Camunda 8 account](/guides/create-account.md)
+- [Migrate from Camunda 7 to Camunda 8](/guides/migrating-from-camunda-7/index.md)
+- [Automate a process using BPMN](/guides/automating-a-process-using-bpmn.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -223,7 +223,7 @@ module.exports = {
         {
           type: "doc",
           docId: "components/components-overview",
-          label: "Components",
+          label: "Concepts",
           position: "left",
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,72 +23,7 @@ module.exports = {
       ],
     },
     {
-      Design: [
-        "guides/automating-a-process-using-bpmn",
-        "guides/create-decision-tables-using-dmn",
-        "guides/utilizing-forms",
-      ],
-      Automate: [
-        "guides/create-cluster",
-        "guides/setting-up-development-project",
-        "guides/setup-client-connection-credentials",
-        "guides/configuring-out-of-the-box-connectors",
-        "guides/use-connectors-in-hybrid-mode",
-        "guides/host-custom-connectors",
-      ],
-      Improve: [
-        "guides/improve-processes-with-optimize",
-        {
-          "DevOps lifecycle": [
-            "guides/devops-lifecycle/integrate-web-modeler-in-ci-cd",
-          ],
-        },
-      ],
-    },
-    {
-      "Migrate from Camunda 7": [
-        "guides/migrating-from-camunda-7/index",
-        "guides/migrating-from-camunda-7/conceptual-differences",
-        "guides/migrating-from-camunda-7/migration-readiness",
-        "guides/migrating-from-camunda-7/adjusting-bpmn-models",
-        "guides/migrating-from-camunda-7/adjusting-dmn-models",
-        "guides/migrating-from-camunda-7/adjusting-source-code",
-      ],
-    },
-  ],
-  Components: [
-    "components/components-overview",
-    {
-      Concepts: [
-        "components/concepts/what-is-camunda-8",
-        "components/concepts/clusters",
-        "components/concepts/processes",
-        "components/concepts/job-workers",
-        "components/concepts/execution-listeners",
-        "components/concepts/process-instance-creation",
-        "components/concepts/messages",
-        "components/concepts/signals",
-        "components/concepts/incidents",
-        "components/concepts/variables",
-        "components/concepts/expressions",
-        "components/concepts/workflow-patterns",
-        "components/concepts/process-instance-modification",
-        "components/concepts/process-instance-migration",
-        "components/concepts/data-retention",
-        "components/concepts/encryption-at-rest",
-        "components/concepts/outbound-connectors-job-workers",
-        "components/concepts/backups",
-        "components/concepts/resource-deletion",
-        "components/concepts/resource-authorizations",
-        {
-          "Access control": [
-            "components/concepts/access-control/user-groups",
-            "components/concepts/access-control/user-task-access-restrictions",
-          ],
-        },
-      ],
-      Console: [
-        "components/console/introduction-to-console",
+      Manage: [
         {
           "Manage your organization": [
             "components/console/manage-organization/organization-settings",
@@ -132,185 +67,18 @@ module.exports = {
           ],
         },
       ],
-    },
-    {
-      type: "category",
-      label: "Modeler",
-      link: {
-        type: "doc",
-        id: "components/modeler/about-modeler",
-      },
-      items: [
-        {
-          "Web Modeler": [
-            "components/modeler/web-modeler/launch-web-modeler",
-            "components/modeler/web-modeler/model-your-first-diagram",
-            "components/modeler/web-modeler/context-pad",
-            "components/modeler/web-modeler/git-sync",
-            "components/modeler/web-modeler/import-diagram",
-            "components/modeler/web-modeler/fix-problems-in-your-diagram",
-            "components/modeler/web-modeler/run-or-publish-your-process",
-            {
-              type: "category",
-              label: "Process applications",
-              link: {
-                type: "doc",
-                id: "components/modeler/web-modeler/process-applications",
-              },
-              items: [
-                "components/modeler/web-modeler/process-application-pipeline",
-                "components/modeler/web-modeler/create-a-process-application",
-                "components/modeler/web-modeler/deploy-process-application",
-                "components/modeler/web-modeler/process-application-versioning",
-              ],
-            },
-            {
-              Collaboration: [
-                "components/modeler/web-modeler/collaboration",
-                "components/modeler/web-modeler/collaborate-with-modes",
-                "components/modeler/web-modeler/design-your-process",
-                "components/modeler/web-modeler/implement-your-process",
-                "components/modeler/web-modeler/play-your-process",
-              ],
-            },
-            "components/modeler/web-modeler/camunda-marketplace",
-            "components/modeler/web-modeler/milestones",
-            "components/modeler/web-modeler/token-simulation",
-            {
-              "Advanced modeling": [
-                "components/modeler/web-modeler/advanced-modeling/business-rule-task-linking",
-                "components/modeler/web-modeler/advanced-modeling/call-activity-linking",
-                "components/modeler/web-modeler/advanced-modeling/form-linking",
-                "components/modeler/web-modeler/advanced-modeling/publish-public-processes",
-                {
-                  "AI features": [
-                    "components/modeler/web-modeler/advanced-modeling/refactoring-suggestions",
-                    "components/modeler/web-modeler/advanced-modeling/camunda-docs-ai",
-                  ],
-                },
-              ],
-            },
-            "components/modeler/web-modeler/file-download",
-          ],
-        },
-        {
-          type: "category",
-          label: "Desktop Modeler",
-          link: {
-            type: "doc",
-            id: "components/modeler/desktop-modeler/index",
-          },
-          items: [
-            "components/modeler/desktop-modeler/install-the-modeler",
-            "components/modeler/desktop-modeler/model-your-first-diagram",
-            "components/modeler/desktop-modeler/connect-to-camunda-8",
-            "components/modeler/desktop-modeler/start-instance",
-            "components/modeler/desktop-modeler/use-connectors",
-            "components/modeler/desktop-modeler/variables",
-            {
-              type: "category",
-              label: "Element templates",
-              link: {
-                type: "doc",
-                id: "components/modeler/desktop-modeler/element-templates/about-templates",
-              },
-              items: [
-                "components/modeler/desktop-modeler/element-templates/configuring-templates",
-                "components/modeler/desktop-modeler/element-templates/using-templates",
-                "components/modeler/desktop-modeler/element-templates/defining-templates",
-                "components/modeler/desktop-modeler/element-templates/c7-defining-templates",
-                "components/modeler/desktop-modeler/element-templates/additional-resources",
-              ],
-            },
-            {
-              "Additional configuration": [
-                "components/modeler/desktop-modeler/flags/flags",
-                "components/modeler/desktop-modeler/plugins/plugins",
-                "components/modeler/desktop-modeler/custom-lint-rules/custom-lint-rules",
-                "components/modeler/desktop-modeler/search-paths/search-paths",
-                "components/modeler/desktop-modeler/telemetry/telemetry",
-              ],
-            },
-            "components/modeler/desktop-modeler/troubleshooting",
-          ],
-        },
-        {
-          BPMN: [
-            "components/modeler/bpmn/modeler-bpmn",
-            "components/modeler/bpmn/bpmn-primer",
-            "components/modeler/bpmn/bpmn-coverage",
-            "components/modeler/bpmn/data-flow",
-            {
-              Tasks: [
-                "components/modeler/bpmn/tasks",
-                "components/modeler/bpmn/service-tasks/service-tasks",
-                "components/modeler/bpmn/user-tasks/user-tasks",
-                "components/modeler/bpmn/receive-tasks/receive-tasks",
-                "components/modeler/bpmn/business-rule-tasks/business-rule-tasks",
-                "components/modeler/bpmn/script-tasks/script-tasks",
-                "components/modeler/bpmn/send-tasks/send-tasks",
-                "components/modeler/bpmn/manual-tasks/manual-tasks",
-                "components/modeler/bpmn/undefined-tasks/undefined-tasks",
-              ],
-            },
-            {
-              Gateways: [
-                "components/modeler/bpmn/gateways",
-                "components/modeler/bpmn/exclusive-gateways/exclusive-gateways",
-                "components/modeler/bpmn/parallel-gateways/parallel-gateways",
-                "components/modeler/bpmn/event-based-gateways/event-based-gateways",
-                "components/modeler/bpmn/inclusive-gateways/inclusive-gateways",
-              ],
-            },
-            {
-              Events: [
-                "components/modeler/bpmn/events",
-                "components/modeler/bpmn/none-events/none-events",
-                "components/modeler/bpmn/message-events/message-events",
-                "components/modeler/bpmn/signal-events/signal-events",
-                "components/modeler/bpmn/timer-events/timer-events",
-                "components/modeler/bpmn/error-events/error-events",
-                "components/modeler/bpmn/escalation-events/escalation-events",
-                "components/modeler/bpmn/terminate-events/terminate-events",
-                "components/modeler/bpmn/link-events/link-events",
-                "components/modeler/bpmn/compensation-events/compensation-events",
-              ],
-            },
-            {
-              Subprocesses: [
-                "components/modeler/bpmn/subprocesses",
-                "components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses",
-                "components/modeler/bpmn/call-activities/call-activities",
-                "components/modeler/bpmn/event-subprocesses/event-subprocesses",
-              ],
-            },
-            {
-              Markers: [
-                "components/modeler/bpmn/markers",
-                "components/modeler/bpmn/multi-instance/multi-instance",
-                "components/modeler/bpmn/compensation-handler/compensation-handler",
-              ],
-            },
-          ],
-        },
-        require("./docs/components/modeler/dmn/sidebar-schema"),
-        require("./docs/components/modeler/feel/sidebar-schema"),
-        require("./docs/components/modeler/forms/sidebar-schema"),
-        "components/modeler/data-handling",
-        require("./docs/components/modeler/reference/sidebar-schema"),
+      Design: [
+        "guides/automating-a-process-using-bpmn",
+        "guides/create-decision-tables-using-dmn",
+        "guides/utilizing-forms",
       ],
-    },
-    {
-      Connectors: [
-        "components/connectors/introduction-to-connectors",
-        "components/connectors/connector-types",
-        {
-          "Use Connectors": [
-            "components/connectors/use-connectors/index",
-            "components/connectors/use-connectors/inbound",
-            "components/connectors/use-connectors/outbound",
-          ],
-        },
+      Automate: [
+        "guides/create-cluster",
+        "guides/setting-up-development-project",
+        "guides/setup-client-connection-credentials",
+        "guides/configuring-out-of-the-box-connectors",
+        "guides/use-connectors-in-hybrid-mode",
+        "guides/host-custom-connectors",
         {
           "Out-of-the-box Connectors": [
             "components/connectors/out-of-the-box-connectors/available-connectors-overview",
@@ -373,31 +141,7 @@ module.exports = {
         },
         "components/connectors/manage-connector-templates",
         {
-          "Building custom Connectors": [
-            "components/connectors/custom-built-connectors/connector-sdk",
-            "components/connectors/custom-built-connectors/connector-templates",
-            "components/connectors/custom-built-connectors/connector-template-generator",
-          ],
-        },
-      ],
-      Zeebe: [
-        "components/zeebe/zeebe-overview",
-        {
-          "Technical concepts": [
-            "components/zeebe/technical-concepts/technical-concepts-overview",
-            "components/zeebe/technical-concepts/architecture",
-            "components/zeebe/technical-concepts/clustering",
-            "components/zeebe/technical-concepts/partitions",
-            "components/zeebe/technical-concepts/internal-processing",
-            "components/zeebe/technical-concepts/process-lifecycles",
-            "components/zeebe/technical-concepts/protocols",
-          ],
-        },
-      ],
-      Operate: [
-        "components/operate/operate-introduction",
-        {
-          "User guide": [
+          "Operate user guide": [
             "components/operate/userguide/basic-operate-navigation",
             "components/operate/userguide/resolve-incidents-update-variables",
             "components/operate/userguide/selections-operations",
@@ -413,11 +157,8 @@ module.exports = {
             "components/operate/userguide/monitor-operation-status",
           ],
         },
-      ],
-      Tasklist: [
-        "components/tasklist/introduction-to-tasklist",
         {
-          "User guide": [
+          "Tasklist user guide": [
             "components/tasklist/userguide/using-tasklist",
             "components/tasklist/userguide/managing-tasks",
             "components/tasklist/userguide/using-filters",
@@ -427,11 +168,10 @@ module.exports = {
           ],
         },
       ],
-      Optimize: [
-        optimizeLink("What is Optimize?", "components/what-is-optimize/"),
-
+      Improve: [
+        "guides/improve-processes-with-optimize",
         {
-          "User guide": [
+          "Optimize user guide": [
             optimizeLink(
               "Collections, dashboards, and reports",
               "components/userguide/collections-dashboards-reports/"
@@ -623,8 +363,91 @@ module.exports = {
             },
           ],
         },
+        {
+          "DevOps lifecycle": [
+            "guides/devops-lifecycle/integrate-web-modeler-in-ci-cd",
+          ],
+        },
       ],
-      "Best Practices": [
+    },
+    {
+      "Migrate from Camunda 7": [
+        "guides/migrating-from-camunda-7/index",
+        "guides/migrating-from-camunda-7/conceptual-differences",
+        "guides/migrating-from-camunda-7/migration-readiness",
+        "guides/migrating-from-camunda-7/adjusting-bpmn-models",
+        "guides/migrating-from-camunda-7/adjusting-dmn-models",
+        "guides/migrating-from-camunda-7/adjusting-source-code",
+      ],
+    },
+  ],
+  Concepts: [
+    "components/components-overview",
+    {
+      Concepts: [
+        "components/concepts/clusters",
+        "components/concepts/processes",
+        "components/concepts/job-workers",
+        "components/concepts/execution-listeners",
+        "components/concepts/process-instance-creation",
+        "components/concepts/messages",
+        "components/concepts/signals",
+        "components/concepts/incidents",
+        "components/concepts/variables",
+        "components/concepts/expressions",
+        "components/concepts/workflow-patterns",
+        "components/concepts/process-instance-modification",
+        "components/concepts/process-instance-migration",
+        "components/concepts/data-retention",
+        "components/concepts/encryption-at-rest",
+        "components/concepts/outbound-connectors-job-workers",
+        "components/concepts/backups",
+        "components/concepts/resource-deletion",
+        "components/concepts/resource-authorizations",
+        {
+          "Access control": [
+            "components/concepts/access-control/user-groups",
+            "components/concepts/access-control/user-task-access-restrictions",
+          ],
+        },
+      ],
+    },
+    {
+      "Orchestration cluster": {
+        Connectors: [
+          "components/connectors/introduction-to-connectors",
+          "components/connectors/connector-types",
+          {
+            "Use Connectors": [
+              "components/connectors/use-connectors/index",
+              "components/connectors/use-connectors/inbound",
+              "components/connectors/use-connectors/outbound",
+            ],
+          },
+          {
+            "Building custom Connectors": [
+              "components/connectors/custom-built-connectors/connector-sdk",
+              "components/connectors/custom-built-connectors/connector-templates",
+              "components/connectors/custom-built-connectors/connector-template-generator",
+            ],
+          },
+        ],
+        Zeebe: [
+          "components/zeebe/technical-concepts/technical-concepts-overview",
+          "components/zeebe/technical-concepts/architecture",
+          "components/zeebe/technical-concepts/clustering",
+          "components/zeebe/technical-concepts/partitions",
+          "components/zeebe/technical-concepts/internal-processing",
+          "components/zeebe/technical-concepts/process-lifecycles",
+          "components/zeebe/technical-concepts/protocols",
+        ],
+        Operate: ["components/operate/operate-introduction"],
+        Tasklist: ["components/tasklist/introduction-to-tasklist"],
+        Optimize: [
+          optimizeLink("What is Optimize?", "components/what-is-optimize/"),
+        ],
+      },
+      "Best practices": [
         "components/best-practices/best-practices-overview",
         {
           "Project management": [

--- a/src/pages/meta.md
+++ b/src/pages/meta.md
@@ -13,6 +13,8 @@ Whether you are reading the docs to understand how Camunda 8 works, or helping w
 
 ## Structure
 
+<!-- NEEDS ATTENTION -->
+
 Camunda 8 docs are structured in such a way that the documentation is SaaS-first, meaning you will be introduced to the following based on how they are used in Camunda 8 SaaS:
 
 - Guides: Step-by-step material to get started with Camunda 8.
@@ -100,7 +102,7 @@ keywords: [microservices, orchestration, getting-started]
 ---
 ```
 
-Take a look at Docusaurs' [guidance on headers and Markdown features](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter) for more details.
+Take a look at Docusaurus' [guidance on headers and Markdown features](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter) for more details.
 
 - id: The id is what connects a specific unique file id to the Docusaurus sidebar, not just the filename. To avoid confusion between the file and the sidebar id, we recommend making both of these the same. For example, a filename may be `learn-about-camunda.md` and therefore we may name the id `learn-about-camunda`.
 - title: The title is what will be shown as the header of the page once clicked on. Note that all titles are to be in sentence-case structure, according to the [Camunda style guide](https://camunda.com/brand/writing-style-guide/). Note that search engines typically display 50-60 characters of a title, so ensure your title does not exceed this.


### PR DESCRIPTION
This PR is **NOT** in a state to merge and should only be for discussion purposes. 

* Move all guides from Components to Guides
  * Get started (as-is)
  * Manage > Console guides (as-is)
  * Design > Modeler (requires extensive review, difficult to split or move as-is)
  * Automate > Connectors, Zeebe, Tasklist, Operate
    * Connectors (requires review, content split between Guides & Concepts)
    * Zeebe (all concepts, no guides)
    * Tasklist  (move user guide, drop overview/intro page)
    * Operate  (move user guide, drop overview/intro page)
  * Improve > Optimize (move user guide, drop overview/intro page)
  * Migrate from C7  
* Rename Components to Concepts
* Rework any renaming content in Concepts to a cohesive structure

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/d586b3f9-65fc-4deb-a6f4-95feaafc08ac">

But I love it! Why can't we _just_ merge this?!
* No actual content moves, just sidebars moves 
* No redirects
* No buy-in from stakeholders (yet, hence the draft PR for discussions)
* Renaming a top nav item will impact _all_ supported versions
* Possible duplicate/redundant guide content
* Lacks holistic perspective/intention for Guide and Concepts (could be fixed with an extensive review)