### PR TITLE
fix portforwarding command example for local k8s

### DIFF
--- a/docs/self-managed/setup/deploy/local/local-kubernetes-cluster.md
+++ b/docs/self-managed/setup/deploy/local/local-kubernetes-cluster.md
@@ -92,7 +92,7 @@ First, port-forward each of the components. Use a separate terminal for each com
 To interact with the Camunda workflow engine via Zeebe Gateway using [zbctl](/apis-tools/community-clients/cli-client/cli-get-started.md) or a local client/worker from outside the Kubernetes cluster, run `kubectl port-forward` to the Zeebe Gateway as follows:
 
 ```sh
-kubectl port-forward svc/camunda-zeebe-gateway 26500:26500
+kubectl port-forward svc/camunda-platform-zeebe-gateway 26500:26500
 ```
 
 :::note

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/local/local-kubernetes-cluster.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/local/local-kubernetes-cluster.md
@@ -94,7 +94,7 @@ First, port-forward each of the components. Use a separate terminal for each com
 To interact with the Camunda workflow engine via Zeebe Gateway using [zbctl](/apis-tools/cli-client/cli-get-started.md) or a local client/worker from outside the Kubernetes cluster, run `kubectl port-forward` to the Zeebe gateway as follows:
 
 ```sh
-kubectl port-forward svc/camunda-zeebe-gateway 26500:26500
+kubectl port-forward svc/camunda-platform-zeebe-gateway 26500:26500
 ```
 
 :::note


### PR DESCRIPTION
## Description

Back- and forward-porting a contributor change for 8.6 here: https://github.com/camunda/camunda-docs/pull/4686

The files and instructions for 8.5 through /next are the same, and the portforwarding command should be updated to match.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
