### PR TITLE
chore: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,8 @@
 
 <!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->
 
-- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
-- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.
+- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8) and/or the `/versioned_docs/version-8.7/` directory.
+- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
 
 <!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
 - [ ] I included my new page in the sidebar file(s).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,9 @@
 
 <!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->
 
-- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8) and/or the `/versioned_docs/version-8.7/` directory.
+- [ ] My changes are for **an upcoming minor release** and:
+  - [ ] are in the `/docs` directory (version 8.8).
+  - [ ] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
 - [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
 
 <!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.


### PR DESCRIPTION
## Description

Now that we have two "next" versions, the PR template is a little confusing.

I don't feel great about hardcoding version numbers in the PR template, but I think doing so adds the most clarity possible, and that's what we need in these confusing times.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
