### PR TITLE
feat: links to fill spring started page

### DIFF
--- a/docs/guides/getting-started-java-spring.md
+++ b/docs/guides/getting-started-java-spring.md
@@ -51,7 +51,7 @@ Next, create a new Spring Boot project:
 
 1. Go to [https://start.spring.io/](https://start.spring.io/) to get started.
 2. Under **Project**, select **Maven**. Under **Language**, select **Java**. Under **Spring Boot**, select the latest non-SNAPSHOT version (currently 3.4.1).
-3. Under **Project Metadata**, configure the following:
+3. Under **Project Metadata**, configure the following or use the [pre-filled shortcut](https://start.spring.io/#!type=maven-project&language=java&packaging=jar&groupId=io.camunda.demo&artifactId=process_payments&name=Process%20payments&description=Process%20payments%20with%20Camunda&packageName=io.camunda.demo.process_payments):
    1. **Group**: `io.camunda.demo`
    2. **Artifact**: `process_payments`
    3. **Name**: `Process payments`

--- a/docs/guides/getting-started-java-spring.md
+++ b/docs/guides/getting-started-java-spring.md
@@ -50,7 +50,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 Next, create a new Spring Boot project:
 
 1. Go to [https://start.spring.io/](https://start.spring.io/) to get started.
-2. Under **Project**, select **Maven**. Under **Language**, select **Java**. Under **Spring Boot**, select the latest non-SNAPSHOT version (currently 3.3.3).
+2. Under **Project**, select **Maven**. Under **Language**, select **Java**. Under **Spring Boot**, select the latest non-SNAPSHOT version (currently 3.4.1).
 3. Under **Project Metadata**, configure the following:
    1. **Group**: `io.camunda.demo`
    2. **Artifact**: `process_payments`

--- a/versioned_docs/version-8.6/guides/getting-started-java-spring.md
+++ b/versioned_docs/version-8.6/guides/getting-started-java-spring.md
@@ -51,7 +51,7 @@ Next, create a new Spring Boot project:
 
 1. Go to [https://start.spring.io/](https://start.spring.io/) to get started.
 2. Under **Project**, select **Maven**. Under **Language**, select **Java**. Under **Spring Boot**, select the latest non-SNAPSHOT version (currently 3.4.1).
-3. Under **Project Metadata**, configure the following:
+3. Under **Project Metadata**, configure the following or use the [pre-filled shortcut](https://start.spring.io/#!type=maven-project&language=java&packaging=jar&groupId=io.camunda.demo&artifactId=process_payments&name=Process%20payments&description=Process%20payments%20with%20Camunda&packageName=io.camunda.demo.process_payments):
    1. **Group**: `io.camunda.demo`
    2. **Artifact**: `process_payments`
    3. **Name**: `Process payments`

--- a/versioned_docs/version-8.6/guides/getting-started-java-spring.md
+++ b/versioned_docs/version-8.6/guides/getting-started-java-spring.md
@@ -50,7 +50,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 Next, create a new Spring Boot project:
 
 1. Go to [https://start.spring.io/](https://start.spring.io/) to get started.
-2. Under **Project**, select **Maven**. Under **Language**, select **Java**. Under **Spring Boot**, select the latest non-SNAPSHOT version (currently 3.3.3).
+2. Under **Project**, select **Maven**. Under **Language**, select **Java**. Under **Spring Boot**, select the latest non-SNAPSHOT version (currently 3.4.1).
 3. Under **Project Metadata**, configure the following:
    1. **Group**: `io.camunda.demo`
    2. **Artifact**: `process_payments`


### PR DESCRIPTION
## Description

- update the current Spring framework version
- add a link to prefill the Spring starter page with the Camunda information leaving out the moving parts

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [x] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.