### PR TITLE
update language around collapsed subprocesses

### DIFF
--- a/docs/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
+++ b/docs/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
@@ -14,6 +14,8 @@ When an embedded subprocess is entered, the start event is activated. The subpro
 
 Embedded subprocesses are often used together with **boundary events**. One or more boundary events can be attached to a subprocess. When an interrupting boundary event is triggered, the entire subprocess (including all active elements) is terminated.
 
+When adding an embedded subprocess to your model, you can either add a collapsed or expanded subprocess. You cannot collapse an existing expanded subprocess in your model.
+
 ## Collapsed subprocesses
 
 :::caution
@@ -22,7 +24,7 @@ Collapsed subprocesses are currently only partially supported by Optimize. While
 All other Camunda components fully support collapsed subprocesses.
 :::
 
-A subprocess can be collapsed to conceal its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
+A collapsed subprocess conceals its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
 
 Collapsed subprocesses serve purely display purposes. For the creation of reusable processes, it is recommended to utilize [call activities](../call-activities/call-activities.md).
 

--- a/versioned_docs/version-8.4/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
+++ b/versioned_docs/version-8.4/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
@@ -14,6 +14,8 @@ When an embedded subprocess is entered, the start event is activated. The subpro
 
 Embedded subprocesses are often used together with **boundary events**. One or more boundary events can be attached to a subprocess. When an interrupting boundary event is triggered, the entire subprocess (including all active elements) is terminated.
 
+When adding an embedded subprocess to your model, you can either add a collapsed or expanded subprocess. You cannot collapse an existing expanded subprocess in your model.
+
 ## Collapsed subprocesses
 
 :::caution
@@ -22,7 +24,7 @@ Collapsed subprocesses are currently only partially supported by Optimize. While
 All other Camunda components fully support collapsed subprocesses.
 :::
 
-A subprocess can be collapsed to conceal its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
+A collapsed subprocess conceals its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
 
 Collapsed subprocesses serve purely display purposes. For the creation of reusable processes, it is recommended to utilize [call activities](../call-activities/call-activities.md).
 

--- a/versioned_docs/version-8.5/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
+++ b/versioned_docs/version-8.5/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
@@ -14,6 +14,8 @@ When an embedded subprocess is entered, the start event is activated. The subpro
 
 Embedded subprocesses are often used together with **boundary events**. One or more boundary events can be attached to a subprocess. When an interrupting boundary event is triggered, the entire subprocess (including all active elements) is terminated.
 
+When adding an embedded subprocess to your model, you can either add a collapsed or expanded subprocess. You cannot collapse an existing expanded subprocess in your model.
+
 ## Collapsed subprocesses
 
 :::caution
@@ -22,7 +24,7 @@ Collapsed subprocesses are currently only partially supported by Optimize. While
 All other Camunda components fully support collapsed subprocesses.
 :::
 
-A subprocess can be collapsed to conceal its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
+A collapsed subprocess conceals its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
 
 Collapsed subprocesses serve purely display purposes. For the creation of reusable processes, it is recommended to utilize [call activities](../call-activities/call-activities.md).
 

--- a/versioned_docs/version-8.6/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
+++ b/versioned_docs/version-8.6/components/modeler/bpmn/embedded-subprocesses/embedded-subprocesses.md
@@ -14,6 +14,8 @@ When an embedded subprocess is entered, the start event is activated. The subpro
 
 Embedded subprocesses are often used together with **boundary events**. One or more boundary events can be attached to a subprocess. When an interrupting boundary event is triggered, the entire subprocess (including all active elements) is terminated.
 
+When adding an embedded subprocess to your model, you can either add a collapsed or expanded subprocess. You cannot collapse an existing expanded subprocess in your model.
+
 ## Collapsed subprocesses
 
 :::caution
@@ -22,7 +24,7 @@ Collapsed subprocesses are currently only partially supported by Optimize. While
 All other Camunda components fully support collapsed subprocesses.
 :::
 
-A subprocess can be collapsed to conceal its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
+A collapsed subprocess conceals its internal details, thereby hiding complexity within an activity and enabling the nesting of multiple levels of subprocesses. This functionality allows you to simplify the view of a process diagram and facilitates drill-down capabilities to examine details.
 
 Collapsed subprocesses serve purely display purposes. For the creation of reusable processes, it is recommended to utilize [call activities](../call-activities/call-activities.md).
 


### PR DESCRIPTION
## Description

There has been some confusion about the ability to collapse expanded subprocesses, which is not currently possible. This PR attempts to clarify the language around collapsed subprocesses.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.
