### PR TITLE
fix the oidc instructions to update deprecated MS Entra steps

### DIFF
--- a/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -232,10 +232,10 @@ The client should be configured to support `grant_type`:
 To successfully authenticate with Entra ID, you should use the `v2.0` API. This means that
 the `CAMUNDA_IDENTITY_ISSUER_BACKEND_URL` value should end with `/v2.0`.
 
-It's also important to follow the [steps described here](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#configure-the-app-manifest) to configure the app manifest and set the [accesstokenAcceptedVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) to `2` like so:
+Follow the [Microsoft Entra instructions](https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#configure-the-app-manifest-in-the-microsoft-entra-admin-center) to configure the app manifest, and set the [requestedAccessTokenVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) under `Api:` to `2`:
 
 ```json
-    "accessTokenAcceptedVersion": 2,
+    "requestedAccessTokenVersion": 2,
 ```
 
 </TabItem>

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -204,10 +204,10 @@ The client should be configured to support `grant_type`:
 To successfully authenticate with Entra ID, you should use the `v2.0` API. This means that
 the `CAMUNDA_IDENTITY_ISSUER_BACKEND_URL` value should end with `/v2.0`.
 
-It's also important to follow the [steps described here](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#configure-the-app-manifest) to configure the app manifest and set the [accesstokenAcceptedVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) to `2` like so:
+Follow the [Microsoft Entra instructions](https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#configure-the-app-manifest-in-the-microsoft-entra-admin-center) to configure the app manifest, and set the [requestedAccessTokenVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) under `Api:` to `2`:
 
 ```json
-	"accessTokenAcceptedVersion": 2,
+    "requestedAccessTokenVersion": 2,
 ```
 
 </TabItem>

--- a/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -225,10 +225,10 @@ The client should be configured to support `grant_type`:
 To successfully authenticate with Entra ID, you should use the `v2.0` API. This means that
 the `CAMUNDA_IDENTITY_ISSUER_BACKEND_URL` value should end with `/v2.0`.
 
-It's also important to follow the [steps described here](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#configure-the-app-manifest) to configure the app manifest and set the [accesstokenAcceptedVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) to `2` like so:
+Follow the [Microsoft Entra instructions](https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#configure-the-app-manifest-in-the-microsoft-entra-admin-center) to configure the app manifest, and set the [requestedAccessTokenVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) under `Api:` to `2`:
 
 ```json
-    "accessTokenAcceptedVersion": 2,
+    "requestedAccessTokenVersion": 2,
 ```
 
 </TabItem>

--- a/versioned_docs/version-8.6/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.6/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -232,10 +232,10 @@ The client should be configured to support `grant_type`:
 To successfully authenticate with Entra ID, you should use the `v2.0` API. This means that
 the `CAMUNDA_IDENTITY_ISSUER_BACKEND_URL` value should end with `/v2.0`.
 
-It's also important to follow the [steps described here](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#configure-the-app-manifest) to configure the app manifest and set the [accesstokenAcceptedVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) to `2` like so:
+Follow the [Microsoft Entra instructions](https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#configure-the-app-manifest-in-the-microsoft-entra-admin-center) to configure the app manifest, and set the [requestedAccessTokenVersion](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) under `Api:` to `2`:
 
 ```json
-    "accessTokenAcceptedVersion": 2,
+    "requestedAccessTokenVersion": 2,
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

The [OIDC page](https://docs.camunda.io/docs/self-managed/setup/guides/connect-to-an-oidc-provider/?authPlatform=microsoftEntraId) references the app manifest in Azure AD Graph format, which has been deprecated and now now longer accessible as of January 7: https://learn.microsoft.com/en-us/entra/identity-platform/azure-active-directory-graph-app-manifest-deprecation#convert-an-app-manifest-in-azure-ad-graph-format-to-microsoft-graph-format

This PR updates the link to the new steps, updates the attribute to the correct reference, and updates the example to the new attribute name.  

Internal slack: https://camunda.slack.com/archives/C026U8GBNSW/p1737545424357219

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
