### PR TITLE
docs: changing the `reset` to `clear`

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -205,11 +205,11 @@ message JobResult{
   optional bool denied = 1;
   // Attributes that were corrected by the worker.
   // The following attributes can be corrected, additional attributes will be ignored:
-  //   * `assignee` - unset by providing an empty string
-  //   * `dueDate` - unset by providing an empty string
-  //   * `followUpDate` - unset by providing an empty string
-  //   * `candidateGroups` - unset by providing an empty list
-  //   * `candidateUsers` - unset by providing an empty list
+  //   * `assignee` - clear by providing an empty string
+  //   * `dueDate` - clear by providing an empty string
+  //   * `followUpDate` - clear by providing an empty string
+  //   * `candidateGroups` - clear by providing an empty list
+  //   * `candidateUsers` - clear by providing an empty list
   //   * `priority` - minimum 0, maximum 100, default 50
   //  Omitting any of the attributes will preserve the persisted attribute's value.
   optional JobResultCorrections corrections = 2;

--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -205,11 +205,11 @@ message JobResult{
   optional bool denied = 1;
   // Attributes that were corrected by the worker.
   // The following attributes can be corrected, additional attributes will be ignored:
-  //   * `assignee` - reset by providing an empty string
-  //   * `dueDate` - reset by providing an empty string
-  //   * `followUpDate` - reset by providing an empty string
-  //   * `candidateGroups` - reset by providing an empty list
-  //   * `candidateUsers` - reset by providing an empty list
+  //   * `assignee` - unset by providing an empty string
+  //   * `dueDate` - unset by providing an empty string
+  //   * `followUpDate` - unset by providing an empty string
+  //   * `candidateGroups` - unset by providing an empty list
+  //   * `candidateUsers` - unset by providing an empty list
   //   * `priority` - minimum 0, maximum 100, default 50
   //  Omitting any of the attributes will preserve the persisted attribute's value.
   optional JobResultCorrections corrections = 2;


### PR DESCRIPTION
## Description
As there might be multiple task listeners that are triggered in sequence, the word `reset` might be misleading as it may imply that a previously made correction can be "reset" (i.e. undone).

Solution: using `clear` instead of `reset`

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [x] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [x] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
