### PR TITLE
Clarify scope of `Execution listeners` in concept page

### DIFF
--- a/docs/components/concepts/execution-listeners.md
+++ b/docs/components/concepts/execution-listeners.md
@@ -24,7 +24,7 @@ An execution listener is a blocking operation, meaning that the workflow executi
 
 ## Define an execution listener
 
-You can configure execution listeners per BPMN element within a process.
+You can configure execution listeners for individual BPMN elements, such as tasks, events, and gateways, as well as for the overall process and subprocesses.
 
 There are two types of execution listener:
 

--- a/versioned_docs/version-8.6/components/concepts/execution-listeners.md
+++ b/versioned_docs/version-8.6/components/concepts/execution-listeners.md
@@ -24,7 +24,7 @@ An execution listener is a blocking operation, meaning that the workflow executi
 
 ## Define an execution listener
 
-You can configure execution listeners per BPMN element within a process.
+You can configure execution listeners for individual BPMN elements, such as tasks, events, and gateways, as well as for the overall process and subprocesses.
 
 There are two types of execution listener:
 


### PR DESCRIPTION
## Description

Previously, the documentation did not clearly state that execution listeners can be defined and executed at the process levels. This ambiguity led to user concerns about the scope of execution listener functionality, as highlighted in a recent [Slack conversation](https://camunda.slack.com/archives/C06CNGWTBAS/p1736938266363259). 

### Changes:
This update enhances the **Define an execution listener** section to explicitly specify that execution listeners can be configured for tasks, events, gateways, as well as for processes and subprocesses.

### Backport:
These updates are applicable to Camunda versions starting from 8.6 and were backported accordingly within the current PR.

### Linked issue:
closes https://github.com/camunda/camunda/issues/26937

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**.
- [x] This is already available but undocumented and should be released within a week.
- [ ] This on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (apply `hold` label or convert to draft PR)
- [ ] This is part of a scheduled alpha or minor. (apply alpha or minor label)
- [ ] There is **no urgency** with this change and can be released at any time.

## PR Checklist

<!-- Camunda maintains 18 months of versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.
- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

<!-- All changes require either an Engineering review or technical writer review. **Many require both!** -->

- [ ] My changes require an [Engineering review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned the Engineering DRI or delegate.
- [x] My changes require a [technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process), and I've assigned @camunda/tech-writers as a reviewer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). -->
