### PR TITLE
fix: switch old warning (v2) to new danger (v3) for infraex

### DIFF
--- a/docs/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/docs/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -724,7 +724,7 @@ Half of the amount of your set `clusterSize` is used to spawn Zeebe brokers.
 
 For example, in the case of `clusterSize: 8`, four Zeebe brokers are provisioned in the newly created region.
 
-:::warning
+:::danger
 It is expected that the Zeebe broker pods will not reach the "Ready" state since they are not yet part of a Zeebe cluster and, therefore, not considered healthy by the readiness probe.
 :::
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
@@ -466,7 +466,7 @@ The base `camunda-values.yml` in `aws/dual-region/kubernetes` requires adjustmen
   <summary>Example output</summary>
   <summary>
 
-:::danger
+:::caution
 For illustration purposes only. These values will not work in your environment.
 :::
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -153,7 +153,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning Uniqueness of txtOwnerId for DNS
+:::danger Uniqueness of txtOwnerId for DNS
 
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
@@ -253,7 +253,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.7/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 
@@ -306,7 +306,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.7-irsa/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
@@ -31,7 +31,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -52,7 +52,7 @@ Modules referenced in this guide have been updated recently from **v2** to **v3*
 
 :::
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/docs/self-managed/setup/deploy/amazon/aws-ec2.md
+++ b/docs/self-managed/setup/deploy/amazon/aws-ec2.md
@@ -14,7 +14,7 @@ This guide is built around the available tools and services that AWS offers, but
 When using this guide with a different cloud provider, note that you will be responsible for configuring and maintaining the resulting infrastructure. Our support is limited to questions related to the guide itself, not to the specific tools and services of the chosen cloud provider.
 :::
 
-:::warning Cost management
+:::danger Cost management
 Following this guide will incur costs on your Cloud provider account, namely for the EC2 instances, and OpenSearch. More information can be found on AWS and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 
 To get an estimate, you can refer to this [example calculation](https://calculator.aws/#/estimate?id=8ce855e2d02d182c4910ec8b4ea2dbf42ea5fd1d), which can be further optimized to suit your specific use cases.

--- a/docs/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
+++ b/docs/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
@@ -44,7 +44,7 @@ For testing Camunda 8 or developing against it, you might consider signing up fo
 
 To keep this guide concise, we provide links to additional documentation covering best practices, allowing you to explore each topic in greater depth.
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your cloud provider account and your Red Hat account, specifically for the managed OpenShift service, OpenShift worker nodes running in EC2, the hosted control plane, Elastic Block Storage (EBS), and Route 53. For more details, refer to [ROSA AWS pricing](https://aws.amazon.com/rosa/pricing/) and the [AWS Pricing Calculator](https://calculator.aws/#/) as total costs vary by region.
 

--- a/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -69,7 +69,7 @@ You can find a reference example of this file here:
 https://github.com/camunda/camunda-deployment-references/blob/main/aws/rosa-hcp/camunda-versions/8.7/procedure/install/helm-values/base.yml
 ```
 
-:::warning Merging YAML files
+:::danger Merging YAML files
 
 This guide references multiple configuration files that need to be merged into a single YAML file. Be cautious to avoid duplicate keys when merging the files. Additionally, pay close attention when copying and pasting YAML content. Ensure that the separator notation `---` does not inadvertently split the configuration into multiple documents.
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -173,7 +173,7 @@ helm install camunda camunda/camunda-platform --skip-crds --version "$CHART_VERS
 
 If you must deploy using Helm 3.2.0 or greater, you have two options. One is to use a SCCs which defines the `RunAsUser` strategy to be at least `RunAsAny`. If that's not possible, then you need to make use of [a post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering).
 
-:::warning
+:::danger
 If using a post-renderer, you **must** use the post-renderer whenever you are updating your release, not only during the initial installation. If you do not, the default values will be used again, which will prevent some services from starting.
 :::
 
@@ -271,7 +271,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress controllers instead, for example, the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
-:::warning
+:::danger
 
 Do not confuse the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eks-helm.md
@@ -105,7 +105,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning
+:::danger
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
 In the example below, it's set to `external-dns` and should be changed if this identifier is already in use. Consult the [documentation](https://kubernetes-sigs.github.io/external-dns/v0.15.0/#note) to learn more about DNS record ownership.
@@ -189,7 +189,7 @@ For more configuration options, refer to the [Helm chart documentation](https://
 
 The following makes use of the [combined ingress setup](../../guides/ingress-setup.md#combined-ingress-setup) by deploying a single ingress for all HTTP components and a separate ingress for the gRPC endpoint.
 
-:::warning
+:::danger
 
 Publicly exposing the Zeebe Gateway without authorization enabled can lead to severe security risks. Consider disabling the ingress for the Zeebe Gateway by setting the `zeebe-gateway.ingress.enabled` to `false`.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eksctl.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eksctl.md
@@ -25,7 +25,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/terraform-setup.md
@@ -33,7 +33,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 For the simplicity of this guide, certain best practices will be provided with links to additional documents, enabling you to explore the topic in more detail.
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 
@@ -90,13 +90,13 @@ There are several ways to authenticate the `AWS` provider.
 
 :::
 
-:::warning
+:::danger
 
 Do not store sensitive information (credentials) in your Terraform files.
 
 :::
 
-:::warning
+:::danger
 
 A user who creates resources in AWS will therefore own these resources. In this particular case, the user will always have admin access to the Kubernetes cluster until the cluster is deleted.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -173,7 +173,7 @@ helm install camunda camunda/camunda-platform --skip-crds --version "$CHART_VERS
 
 If you must deploy using Helm 3.2.0 or greater, you have two options. One is to use a SCCs which defines the `RunAsUser` strategy to be at least `RunAsAny`. If that's not possible, then you need to make use of [a post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering).
 
-:::warning
+:::danger
 If using a post-renderer, you **must** use the post-renderer whenever you are updating your release, not only during the initial installation. If you do not, the default values will be used again, which will prevent some services from starting.
 :::
 
@@ -271,7 +271,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress controllers instead, for example, the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
-:::warning
+:::danger
 
 Do not confuse the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
 

--- a/versioned_docs/version-8.5/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.5/self-managed/concepts/multi-region/dual-region.md
@@ -11,7 +11,7 @@ import DualRegion from "./img/dual-region.svg";
 
 Camunda 8 is compatible with a dual-region setup under certain [limitations](#limitations). This allows Camunda 8 to run in a mix of active-active and active-passive setups, resulting in an overall **active-passive** setup. The following will explore the concept, limitations, and considerations.
 
-:::warning
+:::danger
 
 You should get familiar with the topic, the [limitations](#limitations) of the dual-region setup, and the general [considerations](#considerations) on operating a dual-region setup.
 

--- a/versioned_docs/version-8.5/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -76,7 +76,7 @@ The **failover** phase of the procedure results in the temporary restoration of 
 
 The **failback** phase of the procedure results in completely restoring the failed region to its full functionality. It requires you to have the lost region ready again for the redeployment of Camunda 8.
 
-:::warning
+:::danger
 
 For the **failback** procedure, your recreated region cannot contain any active Camunda 8 deployments or leftover persistent volumes related to Camunda 8 or its Elasticsearch instance. You must start from a clean slate and not bring old data from the lost region, as states may have diverged.
 
@@ -556,7 +556,7 @@ You currently have the following setups:
 
 #### Desired state
 
-:::warning
+:::danger
 
 This step is very important to minimize the risk of losing any data when restoring the backup in the recreated region.
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
@@ -8,7 +8,7 @@ description: "Deploy two Amazon Kubernetes (EKS) clusters with Terraform for a p
 
 import CoreDNSKubeDNS from "./assets/core-dns-kube-dns.svg"
 
-:::warning
+:::danger
 Review our [dual-region concept documentation](./../../../../concepts/multi-region/dual-region.md) before continuing to understand the current limitations and restrictions of this blueprint setup.
 :::
 
@@ -33,7 +33,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 For the simplicity of this guide, certain best practices will be provided with links to additional resources, enabling you to explore the topic in more detail.
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), traffic between regions, and S3. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 
@@ -62,7 +62,7 @@ git clone -b stable/8.5 https://github.com/camunda/c8-multi-region.git
 2. The cloned repository and folder `aws/dual-region/scripts/` provides a helper script [export_environment_prerequisites.sh](https://github.com/camunda/c8-multi-region/blob/stable/8.5/aws/dual-region/scripts/export_environment_prerequisites.sh) to export various environment variables to ease the interaction with a dual-region setup. Consider permanently changing this file for future interactions.
 3. You must adjust these environment variable values within the script to your needs.
 
-:::warning
+:::danger
 
 You have to choose unique namespaces for Camunda 8 installations. The namespace for Camunda 8 installation in the cluster of region 0 (`CAMUNDA_NAMESPACE_0`), needs to have a different name from the namespace for Camunda 8 installation in the cluster of region 1 (`CAMUNDA_NAMESPACE_1`). This is required for proper traffic routing between the clusters.
 
@@ -105,7 +105,7 @@ It's recommended to use a different backend than `local`. Find more information 
 
 :::
 
-:::warning
+:::danger
 
 Do not store sensitive information (credentials) in your Terraform files.
 
@@ -164,7 +164,7 @@ There are several ways to authenticate the `AWS` provider:
 
 ### Execution
 
-:::warning
+:::danger
 
 A user who creates resources in AWS will therefore own these resources. In this particular case, the user will always have admin access to the Kubernetes cluster until the cluster is deleted.
 
@@ -239,7 +239,7 @@ kubectl --context $CLUSTER_1 apply -f https://raw.githubusercontent.com/camunda/
   <summary>Example output</summary>
   <summary>
 
-:::danger
+:::caution
 For illustration purposes only. These values will not work in your environment.
 :::
 
@@ -450,7 +450,7 @@ This overlay contains the multi-region identification for the cluster in region 
 
 #### Preparation
 
-:::warning
+:::danger
 You must change the following environment variables for Zeebe. The default values will not work for you and are only for illustration.
 :::
 
@@ -474,7 +474,7 @@ The base `camunda-values.yml` in `aws/dual-region/kubernetes` requires adjustmen
   <summary>Example output</summary>
   <summary>
 
-:::danger
+:::caution
 For illustration purposes only. These values will not work in your environment.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -105,7 +105,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning
+:::danger
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
 In the example below, it's set to `external-dns` and should be changed if this identifier is already in use. Consult the [documentation](https://kubernetes-sigs.github.io/external-dns/v0.15.0/#note) to learn more about DNS record ownership.
@@ -189,7 +189,7 @@ For more configuration options, refer to the [Helm chart documentation](https://
 
 The following makes use of the [combined ingress setup](/self-managed/setup/guides/ingress-setup.md#combined-ingress-setup) by deploying a single ingress for all HTTP components and a separate ingress for the gRPC endpoint.
 
-:::warning
+:::danger
 
 Publicly exposing the Zeebe Gateway without authorization enabled can lead to severe security risks. Consider disabling the ingress for the Zeebe Gateway by setting the `zeebeGateway.ingress.grpc.enabled` and `zeebeGateway.ingress.rest.enabled` to `false`.
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
@@ -25,7 +25,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -33,7 +33,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 For the simplicity of this guide, certain best practices will be provided with links to additional documents, enabling you to explore the topic in more detail.
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 
@@ -90,13 +90,13 @@ There are several ways to authenticate the `AWS` provider.
 
 :::
 
-:::warning
+:::danger
 
 Do not store sensitive information (credentials) in your Terraform files.
 
 :::
 
-:::warning
+:::danger
 
 A user who creates resources in AWS will therefore own these resources. In this particular case, the user will always have admin access to the Kubernetes cluster until the cluster is deleted.
 

--- a/versioned_docs/version-8.6/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -724,7 +724,7 @@ Half of the amount of your set `clusterSize` is used to spawn Zeebe brokers.
 
 For example, in the case of `clusterSize: 8`, four Zeebe brokers are provisioned in the newly created region.
 
-:::warning
+:::danger
 It is expected that the Zeebe broker pods will not reach the "Ready" state since they are not yet part of a Zeebe cluster and, therefore, not considered healthy by the readiness probe.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
@@ -454,7 +454,7 @@ The base `camunda-values.yml` in `aws/dual-region/kubernetes` requires adjustmen
   <summary>Example output</summary>
   <summary>
 
-:::danger
+:::caution
 For illustration purposes only. These values will not work in your environment.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -152,7 +152,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning Uniqueness of txtOwnerId for DNS
+:::danger Uniqueness of txtOwnerId for DNS
 
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
@@ -252,7 +252,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.6/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 
@@ -305,7 +305,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.6-irsa/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
@@ -35,7 +35,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -54,7 +54,7 @@ Modules referenced in this guide have been updated recently from **v2** to **v3*
 
 :::
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
@@ -48,7 +48,7 @@ For testing Camunda 8 or developing against it, you might consider signing up fo
 
 To keep this guide concise, we provide links to additional documentation covering best practices, allowing you to explore each topic in greater depth.
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your cloud provider account and your Red Hat account, specifically for the managed OpenShift service, OpenShift worker nodes running in EC2, the hosted control plane, Elastic Block Storage (EBS), and Route 53. For more details, refer to [ROSA AWS pricing](https://aws.amazon.com/rosa/pricing/) and the [AWS Pricing Calculator](https://calculator.aws/#/) as total costs vary by region.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -65,7 +65,7 @@ You can find a reference example of this file here:
 https://github.com/camunda/camunda-deployment-references/blob/main/aws/rosa-hcp/camunda-versions/8.6/procedure/install/helm-values/base.yml
 ```
 
-:::warning Merging YAML files
+:::danger Merging YAML files
 
 This guide references multiple configuration files that need to be merged into a single YAML file. Be cautious to avoid duplicate keys when merging the files. Additionally, pay close attention when copying and pasting YAML content. Ensure that the separator notation `---` does not inadvertently split the configuration into multiple documents.
 


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

If you do a docs wide replacement of `warning` to `danger` feel free to close this PR.

With Docusaurus v2 to v3 migration, the `warning` admonition has become the former `caution` admonition.
With v2 `warning` was equal to `danger`.

Speaking of colors, red has become yellow.
I've gone through our documentation (infraex) and adjusted the cases to properly reflect the former usage under v3.

![image](https://github.com/user-attachments/assets/5a0cc251-099e-4fb2-ad0f-c71f1df88cf5)

This is probably the case for a lot more pages and up to your own discretion whether you want to fix it or not.
Probably any usage of `warning` older than 2 weeks is likely a nowadays `danger`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
