### PR TITLE
feat: add migration guide for decision requirements

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -106,6 +106,70 @@ The following conventions apply to all attributes:
 
 </Tabs>
 
+### Operate
+
+#### Search Decision Requirements
+
+- **V1 endpoint**: `POST /v1/drd/search`
+- **V2 endpoint**: `POST /v2/decision-requirements/search`
+
+<Tabs groupId="post-decision-requirements" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments', },
+{label: 'Output adjustments', value: 'output-adjustments', },
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- Filter attribute `id` and `key` removed
+  - Use filter attribute `decisionRequirementsKey`
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- Attributes attribute `id` was removed
+- The attribute `key` was replaced to `decisionRequirementsKey`
+
+</TabItem>
+
+</Tabs>
+
+#### Get Decision Requirements by Key
+
+- **V1 endpoint**: `GET /v1/drd/:key`
+- **V2 endpoint**: `GET /v2/decision-requirements/:decisionRequirementsKey`
+
+<Tabs groupId="get-decision-requirements" defaultValue="input-adjustments" queryString values={
+[
+{label: 'Input adjustments', value: 'input-adjustments', },
+{label: 'Output adjustments', value: 'output-adjustments', },
+]
+}>
+
+<TabItem value='input-adjustments'>
+
+- The request parameters attribute remains the same.
+
+</TabItem>
+
+<TabItem value='output-adjustments'>
+
+- Attributes attribute `id` was removed
+- The attribute `key` was replaced to `decisionRequirementsKey`
+
+</TabItem>
+
+</Tabs>
+
+#### Get decision requirements as XML by key
+
+- **V1 endpoint**: `GET /v1/drd/:key/xml`
+- **V2 endpoint**: `GET /v2/decision-requirements/:decisionRequirementsKey/xml`
+
+The endpoint attributes remains the same.
+
 <!--- TODO: insert output adjustments --->
 
 <!--- TODO: open questions and related resources --->

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -108,7 +108,7 @@ The following conventions apply to all attributes:
 
 ### Operate
 
-#### Search Decision Requirements
+#### Search decision requirements
 
 - **V1 endpoint**: `POST /v1/drd/search`
 - **V2 endpoint**: `POST /v2/decision-requirements/search`
@@ -136,7 +136,7 @@ The following conventions apply to all attributes:
 
 </Tabs>
 
-#### Get Decision Requirements by Key
+#### Get decision requirements by key
 
 - **V1 endpoint**: `GET /v1/drd/:key`
 - **V2 endpoint**: `GET /v2/decision-requirements/:decisionRequirementsKey`

--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -129,7 +129,7 @@ The following conventions apply to all attributes:
 
 <TabItem value='output-adjustments'>
 
-- Attributes attribute `id` was removed
+- Attributes attribute `id` has been removed.
 - The attribute `key` was replaced to `decisionRequirementsKey`
 
 </TabItem>
@@ -150,13 +150,13 @@ The following conventions apply to all attributes:
 
 <TabItem value='input-adjustments'>
 
-- The request parameters attribute remains the same.
+- The request parameters attributes remain unchanged.
 
 </TabItem>
 
 <TabItem value='output-adjustments'>
 
-- Attributes attribute `id` was removed
+- Attributes attribute `id` has been removed.
 - The attribute `key` was replaced to `decisionRequirementsKey`
 
 </TabItem>
@@ -168,7 +168,7 @@ The following conventions apply to all attributes:
 - **V1 endpoint**: `GET /v1/drd/:key/xml`
 - **V2 endpoint**: `GET /v2/decision-requirements/:decisionRequirementsKey/xml`
 
-The endpoint attributes remains the same.
+There are no changes to the request or response for this endpoint.
 
 <!--- TODO: insert output adjustments --->
 


### PR DESCRIPTION
## Description

- Add migration guide for Operate decision requirements

closes https://github.com/camunda/camunda/issues/23745

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
