### PR TITLE
chore: update opensearch local default port for tasklist SM

### DIFF
--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -102,6 +102,8 @@ For OpenSearch we also have similar configurations:
 | camunda.tasklist.opensearch.ssl.selfSigned      | Certificate was self-signed.                                                                                                                                                                                                                                                       | false                 |
 | camunda.tasklist.opensearch.ssl.verifyHostname  | Should the hostname be validated.                                                                                                                                                                                                                                                  | false                 |
 
+For local development environments, OpenSearch is configured to run on port 9205 by default, enhancing the developer experience by avoiding conflicts with Elasticsearch services.
+
 By default, Tasklist always tries to connect to Elasticsearch. To define the database to use, the configuration below is mandatory (if this configuration is missed, Elasticsearch is used as the selected database):
 
 | Name                      | Description                                                                                    | Default value |

--- a/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -96,6 +96,8 @@ For OpenSearch we also have similar configurations:
 | camunda.tasklist.opensearch.ssl.selfSigned      | Certificate was self-signed.                                                                                                                                                                                                                                                       | false                 |
 | camunda.tasklist.opensearch.ssl.verifyHostname  | Should the hostname be validated.                                                                                                                                                                                                                                                  | false                 |
 
+For local development environments, OpenSearch is configured to run on port 9205 by default, enhancing the developer experience by avoiding conflicts with Elasticsearch services.
+
 By default, Tasklist always tries to connect to Elasticsearch. To define the database to use, the configuration below is mandatory (if this configuration is missed, Elasticsearch is used as the selected database):
 
 | Name                      | Description                                                                                    | Default value |

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -96,6 +96,8 @@ For OpenSearch we also have similar configurations:
 | camunda.tasklist.opensearch.ssl.selfSigned      | Certificate was self-signed.                                                                                                                                                                                                                                                       | false                 |
 | camunda.tasklist.opensearch.ssl.verifyHostname  | Should the hostname be validated.                                                                                                                                                                                                                                                  | false                 |
 
+For local development environments, OpenSearch is configured to run on port 9205 by default, enhancing the developer experience by avoiding conflicts with Elasticsearch services.
+
 By default, Tasklist always tries to connect to Elasticsearch. To define the database to use, the configuration below is mandatory (if this configuration is missed, Elasticsearch is used as the selected database):
 
 | Name                      | Description                                                                                   | Default value |

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -102,6 +102,8 @@ For OpenSearch we also have similar configurations:
 | camunda.tasklist.opensearch.ssl.selfSigned      | Certificate was self-signed.                                                                                                                                                                                                                                                       | false                 |
 | camunda.tasklist.opensearch.ssl.verifyHostname  | Should the hostname be validated.                                                                                                                                                                                                                                                  | false                 |
 
+For local development environments, OpenSearch is configured to run on port 9205 by default, enhancing the developer experience by avoiding conflicts with Elasticsearch services.
+
 By default, Tasklist always tries to connect to Elasticsearch. To define the database to use, the configuration below is mandatory (if this configuration is missed, Elasticsearch is used as the selected database):
 
 | Name                      | Description                                                                                    | Default value |


### PR DESCRIPTION
## Description

On local envirovment (not helm) the default port for open search is 9205 and not 9200 (which is user for Helm)
As this can create confusion for developer experience, I updated with the information the document.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
