### PR TITLE
fix: spelling

### DIFF
--- a/docs/components/early-access/alpha/sap/rfc-connector.md
+++ b/docs/components/early-access/alpha/sap/rfc-connector.md
@@ -42,7 +42,7 @@ A descriptor file is required to deploy the SAP RFC Connector to a space in a SA
 ### Deploying to BTP
 
 1. Find the matching `.war` archive for the targeted Camunda 8 SaaS version.  
-    The version follows the format `<C8 version major>.<C8 version minor>.<OData connector version>`.  
+    The version follows the format `<C8 version major>.<C8 version minor>.<RFC connector version>`.  
    Examples:
 
    - `rfc-8.6.0.war` is the RFC Connector in version `0` for C8 SaaS version `8.6`

--- a/versioned_docs/version-8.7/components/early-access/alpha/sap/rfc-connector.md
+++ b/versioned_docs/version-8.7/components/early-access/alpha/sap/rfc-connector.md
@@ -42,7 +42,7 @@ A descriptor file is required to deploy the SAP RFC Connector to a space in a SA
 ### Deploying to BTP
 
 1. Find the matching `.war` archive for the targeted Camunda 8 SaaS version.  
-    The version follows the format `<C8 version major>.<C8 version minor>.<OData connector version>`.  
+    The version follows the format `<C8 version major>.<C8 version minor>.<RFC connector version>`.  
    Examples:
 
    - `rfc-8.6.0.war` is the RFC Connector in version `0` for C8 SaaS version `8.6`


### PR DESCRIPTION
## Description

accidentally mentioned `OData` in the RFC doc, which (obviously) throws people off 😬 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

Once final location of the "SAP Integration" docs are determined, this will need backporting to 8.5 and 8.6 as well.
But for now, `alpha` in `next` docs (both 8.7 and 8.8) is fine.

- [x] My changes are for the **next minor** and are in `/docs` directory (aka `/next/`).
- [ ] My changes are for an **already released minor** and are in `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.


