### PR TITLE
Quick overhaul of outdated information in the migration guide

### DIFF
--- a/docs/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/docs/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -40,7 +40,7 @@ If this affects large parts of your code base, you could write a small abstracti
 
 The "external task topic" from Camunda 7 is directly translated in a "task type name" in Camunda 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ### Service tasks with attached Java code (Java delegates, expressions)
 
@@ -52,13 +52,13 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 
 You can use this worker directly, but more often it might serve as a starting point or simply be used for inspiration.
 
-The community-supported [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
+The [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
 
 The topic `camunda-7-adapter` is set and the following attributes/elements are migrated and put into a task header:
 

--- a/docs/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/docs/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -48,10 +48,6 @@ To migrate existing Connectors, consider the following options:
 
 ### Multi-tenancy
 
-:::note
-[Multi-tenancy](/self-managed/concepts/multi-tenancy.md) is currently in development for Camunda 8.
-:::
-
 There are several differences between how [multi-tenancy](/self-managed/concepts/multi-tenancy.md) works in Camunda 7 and Camunda 8:
 
 1. The [one engine per tenant approach from Camunda 7](https://docs.camunda.org/manual/develop/user-guide/process-engine/multi-tenancy/#one-process-engine-per-tenant) isn't possible with Camunda 8. Camunda 8 only provides multi-tenancy through a tenant identifier.

--- a/docs/guides/migrating-from-camunda-7/index.md
+++ b/docs/guides/migrating-from-camunda-7/index.md
@@ -13,21 +13,19 @@ keywords:
   ]
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 This guide describes how to migrate process solutions developed for Camunda 7 to run them on Camunda 8, including:
 
 - Differences in application architecture
-- How process models and code can generally be migrated, whereas runtime and history data cannot
-- How migration can be very simple for some models, but also marked limitations, where migration might get very complicated
+- How process solutions can be migrated
+- How migration can be very simple for some models, but also marked limitations, where migration might get complicated
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
-- Community extensions that can help with migration
+- Tooling that can help with migration
 - The Clean Delegate approach, which helps you write Camunda 7 solutions that are easier to migrate
 
-We are watching all customer migration projects closely and will update this guide in the future.
+:::note
+We are currently developing improved migration tooling and will overhaul this guide around the 8.7 release. If you embark on a migration journey, please reach out to discuss your use case with us.
+:::
 
 ## What to expect
 

--- a/docs/guides/migrating-from-camunda-7/migration-readiness.md
+++ b/docs/guides/migrating-from-camunda-7/migration-readiness.md
@@ -62,10 +62,10 @@ In general, **workflow engine data** is harder to migrate to Camunda 8:
 ## Migration tooling
 
 :::note
-We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on some solid migration tools.
+We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on several migration tools.
 :::
 
-The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), contains three components that will help you with migration:
+The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration) contains three components to help you with migration:
 
 1. [A converter available in different flavors (web app, CLI) to convert BPMN models from Camunda 7 to Camunda 8](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter). This maps possible BPMN elements and technical attributes into the Camunda 8 format and gives you warnings where this is not possible. The result of a conversion is a model with mapped implementation details as well as hints on what changed, needs to be reviewed, or adjusted to function properly in Camunda 8.
 

--- a/docs/guides/migrating-from-camunda-7/migration-readiness.md
+++ b/docs/guides/migrating-from-camunda-7/migration-readiness.md
@@ -4,19 +4,21 @@ title: Migration preparation
 description: "Learn readiness indicators for migrating from Camunda 7 to Camunda 8."
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 Let's discuss if you need to migrate before diving into the necessary steps and what tools can help you achieve the migration.
 
 ## When to migrate?
 
 New projects should typically be started using Camunda 8.
 
-Existing solutions using Camunda 7 might simply keep running on Camunda 7. Camunda has ongoing [support](https://docs.camunda.org/enterprise/announcement/), so there is no need to rush on a migration project.
+For Camunda 7:
 
-You should consider migrating existing Camunda 7 solutions if:
+- Camunda 7 CE (Community Edition) will EOL (end of life) in October 2025 with a final release (v7.24) happening on Oct 14, 2025.
+- There will be no more Camunda 7 CE releases after that date and the GitHub repo will be archived. The code will still be available, but we’ll close all issues and pull requests, and update the README to reflect the EOL status.
+- Camunda 7 EE (Enterprise Edition) customers will continue to get patch releases (security patches & bug fixes) on a rolling basis.
+
+If you have not yet migrated to Camunda 8, we strongly recommend that you start that process now.
+
+Migrating to Camunda 8 gives you additional advantages if:
 
 - You are looking to leverage a SaaS offering (e.g. to reduce the effort for hardware or infrastructure setup and maintenance).
 - You are in need of performance at scale and/or improved resilience.
@@ -55,15 +57,15 @@ In general, **workflow engine data** is harder to migrate to Camunda 8:
 
 - **Runtime data:** Running process instances of Camunda 7 are stored in the Camunda 7 relational database. Like with a migration from third party workflow engines, you can read this data from Camunda 7 and use it to create the right process instances in Camunda 8 in the right state. This way, you can migrate running process instances from Camunda 7 to Camunda 8. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) is in place to ease this task. This tool is community supported.
 
-- **History data:** Historic data from the workflow engine itself cannot be migrated. However, data in Optimize can be kept.
+- **History data:** Historic data from the workflow engine itself cannot be migrated. A tool allowing this is currently under development.
 
 ## Migration tooling
 
 :::note
-These tools are community maintained. For more assistance, create an issue on the repo directly.
+We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on some solid migration tools.
 :::
 
-The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), available as a community extension, contains three components that will help you with migration:
+The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), contains three components that will help you with migration:
 
 1. [A converter available in different flavors (web app, CLI) to convert BPMN models from Camunda 7 to Camunda 8](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter). This maps possible BPMN elements and technical attributes into the Camunda 8 format and gives you warnings where this is not possible. The result of a conversion is a model with mapped implementation details as well as hints on what changed, needs to be reviewed, or adjusted to function properly in Camunda 8.
 
@@ -71,7 +73,7 @@ The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-commun
 
 3. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) to migrate running process instances from Camunda 7 to Camunda 8. Ideally, you should let running instances finish prior to migrating.
 
-The tools mentioned above are a good starting point, but are only one option for how you can approach your migration, as described below.
+The tools mentioned above are a good starting point.
 
 ## Prepare for smooth migrations
 

--- a/versioned_docs/version-8.3/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/versioned_docs/version-8.3/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -52,7 +52,7 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 

--- a/versioned_docs/version-8.3/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/versioned_docs/version-8.3/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -40,7 +40,7 @@ If this affects large parts of your code base, you could write a small abstracti
 
 The "external task topic" from Camunda 7 is directly translated in a "task type name" in Camunda 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ### Service tasks with attached Java code (Java delegates, expressions)
 
@@ -52,13 +52,13 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 
 You can use this worker directly, but more often it might serve as a starting point or simply be used for inspiration.
 
-The community-supported [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
+The [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
 
 The topic `camunda-7-adapter` is set and the following attributes/elements are migrated and put into a task header:
 

--- a/versioned_docs/version-8.3/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.3/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -48,10 +48,6 @@ To migrate existing Connectors, consider the following options:
 
 ### Multi-tenancy
 
-:::note
-[Multi-tenancy](/self-managed/concepts/multi-tenancy.md) is currently in development for Camunda 8.
-:::
-
 There are several differences between how [multi-tenancy](/self-managed/concepts/multi-tenancy.md) works in Camunda 7 and Camunda 8:
 
 1. The [one engine per tenant approach from Camunda 7](https://docs.camunda.org/manual/develop/user-guide/process-engine/multi-tenancy/#one-process-engine-per-tenant) isn't possible with Camunda 8. Camunda 8 only provides multi-tenancy through a tenant identifier.

--- a/versioned_docs/version-8.3/guides/migrating-from-camunda-7/index.md
+++ b/versioned_docs/version-8.3/guides/migrating-from-camunda-7/index.md
@@ -13,21 +13,19 @@ keywords:
   ]
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 This guide describes how to migrate process solutions developed for Camunda 7 to run them on Camunda 8, including:
 
 - Differences in application architecture
-- How process models and code can generally be migrated, whereas runtime and history data cannot
-- How migration can be very simple for some models, but also marked limitations, where migration might get very complicated
+- How process solutions can be migrated
+- How migration can be very simple for some models, but also marked limitations, where migration might get complicated
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
-- Community extensions that can help with migration
+- Tooling that can help with migration
 - The Clean Delegate approach, which helps you write Camunda 7 solutions that are easier to migrate
 
-We are watching all customer migration projects closely and will update this guide in the future.
+:::note
+We are currently developing improved migration tooling and will overhaul this guide around the 8.7 release. If you embark on a migration journey, please reach out to discuss your use case with us.
+:::
 
 ## What to expect
 

--- a/versioned_docs/version-8.3/guides/migrating-from-camunda-7/migration-readiness.md
+++ b/versioned_docs/version-8.3/guides/migrating-from-camunda-7/migration-readiness.md
@@ -4,19 +4,21 @@ title: Migration preparation
 description: "Learn readiness indicators for migrating from Camunda 7 to Camunda 8."
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 Let's discuss if you need to migrate before diving into the necessary steps and what tools can help you achieve the migration.
 
 ## When to migrate?
 
 New projects should typically be started using Camunda 8.
 
-Existing solutions using Camunda 7 might simply keep running on Camunda 7. Camunda has ongoing [support](https://docs.camunda.org/enterprise/announcement/), so there is no need to rush on a migration project.
+For Camunda 7:
 
-You should consider migrating existing Camunda 7 solutions if:
+- Camunda 7 CE (Community Edition) will EOL (end of life) in October 2025 with a final release (v7.24) happening on Oct 14, 2025.
+- There will be no more Camunda 7 CE releases after that date and the GitHub repo will be archived. The code will still be available, but we’ll close all issues and pull requests, and update the README to reflect the EOL status.
+- Camunda 7 EE (Enterprise Edition) customers will continue to get patch releases (security patches & bug fixes) on a rolling basis.
+
+If you have not yet migrated to Camunda 8, we strongly recommend that you start that process now.
+
+Migrating to Camunda 8 gives you additional advantages if:
 
 - You are looking to leverage a SaaS offering (e.g. to reduce the effort for hardware or infrastructure setup and maintenance).
 - You are in need of performance at scale and/or improved resilience.
@@ -55,15 +57,15 @@ In general, **workflow engine data** is harder to migrate to Camunda 8:
 
 - **Runtime data:** Running process instances of Camunda 7 are stored in the Camunda 7 relational database. Like with a migration from third party workflow engines, you can read this data from Camunda 7 and use it to create the right process instances in Camunda 8 in the right state. This way, you can migrate running process instances from Camunda 7 to Camunda 8. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) is in place to ease this task. This tool is community supported.
 
-- **History data:** Historic data from the workflow engine itself cannot be migrated. However, data in Optimize can be kept.
+- **History data:** Historic data from the workflow engine itself cannot be migrated. A tool allowing this is currently under development.
 
 ## Migration tooling
 
 :::note
-These tools are community maintained. For more assistance, create an issue on the repo directly.
+We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on several migration tools.
 :::
 
-The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), available as a community extension, contains three components that will help you with migration:
+The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration) contains three components to help you with migration:
 
 1. [A converter available in different flavors (web app, CLI) to convert BPMN models from Camunda 7 to Camunda 8](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter). This maps possible BPMN elements and technical attributes into the Camunda 8 format and gives you warnings where this is not possible. The result of a conversion is a model with mapped implementation details as well as hints on what changed, needs to be reviewed, or adjusted to function properly in Camunda 8.
 
@@ -71,7 +73,7 @@ The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-commun
 
 3. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) to migrate running process instances from Camunda 7 to Camunda 8. Ideally, you should let running instances finish prior to migrating.
 
-The tools mentioned above are a good starting point, but are only one option for how you can approach your migration, as described below.
+The tools mentioned above are a good starting point.
 
 ## Prepare for smooth migrations
 

--- a/versioned_docs/version-8.4/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/versioned_docs/version-8.4/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -52,7 +52,7 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 

--- a/versioned_docs/version-8.4/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/versioned_docs/version-8.4/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -40,7 +40,7 @@ If this affects large parts of your code base, you could write a small abstracti
 
 The "external task topic" from Camunda 7 is directly translated in a "task type name" in Camunda 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ### Service tasks with attached Java code (Java delegates, expressions)
 
@@ -52,13 +52,13 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 
 You can use this worker directly, but more often it might serve as a starting point or simply be used for inspiration.
 
-The community-supported [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
+The [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
 
 The topic `camunda-7-adapter` is set and the following attributes/elements are migrated and put into a task header:
 

--- a/versioned_docs/version-8.4/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.4/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -48,10 +48,6 @@ To migrate existing Connectors, consider the following options:
 
 ### Multi-tenancy
 
-:::note
-[Multi-tenancy](/self-managed/concepts/multi-tenancy.md) is currently in development for Camunda 8.
-:::
-
 There are several differences between how [multi-tenancy](/self-managed/concepts/multi-tenancy.md) works in Camunda 7 and Camunda 8:
 
 1. The [one engine per tenant approach from Camunda 7](https://docs.camunda.org/manual/develop/user-guide/process-engine/multi-tenancy/#one-process-engine-per-tenant) isn't possible with Camunda 8. Camunda 8 only provides multi-tenancy through a tenant identifier.

--- a/versioned_docs/version-8.4/guides/migrating-from-camunda-7/index.md
+++ b/versioned_docs/version-8.4/guides/migrating-from-camunda-7/index.md
@@ -13,21 +13,19 @@ keywords:
   ]
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 This guide describes how to migrate process solutions developed for Camunda 7 to run them on Camunda 8, including:
 
 - Differences in application architecture
-- How process models and code can generally be migrated, whereas runtime and history data cannot
-- How migration can be very simple for some models, but also marked limitations, where migration might get very complicated
+- How process solutions can be migrated
+- How migration can be very simple for some models, but also marked limitations, where migration might get complicated
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
-- Community extensions that can help with migration
+- Tooling that can help with migration
 - The Clean Delegate approach, which helps you write Camunda 7 solutions that are easier to migrate
 
-We are watching all customer migration projects closely and will update this guide in the future.
+:::note
+We are currently developing improved migration tooling and will overhaul this guide around the 8.7 release. If you embark on a migration journey, please reach out to discuss your use case with us.
+:::
 
 ## What to expect
 

--- a/versioned_docs/version-8.4/guides/migrating-from-camunda-7/migration-readiness.md
+++ b/versioned_docs/version-8.4/guides/migrating-from-camunda-7/migration-readiness.md
@@ -4,19 +4,21 @@ title: Migration preparation
 description: "Learn readiness indicators for migrating from Camunda 7 to Camunda 8."
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 Let's discuss if you need to migrate before diving into the necessary steps and what tools can help you achieve the migration.
 
 ## When to migrate?
 
 New projects should typically be started using Camunda 8.
 
-Existing solutions using Camunda 7 might simply keep running on Camunda 7. Camunda has ongoing [support](https://docs.camunda.org/enterprise/announcement/), so there is no need to rush on a migration project.
+For Camunda 7:
 
-You should consider migrating existing Camunda 7 solutions if:
+- Camunda 7 CE (Community Edition) will EOL (end of life) in October 2025 with a final release (v7.24) happening on Oct 14, 2025.
+- There will be no more Camunda 7 CE releases after that date and the GitHub repo will be archived. The code will still be available, but we’ll close all issues and pull requests, and update the README to reflect the EOL status.
+- Camunda 7 EE (Enterprise Edition) customers will continue to get patch releases (security patches & bug fixes) on a rolling basis.
+
+If you have not yet migrated to Camunda 8, we strongly recommend that you start that process now.
+
+Migrating to Camunda 8 gives you additional advantages if:
 
 - You are looking to leverage a SaaS offering (e.g. to reduce the effort for hardware or infrastructure setup and maintenance).
 - You are in need of performance at scale and/or improved resilience.
@@ -55,15 +57,15 @@ In general, **workflow engine data** is harder to migrate to Camunda 8:
 
 - **Runtime data:** Running process instances of Camunda 7 are stored in the Camunda 7 relational database. Like with a migration from third party workflow engines, you can read this data from Camunda 7 and use it to create the right process instances in Camunda 8 in the right state. This way, you can migrate running process instances from Camunda 7 to Camunda 8. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) is in place to ease this task. This tool is community supported.
 
-- **History data:** Historic data from the workflow engine itself cannot be migrated. However, data in Optimize can be kept.
+- **History data:** Historic data from the workflow engine itself cannot be migrated. A tool allowing this is currently under development.
 
 ## Migration tooling
 
 :::note
-These tools are community maintained. For more assistance, create an issue on the repo directly.
+We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on several migration tools.
 :::
 
-The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), available as a community extension, contains three components that will help you with migration:
+The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration) contains three components to help you with migration:
 
 1. [A converter available in different flavors (web app, CLI) to convert BPMN models from Camunda 7 to Camunda 8](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter). This maps possible BPMN elements and technical attributes into the Camunda 8 format and gives you warnings where this is not possible. The result of a conversion is a model with mapped implementation details as well as hints on what changed, needs to be reviewed, or adjusted to function properly in Camunda 8.
 
@@ -71,7 +73,7 @@ The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-commun
 
 3. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) to migrate running process instances from Camunda 7 to Camunda 8. Ideally, you should let running instances finish prior to migrating.
 
-The tools mentioned above are a good starting point, but are only one option for how you can approach your migration, as described below.
+The tools mentioned above are a good starting point.
 
 ## Prepare for smooth migrations
 

--- a/versioned_docs/version-8.5/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/versioned_docs/version-8.5/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -40,7 +40,7 @@ If this affects large parts of your code base, you could write a small abstracti
 
 The "external task topic" from Camunda 7 is directly translated in a "task type name" in Camunda 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ### Service tasks with attached Java code (Java delegates, expressions)
 
@@ -52,13 +52,13 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 
 You can use this worker directly, but more often it might serve as a starting point or simply be used for inspiration.
 
-The community-supported [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
+The [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
 
 The topic `camunda-7-adapter` is set and the following attributes/elements are migrated and put into a task header:
 

--- a/versioned_docs/version-8.5/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.5/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -48,10 +48,6 @@ To migrate existing Connectors, consider the following options:
 
 ### Multi-tenancy
 
-:::note
-[Multi-tenancy](/self-managed/concepts/multi-tenancy.md) is currently in development for Camunda 8.
-:::
-
 There are several differences between how [multi-tenancy](/self-managed/concepts/multi-tenancy.md) works in Camunda 7 and Camunda 8:
 
 1. The [one engine per tenant approach from Camunda 7](https://docs.camunda.org/manual/develop/user-guide/process-engine/multi-tenancy/#one-process-engine-per-tenant) isn't possible with Camunda 8. Camunda 8 only provides multi-tenancy through a tenant identifier.

--- a/versioned_docs/version-8.5/guides/migrating-from-camunda-7/index.md
+++ b/versioned_docs/version-8.5/guides/migrating-from-camunda-7/index.md
@@ -13,21 +13,19 @@ keywords:
   ]
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 This guide describes how to migrate process solutions developed for Camunda 7 to run them on Camunda 8, including:
 
 - Differences in application architecture
-- How process models and code can generally be migrated, whereas runtime and history data cannot
-- How migration can be very simple for some models, but also marked limitations, where migration might get very complicated
+- How process solutions can be migrated
+- How migration can be very simple for some models, but also marked limitations, where migration might get complicated
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
-- Community extensions that can help with migration
+- Tooling that can help with migration
 - The Clean Delegate approach, which helps you write Camunda 7 solutions that are easier to migrate
 
-We are watching all customer migration projects closely and will update this guide in the future.
+:::note
+We are currently developing improved migration tooling and will overhaul this guide around the 8.7 release. If you embark on a migration journey, please reach out to discuss your use case with us.
+:::
 
 ## What to expect
 

--- a/versioned_docs/version-8.5/guides/migrating-from-camunda-7/migration-readiness.md
+++ b/versioned_docs/version-8.5/guides/migrating-from-camunda-7/migration-readiness.md
@@ -4,19 +4,21 @@ title: Migration preparation
 description: "Learn readiness indicators for migrating from Camunda 7 to Camunda 8."
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 Let's discuss if you need to migrate before diving into the necessary steps and what tools can help you achieve the migration.
 
 ## When to migrate?
 
 New projects should typically be started using Camunda 8.
 
-Existing solutions using Camunda 7 might simply keep running on Camunda 7. Camunda has ongoing [support](https://docs.camunda.org/enterprise/announcement/), so there is no need to rush on a migration project.
+For Camunda 7:
 
-You should consider migrating existing Camunda 7 solutions if:
+- Camunda 7 CE (Community Edition) will EOL (end of life) in October 2025 with a final release (v7.24) happening on Oct 14, 2025.
+- There will be no more Camunda 7 CE releases after that date and the GitHub repo will be archived. The code will still be available, but we’ll close all issues and pull requests, and update the README to reflect the EOL status.
+- Camunda 7 EE (Enterprise Edition) customers will continue to get patch releases (security patches & bug fixes) on a rolling basis.
+
+If you have not yet migrated to Camunda 8, we strongly recommend that you start that process now.
+
+Migrating to Camunda 8 gives you additional advantages if:
 
 - You are looking to leverage a SaaS offering (e.g. to reduce the effort for hardware or infrastructure setup and maintenance).
 - You are in need of performance at scale and/or improved resilience.
@@ -55,15 +57,15 @@ In general, **workflow engine data** is harder to migrate to Camunda 8:
 
 - **Runtime data:** Running process instances of Camunda 7 are stored in the Camunda 7 relational database. Like with a migration from third party workflow engines, you can read this data from Camunda 7 and use it to create the right process instances in Camunda 8 in the right state. This way, you can migrate running process instances from Camunda 7 to Camunda 8. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) is in place to ease this task. This tool is community supported.
 
-- **History data:** Historic data from the workflow engine itself cannot be migrated. However, data in Optimize can be kept.
+- **History data:** Historic data from the workflow engine itself cannot be migrated. A tool allowing this is currently under development.
 
 ## Migration tooling
 
 :::note
-These tools are community maintained. For more assistance, create an issue on the repo directly.
+We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on several migration tools.
 :::
 
-The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), available as a community extension, contains three components that will help you with migration:
+The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration) contains three components to help you with migration:
 
 1. [A converter available in different flavors (web app, CLI) to convert BPMN models from Camunda 7 to Camunda 8](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter). This maps possible BPMN elements and technical attributes into the Camunda 8 format and gives you warnings where this is not possible. The result of a conversion is a model with mapped implementation details as well as hints on what changed, needs to be reviewed, or adjusted to function properly in Camunda 8.
 
@@ -71,7 +73,7 @@ The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-commun
 
 3. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) to migrate running process instances from Camunda 7 to Camunda 8. Ideally, you should let running instances finish prior to migrating.
 
-The tools mentioned above are a good starting point, but are only one option for how you can approach your migration, as described below.
+The tools mentioned above are a good starting point.
 
 ## Prepare for smooth migrations
 

--- a/versioned_docs/version-8.6/guides/migrating-from-camunda-7/adjusting-source-code.md
+++ b/versioned_docs/version-8.6/guides/migrating-from-camunda-7/adjusting-source-code.md
@@ -40,7 +40,7 @@ If this affects large parts of your code base, you could write a small abstracti
 
 The "external task topic" from Camunda 7 is directly translated in a "task type name" in Camunda 8, therefore `camunda:topic` gets `zeebe:taskDefinition type` in your BPMN model.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) picks up your `@ExternalTaskHandler` beans, wraps them into a JobWorker, and subscribes to the `camunda:topic` you defined as `zeebe:taskDefinition type`.
 
 ### Service tasks with attached Java code (Java delegates, expressions)
 
@@ -52,13 +52,13 @@ In Camunda 7, there are three ways to attach Java code to service tasks in the B
 
 Camunda 8 cannot directly execute custom Java code. Instead, there must be a [job worker](/components/concepts/job-workers.md) executing code.
 
-The community-supported [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
+The [Camunda 7 Adapter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/camunda-7-adapter) implements such a job worker using the [Spring Zeebe SDK](../../apis-tools/spring-zeebe-sdk/getting-started.md). It subscribes to the task type `camunda-7-adapter`. [Task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) are used to configure a delegation class or expression for this worker.
 
 ![Service task in Camunda 7 and Camunda 8](../img/migration-service-task.png)
 
 You can use this worker directly, but more often it might serve as a starting point or simply be used for inspiration.
 
-The community-supported [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
+The [Camunda 7 to Camunda 8 Converter](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter) will adjust the service tasks in your BPMN model automatically for this adapter.
 
 The topic `camunda-7-adapter` is set and the following attributes/elements are migrated and put into a task header:
 

--- a/versioned_docs/version-8.6/guides/migrating-from-camunda-7/conceptual-differences.md
+++ b/versioned_docs/version-8.6/guides/migrating-from-camunda-7/conceptual-differences.md
@@ -48,10 +48,6 @@ To migrate existing Connectors, consider the following options:
 
 ### Multi-tenancy
 
-:::note
-[Multi-tenancy](/self-managed/concepts/multi-tenancy.md) is currently in development for Camunda 8.
-:::
-
 There are several differences between how [multi-tenancy](/self-managed/concepts/multi-tenancy.md) works in Camunda 7 and Camunda 8:
 
 1. The [one engine per tenant approach from Camunda 7](https://docs.camunda.org/manual/develop/user-guide/process-engine/multi-tenancy/#one-process-engine-per-tenant) isn't possible with Camunda 8. Camunda 8 only provides multi-tenancy through a tenant identifier.

--- a/versioned_docs/version-8.6/guides/migrating-from-camunda-7/index.md
+++ b/versioned_docs/version-8.6/guides/migrating-from-camunda-7/index.md
@@ -13,21 +13,19 @@ keywords:
   ]
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 This guide describes how to migrate process solutions developed for Camunda 7 to run them on Camunda 8, including:
 
 - Differences in application architecture
-- How process models and code can generally be migrated, whereas runtime and history data cannot
-- How migration can be very simple for some models, but also marked limitations, where migration might get very complicated
+- How process solutions can be migrated
+- How migration can be very simple for some models, but also marked limitations, where migration might get complicated
 - You need to adjust code that uses the workflow engine API
 - How you might be able to reuse glue code
-- Community extensions that can help with migration
+- Tooling that can help with migration
 - The Clean Delegate approach, which helps you write Camunda 7 solutions that are easier to migrate
 
-We are watching all customer migration projects closely and will update this guide in the future.
+:::note
+We are currently developing improved migration tooling and will overhaul this guide around the 8.7 release. If you embark on a migration journey, please reach out to discuss your use case with us.
+:::
 
 ## What to expect
 

--- a/versioned_docs/version-8.6/guides/migrating-from-camunda-7/migration-readiness.md
+++ b/versioned_docs/version-8.6/guides/migrating-from-camunda-7/migration-readiness.md
@@ -4,19 +4,21 @@ title: Migration preparation
 description: "Learn readiness indicators for migrating from Camunda 7 to Camunda 8."
 ---
 
-:::note
-Migration of existing projects to Camunda 8 is optional. Camunda 7 still has ongoing [support](https://docs.camunda.org/enterprise/announcement/).
-:::
-
 Let's discuss if you need to migrate before diving into the necessary steps and what tools can help you achieve the migration.
 
 ## When to migrate?
 
 New projects should typically be started using Camunda 8.
 
-Existing solutions using Camunda 7 might simply keep running on Camunda 7. Camunda has ongoing [support](https://docs.camunda.org/enterprise/announcement/), so there is no need to rush on a migration project.
+For Camunda 7:
 
-You should consider migrating existing Camunda 7 solutions if:
+- Camunda 7 CE (Community Edition) will EOL (end of life) in October 2025 with a final release (v7.24) happening on Oct 14, 2025.
+- There will be no more Camunda 7 CE releases after that date and the GitHub repo will be archived. The code will still be available, but we’ll close all issues and pull requests, and update the README to reflect the EOL status.
+- Camunda 7 EE (Enterprise Edition) customers will continue to get patch releases (security patches & bug fixes) on a rolling basis.
+
+If you have not yet migrated to Camunda 8, we strongly recommend that you start that process now.
+
+Migrating to Camunda 8 gives you additional advantages if:
 
 - You are looking to leverage a SaaS offering (e.g. to reduce the effort for hardware or infrastructure setup and maintenance).
 - You are in need of performance at scale and/or improved resilience.
@@ -55,15 +57,15 @@ In general, **workflow engine data** is harder to migrate to Camunda 8:
 
 - **Runtime data:** Running process instances of Camunda 7 are stored in the Camunda 7 relational database. Like with a migration from third party workflow engines, you can read this data from Camunda 7 and use it to create the right process instances in Camunda 8 in the right state. This way, you can migrate running process instances from Camunda 7 to Camunda 8. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) is in place to ease this task. This tool is community supported.
 
-- **History data:** Historic data from the workflow engine itself cannot be migrated. However, data in Optimize can be kept.
+- **History data:** Historic data from the workflow engine itself cannot be migrated. A tool allowing this is currently under development.
 
 ## Migration tooling
 
 :::note
-These tools are community maintained. For more assistance, create an issue on the repo directly.
+We are currently developing a powerful migration toolset - expect this to be available around the 8.7 release of Camunda. For the time being, you can already rely on several migration tools.
 :::
 
-The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration), available as a community extension, contains three components that will help you with migration:
+The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-community-hub/camunda-7-to-8-migration) contains three components to help you with migration:
 
 1. [A converter available in different flavors (web app, CLI) to convert BPMN models from Camunda 7 to Camunda 8](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/backend-diagram-converter). This maps possible BPMN elements and technical attributes into the Camunda 8 format and gives you warnings where this is not possible. The result of a conversion is a model with mapped implementation details as well as hints on what changed, needs to be reviewed, or adjusted to function properly in Camunda 8.
 
@@ -71,7 +73,7 @@ The [Camunda 7 to Camunda 8 migration tooling](https://github.com/camunda-commun
 
 3. [A process instance migration tool](https://github.com/camunda-community-hub/camunda-7-to-8-migration/tree/main/process-instance-migration) to migrate running process instances from Camunda 7 to Camunda 8. Ideally, you should let running instances finish prior to migrating.
 
-The tools mentioned above are a good starting point, but are only one option for how you can approach your migration, as described below.
+The tools mentioned above are a good starting point.
 
 ## Prepare for smooth migrations
 


### PR DESCRIPTION
## Description

Quick updates of updated information about migration and timelines.
Quick fix for now - planing a proper overhaul of the migration guide later this year when we release more tooling support

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [X] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.
