### PR TITLE
Document user task listeners for user task modeling

### DIFF
--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -161,6 +161,27 @@ A user task can define an arbitrary number of `taskHeaders`; they are static
 metadata stored with the user task in Zeebe. The headers can be used as
 configuration parameters for tasklist applications.
 
+### User task listeners
+
+User tasks support **user task listeners**, which allow you to execute custom Java code in response to specific user task lifecycle events.
+
+#### Supported events
+
+Currently, user task listeners can react to the following events:
+
+- **Assigning**: Triggered while assigning a user task.
+- **Completing**: Triggered while completing a user task.
+
+#### Configuration
+
+To define a user task listener, include the `zeebe:taskListeners` extension element within the user task in your BPMN model. This element can contain one or more `zeebe:taskListener` elements, each specifying the following properties:
+
+- The `eventType` that triggers the listener (`"assigning"` or `"completing"`).
+- The `type` of the listener (job type used by the external worker).
+- The number of `retries` for the user task listener job (defaults to 3 if omitted).
+
+For more details, see [User task listeners](components/concepts/user-task-listeners.md).
+
 ## Job worker implementation
 
 A user task does not have to be managed by Zeebe. Instead, you can also use
@@ -285,9 +306,26 @@ A job-based user task with an embedded Camunda Form:
 </bpmn:process>
 ```
 
+#### User task listeners
+
+A user task with user task listeners configured:
+
+```xml
+<bpmn:userTask id="configure" name="Configure">
+  <bpmn:extensionElements>
+    <zeebe:taskListeners>
+      <zeebe:taskListener eventType="assigning" type="assigning-user-task-listener" retries="5" />
+      <zeebe:taskListener eventType="completing" type="completing-user-task-listener" />
+    </zeebe:taskListeners>
+    <zeebe:userTask/>
+  </bpmn:extensionElements>
+</bpmn:userTask>
+```
+
 ### References
 
 - [Tasklist](/components/tasklist/introduction-to-tasklist.md)
 - [Form linking in Modeler](/components/modeler/web-modeler/advanced-modeling/form-linking.md)
 - [Job handling](/components/concepts/job-workers.md)
 - [Variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+- [User task listeners](/components/concepts/user-task-listeners.md)

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -180,7 +180,7 @@ To define a user task listener, include the `zeebe:taskListeners` extension elem
 - The `type` of the listener (job type used by the external worker).
 - The number of `retries` for the user task listener job (defaults to 3 if omitted).
 
-For more details, see [User task listeners](components/concepts/user-task-listeners.md).
+For more details, see [user task listeners](components/concepts/user-task-listeners.md).
 
 ## Job worker implementation
 

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -163,7 +163,7 @@ configuration parameters for tasklist applications.
 
 ### User task listeners
 
-User tasks support **user task listeners**, which allow you to execute custom Java code in response to specific user task lifecycle events.
+User tasks support **user task listeners**, which allow you to react to user task lifecycle events.
 
 #### Supported events
 
@@ -174,7 +174,7 @@ Currently, user task listeners can react to the following events:
 
 #### Configuration
 
-To define a user task listener, include the `zeebe:taskListeners` extension element within the user task in your BPMN model. This element can contain one or more `zeebe:taskListener` elements, each specifying the following properties:
+To define a user task listener, include the `zeebe:taskListeners` extension element within the user task in your BPMN model. This element can contain one or more `zeebe:taskListener` elements, each specifying the following attributes:
 
 - The `eventType` that triggers the listener (`"assigning"` or `"completing"`).
 - The `type` of the listener (job type used by the external worker).


### PR DESCRIPTION
## Description

Scope:
- added subsection on how to define user task listeners.
- linked with the `User task listeners` concept page.
- provided an XML example for the user task with the defined user task listeners.

These changes were made together by @ana-vinogradova-camunda and @ce-dmelnych so they don't require additional Engineering review. A Technical writer review is appreciated.

closes https://github.com/camunda/camunda/issues/26343

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
