### PR TITLE
Fix example value for max-message-size

### DIFF
--- a/docs/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/docs/apis-tools/spring-zeebe-sdk/configuration.md
@@ -275,7 +275,7 @@ A custom maxMessageSize allows the client to receive larger or smaller responses
 camunda:
   client:
     zeebe:
-      max-message-size: 3
+      max-message-size: 4194304
 ```
 
 ### Request timeout

--- a/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
@@ -275,7 +275,7 @@ A custom maxMessageSize allows the client to receive larger or smaller responses
 camunda:
   client:
     zeebe:
-      max-message-size: 3
+      max-message-size: 4194304
 ```
 
 ### Request timeout


### PR DESCRIPTION
@npepinpe once told me to use `zeebe.client.message.max-message-size=4194304`, which sounds like the default value and seems to be in bytes. If we use a too small example value, users may think the value is in megabytes. Obviously, we could also just document the unit but even then 3 bytes is likely not a workable value.

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Link to an associated epic when applicable. -->
<!-- Add an assignee and use `component:` or version labels for good hygiene! -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
