### PR TITLE
Revert "bump to alpha3"

### DIFF
--- a/docs/guides/react-components/_install-c8run.md
+++ b/docs/guides/react-components/_install-c8run.md
@@ -11,7 +11,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 
 ### Install and start Camunda 8 Run
 
-1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha3) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
+1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha2) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
 2. Navigate to the new `c8run` directory.
 3. Start Camunda 8 Run by running `./start.sh` (or `.\c8run.exe start` on Windows) in your terminal.
 

--- a/docs/guides/react-components/_install-plain-java.md
+++ b/docs/guides/react-components/_install-plain-java.md
@@ -6,7 +6,7 @@
 For this installation, you must have:
 
 - OpenJDK 21+ locally installed
-- Camunda `8.7.0-alpha3` or later
+- Camunda `8.6.0-alpha2` or later
 
 ### Download and configure Elasticsearch
 
@@ -22,7 +22,7 @@ Confirm Elasticsearch is running by visiting `http://localhost:9200` in a browse
 
 ### Download and configure Camunda
 
-1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.6.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha3).
+1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.6.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
 2. Navigate to the directory where you installed Camunda, and open `/config/application.yaml`. Add the following Elasticsearch exporter as a child of the `zeebe`/`broker` configuration element:
 
 ```

--- a/docs/guides/react-components/_install-plain-java.md
+++ b/docs/guides/react-components/_install-plain-java.md
@@ -22,7 +22,7 @@ Confirm Elasticsearch is running by visiting `http://localhost:9200` in a browse
 
 ### Download and configure Camunda
 
-1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.7.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
+1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.7.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha2).
 2. Navigate to the directory where you installed Camunda, and open `/config/application.yaml`. Add the following Elasticsearch exporter as a child of the `zeebe`/`broker` configuration element:
 
 ```

--- a/docs/guides/react-components/_install-plain-java.md
+++ b/docs/guides/react-components/_install-plain-java.md
@@ -22,7 +22,7 @@ Confirm Elasticsearch is running by visiting `http://localhost:9200` in a browse
 
 ### Download and configure Camunda
 
-1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.6.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
+1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.7.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
 2. Navigate to the directory where you installed Camunda, and open `/config/application.yaml`. Add the following Elasticsearch exporter as a child of the `zeebe`/`broker` configuration element:
 
 ```

--- a/docs/guides/react-components/_install-plain-java.md
+++ b/docs/guides/react-components/_install-plain-java.md
@@ -6,7 +6,7 @@
 For this installation, you must have:
 
 - OpenJDK 21+ locally installed
-- Camunda `8.6.0-alpha2` or later
+- Camunda `8.7.0-alpha2` or later
 
 ### Download and configure Elasticsearch
 

--- a/versioned_docs/version-8.7/guides/react-components/_install-c8run.md
+++ b/versioned_docs/version-8.7/guides/react-components/_install-c8run.md
@@ -11,7 +11,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 
 ### Install and start Camunda 8 Run
 
-1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha3) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
+1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha2) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
 2. Navigate to the new `c8run` directory.
 3. Start Camunda 8 Run by running `./start.sh` (or `.\c8run.exe start` on Windows) in your terminal.
 

--- a/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
+++ b/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
@@ -6,7 +6,7 @@
 For this installation, you must have:
 
 - OpenJDK 21+ locally installed
-- Camunda `8.7.0-alpha3` or later
+- Camunda `8.6.0-alpha2` or later
 
 ### Download and configure Elasticsearch
 
@@ -22,7 +22,7 @@ Confirm Elasticsearch is running by visiting `http://localhost:9200` in a browse
 
 ### Download and configure Camunda
 
-1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.6.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha3).
+1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.6.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
 2. Navigate to the directory where you installed Camunda, and open `/config/application.yaml`. Add the following Elasticsearch exporter as a child of the `zeebe`/`broker` configuration element:
 
 ```

--- a/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
+++ b/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
@@ -22,7 +22,7 @@ Confirm Elasticsearch is running by visiting `http://localhost:9200` in a browse
 
 ### Download and configure Camunda
 
-1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.7.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
+1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.7.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha2).
 2. Navigate to the directory where you installed Camunda, and open `/config/application.yaml`. Add the following Elasticsearch exporter as a child of the `zeebe`/`broker` configuration element:
 
 ```

--- a/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
+++ b/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
@@ -22,7 +22,7 @@ Confirm Elasticsearch is running by visiting `http://localhost:9200` in a browse
 
 ### Download and configure Camunda
 
-1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.6.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
+1. Download and extract the [latest `camunda-zeebe-` release artifact](https://github.com/camunda/camunda/releases) in the **Assets** section of the release page, starting with [8.7.0-alpha2](https://github.com/camunda/camunda/releases/tag/8.6.0-alpha2).
 2. Navigate to the directory where you installed Camunda, and open `/config/application.yaml`. Add the following Elasticsearch exporter as a child of the `zeebe`/`broker` configuration element:
 
 ```

--- a/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
+++ b/versioned_docs/version-8.7/guides/react-components/_install-plain-java.md
@@ -6,7 +6,7 @@
 For this installation, you must have:
 
 - OpenJDK 21+ locally installed
-- Camunda `8.6.0-alpha2` or later
+- Camunda `8.7.0-alpha2` or later
 
 ### Download and configure Elasticsearch
 


### PR DESCRIPTION
Reverts camunda/camunda-docs#4990 as 8.7.0-alpha4 was not released yet and alpha3 has issues.