### PR TITLE
fix: correct component name for TabItem

### DIFF
--- a/docs/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/docs/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -154,7 +154,7 @@ The following alternatives to port-forwarding are possible:
 In our example, we went with port-forwarding to a localhost, but other alternatives can also be used.
 
 <Tabs groupId="c8-connectivity">
-  <TabsItem value="rest-api" label="REST API">
+  <TabItem value="rest-api" label="REST API">
 
 1. Use the [REST API](../../../apis-tools/camunda-api-rest/camunda-api-rest-overview.md) to retrieve the list of the remaining brokers
 
@@ -295,8 +295,8 @@ curl -L -X GET 'http://localhost:8080/v2/topology' \
   </summary>
 </details>
 
-  </TabsItem>
-  <TabsItem value="zbctl" label="zbctl">
+  </TabItem>
+  <TabItem value="zbctl" label="zbctl">
 
 1. Use the [zbctl client](/apis-tools/community-clients/cli-client/index.md) to retrieve list of remaining brokers
 
@@ -343,7 +343,7 @@ Brokers:
 
   </summary>
 </details>
-  </TabsItem>
+  </TabItem>
 </Tabs>
 
 2. Port-forward the service of the Zeebe Gateway to access the [management REST API](../../zeebe-deployment/configuration/gateway.md#managementserver)
@@ -364,7 +364,7 @@ curl -XPOST 'http://localhost:9600/actuator/cluster/brokers?force=true' -H 'Cont
 Port-forwarding the Zeebe Gateway via `kubectl` and printing the topology should reveal that the cluster size has decreased to 4, partitions have been redistributed over the remaining brokers, and new leaders have been elected.
 
 <Tabs groupId="c8-connectivity">
-  <TabsItem value="rest-api" label="REST API">
+  <TabItem value="rest-api" label="REST API">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 8080:8080 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -503,8 +503,8 @@ curl -L -X GET 'http://localhost:8080/v2/topology' \
   </summary>
 </details>
 
-  </TabsItem>
-  <TabsItem value="zbctl" label="zbctl">
+  </TabItem>
+  <TabItem value="zbctl" label="zbctl">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 26500:26500 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -550,7 +550,7 @@ Brokers:
   </summary>
 </details>
 
-</TabsItem>
+</TabItem>
 </Tabs>
 
 You can also use the Zeebe Gateway's REST API to ensure the scaling progress has been completed. For better output readability, we use [jq](https://jqlang.github.io/jq/).
@@ -731,7 +731,7 @@ It is expected that the Zeebe broker pods will not reach the "Ready" state since
 Port-forwarding the Zeebe Gateway via `kubectl` and printing the topology should reveal that the new Zeebe brokers are recognized but yet a full member of the Zeebe cluster.
 
 <Tabs groupId="c8-connectivity">
-  <TabsItem value="rest-api" label="REST API">
+  <TabItem value="rest-api" label="REST API">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 8080:8080 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -898,8 +898,8 @@ curl -L -X GET 'http://localhost:8080/v2/topology' \
   </summary>
 </details>
 
-  </TabsItem>
-  <TabsItem value="zbctl" label="zbctl">
+  </TabItem>
+  <TabItem value="zbctl" label="zbctl">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 26500:26500 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -953,7 +953,7 @@ Brokers:
   </summary>
 </details>
 
-  </TabsItem>
+  </TabItem>
 </Tabs>
 
 </div>

--- a/versioned_docs/version-8.6/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -154,7 +154,7 @@ The following alternatives to port-forwarding are possible:
 In our example, we went with port-forwarding to a localhost, but other alternatives can also be used.
 
 <Tabs groupId="c8-connectivity">
-  <TabsItem value="rest-api" label="REST API">
+  <TabItem value="rest-api" label="REST API">
 
 1. Use the [REST API](../../../apis-tools/camunda-api-rest/camunda-api-rest-overview.md) to retrieve the list of the remaining brokers
 
@@ -295,8 +295,8 @@ curl -L -X GET 'http://localhost:8080/v2/topology' \
   </summary>
 </details>
 
-  </TabsItem>
-  <TabsItem value="zbctl" label="zbctl">
+  </TabItem>
+  <TabItem value="zbctl" label="zbctl">
 
 1. Use the [zbctl client](/apis-tools/community-clients/cli-client/index.md) to retrieve list of remaining brokers
 
@@ -343,7 +343,7 @@ Brokers:
 
   </summary>
 </details>
-  </TabsItem>
+  </TabItem>
 </Tabs>
 
 2. Port-forward the service of the Zeebe Gateway to access the [management REST API](../../zeebe-deployment/configuration/gateway.md#managementserver)
@@ -364,7 +364,7 @@ curl -XPOST 'http://localhost:9600/actuator/cluster/brokers?force=true' -H 'Cont
 Port-forwarding the Zeebe Gateway via `kubectl` and printing the topology should reveal that the cluster size has decreased to 4, partitions have been redistributed over the remaining brokers, and new leaders have been elected.
 
 <Tabs groupId="c8-connectivity">
-  <TabsItem value="rest-api" label="REST API">
+  <TabItem value="rest-api" label="REST API">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 8080:8080 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -503,8 +503,8 @@ curl -L -X GET 'http://localhost:8080/v2/topology' \
   </summary>
 </details>
 
-  </TabsItem>
-  <TabsItem value="zbctl" label="zbctl">
+  </TabItem>
+  <TabItem value="zbctl" label="zbctl">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 26500:26500 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -550,7 +550,7 @@ Brokers:
   </summary>
 </details>
 
-</TabsItem>
+</TabItem>
 </Tabs>
 
 You can also use the Zeebe Gateway's REST API to ensure the scaling progress has been completed. For better output readability, we use [jq](https://jqlang.github.io/jq/).
@@ -731,7 +731,7 @@ It is expected that the Zeebe broker pods will not reach the "Ready" state since
 Port-forwarding the Zeebe Gateway via `kubectl` and printing the topology should reveal that the new Zeebe brokers are recognized but yet a full member of the Zeebe cluster.
 
 <Tabs groupId="c8-connectivity">
-  <TabsItem value="rest-api" label="REST API">
+  <TabItem value="rest-api" label="REST API">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 8080:8080 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -898,8 +898,8 @@ curl -L -X GET 'http://localhost:8080/v2/topology' \
   </summary>
 </details>
 
-  </TabsItem>
-  <TabsItem value="zbctl" label="zbctl">
+  </TabItem>
+  <TabItem value="zbctl" label="zbctl">
 
 ```bash
 kubectl --context $CLUSTER_SURVIVING port-forward services/$HELM_RELEASE_NAME-zeebe-gateway 26500:26500 -n $CAMUNDA_NAMESPACE_SURVIVING
@@ -953,7 +953,7 @@ Brokers:
   </summary>
 </details>
 
-  </TabsItem>
+  </TabItem>
 </Tabs>
 
 </div>


### PR DESCRIPTION
## Description

Discovered in my docusaurus 3 branch, [during a failed build](https://github.com/camunda/camunda-docs/actions/runs/12837674495/job/35801829157?pr=4872).

In two docs we are referencing the `TabsItem` component despite importing the `TabItem` component. I have no idea why this works fine in the main branch, let alone doesn't cause an error. 

I'm making these corrections in main, which I will then propagate to my docusaurus 3 branch after merge.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [x] My changes are for an **already released minor** and are in `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.


- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label)