### PR TITLE
Document job result in Job Workers concept page

### DIFF
--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -93,7 +93,7 @@ For [user task listeners](components/concepts/user-task-listeners.md) job worker
 Job results are used to define:
 
 1. **Corrections**: Updates to specific user task attributes, such as assignee, due date, follow-up date, candidate users, candidate groups, and priority, before the task transition is finalized. For more details, see [Correcting user task data](components/concepts/user-task-listeners.md/#correcting-user-task-data).
-2. **Denial**: Indicates that the operation should be explicitly denied. Denying an operation prevents the task lifecycle transition and discards any corrections made by previous listeners. For more details, see [Denying the operation](components/concepts/user-task-listeners.md/#denying-the-operation).
+2. **Denial**: Indicates that the lifecycle transition should be explicitly denied. Denying the task lifecycle transition rolls back the user task to the previous state, and discards any corrections made by previous listeners. For more details, see [Denying the operation](components/concepts/user-task-listeners.md/#denying-the-operation).
 
 Below is an example of using job result:
 

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -86,6 +86,43 @@ There are several advantages when failing a job with variables. Consider the fol
 
 :::
 
+### Using job result
+
+For [user task listeners](components/concepts/user-task-listeners.md) job workers can provide a **job result**.
+
+Job results are used to define:
+
+1. **Corrections**: Updates to specific user task attributes, such as assignee, due date, follow-up date, candidate users, candidate groups, and priority, before the task transition is finalized. For more details, see [Correcting user task data](components/concepts/user-task-listeners.md/#correcting-user-task-data).
+2. **Denial**: Indicates that the operation should be explicitly denied. Denying an operation prevents the task lifecycle transition and discards any corrections made by previous listeners. For more details, see [Denying the operation](components/concepts/user-task-listeners.md/#denying-the-operation).
+
+Below is an example of using job result:
+
+```java
+final JobHandler userTaskListenerHandler =
+    (jobClient, job) -> {
+        boolean shouldDeny = someValidationLogic(job);
+
+        jobClient
+            .newCompleteCommand(job)
+            // highlight-start
+            .withResult(
+                new CompleteJobResult()
+                    .correctAssignee("john_doe")
+                    .correctPriority(42)
+                    .deny(shouldDeny)) // deny based on validation logic
+            // highlight-end
+            .send();
+    };
+```
+
+If both corrections and denial are provided in the same job result (for example, `.correctAssignee(...)` and `.deny(true)`), the job completion command will be rejected. To avoid this, ensure the job is either completed with corrections (without denial set to `true`) or denied (without corrections).
+
+:::info
+
+The `corrections` and `deny` features are currently available only for user task listener jobs.
+
+:::
+
 ## Timeouts
 
 If the job is not completed or failed within the configured job activation timeout, Zeebe reassigns the job to another job worker. This does not affect the number of `remaining retries`.

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -88,12 +88,12 @@ There are several advantages when failing a job with variables. Consider the fol
 
 ### Using job result
 
-For [user task listeners](components/concepts/user-task-listeners.md) job workers can provide a **job result**.
+Job workers can provide a **job result** for [user task listeners](components/concepts/user-task-listeners.md).
 
 Job results are used to define:
 
-1. **Corrections**: Updates to specific user task attributes, such as assignee, due date, follow-up date, candidate users, candidate groups, and priority, before the task transition is finalized. For more details, see [Correcting user task data](components/concepts/user-task-listeners.md/#correcting-user-task-data).
-2. **Denial**: Indicates that the lifecycle transition should be explicitly denied. Denying the task lifecycle transition rolls back the user task to the previous state, and discards any corrections made by previous listeners. For more details, see [Denying the operation](components/concepts/user-task-listeners.md/#denying-the-operation).
+1. **Corrections**: Updates to specific user task attributes, such as assignee, due date, follow-up date, candidate users, candidate groups, and priority, before the task transition is finalized. For more details, see [correcting user task data](components/concepts/user-task-listeners.md/#correcting-user-task-data).
+2. **Denial**: Indicates that the lifecycle transition should be explicitly denied. Denying the task lifecycle transition rolls back the user task to the previous state, and discards any corrections made by previous listeners. For more details, see [denying the operation](components/concepts/user-task-listeners.md/#denying-the-operation).
 
 Below is an example of using job result:
 

--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -43,11 +43,11 @@ Currently, user task listeners support the following events:
 
 Each user task listener has the following properties:
 
-| Property    | Description                                                                                                   |
-| :---------- | :------------------------------------------------------------------------------------------------------------ |
-| `eventType` | Specifies the user task event that triggers the listener. Supported values are `assigning` and `completing` . |
-| `type`      | The name of the job type.                                                                                     |
-| `retries`   | The number of retries for the user task listener job.                                                         |
+| Property    | Description                                                                                                  |
+| :---------- | :----------------------------------------------------------------------------------------------------------- |
+| `eventType` | Specifies the user task event that triggers the listener. Supported values are `assigning` and `completing`. |
+| `type`      | The name of the job type.                                                                                    |
+| `retries`   | The number of retries for the user task listener job.                                                        |
 
 :::note
 If multiple user task listeners of the same `eventType` (such as multiple `assigning` listeners) are defined on the same user task, they are executed sequentially, one after the other, in the order they are defined in the BPMN model.


### PR DESCRIPTION
## Description

Scope:
- Added a short section on job results in `completing or failing jobs`.
- Linked to the `User task listeners` concept page
- Added note that job result is used for the user task listeners only right now.

These changes were made together by @ana-vinogradova-camunda and @ce-dmelnych so they don't require additional Engineering review. A Technical writer review is appreciated.

closes https://github.com/camunda/camunda/issues/26344

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
