### PR TITLE
[POC] Generate mermaid diagrams from harmonized index schemas

### DIFF
--- a/.github/workflows/sync-harmonized-indexes/1-combine-sources.js
+++ b/.github/workflows/sync-harmonized-indexes/1-combine-sources.js
@@ -1,0 +1,41 @@
+const fs = require("fs").promises;
+const path = require("path");
+const currentDir = __dirname;
+
+// valid values: `templates` or `indexes`
+const config = {
+  sourceDirectoryPath: currentDir + "/templates",
+  outputFile: currentDir + "/templates.json",
+};
+
+// Combines independent JSON files in a directory into one JSON file,
+//   for ease of processing.
+async function combineSources() {
+  // Read all files from directory
+  const files = await fs.readdir(config.sourceDirectoryPath);
+
+  // Filter for .json files and process each
+  const jsonFiles = files.filter((file) => file.endsWith(".json"));
+
+  const combined = {};
+
+  for (const file of jsonFiles) {
+    const content = await fs.readFile(
+      path.join(config.sourceDirectoryPath, file),
+      "utf8"
+    );
+
+    // Use filename without extension as key
+    const key = path.basename(file, ".json");
+    combined[key] = JSON.parse(content);
+  }
+
+  // Write combined object to new file
+  await fs.writeFile(config.outputFile, JSON.stringify(combined, null, 2));
+
+  return combined;
+}
+
+combineSources();
+
+module.exports = { combineSources };

--- a/.github/workflows/sync-harmonized-indexes/2-generate-mermaid-diagrams.js
+++ b/.github/workflows/sync-harmonized-indexes/2-generate-mermaid-diagrams.js
@@ -38,7 +38,7 @@ function generateEntity(entityName, properties) {
       const [propName, propDefinition] = currentProperty;
       const { type } = propDefinition;
 
-      if (type === "object") {
+      if (type === "object" && propDefinition.properties !== undefined) {
         extraEntities.push(generateEntity(propName, propDefinition.properties));
         extraEntities.push(generateRelationship(propName, entityName));
       } else {

--- a/.github/workflows/sync-harmonized-indexes/2-generate-mermaid-diagrams.spec.js
+++ b/.github/workflows/sync-harmonized-indexes/2-generate-mermaid-diagrams.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { generateMermaidDiagrams } = require("./generate-mermaid-diagrams.js");
+const { generateMermaidDiagrams } = require("./2-generate-mermaid-diagrams.js");
 
 // /** @type {Array<import("./identify-missing-changes").VersionConfig>} */
 // let versionConfig;

--- a/.github/workflows/sync-harmonized-indexes/2-generate-mermaid-output.js
+++ b/.github/workflows/sync-harmonized-indexes/2-generate-mermaid-output.js
@@ -1,0 +1,23 @@
+const fs = require("fs").promises;
+const path = require("path");
+const { generateMermaidDiagrams } = require("./2-generate-mermaid-diagrams");
+const currentDir = __dirname;
+
+// valid values: `templates` or `indexes`
+const config = {
+  sourceFile: currentDir + "/templates.json",
+  outputFile: currentDir + "/templates.md",
+};
+async function generateMermaidOutput() {
+  const { sourceFile, outputFile } = config;
+
+  // Read all files from directory
+  const schema = await fs.readFile(sourceFile, "utf8");
+
+  // Filter for .json files and process each
+  const output = generateMermaidDiagrams(JSON.parse(schema));
+
+  await fs.writeFile(outputFile, output);
+}
+
+generateMermaidOutput();

--- a/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.js
+++ b/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.js
@@ -1,0 +1,60 @@
+function generateMermaidDiagrams(schema) {
+  return `\`\`\`mermaid
+erDiagram
+${generateEntities(schema)}
+\`\`\`
+`;
+}
+
+function generateEntities(schema) {
+  return Object.entries(schema.schema).map(([schemaName, definition]) =>
+    generateEntity(schemaName, definition)
+  );
+  // for (const [schemaName, definition] of Object.entries(schema.schema)) {
+  //   const properties = definition.mappings.properties;
+  //   const entityName = schemaName.toUpperCase().replace(/-/g, '_');
+
+  //   mermaid += generateEntity(entityName, properties);
+  //   mermaid += generateClickEvent(entityName, schemaName);
+  //   mermaid += '\n';
+  // }
+
+  // return mermaid;
+}
+
+function generateEntity(entityName, schema) {
+  return `
+    ${entityName} {
+${generateProperties(schema.mappings.properties)}
+    }
+`;
+}
+
+function generateProperties(properties) {
+  return Object.entries(properties)
+    .map(([propName, { type }]) => `        ${type} ${propName}`)
+    .join("\n");
+}
+
+// function convertProperties(properties, parentName = '') {
+//   let result = '';
+//   for (const [propName, propDef] of Object.entries(properties)) {
+//     if (propDef.type === 'object' && propDef.properties) {
+//       result += convertProperties(propDef.properties, `${propName}_`);
+//     } else if (propDef.type !== 'join') {
+//       result += `        ${propDef.type} ${parentName}${propName}\n`;
+//     }
+//   }
+//   return result;
+// }
+
+// function generateEntity(entityName, properties) {
+//   let entity = `    ${entityName} {\n`;
+//   entity += convertProperties(properties);
+//   entity += '    }\n';
+//   return entity;
+// }
+
+module.exports = {
+  generateMermaidDiagrams,
+};

--- a/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.js
+++ b/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.js
@@ -1,29 +1,33 @@
 function generateMermaidDiagrams(schema) {
-  const entities = generateEntities(schema);
+  const batches = batchItems(Object.entries(schema), 3);
 
+  return batches
+    .map((batch) => generateMermaidDiagram(generateEntities(batch).join("\n")))
+    .join("\n");
+}
+
+function batchItems(items, batchSize) {
+  return Array.from(
+    { length: Math.ceil(items.length / batchSize) },
+    (_, index) => items.slice(index * batchSize, index * batchSize + batchSize)
+  );
+}
+
+function generateMermaidDiagram(content) {
   return `\`\`\`mermaid
 erDiagram
-${entities.join("\n")}
+${content}
 \`\`\`
 `;
 }
 
-function generateEntities(schema) {
-  return Object.entries(schema.schema)
-    .map(([schemaName, definition]) =>
-      generateEntity(schemaName, definition.mappings.properties)
-    )
+function generateEntities(items) {
+  return items
+    .map((x) => {
+      const [schemaName, definition] = x;
+      return generateEntity(schemaName, definition.mappings.properties);
+    })
     .flat();
-  // for (const [schemaName, definition] of Object.entries(schema.schema)) {
-  //   const properties = definition.mappings.properties;
-  //   const entityName = schemaName.toUpperCase().replace(/-/g, '_');
-
-  //   mermaid += generateEntity(entityName, properties);
-  //   mermaid += generateClickEvent(entityName, schemaName);
-  //   mermaid += '\n';
-  // }
-
-  // return mermaid;
 }
 
 function generateEntity(entityName, properties) {
@@ -58,25 +62,6 @@ ${currentEntityProps.join("\n")}
 function generateRelationship(childEntity, parentEntity) {
   return `    ${parentEntity} ||--o{ ${childEntity} : has`;
 }
-
-// function convertProperties(properties, parentName = '') {
-//   let result = '';
-//   for (const [propName, propDef] of Object.entries(properties)) {
-//     if (propDef.type === 'object' && propDef.properties) {
-//       result += convertProperties(propDef.properties, `${propName}_`);
-//     } else if (propDef.type !== 'join') {
-//       result += `        ${propDef.type} ${parentName}${propName}\n`;
-//     }
-//   }
-//   return result;
-// }
-
-// function generateEntity(entityName, properties) {
-//   let entity = `    ${entityName} {\n`;
-//   entity += convertProperties(properties);
-//   entity += '    }\n';
-//   return entity;
-// }
 
 module.exports = {
   generateMermaidDiagrams,

--- a/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.spec.js
+++ b/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.spec.js
@@ -8,20 +8,20 @@ const { generateMermaidDiagrams } = require("./generate-mermaid-diagrams.js");
 
 describe("generateMermaidDiagrams", () => {
   describe("given a simple schema", () => {
-    it("renders as an erDiagram", () => {
-      const schema = {
-        schema: {
-          "schema-name": {
-            mappings: {
-              properties: {
-                "some-keyword": { type: "keyword" },
-                "some-long": { type: "long" },
-              },
+    const schema = {
+      schema: {
+        "schema-name": {
+          mappings: {
+            properties: {
+              "some-keyword": { type: "keyword" },
+              "some-long": { type: "long" },
             },
           },
         },
-      };
+      },
+    };
 
+    it("renders as an erDiagram", () => {
       const result = generateMermaidDiagrams(schema);
 
       expect(result).toEqual(`\`\`\`mermaid
@@ -31,7 +31,46 @@ erDiagram
         keyword some-keyword
         long some-long
     }
+\`\`\`
+`);
+    });
+  });
 
+  describe("given a schema with nested properties", () => {
+    const schema = {
+      schema: {
+        "schema-name": {
+          mappings: {
+            properties: {
+              parentKeyword: {
+                type: "keyword",
+              },
+              nestedObject: {
+                type: "object",
+                properties: {
+                  nestedKeyword: { type: "keyword" },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it("renders a relationship", () => {
+      const result = generateMermaidDiagrams(schema);
+
+      expect(result).toEqual(`\`\`\`mermaid
+erDiagram
+
+    schema-name {
+        keyword parentKeyword
+    }
+
+    nestedObject {
+        keyword nestedKeyword
+    }
+    schema-name ||--o{ nestedObject : has
 \`\`\`
 `);
     });

--- a/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.spec.js
+++ b/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.spec.js
@@ -1,0 +1,39 @@
+// @ts-check
+const { generateMermaidDiagrams } = require("./generate-mermaid-diagrams.js");
+
+// /** @type {Array<import("./identify-missing-changes").VersionConfig>} */
+// let versionConfig;
+// /** @type {Array<string>} */
+// let changedFiles;
+
+describe("generateMermaidDiagrams", () => {
+  describe("given a simple schema", () => {
+    it("renders as an erDiagram", () => {
+      const schema = {
+        schema: {
+          "schema-name": {
+            mappings: {
+              properties: {
+                "some-keyword": { type: "keyword" },
+                "some-long": { type: "long" },
+              },
+            },
+          },
+        },
+      };
+
+      const result = generateMermaidDiagrams(schema);
+
+      expect(result).toEqual(`\`\`\`mermaid
+erDiagram
+
+    schema-name {
+        keyword some-keyword
+        long some-long
+    }
+
+\`\`\`
+`);
+    });
+  });
+});

--- a/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.spec.js
+++ b/.github/workflows/sync-harmonized-indexes/generate-mermaid-diagrams.spec.js
@@ -9,13 +9,11 @@ const { generateMermaidDiagrams } = require("./generate-mermaid-diagrams.js");
 describe("generateMermaidDiagrams", () => {
   describe("given a simple schema", () => {
     const schema = {
-      schema: {
-        "schema-name": {
-          mappings: {
-            properties: {
-              "some-keyword": { type: "keyword" },
-              "some-long": { type: "long" },
-            },
+      "schema-name": {
+        mappings: {
+          properties: {
+            "some-keyword": { type: "keyword" },
+            "some-long": { type: "long" },
           },
         },
       },
@@ -38,18 +36,16 @@ erDiagram
 
   describe("given a schema with nested properties", () => {
     const schema = {
-      schema: {
-        "schema-name": {
-          mappings: {
-            properties: {
-              parentKeyword: {
-                type: "keyword",
-              },
-              nestedObject: {
-                type: "object",
-                properties: {
-                  nestedKeyword: { type: "keyword" },
-                },
+      "schema-name": {
+        mappings: {
+          properties: {
+            parentKeyword: {
+              type: "keyword",
+            },
+            nestedObject: {
+              type: "object",
+              properties: {
+                nestedKeyword: { type: "keyword" },
               },
             },
           },
@@ -73,6 +69,50 @@ erDiagram
     schema-name ||--o{ nestedObject : has
 \`\`\`
 `);
+    });
+  });
+
+  describe("given many schemas", () => {
+    const oneSchema = {
+      mappings: {
+        properties: {
+          "some-keyword": { type: "keyword" },
+        },
+      },
+    };
+
+    const schema = {
+      "schema-1": oneSchema,
+      "schema-2": oneSchema,
+      "schema-3": oneSchema,
+      "schema-4": oneSchema,
+      "schema-5": oneSchema,
+      "schema-6": oneSchema,
+      "schema-7": oneSchema,
+    };
+
+    it("emits multiple diagrams in batches of 3", () => {
+      const result = generateMermaidDiagrams(schema);
+
+      const sequences = [
+        "mermaid",
+        "erDiagram",
+        "schema-1",
+        "schema-2",
+        "schema-3",
+        "mermaid",
+        "erDiagram",
+        "schema-4",
+        "schema-5",
+        "schema-6",
+        "mermaid",
+        "erDiagram",
+        "schema-7",
+      ];
+
+      const sequencePattern = new RegExp(sequences.join(".*"), "s");
+
+      expect(result).toMatch(sequencePattern);
     });
   });
 });

--- a/.github/workflows/sync-harmonized-indexes/indexes.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes.json
@@ -1,0 +1,637 @@
+{
+  "camunda-authorization": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "ownerKey": {
+          "type": "long"
+        },
+        "ownerType": {
+          "type": "keyword"
+        },
+        "resourceType": {
+          "type": "keyword"
+        },
+        "permissions": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "resourceIds": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  },
+  "camunda-group": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "memberKey": {
+          "type": "long"
+        },
+        "join": {
+          "type": "join",
+          "eager_global_ordinals": true,
+          "relations": {
+            "group": ["member"]
+          }
+        }
+      }
+    }
+  },
+  "camunda-mapping": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "claimName": {
+          "type": "keyword"
+        },
+        "claimValue": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "camunda-role": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "memberKey": {
+          "type": "long"
+        },
+        "join": {
+          "type": "join",
+          "eager_global_ordinals": true,
+          "relations": {
+            "role": ["member"]
+          }
+        }
+      }
+    }
+  },
+  "camunda-tenant": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "description": {
+          "type": "text"
+        },
+        "memberId": {
+          "type": "keyword"
+        },
+        "memberType": {
+          "type": "keyword"
+        },
+        "join": {
+          "type": "join",
+          "eager_global_ordinals": true,
+          "relations": {
+            "tenant": ["member"]
+          }
+        }
+      }
+    }
+  },
+  "camunda-user": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "username": {
+          "type": "keyword"
+        },
+        "email": {
+          "type": "keyword"
+        },
+        "password": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "camunda-web-session": {
+    "aliases": {},
+    "mappings": {
+      "dynamic": "true",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "creationTime": {
+          "type": "long"
+        },
+        "lastAccessedTime": {
+          "type": "long"
+        },
+        "maxInactiveIntervalInSeconds": {
+          "type": "long"
+        },
+        "attributes": {
+          "type": "object"
+        }
+      }
+    }
+  },
+  "operate-decision-requirements": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "decisionDefinitionId": {
+          "type": "keyword",
+          "eager_global_ordinals": true
+        },
+        "xml": {
+          "type": "text",
+          "index": false
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "decisionRequirementsId": {
+          "type": "keyword"
+        },
+        "resourceName": {
+          "type": "keyword"
+        },
+        "version": {
+          "type": "long"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-decision": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "decisionId": {
+          "type": "keyword",
+          "eager_global_ordinals": true
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "version": {
+          "type": "long"
+        },
+        "decisionRequirementsId": {
+          "type": "keyword"
+        },
+        "decisionRequirementsKey": {
+          "type": "long"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-import-position": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "aliasName": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "indexName": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "position": {
+          "type": "long"
+        },
+        "sequence": {
+          "type": "long"
+        },
+        "postImporterPosition": {
+          "type": "long"
+        },
+        "completed": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "operate-metric": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "eventTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "event": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-migration-steps-repository": {
+    "aliases": {},
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "@type": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "applied": {
+          "type": "boolean"
+        },
+        "content": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "createdDate": {
+          "type": "date"
+        },
+        "appliedDate": {
+          "type": "date"
+        },
+        "description": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "indexName": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "order": {
+          "type": "long"
+        },
+        "version": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      }
+    }
+  },
+  "operate-process": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "bpmnProcessId": {
+          "type": "keyword",
+          "eager_global_ordinals": true
+        },
+        "bpmnXml": {
+          "type": "text",
+          "index": false
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "resourceName": {
+          "type": "keyword"
+        },
+        "version": {
+          "type": "long"
+        },
+        "versionTag": {
+          "type": "keyword"
+        },
+        "flowNodes": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            }
+          }
+        },
+        "isPublic": {
+          "type": "boolean"
+        },
+        "formId": {
+          "type": "keyword"
+        },
+        "formKey": {
+          "type": "keyword"
+        },
+        "isFormEmbedded": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-user": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "password": {
+          "type": "keyword"
+        },
+        "roles": {
+          "type": "keyword"
+        },
+        "userId": {
+          "type": "keyword"
+        },
+        "displayName": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "tasklist-form": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "key": {
+          "type": "long"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "processDefinitionId": {
+          "type": "keyword"
+        },
+        "bpmnId": {
+          "type": "keyword"
+        },
+        "version": {
+          "type": "long"
+        },
+        "embedded": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "isDeleted": {
+          "type": "boolean"
+        },
+        "schema": {
+          "type": "text",
+          "index": false
+        }
+      }
+    }
+  },
+  "tasklist-import-position": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "aliasName": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "indexName": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "position": {
+          "type": "long"
+        },
+        "sequence": {
+          "type": "long"
+        },
+        "completed": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "tasklist-metric": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "eventTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "event": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "tasklist-process": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "flowNodes": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            }
+          }
+        },
+        "userTaskForms": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "definition": {
+              "type": "text"
+            }
+          }
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "startedByForm": {
+          "type": "boolean"
+        },
+        "formKey": {
+          "type": "keyword"
+        },
+        "formId": {
+          "type": "keyword"
+        },
+        "isFormEmbedded": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": "integer"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "bpmnXml": {
+          "type": "text"
+        }
+      }
+    }
+  },
+  "tasklist-user": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "password": {
+          "type": "keyword"
+        },
+        "roles": {
+          "type": "keyword"
+        },
+        "userId": {
+          "type": "keyword"
+        },
+        "displayName": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes.md
+++ b/.github/workflows/sync-harmonized-indexes/indexes.md
@@ -21,7 +21,6 @@ erDiagram
         long memberKey
         join join
     }
-    camunda-group ||--o{ camunda-group: "group:member"
 
     camunda-mapping {
         keyword id
@@ -134,6 +133,10 @@ erDiagram
         long order
         text version
     }
+```
+
+```mermaid
+erDiagram
 
     operate-process {
         keyword bpmnProcessId
@@ -177,7 +180,6 @@ erDiagram
         boolean isDeleted
         text schema
     }
-
 ```
 
 ```mermaid

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-authorization.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-authorization.json
@@ -1,0 +1,30 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "ownerKey": {
+        "type": "long"
+      },
+      "ownerType": {
+        "type": "keyword"
+      },
+      "resourceType": {
+        "type": "keyword"
+      },
+      "permissions": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "resourceIds": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-group.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-group.json
@@ -1,0 +1,26 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "memberKey": {
+        "type": "long"
+      },
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "group": ["member"]
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-mapping.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-mapping.json
@@ -1,0 +1,22 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "claimName": {
+        "type": "keyword"
+      },
+      "claimValue": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-role.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-role.json
@@ -1,0 +1,26 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "memberKey": {
+        "type": "long"
+      },
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "role": ["member"]
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-tenant.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-tenant.json
@@ -1,0 +1,35 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "description": {
+        "type": "text"
+      },
+      "memberId": {
+        "type": "keyword"
+      },
+      "memberType": {
+        "type": "keyword"
+      },
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "tenant": ["member"]
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-user.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-user.json
@@ -1,0 +1,25 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "username": {
+        "type": "keyword"
+      },
+      "email": {
+        "type": "keyword"
+      },
+      "password": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/camunda-web-session.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/camunda-web-session.json
@@ -1,0 +1,23 @@
+{
+  "aliases": {},
+  "mappings": {
+    "dynamic": "true",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "creationTime": {
+        "type": "long"
+      },
+      "lastAccessedTime": {
+        "type": "long"
+      },
+      "maxInactiveIntervalInSeconds": {
+        "type": "long"
+      },
+      "attributes": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-decision-requirements.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-decision-requirements.json
@@ -1,0 +1,39 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "decisionDefinitionId": {
+        "type": "keyword",
+        "eager_global_ordinals": true
+      },
+      "xml": {
+        "type": "text",
+        "index": false
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "decisionRequirementsId": {
+        "type": "keyword"
+      },
+      "resourceName": {
+        "type": "keyword"
+      },
+      "version": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-decision.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-decision.json
@@ -1,0 +1,35 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "decisionId": {
+        "type": "keyword",
+        "eager_global_ordinals": true
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "version": {
+        "type": "long"
+      },
+      "decisionRequirementsId": {
+        "type": "keyword"
+      },
+      "decisionRequirementsKey": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-import-position.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-import-position.json
@@ -1,0 +1,31 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "aliasName": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "indexName": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "position": {
+        "type": "long"
+      },
+      "sequence": {
+        "type": "long"
+      },
+      "postImporterPosition": {
+        "type": "long"
+      },
+      "completed": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-metric.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-metric.json
@@ -1,0 +1,23 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "eventTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "event": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-migration-steps-repository.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-migration-steps-repository.json
@@ -1,0 +1,65 @@
+{
+  "aliases": {},
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "@type": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "applied": {
+        "type": "boolean"
+      },
+      "content": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "createdDate": {
+        "type": "date"
+      },
+      "appliedDate": {
+        "type": "date"
+      },
+      "description": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "indexName": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "order": {
+        "type": "long"
+      },
+      "version": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-process.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-process.json
@@ -1,0 +1,62 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "bpmnProcessId": {
+        "type": "keyword",
+        "eager_global_ordinals": true
+      },
+      "bpmnXml": {
+        "type": "text",
+        "index": false
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "resourceName": {
+        "type": "keyword"
+      },
+      "version": {
+        "type": "long"
+      },
+      "versionTag": {
+        "type": "keyword"
+      },
+      "flowNodes": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "isPublic": {
+        "type": "boolean"
+      },
+      "formId": {
+        "type": "keyword"
+      },
+      "formKey": {
+        "type": "keyword"
+      },
+      "isFormEmbedded": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/operate-user.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/operate-user.json
@@ -1,0 +1,22 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "password": {
+        "type": "keyword"
+      },
+      "roles": {
+        "type": "keyword"
+      },
+      "userId": {
+        "type": "keyword"
+      },
+      "displayName": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/tasklist-form.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/tasklist-form.json
@@ -1,0 +1,35 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "key": {
+        "type": "long"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "processDefinitionId": {
+        "type": "keyword"
+      },
+      "bpmnId": {
+        "type": "keyword"
+      },
+      "version": {
+        "type": "long"
+      },
+      "embedded": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "isDeleted": {
+        "type": "boolean"
+      },
+      "schema": {
+        "type": "text",
+        "index": false
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/tasklist-import-position.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/tasklist-import-position.json
@@ -1,0 +1,28 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "aliasName": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "indexName": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "position": {
+        "type": "long"
+      },
+      "sequence": {
+        "type": "long"
+      },
+      "completed": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/tasklist-metric.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/tasklist-metric.json
@@ -1,0 +1,23 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "eventTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "event": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/tasklist-process.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/tasklist-process.json
@@ -1,0 +1,63 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "flowNodes": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "userTaskForms": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "definition": {
+            "type": "text"
+          }
+        }
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "startedByForm": {
+        "type": "boolean"
+      },
+      "formKey": {
+        "type": "keyword"
+      },
+      "formId": {
+        "type": "keyword"
+      },
+      "isFormEmbedded": {
+        "type": "boolean"
+      },
+      "version": {
+        "type": "integer"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "bpmnXml": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/indexes/tasklist-user.json
+++ b/.github/workflows/sync-harmonized-indexes/indexes/tasklist-user.json
@@ -1,0 +1,22 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "password": {
+        "type": "keyword"
+      },
+      "roles": {
+        "type": "keyword"
+      },
+      "userId": {
+        "type": "keyword"
+      },
+      "displayName": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates.json
+++ b/.github/workflows/sync-harmonized-indexes/templates.json
@@ -1,0 +1,1037 @@
+{
+  "operate-batch-operation": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "operationsFinishedCount": {
+          "type": "long"
+        },
+        "endDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "instancesCount": {
+          "type": "long"
+        },
+        "operationsTotalCount": {
+          "type": "long"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "startDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "username": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-decision-instance": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "executionIndex": {
+          "type": "integer"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "position": {
+          "type": "long"
+        },
+        "evaluationDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "evaluationFailure": {
+          "type": "keyword"
+        },
+        "decisionRequirementsKey": {
+          "type": "long"
+        },
+        "decisionRequirementsId": {
+          "type": "keyword"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "elementInstanceKey": {
+          "type": "long"
+        },
+        "elementId": {
+          "type": "keyword"
+        },
+        "decisionId": {
+          "type": "keyword"
+        },
+        "decisionDefinitionId": {
+          "type": "keyword"
+        },
+        "decisionName": {
+          "type": "keyword"
+        },
+        "rootDecisionId": {
+          "type": "keyword"
+        },
+        "rootDecisionName": {
+          "type": "keyword"
+        },
+        "rootDecisionDefinitionId": {
+          "type": "keyword"
+        },
+        "decisionType": {
+          "type": "keyword"
+        },
+        "decisionVersion": {
+          "type": "keyword"
+        },
+        "result": {
+          "type": "text",
+          "index": false
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "evaluatedInputs": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "value": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        "evaluatedOutputs": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "value": {
+              "type": "object",
+              "enabled": false
+            },
+            "ruleId": {
+              "type": "keyword"
+            },
+            "ruleIndex": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operate-event": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "dateTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "jobRetries": {
+              "type": "integer"
+            },
+            "incidentErrorType": {
+              "type": "keyword"
+            },
+            "jobCustomHeaders": {
+              "type": "object",
+              "enabled": false
+            },
+            "incidentErrorMessage": {
+              "type": "text"
+            },
+            "jobWorker": {
+              "type": "keyword"
+            },
+            "jobKey": {
+              "type": "long"
+            },
+            "jobType": {
+              "type": "keyword"
+            },
+            "jobDeadline": {
+              "format": "date_time || epoch_millis",
+              "type": "date"
+            },
+            "messageName": {
+              "type": "keyword"
+            },
+            "correlationKey": {
+              "type": "keyword"
+            }
+          }
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "eventSourceType": {
+          "type": "keyword"
+        },
+        "eventType": {
+          "type": "keyword"
+        },
+        "flowNodeId": {
+          "type": "keyword"
+        },
+        "flowNodeInstanceKey": {
+          "type": "long"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "position": {
+          "type": "long"
+        },
+        "positionIncident": {
+          "type": "long",
+          "index": false
+        },
+        "positionProcessMessageSubscription": {
+          "type": "long",
+          "index": false
+        },
+        "positionJob": {
+          "type": "long",
+          "index": false
+        }
+      }
+    }
+  },
+  "operate-flownode-instance": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "flowNodeId": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "endDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "incidentKey": {
+          "type": "long"
+        },
+        "scopeKey": {
+          "type": "long"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "position": {
+          "type": "long"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "startDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "treePath": {
+          "type": "keyword"
+        },
+        "level": {
+          "type": "long"
+        },
+        "incident": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-incident": {
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "ca_path_tree": {
+            "tokenizer": "ca_hierarchy"
+          }
+        },
+        "tokenizer": {
+          "ca_hierarchy": {
+            "type": "path_hierarchy",
+            "delimiter": "/"
+          }
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "creationTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "flowNodeId": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "errorType": {
+          "type": "keyword"
+        },
+        "flowNodeInstanceKey": {
+          "type": "long"
+        },
+        "errorMessage": {
+          "type": "text"
+        },
+        "errorMessageHash": {
+          "type": "integer"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "jobKey": {
+          "type": "long"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "treePath": {
+          "type": "text",
+          "analyzer": "ca_path_tree",
+          "fielddata": true
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "position": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "operate-job": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "flowNodeInstanceId": {
+          "type": "long"
+        },
+        "flowNodeId": {
+          "type": "keyword"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "worker": {
+          "type": "keyword"
+        },
+        "retries": {
+          "type": "integer"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "errorMessage": {
+          "type": "keyword"
+        },
+        "errorCode": {
+          "type": "keyword"
+        },
+        "deadline": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "endTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "customHeaders": {
+          "type": "object",
+          "enabled": false
+        },
+        "jobKind": {
+          "type": "keyword"
+        },
+        "listenerEventType": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "jobFailedWithRetriesLeft": {
+          "type": "boolean"
+        },
+        "position": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "operate-list-view": {
+    "settings": {
+      "index": {
+        "refresh_interval": "2s",
+        "analysis": {
+          "normalizer": {
+            "case_insensitive": {
+              "type": "custom",
+              "filter": "lowercase"
+            }
+          }
+        }
+      },
+      "analysis": {
+        "analyzer": {
+          "ca_path_tree": {
+            "tokenizer": "ca_hierarchy"
+          }
+        },
+        "tokenizer": {
+          "ca_hierarchy": {
+            "type": "path_hierarchy",
+            "delimiter": "/"
+          }
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "varName": {
+          "type": "keyword"
+        },
+        "endDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "errorMessage": {
+          "type": "text"
+        },
+        "processName": {
+          "normalizer": "case_insensitive",
+          "type": "keyword"
+        },
+        "joinRelation": {
+          "type": "join",
+          "eager_global_ordinals": true,
+          "relations": {
+            "processInstance": ["activity", "variable"]
+          }
+        },
+        "activityId": {
+          "eager_global_ordinals": true,
+          "type": "keyword"
+        },
+        "varValue": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "activityState": {
+          "type": "keyword"
+        },
+        "incidentKeys": {
+          "type": "long"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "scopeKey": {
+          "type": "long"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "processVersion": {
+          "type": "long"
+        },
+        "processVersionTag": {
+          "type": "keyword"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "activityType": {
+          "type": "keyword"
+        },
+        "batchOperationIds": {
+          "type": "keyword"
+        },
+        "parentProcessInstanceKey": {
+          "type": "long"
+        },
+        "parentFlowNodeInstanceKey": {
+          "type": "long"
+        },
+        "startDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "key": {
+          "type": "long"
+        },
+        "treePath": {
+          "type": "text",
+          "analyzer": "ca_path_tree",
+          "fielddata": true
+        },
+        "incident": {
+          "type": "boolean"
+        },
+        "pendingIncident": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "jobFailedWithRetriesLeft": {
+          "type": "boolean"
+        },
+        "position": {
+          "type": "long"
+        },
+        "positionIncident": {
+          "type": "long",
+          "index": false
+        },
+        "positionJob": {
+          "type": "long",
+          "index": false
+        }
+      }
+    }
+  },
+  "operate-message": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "messageName": {
+          "type": "keyword"
+        },
+        "correlationKey": {
+          "type": "keyword"
+        },
+        "publishDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "expireDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "deadline": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "timeToLive": {
+          "type": "long"
+        },
+        "messageId": {
+          "type": "keyword"
+        },
+        "variables": {
+          "type": "text"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-operation": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "variableName": {
+          "type": "keyword"
+        },
+        "variableValue": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "lockExpirationTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "errorMessage": {
+          "type": "text"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "incidentKey": {
+          "type": "long"
+        },
+        "scopeKey": {
+          "type": "long"
+        },
+        "lockOwner": {
+          "type": "keyword"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "decisionDefinitionKey": {
+          "type": "long"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "batchOperationId": {
+          "type": "keyword"
+        },
+        "zeebeCommandKey": {
+          "type": "keyword"
+        },
+        "username": {
+          "type": "keyword"
+        },
+        "modifyInstructions": {
+          "type": "text"
+        },
+        "migrationPlan": {
+          "type": "text"
+        },
+        "completedDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        }
+      }
+    }
+  },
+  "operate-post-importer-queue": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "actionType": {
+          "type": "keyword"
+        },
+        "intent": {
+          "type": "keyword"
+        },
+        "creationTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "position": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "operate-sequence-flow": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "activityId": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "operate-variable": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "partitionId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "scopeKey": {
+          "type": "long"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        },
+        "processDefinitionKey": {
+          "type": "long"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "key": {
+          "type": "long"
+        },
+        "fullValue": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "isPreview": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "position": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "tasklist-draft-task-variable": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "partitionId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "taskId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "key": {
+          "type": "long"
+        },
+        "fullValue": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "isPreview": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "tasklist-task-variable": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "partitionId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "taskId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "key": {
+          "type": "long"
+        },
+        "fullValue": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "isPreview": {
+          "type": "boolean"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "processInstanceKey": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "tasklist-task": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "join": {
+          "type": "join",
+          "eager_global_ordinals": true,
+          "relations": {
+            "task": ["localVariable"],
+            "process": ["variable", "task"]
+          }
+        },
+        "flowNodeBpmnId": {
+          "type": "keyword"
+        },
+        "flowNodeInstanceId": {
+          "type": "keyword"
+        },
+        "partitionId": {
+          "type": "integer"
+        },
+        "completionTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "processInstanceId": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "position": {
+          "type": "long"
+        },
+        "state": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "long"
+        },
+        "creationTime": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "bpmnProcessId": {
+          "type": "keyword"
+        },
+        "processDefinitionId": {
+          "type": "keyword"
+        },
+        "assignee": {
+          "type": "keyword"
+        },
+        "candidateGroups": {
+          "type": "keyword"
+        },
+        "candidateUsers": {
+          "type": "keyword"
+        },
+        "formKey": {
+          "type": "keyword"
+        },
+        "formId": {
+          "type": "keyword"
+        },
+        "formVersion": {
+          "type": "long"
+        },
+        "isFormEmbedded": {
+          "type": "boolean"
+        },
+        "followUpDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "dueDate": {
+          "format": "date_time || epoch_millis",
+          "type": "date"
+        },
+        "tenantId": {
+          "type": "keyword"
+        },
+        "implementation": {
+          "type": "keyword"
+        },
+        "externalFormReference": {
+          "type": "keyword"
+        },
+        "processDefinitionVersion": {
+          "type": "integer"
+        },
+        "customHeaders": {
+          "type": "object",
+          "dynamic": true
+        },
+        "priority": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "fullValue": {
+          "type": "keyword",
+          "ignore_above": 8191
+        },
+        "scopeKey": {
+          "type": "keyword"
+        },
+        "isTruncated": {
+          "type": "boolean"
+        },
+        "action": {
+          "type": "keyword"
+        },
+        "changedAttributes": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates.md
+++ b/.github/workflows/sync-harmonized-indexes/templates.md
@@ -345,7 +345,4 @@ erDiagram
         keyword action
         keyword changedAttributes
     }
-    tasklist-task ||--o{ tasklist-task: "task:localVariable"
-    tasklist-task ||--o{ tasklist-task: "process:[variable,task]"
-
 ```

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-batch-operation.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-batch-operation.json
@@ -1,0 +1,36 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "operationsFinishedCount": {
+        "type": "long"
+      },
+      "endDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "instancesCount": {
+        "type": "long"
+      },
+      "operationsTotalCount": {
+        "type": "long"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "startDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "username": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-decision-instance.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-decision-instance.json
@@ -1,0 +1,120 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "executionIndex": {
+        "type": "integer"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "position": {
+        "type": "long"
+      },
+      "evaluationDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "evaluationFailure": {
+        "type": "keyword"
+      },
+      "decisionRequirementsKey": {
+        "type": "long"
+      },
+      "decisionRequirementsId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "elementInstanceKey": {
+        "type": "long"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "decisionId": {
+        "type": "keyword"
+      },
+      "decisionDefinitionId": {
+        "type": "keyword"
+      },
+      "decisionName": {
+        "type": "keyword"
+      },
+      "rootDecisionId": {
+        "type": "keyword"
+      },
+      "rootDecisionName": {
+        "type": "keyword"
+      },
+      "rootDecisionDefinitionId": {
+        "type": "keyword"
+      },
+      "decisionType": {
+        "type": "keyword"
+      },
+      "decisionVersion": {
+        "type": "keyword"
+      },
+      "result": {
+        "type": "text",
+        "index": false
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "evaluatedInputs": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          },
+          "value": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
+      "evaluatedOutputs": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          },
+          "value": {
+            "type": "object",
+            "enabled": false
+          },
+          "ruleId": {
+            "type": "keyword"
+          },
+          "ruleIndex": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-event.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-event.json
@@ -1,0 +1,96 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "dateTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "jobRetries": {
+            "type": "integer"
+          },
+          "incidentErrorType": {
+            "type": "keyword"
+          },
+          "jobCustomHeaders": {
+            "type": "object",
+            "enabled": false
+          },
+          "incidentErrorMessage": {
+            "type": "text"
+          },
+          "jobWorker": {
+            "type": "keyword"
+          },
+          "jobKey": {
+            "type": "long"
+          },
+          "jobType": {
+            "type": "keyword"
+          },
+          "jobDeadline": {
+            "format": "date_time || epoch_millis",
+            "type": "date"
+          },
+          "messageName": {
+            "type": "keyword"
+          },
+          "correlationKey": {
+            "type": "keyword"
+          }
+        }
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "eventSourceType": {
+        "type": "keyword"
+      },
+      "eventType": {
+        "type": "keyword"
+      },
+      "flowNodeId": {
+        "type": "keyword"
+      },
+      "flowNodeInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      },
+      "positionIncident": {
+        "type": "long",
+        "index": false
+      },
+      "positionProcessMessageSubscription": {
+        "type": "long",
+        "index": false
+      },
+      "positionJob": {
+        "type": "long",
+        "index": false
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-flownode-instance.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-flownode-instance.json
@@ -1,0 +1,63 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "flowNodeId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "endDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "incidentKey": {
+        "type": "long"
+      },
+      "scopeKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "startDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "treePath": {
+        "type": "keyword"
+      },
+      "level": {
+        "type": "long"
+      },
+      "incident": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-incident.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-incident.json
@@ -1,0 +1,76 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "ca_path_tree": {
+          "tokenizer": "ca_hierarchy"
+        }
+      },
+      "tokenizer": {
+        "ca_hierarchy": {
+          "type": "path_hierarchy",
+          "delimiter": "/"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "creationTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "flowNodeId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "errorType": {
+        "type": "keyword"
+      },
+      "flowNodeInstanceKey": {
+        "type": "long"
+      },
+      "errorMessage": {
+        "type": "text"
+      },
+      "errorMessageHash": {
+        "type": "integer"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "jobKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "treePath": {
+        "type": "text",
+        "analyzer": "ca_path_tree",
+        "fielddata": true
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-job.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-job.json
@@ -1,0 +1,76 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "flowNodeInstanceId": {
+        "type": "long"
+      },
+      "flowNodeId": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "worker": {
+        "type": "keyword"
+      },
+      "retries": {
+        "type": "integer"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "errorMessage": {
+        "type": "keyword"
+      },
+      "errorCode": {
+        "type": "keyword"
+      },
+      "deadline": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "customHeaders": {
+        "type": "object",
+        "enabled": false
+      },
+      "jobKind": {
+        "type": "keyword"
+      },
+      "listenerEventType": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "jobFailedWithRetriesLeft": {
+        "type": "boolean"
+      },
+      "position": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-list-view.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-list-view.json
@@ -1,0 +1,142 @@
+{
+  "settings": {
+    "index": {
+      "refresh_interval": "2s",
+      "analysis": {
+        "normalizer": {
+          "case_insensitive": {
+            "type": "custom",
+            "filter": "lowercase"
+          }
+        }
+      }
+    },
+    "analysis": {
+      "analyzer": {
+        "ca_path_tree": {
+          "tokenizer": "ca_hierarchy"
+        }
+      },
+      "tokenizer": {
+        "ca_hierarchy": {
+          "type": "path_hierarchy",
+          "delimiter": "/"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "varName": {
+        "type": "keyword"
+      },
+      "endDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "errorMessage": {
+        "type": "text"
+      },
+      "processName": {
+        "normalizer": "case_insensitive",
+        "type": "keyword"
+      },
+      "joinRelation": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "processInstance": ["activity", "variable"]
+        }
+      },
+      "activityId": {
+        "eager_global_ordinals": true,
+        "type": "keyword"
+      },
+      "varValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "activityState": {
+        "type": "keyword"
+      },
+      "incidentKeys": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "scopeKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "processVersion": {
+        "type": "long"
+      },
+      "processVersionTag": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "activityType": {
+        "type": "keyword"
+      },
+      "batchOperationIds": {
+        "type": "keyword"
+      },
+      "parentProcessInstanceKey": {
+        "type": "long"
+      },
+      "parentFlowNodeInstanceKey": {
+        "type": "long"
+      },
+      "startDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "key": {
+        "type": "long"
+      },
+      "treePath": {
+        "type": "text",
+        "analyzer": "ca_path_tree",
+        "fielddata": true
+      },
+      "incident": {
+        "type": "boolean"
+      },
+      "pendingIncident": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "jobFailedWithRetriesLeft": {
+        "type": "boolean"
+      },
+      "position": {
+        "type": "long"
+      },
+      "positionIncident": {
+        "type": "long",
+        "index": false
+      },
+      "positionJob": {
+        "type": "long",
+        "index": false
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-message.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-message.json
@@ -1,0 +1,46 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "messageName": {
+        "type": "keyword"
+      },
+      "correlationKey": {
+        "type": "keyword"
+      },
+      "publishDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "expireDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "deadline": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "timeToLive": {
+        "type": "long"
+      },
+      "messageId": {
+        "type": "keyword"
+      },
+      "variables": {
+        "type": "text"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-operation.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-operation.json
@@ -1,0 +1,70 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "variableName": {
+        "type": "keyword"
+      },
+      "variableValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "lockExpirationTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "errorMessage": {
+        "type": "text"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "incidentKey": {
+        "type": "long"
+      },
+      "scopeKey": {
+        "type": "long"
+      },
+      "lockOwner": {
+        "type": "keyword"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "decisionDefinitionKey": {
+        "type": "long"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "batchOperationId": {
+        "type": "keyword"
+      },
+      "zeebeCommandKey": {
+        "type": "keyword"
+      },
+      "username": {
+        "type": "keyword"
+      },
+      "modifyInstructions": {
+        "type": "text"
+      },
+      "migrationPlan": {
+        "type": "text"
+      },
+      "completedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-post-importer-queue.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-post-importer-queue.json
@@ -1,0 +1,32 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "actionType": {
+        "type": "keyword"
+      },
+      "intent": {
+        "type": "keyword"
+      },
+      "creationTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "position": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-sequence-flow.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-sequence-flow.json
@@ -1,0 +1,31 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "activityId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/operate-variable.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/operate-variable.json
@@ -1,0 +1,48 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "partitionId": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "scopeKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "key": {
+        "type": "long"
+      },
+      "fullValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "isPreview": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/tasklist-draft-task-variable.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/tasklist-draft-task-variable.json
@@ -1,0 +1,36 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "partitionId": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "taskId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "key": {
+        "type": "long"
+      },
+      "fullValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "isPreview": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/tasklist-task-variable.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/tasklist-task-variable.json
@@ -1,0 +1,39 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "partitionId": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "taskId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "key": {
+        "type": "long"
+      },
+      "fullValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "isPreview": {
+        "type": "boolean"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/.github/workflows/sync-harmonized-indexes/templates/tasklist-task.json
+++ b/.github/workflows/sync-harmonized-indexes/templates/tasklist-task.json
@@ -1,0 +1,124 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "task": ["localVariable"],
+          "process": ["variable", "task"]
+        }
+      },
+      "flowNodeBpmnId": {
+        "type": "keyword"
+      },
+      "flowNodeInstanceId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "completionTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "processInstanceId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "creationTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionId": {
+        "type": "keyword"
+      },
+      "assignee": {
+        "type": "keyword"
+      },
+      "candidateGroups": {
+        "type": "keyword"
+      },
+      "candidateUsers": {
+        "type": "keyword"
+      },
+      "formKey": {
+        "type": "keyword"
+      },
+      "formId": {
+        "type": "keyword"
+      },
+      "formVersion": {
+        "type": "long"
+      },
+      "isFormEmbedded": {
+        "type": "boolean"
+      },
+      "followUpDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "dueDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "implementation": {
+        "type": "keyword"
+      },
+      "externalFormReference": {
+        "type": "keyword"
+      },
+      "processDefinitionVersion": {
+        "type": "integer"
+      },
+      "customHeaders": {
+        "type": "object",
+        "dynamic": true
+      },
+      "priority": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "fullValue": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "scopeKey": {
+        "type": "keyword"
+      },
+      "isTruncated": {
+        "type": "boolean"
+      },
+      "action": {
+        "type": "keyword"
+      },
+      "changedAttributes": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/docs/self-managed/operational-guides/backup-restore/_harmonized-indexes-main.md
+++ b/docs/self-managed/operational-guides/backup-restore/_harmonized-indexes-main.md
@@ -6,11 +6,11 @@ erDiagram
         keyword ownerType
         keyword resourceType
     }
-    camunda-authorization-permissions {
+    permissions {
         keyword type
         keyword resourceIds
     }
-    camunda-authorization ||--o{ camunda-authorization-permissions : has
+    camunda-authorization ||--o{ permissions : has
 
     camunda-mapping {
         keyword id

--- a/docs/self-managed/operational-guides/backup-restore/_harmonized-indexes-main.md
+++ b/docs/self-managed/operational-guides/backup-restore/_harmonized-indexes-main.md
@@ -1,0 +1,30 @@
+```mermaid
+erDiagram
+    camunda-authorization {
+        keyword id
+        long ownerKey
+        keyword ownerType
+        keyword resourceType
+    }
+    camunda-authorization-permissions {
+        keyword type
+        keyword resourceIds
+    }
+    camunda-authorization ||--o{ camunda-authorization-permissions : has
+
+    camunda-mapping {
+        keyword id
+        long key
+        keyword claimName
+        keyword claimValue
+        keyword name
+    }
+
+    camunda-role {
+        keyword id
+        long key
+        keyword name
+        long memberKey
+        join join
+    }
+```

--- a/docs/self-managed/operational-guides/backup-restore/_harmonized-indexes-runtime.md
+++ b/docs/self-managed/operational-guides/backup-restore/_harmonized-indexes-runtime.md
@@ -1,0 +1,30 @@
+```mermaid
+erDiagram
+    "operate-metric-*" {
+        keyword id
+        date eventTime
+        keyword event
+        keyword value
+        keyword tenantId
+    }
+
+    "tasklist-process-*" {
+        keyword id
+        keyword key
+        keyword name
+        integer partitionId
+        keyword bpmnProcessId
+        boolean startedByForm
+        keyword formKey
+        keyword formId
+        boolean isFormEmbedded
+        integer version
+        keyword tenantId
+        text bpmnXml
+        keyword flowNodes_id
+        keyword flowNodes_name
+        keyword userTaskForms_id
+        text userTaskForms_definition
+    }
+
+```

--- a/docs/self-managed/operational-guides/backup-restore/harmonized-indexes.md
+++ b/docs/self-managed/operational-guides/backup-restore/harmonized-indexes.md
@@ -1,0 +1,19 @@
+---
+id: harmonized-indexes
+title: "Harmonized Indexes"
+sidebar_label: "Harmonized Indexes"
+keywords: ["schema", "elasticsearch"]
+---
+
+import MainIndexes from './\_harmonized-indexes-main.md';
+import RuntimeIndexes from './\_harmonized-indexes-runtime.md';
+
+something something harmonized index schema
+
+### Main Indexes
+
+<MainIndexes />
+
+### Runtime Indexes
+
+<RuntimeIndexes />

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "api:generate:tasklist": "npm run api:generate tasklist",
     "api:generate:zeebe": "npm run api:generate zeebe",
     "api:generate:adminsm": "npm run api:generate adminsm",
-    "api:generate:camunda": "npm run api:generate camunda"
+    "api:generate:camunda": "npm run api:generate camunda",
+    "indexes:combine": "node ./.github/workflows/sync-harmonized-indexes/1-combine-sources.js",
+    "indexes:generate": "node ./.github/workflows/sync-harmonized-indexes/2-generate-mermaid-output.js"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.2.4",

--- a/sidebars.js
+++ b/sidebars.js
@@ -1047,6 +1047,7 @@ module.exports = {
             "self-managed/operational-guides/backup-restore/operate-tasklist-backup",
             "self-managed/operational-guides/backup-restore/zeebe-backup-and-restore",
             "self-managed/operational-guides/backup-restore/modeler-backup-and-restore",
+            "self-managed/operational-guides/backup-restore/harmonized-indexes",
           ],
         },
         {

--- a/src/theme/Mermaid/index.js
+++ b/src/theme/Mermaid/index.js
@@ -1,0 +1,20 @@
+import React from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import {
+  MermaidContainerClassName,
+  useMermaidSvg,
+} from "@docusaurus/theme-mermaid/client";
+import styles from "./styles.module.css";
+function MermaidDiagram({ value }) {
+  const svg = useMermaidSvg(value);
+  return (
+    <div
+      className={`${MermaidContainerClassName} ${styles.container}`}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}
+export default function Mermaid(props) {
+  return <BrowserOnly>{() => <MermaidDiagram {...props} />}</BrowserOnly>;
+}

--- a/src/theme/Mermaid/styles.module.css
+++ b/src/theme/Mermaid/styles.module.css
@@ -1,0 +1,7 @@
+.container {
+  max-width: 100%;
+}
+
+.container > svg {
+  max-width: 100%;
+}


### PR DESCRIPTION
Should not be merged as-is. This PR exists for the purpose of soliciting feedback.

## Description

My hackathon project, a proof of concept of #4870. 

Adds a new page containing diagrams of the main & runtime harmonized indexes. Includes scripts to generate those diagrams from the upstream index schemas.

## Preview

https://preview.docs.camunda.cloud/pr-4918/docs/next/self-managed/operational-guides/backup-restore/harmonized-indexes/

![image](https://github.com/user-attachments/assets/033b221c-c674-48b7-958b-2c952e35ac08)

## What's in this PR

1. Copies the [harmonized index schemas from upstream](https://github.com/camunda/camunda/tree/main/webapps-schema/src/main/resources/schema/elasticsearch/create) for ease of working. Long-term, I'd expect us to check out the `camunda/camunda` repo as part of the workflow.
2. Adds a script (`1-combine-sources`) to combine all the JSON files into one big one (or technically two, to retain the distinction between main & runtime indexes). I'm undecided if this would be useful for a long-term workflow.
3. Adds a script (`2-generate-mermaid-diagrams`) to generate proper markdown to emit mermaid diagrams for all schemas in a JSON file. 
   - Note that I would like **extra hackathon points** for not only **writing unit tests** during a hackathon, but using **TDD** to derive this logic.
4. Adds a script (`2-generate-mermaid-output`) to dump the generated markdown into a file.
5. Adds markdown partials to include that output in [a new page](https://preview.docs.camunda.cloud/pr-4918/docs/next/self-managed/operational-guides/backup-restore/harmonized-indexes/).

## Implementation notes

- I put the new page under self-managed/backup and restore because that seemed like the most likely place someone might be interested in knowing what the schema looked like.
- The schema definitions aren't truly an "Entity Relationship" diagram; that type of diagram seemed like the best fit that I could find.
- The mermaid integration into docusaurus is such that very large diagrams become unreadably small. The diagram is limited to the width of the page, and is itself an SVG, and it gets scaled down to fit the page. 
   - I intentionally left 6 entities in one diagram so you can see this scaling in action, in the 4th row of entities as you scroll down the page.
   - In response, I chose for this prototype to create diagrams of 3 schemas, and stack them on top of each other vertically. I looked briefly into adding scrollbars and making one big scrollable diagram, but I didn't have success with that.
   - We do have the ability to control [the layout algorithm](https://mermaid.js.org/intro/syntax-reference.html#supported-layout-algorithms), but neither of them lays the entities out in a more readable format than what you're seeing.
- There are multiple concepts in the schemas that we'll need to address somehow.  
   - `object` types: an index defines nested types in its schema. I chose to represent these using ERD relationships, extracting the nested type into a separate entity (see `camunda-authorization` index). This is visually inaccurate according to ERDs; it is not a separate index; but it might be a better way to describe things?
      - An example would be grouping a `firstName` and `lastName` under a `name`, or this from our indexes: 
        ```json
        "permissions": {
          "type": "object",
          "properties": {
            "type": {
              "type": "keyword"
            },
            "resourceIds": {
              "type": "keyword"
            }
          }
        }
        ```
   - `join` types: in this case, an item in an index references other items in the same index, through a defined relationship. This is not exactly a concept that a traditional Entity Relationship diagram handles out of the box. I tried joining a couple indexes to themselves (see `camunda-group` and `tasklist-task` indexes) to represent this; I left the others as using the type `join`.
      - Here's an example from a schema: 
         ```json
         "joinRelation": {
            "type": "join",
            "eager_global_ordinals": true,
            "relations": {
              "processInstance": ["activity", "variable"]
            }
          },
          ```
   - There may be some implied "relationships" across indexes, which I did not represent. For example, the `operate-decision` index includes a `decisionRequirementsKey` property, which I _think_ might refer to the `key` of an item in the `operate-decision-requirements` index. 
      - It would make a more complete diagram to include these implied relationships, if I am understanding them correctly.
      - However it would destroy my workaround for mermaid/docusaurus's tendency to squish large diagrams, as I would need all entities in one diagram. That isn't a reason not to do it, but including the relationships would mean I'd have to find a different workaround.
      - The implied relationships are not represented in the indexes. If we chose to represent them in the diagrams, I'd need to maintain a list of relationships here, separate from the upstream source. Again, not a reason not to do it, but it does introduce complexity and fragility.

## Other changes required before "done"

1. The generation of the markdown from JSON schemas would happen in a GitHub workflow.
2. Content for the page needs to be written. https://docs.google.com/document/d/1EFZ19Gx8Nf559pP_Bg8ObFMfGYdlq20age8P_WiSBOY/edit?tab=t.0#heading=h.c447h0byekxu is a good starting point for this. I will likely solicit a technical writer to help me with this 😅 


## Decisions to be made/feedback I'm interested in

Because I think it will be easier for reviewers, I will post a list of questions in a comment, so that you can reply to it with any of your feedback.

## When should this change go live?

Never, at least not in this form!


