### PR TITLE
docs: add migration guide for tasklist endpoints

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -140,7 +140,7 @@ The following conventions apply to all attributes:
 
 - Response structure changes as outlined in [general changes][].
 - `id` renamed
-  - User `variableKey` as this refers to the unique system identifier of the variable.
+  - Use `variableKey` as this refers to the unique system identifier of the variable.
 - `value` renamed
   - Use `fullValue` as this represents the full variable value in case the `value` is only a preview due to size constraints. If the `value` is not a preview, the `fullValue` is empty.
 - `previewValue` renamed
@@ -173,46 +173,69 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
-- Request structure changed as outlined in [general changes][].
-- `assigned (boolean)` removed
-  - **V2:** Use `assignee` with `{ "$exists": false }`
-- `assignees (string[])` removed
-  - **V2:** Use `assignee` with `{ "$in": [ "xyz", ... ] }`
+- Request structure changes as outlined in [general changes][].
+  - The `pageSize` is the `limit` in the `page` object.
+  - The `searchAfter` and `searchBefore` are in the `page` object.
+  - The `searchAfterOrEqual` and `searchBeforeOrEqual` options have been removed.
+- `assigned` removed
+  - Use `assignee` with `{ "$exists": false }`. Multiple filters can be combined in one attribute.
+- `assignees` removed
+  - Use `assignee` with `{ "$in": [ "xyz", ... ] }`. Multiple filters can be combined in one attribute.
 - `taskDefinitionId` renamed
-  - **V2:** Use `elementId`
-- `candidateGroups (string[])` removed
-  - **V2:** Use `candidateGroup` with `{ "$in": [ "xyz", ... ] }`
-- `taskVariables` renamed
-  - **V2:** Use `variables`
-- `candidateUsers (string[])` removed
-  - **V2:** Use `candidateUser` with `{ "$in": [ "xyz", ... ] }`
-- `tenantIds (string[])` removed
-  - **V2:** Use `tenantIds` with `{ "$in": [ "xyz", ... ] }`
-- `implementation` removed
-  - **V2:** Only Camunda user tasks returned
+  - Use `elementId` as this refers to the user-provided identifier of the BPMN element that created the user task.
+- `candidateGroups` removed
+  - Use `candidateGroup` with `{ "$in": [ "xyz", ... ] }`.
+- `candidateUsers` removed
+  - Use `candidateUser` with `{ "$in": [ "xyz", ... ] }`.
+- `followUpDate` and `dueDate` filter options renamed
+  - Instead of `from` and `to`, use `$gte` and `$lte`. Additionally, you can use new comparison filter options.
+- `taskVariables` split up and renamed
+  - You can define `localVariables` and `processInstanceVariables`.
+  - Local variables match the defined `name` and `value` and exist in the local scope of the BPMN element instance that created the user task.
+  - Process instance variables match the defined `name` and `value` and exist anywhere in the process instance that the user task belongs to.
+- `tenantIds` removed
+  - Use `tenantId` with `{ "$in": [ "xyz", ... ] }`.
 - `includeVariables` removed
-  - **V2:** Variables not included by default; use `GET /v2/user-tasks/{key}/variables/search` to retrieve them.
+  - The endpoint does not return variables. Use the [Search task variables](#search-task-variables) endpoint to retrieve them.
+- `implementation` removed
+  - The V2 API supports only Camunda user tasks.
+- `priority` filter options renamed
+  - Filter object keys need a `$` prefix. Additionally, you can use new comparison filter options like `$neq`, `$exists`, and `$in`.
+- `userTaskKey` added
+  - Filter for specific user tasks by their unique system identifiers.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
 - Response structure changes as outlined in [general changes][].
-- The attribute `id` renamed to `userTaskKey`.
-- The attribute `taskDefinitionId` renamed to `elementId`.
-- The attribute `taskState` renamed to `state`.
-- The attribute `processName` renamed to `processDefinitionId`.
-- The following attributes were added:
-  - `customHeaders`
-  - `externalFormReference`
-  - `processDefinitionVersion`
-- The following attributes were removed:
-  - `isFirst` - Used to identify if the task was the first in the process.
-  - `variables` - Use search variables to retrieve variables from a user task.
-  - `implementation` - On V2, only user tasks are returned.
-  - `isFormEmbedded` - User tasks do not support embedded forms.
-  - `formVersion` - For user tasks, use the `formKey` to retrieve form data.
-  - `formId` - For user tasks, use the `formKey` to retrieve form data.
+  - `sortValues` do not exist per result item. Instead, the `page` object contains `firstSortValues` and `lastSortValues`, referring to the `sortValues` of the first and last item of the result set.
+- `id` renamed
+  - Use `userTaskKey` as this refers to the unique system identifier of the user task.
+- `taskDefinitionId` renamed
+  - Use `elementId`.
+- `taskState` renamed
+  - Use `state`.
+- `processName` renamed
+  - Use `processDefinitionId`.
+- `customHeaders` added
+  - TBD
+- `externalFormReference` added
+  - TBD
+- `processDefinitionVersion` added
+  - TBD
+- `isFirst` removed
+  - Used to identify if the task was the first in the process.
+- `variables` removed
+  - Use search variables to retrieve variables from a user task.
+- `implementation` removed
+  - On V2, only user tasks are returned.
+- `isFormEmbedded` removed
+  - User tasks do not support embedded forms.
+- `formVersion` removed
+  - For user tasks, use the `formKey` to retrieve form data.
+- `formId` removed
+  - For user tasks, use the `formKey` to retrieve form data.
 
 </TabItem>
 

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -95,14 +95,12 @@ The following conventions apply to all attributes:
 <TabItem value='output-adjustments'>
 
 - Embedded forms are no longer returned as Camunda user tasks don't support them.
-- `isDeleted` removed
-  - The endpoint does not serve this information anymore.
-- `processDefinitionKey` removed
-  - You can identify the related entity from the endpoint resource and the provided key parameter, the form response does not contain it additionally anymore.
-- `id` renamed
-  - Use `formKey` as this refers to the unique system identifier of the form.
-- `title` renamed
-  - Use `formId` as this aligns better with the attribute defined in the form schema.
+- Renamed atttibutes
+  - `id` - Use `formKey` as this refers to the unique system identifier of the form.
+  - `title` - Use `formId` as this aligns better with the attribute defined in the form schema.
+- Removed attributes
+  - `isDeleted` - The endpoint does not serve this information anymore.
+  - `processDefinitionKey` - You can identify the related entity from the endpoint resource and the provided key parameter, the form response does not contain it additionally anymore.
 
 </TabItem>
 </Tabs>
@@ -129,32 +127,27 @@ The following conventions apply to all attributes:
 <TabItem value='input-adjustments'>
 
 - Request structure changes as outlined in [general changes][].
-- `variableNames` renamed and type changed
-  - Use the `filter` object's `name`, either with a plain string for one exact match or with `{ "$in": [ "xyz", ... ]}`.
-- `includeVariables` removed
-  - The endpoint returns all variables associated with the user task.
+- Renamed attributes
+  - `variableNames` - Use the `filter` object's `name`, either with a plain string for one exact match or with `{ "$in": [ "xyz", ... ]}`.
+- Removed attributes
+  - `includeVariables` - The endpoint returns all variables associated with the user task.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
 - Response structure changes as outlined in [general changes][].
-- `id` renamed
-  - Use `variableKey` as this refers to the unique system identifier of the variable.
-- `value` renamed
-  - Use `fullValue` as this represents the full variable value in case the `value` is only a preview due to size constraints. If the `value` is not a preview, the `fullValue` is empty.
-- `previewValue` renamed
-  - Use `value` as this always represents the variable value. This can be a preview value due to size constraints. In that case, the `fullValue` contains the full variable value.
-- `isValueTruncated` renamed
-  - Use `isTruncated` as a replacement
-- `draft` removed
-  - Draft variables are not supported in V2 anymore, see also the [Save draft variables](#save-task-draft-variables) endpoint for further details.
-- `scopeKey` added
-  - Variables belong to a specific scope, e.g., the process instance or the element instance of a user task. This value represents the scope the variables is related to.
-- `processInstanceKey` added
-  - A variable belongs to process instance and this value represents the unique system identifier of that instance.
-- `tenantId` added
-  - Variables can belong to a dedicated tenant and this value represents the one it belongs to. See [multi-tenancy][] for further details.
+- Renamed attributes
+  - `id` - Use `variableKey` as this refers to the unique system identifier of the variable.
+  - `value` - Use `fullValue` as this represents the full variable value in case the `value` is only a preview due to size constraints. If the `value` is not a preview, the `fullValue` is empty.
+  - `previewValue` - Use `value` as this always represents the variable value. This can be a preview value due to size constraints. In that case, the `fullValue` contains the full variable value.
+  - `isValueTruncated` - Use `isTruncated` as a replacement
+- Removed attributes
+  - `draft` - Draft variables are not supported in V2 anymore, see also the [Save draft variables](#save-task-draft-variables) endpoint for further details.
+- Added attributes
+  - `scopeKey` - Variables belong to a specific scope, e.g., the process instance or the element instance of a user task. This value represents the scope the variables is related to.
+  - `processInstanceKey` - A variable belongs to process instance and this value represents the unique system identifier of that instance.
+  - `tenantId` - Variables can belong to a dedicated tenant and this value represents the one it belongs to. See [multi-tenancy][] for further details.
 
 </TabItem>
 </Tabs>
@@ -174,39 +167,29 @@ The following conventions apply to all attributes:
 <TabItem value='input-adjustments'>
 
 - Request structure changes as outlined in [general changes][].
-  - The `pageSize` is the `limit` in the `page` object.
+  - The `pageSize` is now the `limit` in the `page` object.
   - The `searchAfter` and `searchBefore` are in the `page` object.
-  - The `searchAfterOrEqual` and `searchBeforeOrEqual` options have been removed.
-- `assigned` removed
-  - Use `assignee` with `{ "$exists": false }`. Multiple filters can be combined in one attribute.
-- `assignees` removed
-  - Use `assignee` with `{ "$in": [ "xyz", ... ] }`. Multiple filters can be combined in one attribute.
-- `taskDefinitionId` renamed
-  - Use `elementId` as this refers to the user-provided identifier of the BPMN element that created the user task.
-- `candidateGroups` removed
-  - Use `candidateGroup` with `{ "$in": [ "xyz", ... ] }`.
-- `candidateUsers` removed
-  - Use `candidateUser` with `{ "$in": [ "xyz", ... ] }`.
-- `followUpDate` and `dueDate` filter options renamed
-  - Instead of `from` and `to`, use `$gte` and `$lte`. Additionally, you can use new comparison filter options.
-- `taskVariables` split up and renamed
-  - You can define `localVariables` and `processInstanceVariables`.
-  - Local variables match the defined `name` and `value` and exist in the local scope of the BPMN element instance that created the user task.
-  - Process instance variables match the defined `name` and `value` and exist anywhere in the process instance that the user task belongs to.
-- `tenantIds` removed
-  - Use `tenantId` with `{ "$in": [ "xyz", ... ] }`.
-- `includeVariables` removed
-  - The endpoint does not return variables. Use the [Search task variables](#search-task-variables) endpoint to retrieve them.
-- `implementation` removed
-  - The V2 API supports only Camunda user tasks.
-- `priority` filter options renamed
-  - Filter object keys need a `$` prefix. Additionally, you can use new comparison filter options like `$neq`, `$exists`, and `$in`.
-- `userTaskKey` added
-  - Filter for specific user tasks by their unique system identifiers.
-- `processDefinitionId` added
-  - Filter for user tasks by the user-provided unique identifier of the process.
-- `elementInstanceKey` added
-  - Find tasks by the unique system identifier of the instance of the BPMN element that created the user task.
+  - The `searchAfterOrEqual` and `searchBeforeOrEqual` options do not exist.
+- Renamed attributes
+  - `taskDefinitionId` - Use `elementId` as this refers to the user-provided identifier of the BPMN element that created the user task.
+  - `followUpDate` and `dueDate` filter options - Instead of `from` and `to`, use `$gte` and `$lte`. Additionally, you can use new comparison filter options.
+  - `priority` filter options - Filter object keys need a `$` prefix. Additionally, you can use new comparison filter options like `$neq`, `$exists`, and `$in`.
+- Removed attributes
+  - `assigned` - Use `assignee` with `{ "$exists": false }`. Multiple filters can be combined in one attribute.
+  - `assignees` - Use `assignee` with `{ "$in": [ "xyz", ... ] }`. Multiple filters can be combined in one attribute.
+  - `candidateGroups` - Use `candidateGroup` with `{ "$in": [ "xyz", ... ] }`.
+  - `candidateUsers` - Use `candidateUser` with `{ "$in": [ "xyz", ... ] }`.
+  - `taskVariables` split up and renamed
+    - You can define `localVariables` and `processInstanceVariables`.
+    - Local variables match the defined `name` and `value` and exist in the local scope of the BPMN element instance that created the user task.
+    - Process instance variables match the defined `name` and `value` and exist anywhere in the process instance that the user task belongs to.
+  - `tenantIds` - Use `tenantId` with `{ "$in": [ "xyz", ... ] }`.
+  - `includeVariables` - The endpoint does not return variables. Use the [Search task variables](#search-task-variables) endpoint to retrieve them.
+  - `implementation` - The V2 API supports only Camunda user tasks.
+- Added attributes
+  - `userTaskKey` - Filter for specific user tasks by their unique system identifiers.
+  - `processDefinitionId` - Filter for user tasks by the user-provided unique identifier of the process.
+  - `elementInstanceKey` - Find tasks by the unique system identifier of the instance of the BPMN element that created the user task.
 
 </TabItem>
 
@@ -214,32 +197,23 @@ The following conventions apply to all attributes:
 
 - Response structure changes as outlined in [general changes][].
   - `sortValues` do not exist per result item. Instead, the `page` object contains `firstSortValues` and `lastSortValues`, referring to the `sortValues` of the first and last item of the result set.
-- `id` renamed
-  - Use `userTaskKey`, this still refers to the unique system identifier of the user task.
-- `taskDefinitionId` renamed
-  - Use `elementId`, this still refers to the user-provided identifier of the BPMN element that created the user task.
-- `taskState` renamed
-  - Use `state`.
-- `processName` renamed
-  - Use `processDefinitionId`, this still refers to the user-provided identifier of the process.
-- `customHeaders` added
-  - TBD
-- `externalFormReference` added
-  - TBD
-- `processDefinitionVersion` added
-  - TBD
-- `isFirst` removed
-  - Used to identify if the task was the first in the process.
-- `variables` removed
-  - Use search variables to retrieve variables from a user task.
-- `implementation` removed
-  - On V2, only user tasks are returned.
-- `isFormEmbedded` removed
-  - User tasks do not support embedded forms.
-- `formVersion` removed
-  - For user tasks, use the `formKey` to retrieve form data.
-- `formId` removed
-  - For user tasks, use the `formKey` to retrieve form data.
+- Renamed attributes
+  - `id` - Use `userTaskKey`, this still refers to the unique system identifier of the user task.
+  - `formKey` - This now is a unique system identifier, referencing a linked Camunda form in a specific version. Previously, this encoded an embedded form , a linked Camunda form, or an external form reference.
+  - `taskDefinitionId` - Use `elementId`, this still refers to the user-provided identifier of the BPMN element that created the user task.
+  - `taskState` - Use `state`, this still refers to the user task's current state
+  - `processName` - Use `processDefinitionId`, this still refers to the user-provided identifier of the process.
+- Removed attributes
+  - `isFirst` - This used to identify if the task was the first in the process.
+  - `variables` - Use the [Search user task variables endpoint][] to retrieve variables for a user task.
+  - `implementation` - The V2 API supports only Camunda user tasks.
+  - `isFormEmbedded` - The V2 API does not support embedded forms anymore.
+  - `formVersion` - Use the [Get user task form endpoint][] to retrieve form data bound to this user task. The `formKey` references the form of a specific `formId`, linked to this user task in a specific version.
+  - `formId` - Use the [Get user task form endpoint][] to retrieve form data bound to this user task. The `formKey` references the form of a specific `formId`, linked to this user task in a specific version.
+- Added attributes
+  - `customHeaders` - Any user-provided custom header values provided for the user task.
+  - `externalFormReference` - The user-provided reference to the an external form for the user task. Previously, the `formKey` encoded this value.
+  - `processDefinitionVersion` - The version of the process this user task belongs to.
 
 </TabItem>
 

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -62,7 +62,7 @@ The following conventions apply to all attributes:
 - `key` and `id` fields contain the entity as a prefix, for example, `userTaskKey`, `processDefinitionId`. This applies when referencing other resources like `formKey` in the user task entity, in the respective entities themselves like `userTaskKey` in the user task entity.
 - The full entity is the prefix to avoid confusion, for example `processDefinitionKey` instead of `processKey` (the latter could be interpreted as process instance or process definition).
 - Other attributes of entities themselves have no prefix to avoid clutter, for example version in the process definition entity. In other resources, they have to be referenced with a prefix, like `processDefinitionVersion` in the process instance entity.
-- The `bpmnProcessId` is now called `processDefinitionId` to be easily relatable to the process definition entity, like the `processDefinitionKey`.
+- The `bpmnProcessId` and `processName` are now called `processDefinitionId` to be easily relatable to the process definition entity, like the `processDefinitionKey`.
 - The `decisionKey` and `dmnDecisionKey` are now aligned to `decisionDefinitionKey`, the `decisionId` and `dmnDecisionId` to `decisionDefinitionId`. Similar to the `processDefinitionId` being related to the process definition, those attributes are now easily relatable to the decision definition entity.
 
 <!--- Insert Operate section with V1 endpoint and V2 endpoint to use with input/output adjustments --->
@@ -203,6 +203,10 @@ The following conventions apply to all attributes:
   - Filter object keys need a `$` prefix. Additionally, you can use new comparison filter options like `$neq`, `$exists`, and `$in`.
 - `userTaskKey` added
   - Filter for specific user tasks by their unique system identifiers.
+- `processDefinitionId` added
+  - Filter for user tasks by the user-provided unique identifier of the process.
+- `elementInstanceKey` added
+  - Find tasks by the unique system identifier of the instance of the BPMN element that created the user task.
 
 </TabItem>
 
@@ -211,13 +215,13 @@ The following conventions apply to all attributes:
 - Response structure changes as outlined in [general changes][].
   - `sortValues` do not exist per result item. Instead, the `page` object contains `firstSortValues` and `lastSortValues`, referring to the `sortValues` of the first and last item of the result set.
 - `id` renamed
-  - Use `userTaskKey` as this refers to the unique system identifier of the user task.
+  - Use `userTaskKey`, this still refers to the unique system identifier of the user task.
 - `taskDefinitionId` renamed
-  - Use `elementId`.
+  - Use `elementId`, this still refers to the user-provided identifier of the BPMN element that created the user task.
 - `taskState` renamed
   - Use `state`.
 - `processName` renamed
-  - Use `processDefinitionId`.
+  - Use `processDefinitionId`, this still refers to the user-provided identifier of the process.
 - `customHeaders` added
   - TBD
 - `externalFormReference` added

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -85,16 +85,25 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
-- Filter attribute `assigned (boolean)` removed
-  - Use filter attribute `assignee` with condition `{ "$exists": false }`
-- Filter attribute `assignees (string[])` removed
-  - Use filter attribute `assignee` with condition `{ “$in”: [ “xyz”, ... ] }`
-- Filter attribute `taskDefinitionId` renamed
-  - Use filter attribute `elementId`
-- Filter attribute `candidateGroups (string[])` removed
-  - Use filter attribute `candidateGroup` with condition `{ “$in”: [ “xyz”, ... ] }`
-- Filter attribute `candidateUsers (string[])` removed
-  - Use filter attribute `candidateUser` with condition `{ “$in”: [ “xyz”, ... ] }`
+- Request structure changes as outlined above.
+- `assigned (boolean)` removed
+  - **V2:** Use `assignee` with `{ "$exists": false }`
+- `assignees (string[])` removed
+  - **V2:** Use `assignee` with `{ "$in": [ "xyz", ... ] }`
+- `taskDefinitionId` renamed
+  - **V2:** Use `elementId`
+- `candidateGroups (string[])` removed
+  - **V2:** Use `candidateGroup` with `{ "$in": [ "xyz", ... ] }`
+- `taskVariables` renamed
+  - **V2:** Use `variables`
+- `candidateUsers (string[])` removed
+  - **V2:** Use `candidateUser` with `{ "$in": [ "xyz", ... ] }`
+- `tenantIds (string[])` removed
+  - **V2:** Use `tenantIds` with `{ "$in": [ "xyz", ... ] }`
+- `implementation` removed
+  - **V2:** Only Camunda user tasks returned
+- `includeVariables` removed
+  - **V2:** Variables not included by default; use `GET /v2/user-tasks/{key}/variables/search` to retrieve them.
 
 </TabItem>
 
@@ -119,6 +128,267 @@ The following conventions apply to all attributes:
 
 </TabItem>
 
+</Tabs>
+
+---
+
+#### Get User Task
+
+- **V1 endpoint**: `GET /v1/tasks/{taskId}`
+- **V2 endpoint**: `GET /v2/user-tasks/{userTaskKey}`
+
+<Tabs groupId="get-user-task" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+No input adjustments.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+Same output adjustments as **Search Tasks**.
+
+</TabItem>
+</Tabs>
+
+---
+
+#### Assign User Task
+
+- **V1 endpoint**: `PATCH /v1/tasks/{taskId}/assign`
+- **V2 endpoint**: `POST /v2/user-tasks/{userTaskKey}/assignment`
+
+<Tabs groupId="assign-user-task" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- `allowOverrideAssignment` renamed to `allowOverride`
+- `action` attribute added (defaults to `"assign"` if not provided)
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- V1 returned `200` with the User Task body
+- V2 returns `204` (No Content)
+
+</TabItem>
+</Tabs>
+
+---
+
+#### Unassign User Task
+
+- **V1 endpoint**: `PATCH /v1/tasks/{taskId}/unassign`
+- **V2 endpoint**: `DELETE /v2/user-tasks/{userTaskKey}/assignee`
+
+<Tabs groupId="unassign-user-task" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+No input adjustments.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- V1 returned `200` with the User Task body
+- V2 returns `204` (No Content)
+
+</TabItem>
+</Tabs>
+
+---
+
+#### Complete User Task
+
+- **V1 endpoint**: `PATCH /v1/tasks/{taskId}/complete`
+- **V2 endpoint**: `POST /v2/user-tasks/{userTaskKey}/completion`
+
+<Tabs groupId="complete-user-task" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- `action` attribute added (defaults to `"complete"` if not provided)
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- V1 returned `200` with the User Task body
+- V2 returns `204` (No Content)
+
+</TabItem>
+</Tabs>
+
+---
+
+#### Save Task Draft Variables
+
+- **V1 endpoint**: `POST /v1/tasks/{taskId}/variables`
+- **V2 endpoint**: Not supported
+
+<Tabs groupId="save-task-draft-vars" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+Not applicable, as this feature is not supported in V2.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+Not applicable, as this feature is not supported in V2.
+
+</TabItem>
+</Tabs>
+
+---
+
+#### Update User Task
+
+- **V1 endpoint**: No direct V1 equivalent
+- **V2 endpoint**: `PATCH /v2/user-tasks/{userTaskKey}`
+
+<Tabs groupId="update-user-task" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+This is a new endpoint in V2, no V1 adjustments.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+Refer to the documentation for which attributes can be updated:  
+[Update User Task Documentation](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/update-user-task/)
+
+</TabItem>
+</Tabs>
+
+---
+
+#### Search Variables by a Task
+
+- **V1 endpoint**: `POST /v1/tasks/{taskId}/variables/search`
+- **V2 endpoint**: `GET /v2/user-tasks/{userTaskKey}/variables`
+
+<Tabs groupId="search-vars-by-task" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- `includeVariables` removed
+  - **V2:** Returns all variables associated with the user task.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- Unified response structure.
+- Variables associated with both process and user task scopes returned with `scopeKey`.
+- `draft` removed (no draft variables).
+- `id` replaced with `variableKey`.
+
+</TabItem>
+</Tabs>
+
+### Forms
+
+#### Get Form
+
+- **V1 endpoint**: `GET /v1/forms/{formId}`
+- **V2 endpoints**:
+  - `GET /v2/user-tasks/{userTaskKey}/form`
+  - `GET /v2/process-definitions/{processDefinitionKey}/form`
+
+<Tabs groupId="get-form" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- No input parameters in V2; all input attributes removed.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- Embedded forms no longer returned; only supported for user tasks.
+- `isDeleted` and `processDefinitionKey` removed.
+- `id` renamed to `formKey`.
+- `title` renamed to `bpmnId`.
+
+</TabItem>
+</Tabs>
+
+### Variables
+
+#### Get Variable by ID
+
+- **V1 endpoint**: `GET /v1/variables/{variableId}`
+- **V2 endpoint**: `POST /v2/variables/search`
+
+<Tabs groupId="get-variable-by-id" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments'},
+{label: 'Output adjustments', value: 'output-adjustments'},
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- Transitioned from GET to POST with filtering options.
+- Unified request structure as above.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- Unified response structure.
+- Variables associated with both process and user task scopes returned with `scopeKey`.
+- `draft` removed.
+- `id` replaced with `variableKey`.
+
+</TabItem>
 </Tabs>
 
 <!--- TODO: insert output adjustments --->

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -94,10 +94,15 @@ The following conventions apply to all attributes:
 
 <TabItem value='output-adjustments'>
 
-- Embedded forms no longer returned; only supported for user tasks.
-- `isDeleted` and `processDefinitionKey` removed.
-- `id` renamed to `formKey`.
-- `title` renamed to `bpmnId`.
+- Embedded forms are no longer returned as Camunda user tasks don't support them.
+- `isDeleted` removed
+  - This information is not served anymore.
+- `processDefinitionKey` removed
+  - The form content is fetched per user task or process definition, so this relational information is not necessary in the context anymore.
+- `id` renamed
+  - Use `formKey` as this refers to the unique system identifier of the form
+- `title` renamed
+  - Use `formId` as this aligns better with the attribute defined in the form schema
 
 </TabItem>
 </Tabs>

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -292,7 +292,7 @@ This is a new endpoint in V2, no V1 adjustments.
 <TabItem value='output-adjustments'>
 
 Refer to the documentation for which attributes can be updated:  
-[Update User Task Documentation](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/update-user-task/)
+[Update User Task Documentation](docs/apis-tools/camunda-api-rest/specifications/update-user-task.api.mdx)
 
 </TabItem>
 </Tabs>

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -100,7 +100,22 @@ The following conventions apply to all attributes:
 
 <TabItem value='output-adjustments'>
 
-<!--- TODO: insert output adjustments --->
+- Response structure changes as outlined in [General changes](#general-changes).
+- The attribute `id` renamed to `userTaskKey`.
+- The attribute `taskDefinitionId` renamed to `elementId`.
+- The attribute `taskState` renamed to `state`.
+- The attribute `processName` renamed to `processDefinitionId`.
+- The following attributes were added:
+  - `customHeaders`
+  - `externalFormReference`
+  - `processDefinitionVersion`
+- The following attributes were removed:
+  - `isFirst` - Used to identify if the task was the first in the process.
+  - `variables` - Use Search Variables in order to retrieve variables from a user task.
+  - `implementation` - On V2, only user tasks are returned.
+  - `isFormEmbedded` - User tasks do not support embedded forms.
+  - `formVersion` - For user tasks, use the `formKey` to retrieve form data.
+  - `formId` - For user tasks, use the `formKey` to retrieve form data.
 
 </TabItem>
 

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -382,6 +382,6 @@ Same output adjustments as **Search tasks**.
 
 <!--- TODO: insert link to C8 REST API guidelines --->
 
-[setting variables]: /apis-tools/camunda-api-rest/specifications/create-element-instance-variables.mdx
+[setting variables]: /apis-tools/camunda-api-rest/specifications/create-element-instance-variables.api.mdx
 [general changes]: #general-endpoint-changes
 [multi-tenancy]: /self-managed/concepts/multi-tenancy.md

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -323,39 +323,6 @@ Same output adjustments as **Search tasks**.
 </TabItem>
 </Tabs>
 
-### Variables
-
-#### Get variable by ID
-
-- **V1 endpoint**: `GET /v1/variables/{variableId}`
-- **V2 endpoint**: `POST /v2/variables/search`
-
-<Tabs groupId="get-variable-by-id" defaultValue="input-adjustments" queryString values={
-[
-{label: 'Input adjustments', value: 'input-adjustments'},
-{label: 'Output adjustments', value: 'output-adjustments'},
-]
-}>
-
-<TabItem value='input-adjustments'>
-
-- Transitioned from GET to POST with filtering options.
-- Unified request structure as above.
-
-</TabItem>
-
-<TabItem value='output-adjustments'>
-
-- Unified response structure.
-- Variables associated with both process and user task scopes returned with `scopeKey`.
-- `draft` removed.
-- `id` replaced with `variableKey`.
-
-</TabItem>
-</Tabs>
-
-<!--- TODO: insert output adjustments --->
-
 <!--- TODO: open questions and related resources --->
 
 <!--- TODO: insert link to C8 REST API guidelines --->

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -109,7 +109,7 @@ The following conventions apply to all attributes:
 
 <TabItem value='output-adjustments'>
 
-- Response structure changes as outlined in [General changes](#general-changes).
+- Response structure changes as outlined in [general changes](#general-changes).
 - The attribute `id` renamed to `userTaskKey`.
 - The attribute `taskDefinitionId` renamed to `elementId`.
 - The attribute `taskState` renamed to `state`.
@@ -120,7 +120,7 @@ The following conventions apply to all attributes:
   - `processDefinitionVersion`
 - The following attributes were removed:
   - `isFirst` - Used to identify if the task was the first in the process.
-  - `variables` - Use Search Variables in order to retrieve variables from a user task.
+  - `variables` - Use search variables to retrieve variables from a user task.
   - `implementation` - On V2, only user tasks are returned.
   - `isFormEmbedded` - User tasks do not support embedded forms.
   - `formVersion` - For user tasks, use the `formKey` to retrieve form data.
@@ -132,7 +132,7 @@ The following conventions apply to all attributes:
 
 ---
 
-#### Get User Task
+#### Get user task
 
 - **V1 endpoint**: `GET /v1/tasks/{taskId}`
 - **V2 endpoint**: `GET /v2/user-tasks/{userTaskKey}`
@@ -152,14 +152,14 @@ No input adjustments.
 
 <TabItem value='output-adjustments'>
 
-Same output adjustments as **Search Tasks**.
+Same output adjustments as **Search tasks**.
 
 </TabItem>
 </Tabs>
 
 ---
 
-#### Assign User Task
+#### Assign user task
 
 - **V1 endpoint**: `PATCH /v1/tasks/{taskId}/assign`
 - **V2 endpoint**: `POST /v2/user-tasks/{userTaskKey}/assignment`
@@ -180,7 +180,7 @@ Same output adjustments as **Search Tasks**.
 
 <TabItem value='output-adjustments'>
 
-- V1 returned `200` with the User Task body
+- V1 returned `200` with the user task body
 - V2 returns `204` (No Content)
 
 </TabItem>
@@ -188,7 +188,7 @@ Same output adjustments as **Search Tasks**.
 
 ---
 
-#### Unassign User Task
+#### Unassign user task
 
 - **V1 endpoint**: `PATCH /v1/tasks/{taskId}/unassign`
 - **V2 endpoint**: `DELETE /v2/user-tasks/{userTaskKey}/assignee`
@@ -208,7 +208,7 @@ No input adjustments.
 
 <TabItem value='output-adjustments'>
 
-- V1 returned `200` with the User Task body
+- V1 returned `200` with the user task body
 - V2 returns `204` (No Content)
 
 </TabItem>
@@ -216,7 +216,7 @@ No input adjustments.
 
 ---
 
-#### Complete User Task
+#### Complete user task
 
 - **V1 endpoint**: `PATCH /v1/tasks/{taskId}/complete`
 - **V2 endpoint**: `POST /v2/user-tasks/{userTaskKey}/completion`
@@ -236,7 +236,7 @@ No input adjustments.
 
 <TabItem value='output-adjustments'>
 
-- V1 returned `200` with the User Task body
+- V1 returned `200` with the user task body
 - V2 returns `204` (No Content)
 
 </TabItem>
@@ -244,7 +244,7 @@ No input adjustments.
 
 ---
 
-#### Save Task Draft Variables
+#### Save task draft variables
 
 - **V1 endpoint**: `POST /v1/tasks/{taskId}/variables`
 - **V2 endpoint**: Not supported
@@ -271,7 +271,7 @@ Not applicable, as this feature is not supported in V2.
 
 ---
 
-#### Update User Task
+#### Update user task
 
 - **V1 endpoint**: No direct V1 equivalent
 - **V2 endpoint**: `PATCH /v2/user-tasks/{userTaskKey}`
@@ -291,15 +291,14 @@ This is a new endpoint in V2, no V1 adjustments.
 
 <TabItem value='output-adjustments'>
 
-Refer to the documentation for which attributes can be updated:  
-[Update User Task Documentation](docs/apis-tools/camunda-api-rest/specifications/update-user-task.api.mdx)
+Refer to [the documentation](docs/apis-tools/camunda-api-rest/specifications/update-user-task.api.mdx) for which attributes can be updated:
 
 </TabItem>
 </Tabs>
 
 ---
 
-#### Search Variables by a Task
+#### Search variables by a task
 
 - **V1 endpoint**: `POST /v1/tasks/{taskId}/variables/search`
 - **V2 endpoint**: `GET /v2/user-tasks/{userTaskKey}/variables`
@@ -330,7 +329,7 @@ Refer to the documentation for which attributes can be updated:
 
 ### Forms
 
-#### Get Form
+#### Get form
 
 - **V1 endpoint**: `GET /v1/forms/{formId}`
 - **V2 endpoints**:
@@ -362,7 +361,7 @@ Refer to the documentation for which attributes can be updated:
 
 ### Variables
 
-#### Get Variable by ID
+#### Get variable by ID
 
 - **V1 endpoint**: `GET /v1/variables/{variableId}`
 - **V2 endpoint**: `POST /v2/variables/search`

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -233,14 +233,13 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
-No input adjustments.
+- No input adjustments.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
-- V1 returned `200` with the user task body
-- V2 returns `204` (No Content)
+- Response object removed - The V2 API returns a 204 status, indicating that the task was unassigned. Fetching the updated data of the user task should be done through the respective API since the data can change concurrently at any time.
 
 </TabItem>
 </Tabs>
@@ -259,14 +258,16 @@ No input adjustments.
 
 <TabItem value='input-adjustments'>
 
-- `action` attribute added (defaults to `"complete"` if not provided)
+- Adjusted attributes
+  - `variables` - Provide the variables as a proper JSON object instead of an array of objects with a `name` and a serialized JSON string `value`.
+- Added attributes
+  - `action` - Provide any custom lifecycle for this action or use the default value of `"assign"`.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
-- V1 returned `200` with the user task body
-- V2 returns `204` (No Content)
+- Response object removed - The V2 API returns a 204 status, indicating that the task was completed. Fetching the updated data of the user task should be done through the respective API since the data can change concurrently at any time.
 
 </TabItem>
 </Tabs>
@@ -285,15 +286,16 @@ No input adjustments.
 
 <TabItem value='input-adjustments'>
 
-- `allowOverrideAssignment` renamed to `allowOverride`
-- `action` attribute added (defaults to `"assign"` if not provided)
+- Renamed attributes
+  - `allowOverrideAssignment` - Use `allowOverride`, this still refers to allowing to override any existing assignee.
+- Added attributes
+  - `action` - Provide any custom lifecycle for this action or use the default value of `"assign"`.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
-- V1 returned `200` with the user task body
-- V2 returns `204` (No Content)
+- Response object removed - The V2 API returns a 204 status, indicating that the task was assigned. Fetching the updated data of the user task should be done through the respective API since the data can change concurrently at any time.
 
 </TabItem>
 </Tabs>
@@ -312,13 +314,13 @@ No input adjustments.
 
 <TabItem value='input-adjustments'>
 
-No input adjustments.
+- No input adjustments.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
-Same output adjustments as **Search tasks**.
+- Except for the response structure changes, all adjustments from [Search tasks](#search-tasks) apply.
 
 </TabItem>
 </Tabs>

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -87,8 +87,8 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
-- Forms are not directly fetched anymore, they are fetched by user task or process definition to get the respective form data
-- All input attributes removed
+- You cannot fetch forms directly anymore. Instead, fetch them by user task or process definition to get the respective form data.
+- The respective endpoint only takes the key of the resource the form is related to as input parameter.
 
 </TabItem>
 
@@ -96,13 +96,13 @@ The following conventions apply to all attributes:
 
 - Embedded forms are no longer returned as Camunda user tasks don't support them.
 - `isDeleted` removed
-  - This information is not served anymore.
+  - The endpoint does not serve this information anymore.
 - `processDefinitionKey` removed
-  - The form content is fetched per user task or process definition, so this relational information is not necessary in the context anymore.
+  - You can identify the related entity from the endpoint resource and the provided key parameter, the form response does not contain it additionally anymore.
 - `id` renamed
-  - Use `formKey` as this refers to the unique system identifier of the form
+  - Use `formKey` as this refers to the unique system identifier of the form.
 - `title` renamed
-  - Use `formId` as this aligns better with the attribute defined in the form schema
+  - Use `formId` as this aligns better with the attribute defined in the form schema.
 
 </TabItem>
 </Tabs>
@@ -117,7 +117,7 @@ The following conventions apply to all attributes:
 #### Search task variables
 
 - **V1 endpoint**: `POST /v1/tasks/{taskId}/variables/search`
-- **V2 endpoint**: `GET /v2/user-tasks/{userTaskKey}/variables`
+- **V2 endpoint**: `POST /v2/user-tasks/{userTaskKey}/variables/search`
 
 <Tabs groupId="search-vars-by-task" defaultValue="input-adjustments" queryString values={
 [
@@ -128,17 +128,33 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
+- Request structure changes as outlined in [general changes][].
+- `variableNames` renamed and type changed
+  - Use the `filter` object's `name`, either with a plain string for one exact match or with `{ "$in": [ "xyz", ... ]}`.
 - `includeVariables` removed
-  - **V2:** Returns all variables associated with the user task.
+  - The endpoint returns all variables associated with the user task.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
-- Unified response structure.
-- Variables associated with both process and user task scopes returned with `scopeKey`.
-- `draft` removed (no draft variables).
-- `id` replaced with `variableKey`.
+- Response structure changes as outlined in [general changes][].
+- `id` renamed
+  - User `variableKey` as this refers to the unique system identifier of the variable.
+- `value` renamed
+  - Use `fullValue` as this represents the full variable value in case the `value` is only a preview due to size constraints. If the `value` is not a preview, the `fullValue` is empty.
+- `previewValue` renamed
+  - Use `value` as this always represents the variable value. This can be a preview value due to size constraints. In that case, the `fullValue` contains the full variable value.
+- `isValueTruncated` renamed
+  - Use `isTruncated` as a replacement
+- `draft` removed
+  - Draft variables are not supported in V2 anymore, see also the [Save draft variables](#save-task-draft-variables) endpoint for further details.
+- `scopeKey` added
+  - Variables belong to a specific scope, e.g., the process instance or the element instance of a user task. This value represents the scope the variables is related to.
+- `processInstanceKey` added
+  - A variable belongs to process instance and this value represents the unique system identifier of that instance.
+- `tenantId` added
+  - Variables can belong to a dedicated tenant and this value represents the one it belongs to. See [multi-tenancy][] for further details.
 
 </TabItem>
 </Tabs>
@@ -157,7 +173,7 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
-- Request structure changed as outlined in [general changes]().
+- Request structure changed as outlined in [general changes][].
 - `assigned (boolean)` removed
   - **V2:** Use `assignee` with `{ "$exists": false }`
 - `assignees (string[])` removed
@@ -181,7 +197,7 @@ The following conventions apply to all attributes:
 
 <TabItem value='output-adjustments'>
 
-- Response structure changes as outlined in [general changes](#general-changes).
+- Response structure changes as outlined in [general changes][].
 - The attribute `id` renamed to `userTaskKey`.
 - The attribute `taskDefinitionId` renamed to `elementId`.
 - The attribute `taskState` renamed to `state`.
@@ -344,3 +360,5 @@ Same output adjustments as **Search tasks**.
 <!--- TODO: insert link to C8 REST API guidelines --->
 
 [setting variables]: /apis-tools/camunda-api-rest/specifications/create-element-instance-variables.mdx
+[general changes]: #general-endpoint-changes
+[multi-tenancy]: /self-managed/concepts/multi-tenancy.md

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -143,9 +143,9 @@ The following conventions apply to all attributes:
   - `previewValue` - Use `value` as this always represents the variable value. This can be a preview value due to size constraints. In that case, the `fullValue` contains the full variable value.
   - `isValueTruncated` - Use `isTruncated` as a replacement
 - Removed attributes
-  - `draft` - Draft variables are not supported in V2 anymore, see also the [Save draft variables](#save-task-draft-variables) endpoint for further details.
+  - `draft` - Draft variables are not supported in V2 anymore, see also the [save draft variables](#save-task-draft-variables) endpoint for further details.
 - Added attributes
-  - `scopeKey` - Variables belong to a specific scope, e.g., the process instance or the element instance of a user task. This value represents the scope the variables is related to.
+  - `scopeKey` - Variables belong to a specific scope, for example, the process instance or the element instance of a user task. This value represents the scope the variables is related to.
   - `processInstanceKey` - A variable belongs to process instance and this value represents the unique system identifier of that instance.
   - `tenantId` - Variables can belong to a dedicated tenant and this value represents the one it belongs to. See [multi-tenancy][] for further details.
 
@@ -184,7 +184,7 @@ The following conventions apply to all attributes:
     - Local variables match the defined `name` and `value` and exist in the local scope of the BPMN element instance that created the user task.
     - Process instance variables match the defined `name` and `value` and exist anywhere in the process instance that the user task belongs to.
   - `tenantIds` - Use `tenantId` with `{ "$in": [ "xyz", ... ] }`.
-  - `includeVariables` - The endpoint does not return variables. Use the [Search task variables](#search-task-variables) endpoint to retrieve them.
+  - `includeVariables` - The endpoint does not return variables. Use the [search task variables](#search-task-variables) endpoint to retrieve them.
   - `implementation` - The V2 API supports only Camunda user tasks.
 - Added attributes
   - `userTaskKey` - Filter for specific user tasks by their unique system identifiers.
@@ -199,20 +199,20 @@ The following conventions apply to all attributes:
   - `sortValues` do not exist per result item. Instead, the `page` object contains `firstSortValues` and `lastSortValues`, referring to the `sortValues` of the first and last item of the result set.
 - Renamed attributes
   - `id` - Use `userTaskKey`, this still refers to the unique system identifier of the user task.
-  - `formKey` - This now is a unique system identifier, referencing a linked Camunda form in a specific version. Previously, this encoded an embedded form , a linked Camunda form, or an external form reference.
+  - `formKey` - This now is a unique system identifier, referencing a linked Camunda form in a specific version. Previously, this encoded an embedded form, a linked Camunda form, or an external form reference.
   - `taskDefinitionId` - Use `elementId`, this still refers to the user-provided identifier of the BPMN element that created the user task.
-  - `taskState` - Use `state`, this still refers to the user task's current state
+  - `taskState` - Use `state`, this still refers to the user task's current state.
   - `processName` - Use `processDefinitionId`, this still refers to the user-provided identifier of the process.
 - Removed attributes
   - `isFirst` - This used to identify if the task was the first in the process.
-  - `variables` - Use the [Search user task variables endpoint][] to retrieve variables for a user task.
+  - `variables` - Use the [search user task variables endpoint][] to retrieve variables for a user task.
   - `implementation` - The V2 API supports only Camunda user tasks.
   - `isFormEmbedded` - The V2 API does not support embedded forms anymore.
-  - `formVersion` - Use the [Get user task form endpoint][] to retrieve form data bound to this user task. The `formKey` references the form of a specific `formId`, linked to this user task in a specific version.
-  - `formId` - Use the [Get user task form endpoint][] to retrieve form data bound to this user task. The `formKey` references the form of a specific `formId`, linked to this user task in a specific version.
+  - `formVersion` - Use the [get user task form endpoint][] to retrieve form data bound to this user task. The `formKey` references the form of a specific `formId`, linked to this user task in a specific version.
+  - `formId` - Use the [get user task form endpoint][] to retrieve form data bound to this user task. The `formKey` references the form of a specific `formId`, linked to this user task in a specific version.
 - Added attributes
   - `customHeaders` - Any user-provided custom header values provided for the user task.
-  - `externalFormReference` - The user-provided reference to the an external form for the user task. Previously, the `formKey` encoded this value.
+  - `externalFormReference` - The user-provided reference to an external form for the user task. Previously, the `formKey` encoded this value.
   - `processDefinitionVersion` - The version of the process this user task belongs to.
 
 </TabItem>
@@ -320,7 +320,7 @@ The following conventions apply to all attributes:
 
 <TabItem value='output-adjustments'>
 
-- Except for the response structure changes, all adjustments from [Search tasks](#search-tasks) apply.
+- Except for the response structure changes, all adjustments from [search tasks](#search-tasks) apply.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

Provide the migration guide from Tasklist endpoint
- All task endpoints / Update as well the User Task input/output attributes
- Forms
- Variables

closes https://github.com/camunda/camunda/issues/23740

## When should this change go live?

This can be live as soon as it is approved, as it is related to the next version and the feature is already present in alphass

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
