### PR TITLE
Identity for cluster clients in 8.7 Clusters

### DIFF
--- a/docs/components/console/manage-clusters/manage-api-clients.md
+++ b/docs/components/console/manage-clusters/manage-api-clients.md
@@ -40,6 +40,10 @@ When the rate limit is triggered, the client will receive an HTTP 429 response. 
 
 ## Create a client
 
+:::caution
+In **8.7** Clusters, the Client Scopes will be managed through the cluster Identity component. The only scope that is still managed in Console is the Cluster **Secrets** scope. To learn more about managing Clients in **8.7** Clusters please refer to the [Identity](/components/identity/manage-api-clients.md) Documentation.
+:::
+
 Currently, Camunda 8 SaaS supports the following scopes:
 
 - Zeebe - Access to the [Zeebe gRPC](/apis-tools/zeebe-api/grpc.md) and [REST](/apis-tools/camunda-api-rest/camunda-api-rest-overview.md) APIs.


### PR DESCRIPTION
## Description

Related to: https://github.com/camunda/product-hub/issues/2222

The way Custer API clients are manages will change with the 8.7 Identity Integration. 
In Console Clients can still be created, but all scopes (except for the `Secrets` Scope) will be managed in the Cluster Identity Deployment. 
Afaik, currently the Identity Documentation does not exist. But the Console API client documentation should refer to the Identity Documentation. (Link in this change is a placeholder)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [x] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [ x ] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

