### PR TITLE
d3: migrate warnings to dangers

### DIFF
--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -15,7 +15,7 @@ CPT is based on [JUnit 5](https://junit.org/junit5/) and [Testcontainers](https:
 - Connectors
 - Elasticsearch
 
-:::warning Disclaimer
+:::danger Disclaimer
 For Camunda 8.6, CPT is in an [alpha version](/components/early-access/alpha/alpha-features.md#alpha).
 
 For a mature testing library, take a look at [Zeebe Process Test](/apis-tools/java-client/zeebe-process-test.md).

--- a/docs/components/connectors/out-of-the-box-connectors/email.md
+++ b/docs/components/connectors/out-of-the-box-connectors/email.md
@@ -102,7 +102,7 @@ Example of a returned JSON array:
 
 Retrieve the contents of an email, using the unique `messageId` associated with the email message.
 
-:::warning
+:::danger
 Reading an email using POP3 protocol will delete the email
 :::
 

--- a/docs/components/connectors/out-of-the-box-connectors/google-gemini.md
+++ b/docs/components/connectors/out-of-the-box-connectors/google-gemini.md
@@ -185,7 +185,7 @@ Google supports multiple ways to obtain both types of token. Refer to the [offic
 
 #### Example 1: Obtain JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/service-account).
 :::
@@ -209,7 +209,7 @@ print(credentials.token)
 
 #### Example 2: Obtain bearer and refresh token with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/web-server).
 :::

--- a/docs/components/connectors/out-of-the-box-connectors/google-sheets.md
+++ b/docs/components/connectors/out-of-the-box-connectors/google-sheets.md
@@ -258,7 +258,7 @@ the [Google Cloud API Library](https://console.cloud.google.com/apis/library).
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow
@@ -285,7 +285,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow

--- a/docs/components/connectors/out-of-the-box-connectors/googledrive.md
+++ b/docs/components/connectors/out-of-the-box-connectors/googledrive.md
@@ -85,7 +85,7 @@ You also enable _Google Docs API_ and _Google Drive API_ for every client intend
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/service-account).
 :::
@@ -109,7 +109,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/web-server).
 :::

--- a/docs/components/connectors/out-of-the-box-connectors/kafka.md
+++ b/docs/components/connectors/out-of-the-box-connectors/kafka.md
@@ -353,7 +353,7 @@ This schema defines a structure for a record that includes a name (string), an a
 
 For example, `=(value.itemId = "a4f6j2")` only triggers the start event or continues the catch event if the Kafka message has a matching itemId in the incoming message payload. Leave this field empty to trigger your process every time.
 
-:::warning
+:::danger
 By default, this Connector does not commit the offset if the message cannot be processed. This includes cases where the activation condition is not met.
 This means that if there is a message in the topic that cannot be processed due to an activation condition mismatch, the Kafka subscription will be stopped.
 

--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -18,7 +18,7 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
-:::warning
+:::danger
 `secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
 :::
 

--- a/docs/components/early-access/alpha/sap/odata-connector.md
+++ b/docs/components/early-access/alpha/sap/odata-connector.md
@@ -42,7 +42,7 @@ WebIDESystem: <SAP system ID>
 WebIDEUsage: odata_gen
 ```
 
-:::warning
+:::danger
 Currently, only `BasicAuthentication` is supported on the Destination by the SAP OData Connector.
 :::
 

--- a/docs/components/early-access/alpha/sap/rfc-connector.md
+++ b/docs/components/early-access/alpha/sap/rfc-connector.md
@@ -141,7 +141,7 @@ This corresponds with the BAPI's/FM's `exporting` definition, meaning it exports
 
 The `tables parameter` can be both "exporting" and "importing".
 
-:::warning
+:::danger
 Sending tables as tabular data to an RFC target is not yet supported.
 :::
 

--- a/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/docs/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -400,7 +400,7 @@ Configures the [task](../../../bpmn/service-tasks/#task-definition) for a servic
 
 #### `zeebe:taskDefinition:type`
 
-:::warning
+:::danger
 `zeebe:taskDefinition:type` is a deprecated binding. Instead, use `zeebe:taskDefinition` with `property=type`.
 :::
 

--- a/docs/guides/react-components/_install-plain-java.md
+++ b/docs/guides/react-components/_install-plain-java.md
@@ -10,7 +10,7 @@ For this installation, you must have:
 
 ### Download and configure Elasticsearch
 
-:::warning
+:::danger
 Disabling Elasticsearch's security packages is for non-production only!
 :::
 

--- a/docs/self-managed/identity/troubleshooting/troubleshoot-identity.md
+++ b/docs/self-managed/identity/troubleshooting/troubleshoot-identity.md
@@ -88,6 +88,6 @@ these options:
    3. In the `camunda-platform` realm, set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/latest/server_admin/#_ssl_modes) for your version of Keycloak.
    4. Restart the Identity service again. Identity should now start successfully
 
-:::warning
+:::danger
 We would only recommend that requirements for SSL are disabled in a development environment.
 :::

--- a/docs/self-managed/operate-deployment/operate-authentication.md
+++ b/docs/self-managed/operate-deployment/operate-authentication.md
@@ -151,7 +151,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 Identity requires the following parameters:
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [connecting to an OpenID Connect provider](/self-managed/setup/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/docs/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
+++ b/docs/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
@@ -35,7 +35,7 @@ psql -U <DATABASE_USER> -h <DATABASE_HOST> -p <DATABASE_PORT> -f dump.psql <DATA
 
 After the database has been restored, you can start Web Modeler again.
 
-:::warning
+:::danger
 When restoring Web Modeler data from a backup, ensure that the ids of the users stored in your OIDC provider (e.g. Keycloak) do not change in between the backup and restore.
 Otherwise, users may not be able to access their projects after the restore (see [Web Modeler's troubleshooting guide](self-managed/modeler/web-modeler/troubleshooting/troubleshoot-missing-data.md)).
 :::

--- a/docs/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
+++ b/docs/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
@@ -8,7 +8,7 @@ keywords: ["backup", "backups"]
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-:::warning breaking changes!
+:::danger breaking changes!
 As of the Camunda 8.6 release, the `/actuator` endpoints (including `/backups`) now default to port 9600. Ensure your `management.server.port` configuration parameter is correctly set before continuing.
 :::
 

--- a/docs/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/docs/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -724,7 +724,7 @@ Half of the amount of your set `clusterSize` is used to spawn Zeebe brokers.
 
 For example, in the case of `clusterSize: 8`, four Zeebe brokers are provisioned in the newly created region.
 
-:::warning
+:::danger
 It is expected that the Zeebe broker pods will not reach the "Ready" state since they are not yet part of a Zeebe cluster and, therefore, not considered healthy by the readiness probe.
 :::
 

--- a/docs/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/docs/self-managed/operational-guides/update-guide/820-to-830.md
@@ -139,7 +139,7 @@ these data, users should be assigned to the `<default>` tenant [in Identity](../
 
 ## Connectors
 
-:::warning [Breaking changes!]
+:::danger [Breaking changes!]
 The HTTP Webhook Connector no longer returns a response body by default. If you want to return a response body, you must explicitly define a response body expression.
 See the [usage guide](../../../../components/connectors/use-connectors/inbound) or the [Webhook Connector documentation](../../../../components/connectors/protocol/http-webhook) for more details.
 :::

--- a/docs/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/docs/self-managed/operational-guides/update-guide/840-to-850.md
@@ -64,7 +64,7 @@ The `UserTask` events like `UserTask:CREATED` don't export the string value prop
 As a replacement, user task events now feature the string array properties `candidateUsersList` and `candidateGroupsList`.
 Custom exporters using these events must be modified accordingly.
 
-:::warning Breaking Change
+:::danger Breaking Change
 The values of the `candidateUsers` and `candidateGroups` properties in user task records are lost during an update from `8.4` to `8.5`.
 There is no data migration that moves the values from `candidateUsers` and `candidateGroups` to `candidateUsersList` and `candidateGroupsList`
 since the Zeebe user tasks are only experimental in `8.4`.

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -153,7 +153,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning Uniqueness of txtOwnerId for DNS
+:::danger Uniqueness of txtOwnerId for DNS
 
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
@@ -253,7 +253,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.7/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 
@@ -306,7 +306,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.7-irsa/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
@@ -31,7 +31,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/docs/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/docs/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -52,7 +52,7 @@ Modules referenced in this guide have been updated recently from **v2** to **v3*
 
 :::
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/docs/self-managed/setup/deploy/amazon/aws-ec2.md
+++ b/docs/self-managed/setup/deploy/amazon/aws-ec2.md
@@ -14,7 +14,7 @@ This guide is built around the available tools and services that AWS offers, but
 When using this guide with a different cloud provider, note that you will be responsible for configuring and maintaining the resulting infrastructure. Our support is limited to questions related to the guide itself, not to the specific tools and services of the chosen cloud provider.
 :::
 
-:::warning Cost management
+:::danger Cost management
 Following this guide will incur costs on your Cloud provider account, namely for the EC2 instances, and OpenSearch. More information can be found on AWS and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 
 To get an estimate, you can refer to this [example calculation](https://calculator.aws/#/estimate?id=8ce855e2d02d182c4910ec8b4ea2dbf42ea5fd1d), which can be further optimized to suit your specific use cases.

--- a/docs/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
+++ b/docs/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
@@ -44,7 +44,7 @@ For testing Camunda 8 or developing against it, you might consider signing up fo
 
 To keep this guide concise, we provide links to additional documentation covering best practices, allowing you to explore each topic in greater depth.
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your cloud provider account and your Red Hat account, specifically for the managed OpenShift service, OpenShift worker nodes running in EC2, the hosted control plane, Elastic Block Storage (EBS), and Route 53. For more details, refer to [ROSA AWS pricing](https://aws.amazon.com/rosa/pricing/) and the [AWS Pricing Calculator](https://calculator.aws/#/) as total costs vary by region.
 

--- a/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/docs/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -69,7 +69,7 @@ You can find a reference example of this file here:
 https://github.com/camunda/camunda-deployment-references/blob/main/aws/rosa-hcp/camunda-versions/8.7/procedure/install/helm-values/base.yml
 ```
 
-:::warning Merging YAML files
+:::danger Merging YAML files
 
 This guide references multiple configuration files that need to be merged into a single YAML file. Be cautious to avoid duplicate keys when merging the files. Additionally, pay close attention when copying and pasting YAML content. Ensure that the separator notation `---` does not inadvertently split the configuration into multiple documents.
 

--- a/docs/self-managed/setup/deploy/other/docker.md
+++ b/docs/self-managed/setup/deploy/other/docker.md
@@ -5,7 +5,7 @@ keywords: ["camunda docker"]
 description: "Step through multi-platform support, configuration, Docker images, and Docker Compose."
 ---
 
-:::warning
+:::danger
 While the Docker images themselves are supported for production usage, [Docker Compose](/self-managed/setup/deploy/local/docker-compose.md) files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](/self-managed/setup/install.md) in production.
 :::
 

--- a/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -206,7 +206,7 @@ global:
 </TabItem>
 </Tabs>
 
-:::warning
+:::danger
 Once set, your initial claim name and value cannot be updated using environment or Helm values, and must be changed directly in the database.
 :::
 

--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -80,7 +80,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 ## Configure Identity
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [Connecting to an OpenID Connect provider](/self-managed/setup/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/docs/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -297,7 +297,7 @@ Brokers:
 
 ### 4. Shut down the brokers when the scaling operation has completed
 
-:::warning
+:::danger
 If you shut down brokers before Zeebe has scaled down and moved all partitions away from the brokers, scaling operation would never complete and may result in data loss.
 :::
 

--- a/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -103,7 +103,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3
 
 This will generate a new certificate, `cert.pem`, and a new passwordless key, `key.pem`.
 
-:::warning
+:::danger
 Do not use these in production! Again, this is for development and testing purposes only.
 :::
 

--- a/docs/self-managed/zeebe-deployment/zeebe-gateway/filters.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-gateway/filters.md
@@ -5,7 +5,7 @@ sidebar_label: "Filters"
 description: "All communication from a client to a broker must first pass through a gateway. There, it can be filtered before being dispatched."
 ---
 
-:::warning
+:::danger
 
 Filters are only applied to the REST API of the gateway, and do not affect any gRPC calls.
 

--- a/docs/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
@@ -4,7 +4,7 @@ title: "Interceptors"
 sidebar_label: "Interceptors"
 ---
 
-:::warning
+:::danger
 
 Interceptors are only applied to the gRPC API of the gateway, and do not affect any REST calls.
 

--- a/docs/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/docs/self-managed/zeebe-deployment/zeebe-installation.md
@@ -4,7 +4,7 @@ title: "Overview"
 sidebar_label: "Overview"
 ---
 
-:::warning
+:::danger
 Zeebe does not support network file systems (NFS) other types of network storage volumes at this time. Usage of NFS may cause data corruption.
 :::
 

--- a/optimize/components/userguide/process-analysis/user-task-analytics.md
+++ b/optimize/components/userguide/process-analysis/user-task-analytics.md
@@ -53,7 +53,7 @@ To evaluate user tasks, the following features are available in the report build
 
 ## Good to know
 
-:::warning Known limitations
+:::danger Known limitations
 
 - Currently, user task analytics can be used only with assigned or unassigned time. We are working on analyzing net-work time.
 - This will only work with Tasklist and custom task applications implementing the complete [Camunda Tasklist Lifecycle]($docs$/apis-tools/frontend-development/task-applications/introduction-to-task-applications/).

--- a/optimize_versioned_docs/version-3.13.0/components/userguide/process-analysis/user-task-analytics.md
+++ b/optimize_versioned_docs/version-3.13.0/components/userguide/process-analysis/user-task-analytics.md
@@ -53,7 +53,7 @@ To evaluate user tasks, the following features are available in the report build
 
 ## Good to know
 
-:::warning Known limitations
+:::danger Known limitations
 
 - Currently, user task analytics can be used only with assigned or unassigned time. We are working on analyzing net-work time.
 - This will only work with Tasklist and custom task applications implementing the complete [Camunda Tasklist Lifecycle]($docs$/apis-tools/frontend-development/task-applications/introduction-to-task-applications/).

--- a/optimize_versioned_docs/version-3.14.0/components/userguide/process-analysis/user-task-analytics.md
+++ b/optimize_versioned_docs/version-3.14.0/components/userguide/process-analysis/user-task-analytics.md
@@ -53,7 +53,7 @@ To evaluate user tasks, the following features are available in the report build
 
 ## Good to know
 
-:::warning Known limitations
+:::danger Known limitations
 
 - Currently, user task analytics can be used only with assigned or unassigned time. We are working on analyzing net-work time.
 - This will only work with Tasklist and custom task applications implementing the complete [Camunda Tasklist Lifecycle]($docs$/apis-tools/frontend-development/task-applications/introduction-to-task-applications/).

--- a/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
+++ b/versioned_docs/version-8.3/apis-tools/java-client/job-worker.md
@@ -149,7 +149,7 @@ public ZeebeClientBuilder configureClientMetrics(
 
 ## Job streaming
 
-:::warning
+:::danger
 Job streaming is an experimental feature which is still under development. It is an opt-in feature which is disabled by default.
 :::
 

--- a/versioned_docs/version-8.3/components/concepts/job-workers.md
+++ b/versioned_docs/version-8.3/components/concepts/job-workers.md
@@ -96,7 +96,7 @@ The fact that jobs may be worked on more than once means that Zeebe is an "at le
 
 ## Job streaming
 
-:::warning
+:::danger
 Job streaming is an experimental feature which is still under development. It is an opt-in feature which is disabled by default. [See the job worker documentation for details on usage](/apis-tools/java-client/job-worker.md).
 :::
 

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/google-sheets.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/google-sheets.md
@@ -257,7 +257,7 @@ the [Google Cloud API Library](https://console.cloud.google.com/apis/library).
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow
@@ -284,7 +284,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow

--- a/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/googledrive.md
+++ b/versioned_docs/version-8.3/components/connectors/out-of-the-box-connectors/googledrive.md
@@ -82,7 +82,7 @@ You also enable _Google Docs API_ and _Google Drive API_ for every client intend
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/service-account).
 :::
@@ -106,7 +106,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/web-server).
 :::

--- a/versioned_docs/version-8.3/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.3/components/connectors/use-connectors/index.md
@@ -14,7 +14,7 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
-:::warning
+:::danger
 `secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
 :::
 

--- a/versioned_docs/version-8.3/self-managed/identity/troubleshooting/common-problems.md
+++ b/versioned_docs/version-8.3/self-managed/identity/troubleshooting/common-problems.md
@@ -52,6 +52,6 @@ these options:
    3. In the `camunda-platform` realm, set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/22.0.1/server_admin/#_ssl_modes).
    4. Restart the Identity service again. Identity should now start successfully
 
-:::warning
+:::danger
 We would only recommend that requirements for SSL are disabled in a development environment.
 :::

--- a/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
@@ -35,7 +35,7 @@ psql -U <DATABASE_USER> -h <DATABASE_HOST> -p <DATABASE_PORT> -f dump.psql <DATA
 
 After the database has been restored, you can start Web Modeler again.
 
-:::warning
+:::danger
 When restoring Web Modeler data from a backup, ensure that the ids of the users stored in your OIDC provider (e.g. Keycloak) do not change in between the backup and restore.
 Otherwise, users may not be able to log in after the restore (see [Web Modeler's login troubleshooting guide](self-managed/modeler/web-modeler/troubleshooting/troubleshoot-login.md#unique-constraint-violation)).
 :::

--- a/versioned_docs/version-8.3/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/versioned_docs/version-8.3/self-managed/operational-guides/update-guide/820-to-830.md
@@ -143,7 +143,7 @@ data, users should be assigned to the `<default>` tenant [in Identity](../../../
 
 ## Connectors
 
-:::warning [Breaking changes!]
+:::danger [Breaking changes!]
 The HTTP Webhook Connector no longer returns a response body by default. If you want to return a response body, you must explicitly define a response body expression.
 See the [usage guide](../../../../components/connectors/use-connectors/inbound) or the [Webhook Connector documentation](../../../../components/connectors/protocol/http-webhook) for more details.
 :::

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/docker.md
@@ -83,7 +83,7 @@ You can also find more information on the supported [configuration variables](..
 
 A Docker Compose configuration to run Zeebe, Operate, Tasklist, Optimize, Identity, and Connectors Bundle is available via `docker-compose.yaml`.
 
-:::warning
+:::danger
 While the Docker images themselves are supported for production usage, the Docker Compose files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](./helm-kubernetes/overview.md) in production.
 :::
 

--- a/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.3/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -173,7 +173,7 @@ helm install camunda camunda/camunda-platform --skip-crds --version "$CHART_VERS
 
 If you must deploy using Helm 3.2.0 or greater, you have two options. One is to use a SCCs which defines the `RunAsUser` strategy to be at least `RunAsAny`. If that's not possible, then you need to make use of [a post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering).
 
-:::warning
+:::danger
 If using a post-renderer, you **must** use the post-renderer whenever you are updating your release, not only during the initial installation. If you do not, the default values will be used again, which will prevent some services from starting.
 :::
 
@@ -271,7 +271,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress controllers instead, for example, the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
-:::warning
+:::danger
 
 Do not confuse the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -137,7 +137,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3
 
 This will generate a new certificate, `cert.pem`, and a new passwordless key, `key.pem`.
 
-:::warning
+:::danger
 Do not use these in production! Again, this is for development and testing purposes only.
 :::
 

--- a/versioned_docs/version-8.3/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.3/self-managed/zeebe-deployment/zeebe-installation.md
@@ -4,7 +4,7 @@ title: "Overview"
 sidebar_label: "Overview"
 ---
 
-:::warning
+:::danger
 Zeebe does not support network file systems (NFS) other types of network storage volumes at this time. Usage of NFS may cause data corruption.
 :::
 

--- a/versioned_docs/version-8.4/components/connectors/out-of-the-box-connectors/google-sheets.md
+++ b/versioned_docs/version-8.4/components/connectors/out-of-the-box-connectors/google-sheets.md
@@ -257,7 +257,7 @@ the [Google Cloud API Library](https://console.cloud.google.com/apis/library).
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow
@@ -284,7 +284,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow

--- a/versioned_docs/version-8.4/components/connectors/out-of-the-box-connectors/googledrive.md
+++ b/versioned_docs/version-8.4/components/connectors/out-of-the-box-connectors/googledrive.md
@@ -82,7 +82,7 @@ You also enable _Google Docs API_ and _Google Drive API_ for every client intend
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/service-account).
 :::
@@ -106,7 +106,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/web-server).
 :::

--- a/versioned_docs/version-8.4/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.4/components/connectors/use-connectors/index.md
@@ -14,7 +14,7 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
-:::warning
+:::danger
 `secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
 :::
 

--- a/versioned_docs/version-8.4/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.4/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -330,7 +330,7 @@ Configures the [task](../../../bpmn/service-tasks/#task-definition) for a servic
 
 #### `zeebe:taskDefinition:type`
 
-:::warning
+:::danger
 `zeebe:taskDefinition:type` is a deprecated binding. Instead, use `zeebe:taskDefinition` with `property=type`.
 :::
 

--- a/versioned_docs/version-8.4/self-managed/identity/troubleshooting/troubleshoot-identity.md
+++ b/versioned_docs/version-8.4/self-managed/identity/troubleshooting/troubleshoot-identity.md
@@ -88,6 +88,6 @@ these options:
    3. In the `camunda-platform` realm, set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/22.0.1/server_admin/#_ssl_modes).
    4. Restart the Identity service again. Identity should now start successfully
 
-:::warning
+:::danger
 We would only recommend that requirements for SSL are disabled in a development environment.
 :::

--- a/versioned_docs/version-8.4/self-managed/operate-deployment/operate-authentication.md
+++ b/versioned_docs/version-8.4/self-managed/operate-deployment/operate-authentication.md
@@ -151,7 +151,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 Identity requires the following parameters:
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [connecting to an OpenID Connect provider](../platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/versioned_docs/version-8.4/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
+++ b/versioned_docs/version-8.4/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
@@ -35,7 +35,7 @@ psql -U <DATABASE_USER> -h <DATABASE_HOST> -p <DATABASE_PORT> -f dump.psql <DATA
 
 After the database has been restored, you can start Web Modeler again.
 
-:::warning
+:::danger
 When restoring Web Modeler data from a backup, ensure that the ids of the users stored in your OIDC provider (e.g. Keycloak) do not change in between the backup and restore.
 Otherwise, users may not be able to log in after the restore (see [Web Modeler's login troubleshooting guide](self-managed/modeler/web-modeler/troubleshooting/troubleshoot-login.md#unique-constraint-violation)).
 :::

--- a/versioned_docs/version-8.4/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/versioned_docs/version-8.4/self-managed/operational-guides/update-guide/820-to-830.md
@@ -139,7 +139,7 @@ these data, users should be assigned to the `<default>` tenant [in Identity](../
 
 ## Connectors
 
-:::warning [Breaking changes!]
+:::danger [Breaking changes!]
 The HTTP Webhook Connector no longer returns a response body by default. If you want to return a response body, you must explicitly define a response body expression.
 See the [usage guide](../../../../components/connectors/use-connectors/inbound) or the [Webhook Connector documentation](../../../../components/connectors/protocol/http-webhook) for more details.
 :::

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/docker.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/docker.md
@@ -84,7 +84,7 @@ You can also find more information on the supported [configuration variables](..
 A Docker Compose configuration to run Zeebe, Operate, Tasklist, Optimize, Identity, and Connectors Bundle is available via `docker-compose.yaml`..
 Follow the instructions in the [README](https://github.com/camunda/camunda-self-managed#docker-compose).
 
-:::warning
+:::danger
 While the Docker images themselves are supported for production usage, the Docker Compose files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](./helm-kubernetes/overview.md) in production.
 :::
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md
@@ -25,7 +25,7 @@ The steps below are a general approach for the Camunda components; it is importa
 configuration](#component-specific-configuration) to ensure the components are configured correctly.
 :::
 
-:::warning
+:::danger
 Internally the Camunda components use Identity to handle authentication with your OIDC provider. However, the Identity
 UI is not available for this version.
 :::

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eks-helm.md
@@ -105,7 +105,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning
+:::danger
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
 In the example below, it's set to `external-dns` and should be changed if this identifier is already in use. Consult the [documentation](https://kubernetes-sigs.github.io/external-dns/v0.15.0/#note) to learn more about DNS record ownership.
@@ -189,7 +189,7 @@ For more configuration options, refer to the [Helm chart documentation](https://
 
 The following makes use of the [combined ingress setup](../../guides/ingress-setup.md#combined-ingress-setup) by deploying a single ingress for all HTTP components and a separate ingress for the gRPC endpoint.
 
-:::warning
+:::danger
 
 Publicly exposing the Zeebe Gateway without authorization enabled can lead to severe security risks. Consider disabling the ingress for the Zeebe Gateway by setting the `zeebe-gateway.ingress.enabled` to `false`.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eksctl.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/eksctl.md
@@ -25,7 +25,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/terraform-setup.md
@@ -33,7 +33,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 For the simplicity of this guide, certain best practices will be provided with links to additional documents, enabling you to explore the topic in more detail.
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 
@@ -90,13 +90,13 @@ There are several ways to authenticate the `AWS` provider.
 
 :::
 
-:::warning
+:::danger
 
 Do not store sensitive information (credentials) in your Terraform files.
 
 :::
 
-:::warning
+:::danger
 
 A user who creates resources in AWS will therefore own these resources. In this particular case, the user will always have admin access to the Kubernetes cluster until the cluster is deleted.
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/redhat-openshift.md
@@ -173,7 +173,7 @@ helm install camunda camunda/camunda-platform --skip-crds --version "$CHART_VERS
 
 If you must deploy using Helm 3.2.0 or greater, you have two options. One is to use a SCCs which defines the `RunAsUser` strategy to be at least `RunAsAny`. If that's not possible, then you need to make use of [a post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering).
 
-:::warning
+:::danger
 If using a post-renderer, you **must** use the post-renderer whenever you are updating your release, not only during the initial installation. If you do not, the default values will be used again, which will prevent some services from starting.
 :::
 
@@ -271,7 +271,7 @@ To use these routes for the Zeebe Gateway, configure this through Ingress as wel
 
 An alternative to using [routes](https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html) is to install and use one of the Kubernetes Ingress controllers instead, for example, the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx).
 
-:::warning
+:::danger
 
 Do not confuse the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx) with the [NGINX Ingress Controller](https://www.redhat.com/en/blog/using-nginx-ingress-controller-red-hat-openshift) that is endorsed by Red Hat for usage with OpenShift. Despite very similar names, they are two different products.
 

--- a/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -80,7 +80,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 ## Configure Identity
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [Connecting to an OpenID Connect provider](../platform-deployment/helm-kubernetes/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -297,7 +297,7 @@ Brokers:
 
 ### 4. Shut down the brokers when the scaling operation has completed
 
-:::warning
+:::danger
 If you shut down brokers before Zeebe has scaled down and moved all partitions away from the brokers, scaling operation would never complete and may result in data loss.
 :::
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -137,7 +137,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3
 
 This will generate a new certificate, `cert.pem`, and a new passwordless key, `key.pem`.
 
-:::warning
+:::danger
 Do not use these in production! Again, this is for development and testing purposes only.
 :::
 

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/zeebe-installation.md
@@ -4,7 +4,7 @@ title: "Overview"
 sidebar_label: "Overview"
 ---
 
-:::warning
+:::danger
 Zeebe does not support network file systems (NFS) other types of network storage volumes at this time. Usage of NFS may cause data corruption.
 :::
 

--- a/versioned_docs/version-8.5/components/connectors/out-of-the-box-connectors/google-sheets.md
+++ b/versioned_docs/version-8.5/components/connectors/out-of-the-box-connectors/google-sheets.md
@@ -258,7 +258,7 @@ the [Google Cloud API Library](https://console.cloud.google.com/apis/library).
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow
@@ -285,7 +285,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow

--- a/versioned_docs/version-8.5/components/connectors/out-of-the-box-connectors/googledrive.md
+++ b/versioned_docs/version-8.5/components/connectors/out-of-the-box-connectors/googledrive.md
@@ -84,7 +84,7 @@ You also enable _Google Docs API_ and _Google Drive API_ for every client intend
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/service-account).
 :::
@@ -108,7 +108,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/web-server).
 :::

--- a/versioned_docs/version-8.5/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.5/components/connectors/use-connectors/index.md
@@ -14,7 +14,7 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
-:::warning
+:::danger
 `secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
 :::
 

--- a/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.5/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -400,7 +400,7 @@ Configures the [task](../../../bpmn/service-tasks/#task-definition) for a servic
 
 #### `zeebe:taskDefinition:type`
 
-:::warning
+:::danger
 `zeebe:taskDefinition:type` is a deprecated binding. Instead, use `zeebe:taskDefinition` with `property=type`.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.5/self-managed/concepts/multi-region/dual-region.md
@@ -11,7 +11,7 @@ import DualRegion from "./img/dual-region.svg";
 
 Camunda 8 is compatible with a dual-region setup under certain [limitations](#limitations). This allows Camunda 8 to run in a mix of active-active and active-passive setups, resulting in an overall **active-passive** setup. The following will explore the concept, limitations, and considerations.
 
-:::warning
+:::danger
 
 You should get familiar with the topic, the [limitations](#limitations) of the dual-region setup, and the general [considerations](#considerations) on operating a dual-region setup.
 

--- a/versioned_docs/version-8.5/self-managed/identity/troubleshooting/troubleshoot-identity.md
+++ b/versioned_docs/version-8.5/self-managed/identity/troubleshooting/troubleshoot-identity.md
@@ -88,6 +88,6 @@ these options:
    3. In the `camunda-platform` realm, set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/latest/server_admin/#_ssl_modes) for your version of Keycloak.
    4. Restart the Identity service again. Identity should now start successfully
 
-:::warning
+:::danger
 We would only recommend that requirements for SSL are disabled in a development environment.
 :::

--- a/versioned_docs/version-8.5/self-managed/operate-deployment/operate-authentication.md
+++ b/versioned_docs/version-8.5/self-managed/operate-deployment/operate-authentication.md
@@ -151,7 +151,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 Identity requires the following parameters:
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [connecting to an OpenID Connect provider](/self-managed/setup/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/versioned_docs/version-8.5/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
@@ -35,7 +35,7 @@ psql -U <DATABASE_USER> -h <DATABASE_HOST> -p <DATABASE_PORT> -f dump.psql <DATA
 
 After the database has been restored, you can start Web Modeler again.
 
-:::warning
+:::danger
 When restoring Web Modeler data from a backup, ensure that the ids of the users stored in your OIDC provider (e.g. Keycloak) do not change in between the backup and restore.
 Otherwise, users may not be able to log in after the restore (see [Web Modeler's login troubleshooting guide](self-managed/modeler/web-modeler/troubleshooting/troubleshoot-login.md#unique-constraint-violation)).
 :::

--- a/versioned_docs/version-8.5/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -76,7 +76,7 @@ The **failover** phase of the procedure results in the temporary restoration of 
 
 The **failback** phase of the procedure results in completely restoring the failed region to its full functionality. It requires you to have the lost region ready again for the redeployment of Camunda 8.
 
-:::warning
+:::danger
 
 For the **failback** procedure, your recreated region cannot contain any active Camunda 8 deployments or leftover persistent volumes related to Camunda 8 or its Elasticsearch instance. You must start from a clean slate and not bring old data from the lost region, as states may have diverged.
 
@@ -556,7 +556,7 @@ You currently have the following setups:
 
 #### Desired state
 
-:::warning
+:::danger
 
 This step is very important to minimize the risk of losing any data when restoring the backup in the recreated region.
 

--- a/versioned_docs/version-8.5/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/update-guide/820-to-830.md
@@ -139,7 +139,7 @@ these data, users should be assigned to the `<default>` tenant [in Identity](../
 
 ## Connectors
 
-:::warning [Breaking changes!]
+:::danger [Breaking changes!]
 The HTTP Webhook Connector no longer returns a response body by default. If you want to return a response body, you must explicitly define a response body expression.
 See the [usage guide](../../../../components/connectors/use-connectors/inbound) or the [Webhook Connector documentation](../../../../components/connectors/protocol/http-webhook) for more details.
 :::

--- a/versioned_docs/version-8.5/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/update-guide/840-to-850.md
@@ -64,7 +64,7 @@ The `UserTask` events like `UserTask:CREATED` don't export the string value prop
 As a replacement, user task events now feature the string array properties `candidateUsersList` and `candidateGroupsList`.
 Custom exporters using these events must be modified accordingly.
 
-:::warning Breaking Change
+:::danger Breaking Change
 The values of the `candidateUsers` and `candidateGroups` properties in user task records are lost during an update from `8.4` to `8.5`.
 There is no data migration that moves the values from `candidateUsers` and `candidateGroups` to `candidateUsersList` and `candidateGroupsList`
 since the Zeebe user tasks are only experimental in `8.4`.

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
@@ -8,7 +8,7 @@ description: "Deploy two Amazon Kubernetes (EKS) clusters with Terraform for a p
 
 import CoreDNSKubeDNS from "./assets/core-dns-kube-dns.svg"
 
-:::warning
+:::danger
 Review our [dual-region concept documentation](./../../../../concepts/multi-region/dual-region.md) before continuing to understand the current limitations and restrictions of this blueprint setup.
 :::
 
@@ -33,7 +33,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 For the simplicity of this guide, certain best practices will be provided with links to additional resources, enabling you to explore the topic in more detail.
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), traffic between regions, and S3. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 
@@ -62,7 +62,7 @@ git clone -b stable/8.5 https://github.com/camunda/c8-multi-region.git
 2. The cloned repository and folder `aws/dual-region/scripts/` provides a helper script [export_environment_prerequisites.sh](https://github.com/camunda/c8-multi-region/blob/stable/8.5/aws/dual-region/scripts/export_environment_prerequisites.sh) to export various environment variables to ease the interaction with a dual-region setup. Consider permanently changing this file for future interactions.
 3. You must adjust these environment variable values within the script to your needs.
 
-:::warning
+:::danger
 
 You have to choose unique namespaces for Camunda 8 installations. The namespace for Camunda 8 installation in the cluster of region 0 (`CAMUNDA_NAMESPACE_0`), needs to have a different name from the namespace for Camunda 8 installation in the cluster of region 1 (`CAMUNDA_NAMESPACE_1`). This is required for proper traffic routing between the clusters.
 
@@ -105,7 +105,7 @@ It's recommended to use a different backend than `local`. Find more information 
 
 :::
 
-:::warning
+:::danger
 
 Do not store sensitive information (credentials) in your Terraform files.
 
@@ -164,7 +164,7 @@ There are several ways to authenticate the `AWS` provider:
 
 ### Execution
 
-:::warning
+:::danger
 
 A user who creates resources in AWS will therefore own these resources. In this particular case, the user will always have admin access to the Kubernetes cluster until the cluster is deleted.
 
@@ -450,7 +450,7 @@ This overlay contains the multi-region identification for the cluster in region 
 
 #### Preparation
 
-:::warning
+:::danger
 You must change the following environment variables for Zeebe. The default values will not work for you and are only for illustration.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -105,7 +105,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning
+:::danger
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
 In the example below, it's set to `external-dns` and should be changed if this identifier is already in use. Consult the [documentation](https://kubernetes-sigs.github.io/external-dns/v0.15.0/#note) to learn more about DNS record ownership.
@@ -189,7 +189,7 @@ For more configuration options, refer to the [Helm chart documentation](https://
 
 The following makes use of the [combined ingress setup](/self-managed/setup/guides/ingress-setup.md#combined-ingress-setup) by deploying a single ingress for all HTTP components and a separate ingress for the gRPC endpoint.
 
-:::warning
+:::danger
 
 Publicly exposing the Zeebe Gateway without authorization enabled can lead to severe security risks. Consider disabling the ingress for the Zeebe Gateway by setting the `zeebeGateway.ingress.grpc.enabled` and `zeebeGateway.ingress.rest.enabled` to `false`.
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
@@ -25,7 +25,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -33,7 +33,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 For the simplicity of this guide, certain best practices will be provided with links to additional documents, enabling you to explore the topic in more detail.
 
-:::warning
+:::danger
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 :::
 
@@ -90,13 +90,13 @@ There are several ways to authenticate the `AWS` provider.
 
 :::
 
-:::warning
+:::danger
 
 Do not store sensitive information (credentials) in your Terraform files.
 
 :::
 
-:::warning
+:::danger
 
 A user who creates resources in AWS will therefore own these resources. In this particular case, the user will always have admin access to the Kubernetes cluster until the cluster is deleted.
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/other/docker.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/other/docker.md
@@ -4,7 +4,7 @@ title: "Docker"
 keywords: ["camunda docker"]
 ---
 
-:::warning
+:::danger
 While the Docker images themselves are supported for production usage, [Docker Compose](/self-managed/setup/deploy/local/docker-compose.md) files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](/self-managed/setup/install.md) in production.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -103,7 +103,7 @@ global:
 </TabItem>
 </Tabs>
 
-:::warning
+:::danger
 Once set, your initial claim name and value cannot be updated using environment or Helm values, and must be changed directly in the database.
 :::
 
@@ -199,7 +199,7 @@ global:
 </TabItem>
 </Tabs>
 
-:::warning
+:::danger
 Once set, your initial claim name and value cannot be updated using environment or Helm values, and must be changed directly in the database.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -80,7 +80,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 ## Configure Identity
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [Connecting to an OpenID Connect provider](/self-managed/setup/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -297,7 +297,7 @@ Brokers:
 
 ### 4. Shut down the brokers when the scaling operation has completed
 
-:::warning
+:::danger
 If you shut down brokers before Zeebe has scaled down and moved all partitions away from the brokers, scaling operation would never complete and may result in data loss.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/security/client-authorization.md
@@ -222,7 +222,7 @@ public class SecureClient {
 
 #### Go
 
-:::warning
+:::danger
 The Go client _only_ supports gRPC calls, and as such the `CredentialsProvider` interface is tightly coupled to it.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -161,7 +161,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3
 
 This will generate a new certificate, `cert.pem`, and a new passwordless key, `key.pem`.
 
-:::warning
+:::danger
 Do not use these in production! Again, this is for development and testing purposes only.
 :::
 

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
@@ -4,7 +4,7 @@ title: "Interceptors"
 sidebar_label: "Interceptors"
 ---
 
-:::warning
+:::danger
 
 Interceptors are only applied to the gRPC API of the gateway, and do not affect any REST calls.
 As such, it's not possible yet to hook into the request/response cycle of a REST call, such as

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/zeebe-installation.md
@@ -4,7 +4,7 @@ title: "Overview"
 sidebar_label: "Overview"
 ---
 
-:::warning
+:::danger
 Zeebe does not support network file systems (NFS) other types of network storage volumes at this time. Usage of NFS may cause data corruption.
 :::
 

--- a/versioned_docs/version-8.6/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.6/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -45,7 +45,7 @@ For example, if you increase the `maxMessageSize` to 10MB, increase these proper
 
 ### Query API
 
-:::warning
+:::danger
 Query API endpoints do not currently support [resource authorizations][], and can be used to expand user access to restricted resources. If you use resource permissions, allowing public access to those endpoints is not recommended.
 :::
 

--- a/versioned_docs/version-8.6/apis-tools/testing/getting-started.md
+++ b/versioned_docs/version-8.6/apis-tools/testing/getting-started.md
@@ -15,7 +15,7 @@ CPT is based on [JUnit 5](https://junit.org/junit5/) and [Testcontainers](https:
 - Connectors
 - Elasticsearch
 
-:::warning Disclaimer
+:::danger Disclaimer
 For Camunda 8.6, CPT is in an [alpha version](/reference/alpha-features.md#alpha).
 
 For a mature testing library, take a look at [Zeebe Process Test](/apis-tools/java-client/zeebe-process-test.md).

--- a/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/email.md
+++ b/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/email.md
@@ -102,7 +102,7 @@ Example of a returned JSON array:
 
 Retrieve the contents of an email, using the unique `messageId` associated with the email message.
 
-:::warning
+:::danger
 Reading an email using POP3 protocol will delete the email
 :::
 

--- a/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/google-sheets.md
+++ b/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/google-sheets.md
@@ -258,7 +258,7 @@ the [Google Cloud API Library](https://console.cloud.google.com/apis/library).
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow
@@ -285,7 +285,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to
 security concerns.
 For production usage, follow

--- a/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/googledrive.md
+++ b/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/googledrive.md
@@ -84,7 +84,7 @@ You also enable _Google Docs API_ and _Google Drive API_ for every client intend
 
 #### Example 1: Obtaining JWT bearer token with a service account
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/service-account).
 :::
@@ -108,7 +108,7 @@ print(credentials.token)
 
 #### Example 2: Obtaining bearer and refresh tokens with OAuth client
 
-:::warning
+:::danger
 The following code snippet is for demonstration purposes only and must not be used for real production systems due to security concerns.
 For production usage, follow the [official Google guidelines](https://developers.google.com/identity/protocols/oauth2/web-server).
 :::

--- a/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/kafka.md
+++ b/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/kafka.md
@@ -353,7 +353,7 @@ This schema defines a structure for a record that includes a name (string), an a
 
 For example, `=(value.itemId = "a4f6j2")` only triggers the start event or continues the catch event if the Kafka message has a matching itemId in the incoming message payload. Leave this field empty to trigger your process every time.
 
-:::warning
+:::danger
 By default, this Connector does not commit the offset if the message cannot be processed. This includes cases where the activation condition is not met.
 This means that if there is a message in the topic that cannot be processed due to an activation condition mismatch, the Kafka subscription will be stopped.
 

--- a/versioned_docs/version-8.6/components/connectors/use-connectors/index.md
+++ b/versioned_docs/version-8.6/components/connectors/use-connectors/index.md
@@ -14,7 +14,7 @@ New to modeling with Camunda? The steps below assume some experience with Camund
 
 ## Using secrets
 
-:::warning
+:::danger
 `secrets.*` is a deprecated syntax. Instead, use `{{secrets.*}}`
 :::
 

--- a/versioned_docs/version-8.6/components/modeler/desktop-modeler/element-templates/defining-templates.md
+++ b/versioned_docs/version-8.6/components/modeler/desktop-modeler/element-templates/defining-templates.md
@@ -400,7 +400,7 @@ Configures the [task](../../../bpmn/service-tasks/#task-definition) for a servic
 
 #### `zeebe:taskDefinition:type`
 
-:::warning
+:::danger
 `zeebe:taskDefinition:type` is a deprecated binding. Instead, use `zeebe:taskDefinition` with `property=type`.
 :::
 

--- a/versioned_docs/version-8.6/guides/react-components/_install-plain-java.md
+++ b/versioned_docs/version-8.6/guides/react-components/_install-plain-java.md
@@ -10,7 +10,7 @@ For this installation, you must have:
 
 ### Download and configure Elasticsearch
 
-:::warning
+:::danger
 Disabling Elasticsearch's security packages is for non-production only!
 :::
 

--- a/versioned_docs/version-8.6/self-managed/identity/troubleshooting/troubleshoot-identity.md
+++ b/versioned_docs/version-8.6/self-managed/identity/troubleshooting/troubleshoot-identity.md
@@ -88,6 +88,6 @@ these options:
    3. In the `camunda-platform` realm, set `Require SSL` to `none` by following the steps in [SSL modes](https://www.keycloak.org/docs/latest/server_admin/#_ssl_modes) for your version of Keycloak.
    4. Restart the Identity service again. Identity should now start successfully
 
-:::warning
+:::danger
 We would only recommend that requirements for SSL are disabled in a development environment.
 :::

--- a/versioned_docs/version-8.6/self-managed/operate-deployment/operate-authentication.md
+++ b/versioned_docs/version-8.6/self-managed/operate-deployment/operate-authentication.md
@@ -151,7 +151,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 Identity requires the following parameters:
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [connecting to an OpenID Connect provider](/self-managed/setup/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/versioned_docs/version-8.6/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
@@ -35,7 +35,7 @@ psql -U <DATABASE_USER> -h <DATABASE_HOST> -p <DATABASE_PORT> -f dump.psql <DATA
 
 After the database has been restored, you can start Web Modeler again.
 
-:::warning
+:::danger
 When restoring Web Modeler data from a backup, ensure that the ids of the users stored in your OIDC provider (e.g. Keycloak) do not change in between the backup and restore.
 Otherwise, users may not be able to access their projects after the restore (see [Web Modeler's troubleshooting guide](self-managed/modeler/web-modeler/troubleshooting/troubleshoot-missing-data.md)).
 :::

--- a/versioned_docs/version-8.6/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/backup-restore/operate-tasklist-backup.md
@@ -8,7 +8,7 @@ keywords: ["backup", "backups"]
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-:::warning breaking changes!
+:::danger breaking changes!
 As of the Camunda 8.6 release, the `/actuator` endpoints (including `/backups`) now default to port 9600. Ensure your `management.server.port` configuration parameter is correctly set before continuing.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/operational-guides/multi-region/dual-region-ops.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/multi-region/dual-region-ops.md
@@ -724,7 +724,7 @@ Half of the amount of your set `clusterSize` is used to spawn Zeebe brokers.
 
 For example, in the case of `clusterSize: 8`, four Zeebe brokers are provisioned in the newly created region.
 
-:::warning
+:::danger
 It is expected that the Zeebe broker pods will not reach the "Ready" state since they are not yet part of a Zeebe cluster and, therefore, not considered healthy by the readiness probe.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/820-to-830.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/820-to-830.md
@@ -139,7 +139,7 @@ these data, users should be assigned to the `<default>` tenant [in Identity](../
 
 ## Connectors
 
-:::warning [Breaking changes!]
+:::danger [Breaking changes!]
 The HTTP Webhook Connector no longer returns a response body by default. If you want to return a response body, you must explicitly define a response body expression.
 See the [usage guide](../../../../components/connectors/use-connectors/inbound) or the [Webhook Connector documentation](../../../../components/connectors/protocol/http-webhook) for more details.
 :::

--- a/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/840-to-850.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/840-to-850.md
@@ -64,7 +64,7 @@ The `UserTask` events like `UserTask:CREATED` don't export the string value prop
 As a replacement, user task events now feature the string array properties `candidateUsersList` and `candidateGroupsList`.
 Custom exporters using these events must be modified accordingly.
 
-:::warning Breaking Change
+:::danger Breaking Change
 The values of the `candidateUsers` and `candidateGroups` properties in user task records are lost during an update from `8.4` to `8.5`.
 There is no data migration that moves the values from `candidateUsers` and `candidateGroups` to `candidateUsersList` and `candidateGroupsList`
 since the Zeebe user tasks are only experimental in `8.4`.

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -152,7 +152,7 @@ Consider setting `domainFilters` via `--set` to restrict access to certain hoste
 Make sure to have `EXTERNAL_DNS_IRSA_ARN` exported prior by either having followed the [eksctl](./eksctl.md#policy-for-external-dns) or [Terraform](./terraform-setup.md#outputs) guide.
 :::
 
-:::warning Uniqueness of txtOwnerId for DNS
+:::danger Uniqueness of txtOwnerId for DNS
 
 If you are already running `external-dns` in a different cluster, ensure each instance has a **unique** `txtOwnerId` for the TXT record. Without unique identifiers, the `external-dns` instances will conflict and inadvertently delete existing DNS records.
 
@@ -252,7 +252,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.6/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 
@@ -305,7 +305,7 @@ The annotation `kubernetes.io/tls-acme=true` will be [interpreted by cert-manage
 https://github.com/camunda/camunda-tf-eks-module/blob/main/examples/camunda-8.6-irsa/helm-values/values-domain.yml
 ```
 
-:::warning Exposure of the Zeebe Gateway
+:::danger Exposure of the Zeebe Gateway
 
 Publicly exposing the Zeebe Gateway without proper authorization can pose significant security risks. To avoid this, consider disabling the Ingress for the Zeebe Gateway by setting the following values to `false` in your configuration file:
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eksctl.md
@@ -35,7 +35,7 @@ To try out Camunda 8 or develop against it, consider signing up for our [SaaS of
 
 While the guide is primarily tailored for UNIX systems, it can also be run under Windows by utilizing the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/about).
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -54,7 +54,7 @@ Modules referenced in this guide have been updated recently from **v2** to **v3*
 
 :::
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your Cloud provider account, namely for the managed Kubernetes service, running Kubernetes nodes in EC2, Elastic Block Storage (EBS), and Route53. More information can be found on [AWS](https://aws.amazon.com/eks/pricing/) and their [pricing calculator](https://calculator.aws/#/) as the total cost varies per region.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
@@ -48,7 +48,7 @@ For testing Camunda 8 or developing against it, you might consider signing up fo
 
 To keep this guide concise, we provide links to additional documentation covering best practices, allowing you to explore each topic in greater depth.
 
-:::warning Cost management
+:::danger Cost management
 
 Following this guide will incur costs on your cloud provider account and your Red Hat account, specifically for the managed OpenShift service, OpenShift worker nodes running in EC2, the hosted control plane, Elastic Block Storage (EBS), and Route 53. For more details, refer to [ROSA AWS pricing](https://aws.amazon.com/rosa/pricing/) and the [AWS Pricing Calculator](https://calculator.aws/#/) as total costs vary by region.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/openshift/redhat-openshift.md
@@ -65,7 +65,7 @@ You can find a reference example of this file here:
 https://github.com/camunda/camunda-deployment-references/blob/main/aws/rosa-hcp/camunda-versions/8.6/procedure/install/helm-values/base.yml
 ```
 
-:::warning Merging YAML files
+:::danger Merging YAML files
 
 This guide references multiple configuration files that need to be merged into a single YAML file. Be cautious to avoid duplicate keys when merging the files. Additionally, pay close attention when copying and pasting YAML content. Ensure that the separator notation `---` does not inadvertently split the configuration into multiple documents.
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/other/docker.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/other/docker.md
@@ -5,7 +5,7 @@ keywords: ["camunda docker"]
 description: "Step through multi-platform support, configuration, Docker images, and Docker Compose."
 ---
 
-:::warning
+:::danger
 While the Docker images themselves are supported for production usage, [Docker Compose](/self-managed/setup/deploy/local/docker-compose.md) files are designed to be used by developers to run an environment locally; they are not designed to be used in production. We recommend to use [Kubernetes](/self-managed/setup/install.md) in production.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/setup/guides/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.6/self-managed/setup/guides/connect-to-an-oidc-provider.md
@@ -206,7 +206,7 @@ global:
 </TabItem>
 </Tabs>
 
-:::warning
+:::danger
 Once set, your initial claim name and value cannot be updated using environment or Helm values, and must be changed directly in the database.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -80,7 +80,7 @@ export SPRING_PROFILES_ACTIVE=identity-auth
 
 ## Configure Identity
 
-:::warning
+:::danger
 These configuration variables are deprecated. To connect using the updated values, see [Connecting to an OpenID Connect provider](/self-managed/setup/guides/connect-to-an-oidc-provider.md).
 :::
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -297,7 +297,7 @@ Brokers:
 
 ### 4. Shut down the brokers when the scaling operation has completed
 
-:::warning
+:::danger
 If you shut down brokers before Zeebe has scaled down and moved all partitions away from the brokers, scaling operation would never complete and may result in data loss.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -103,7 +103,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3
 
 This will generate a new certificate, `cert.pem`, and a new passwordless key, `key.pem`.
 
-:::warning
+:::danger
 Do not use these in production! Again, this is for development and testing purposes only.
 :::
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/zeebe-gateway/filters.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/zeebe-gateway/filters.md
@@ -5,7 +5,7 @@ sidebar_label: "Filters"
 description: "All communication from a client to a broker must first pass through a gateway. There, it can be filtered before being dispatched."
 ---
 
-:::warning
+:::danger
 
 Filters are only applied to the REST API of the gateway, and do not affect any gRPC calls.
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/zeebe-gateway/interceptors.md
@@ -4,7 +4,7 @@ title: "Interceptors"
 sidebar_label: "Interceptors"
 ---
 
-:::warning
+:::danger
 
 Interceptors are only applied to the gRPC API of the gateway, and do not affect any REST calls.
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/zeebe-installation.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/zeebe-installation.md
@@ -4,7 +4,7 @@ title: "Overview"
 sidebar_label: "Overview"
 ---
 
-:::warning
+:::danger
 Zeebe does not support network file systems (NFS) other types of network storage volumes at this time. Usage of NFS may cause data corruption.
 :::
 


### PR DESCRIPTION
## Description

Replaces all usage of `:::warning` with `:::danger`. 

## Why?

As pointed out by @Langleu, in Docusaurus 3 the semantics of the `:::warning` admonition changed. 

Previously, it was emitted as a red "danger" block, like in this old preview site from before the docusaurus 3 upgrade:

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/b7eaccd9-6f06-496a-910e-ff9dcbe2a284" />

In Docusaurus 3, it is now emitted as a yellow "caution" block, like in the live docs:

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/0a040f3c-e0c9-4fd7-b127-d27551df1507" />



## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label). Not disastrous, but I would like to merge it this morning before I start cutting versions for 8.7/8.8 alpha.
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) 