### PR TITLE
Job streaming should be disabled by default

### DIFF
--- a/docs/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/docs/apis-tools/spring-zeebe-sdk/configuration.md
@@ -510,7 +510,7 @@ You could also provide a custom class that can customize the `JobWorker` configu
 
 Read more about this feature in the [job streaming documentation](/apis-tools/java-client/job-worker.md#job-streaming).
 
-To enable job streaming on the Zeebe client, you can configure it:
+Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, you can configure it:
 
 ```yaml
 camunda:

--- a/docs/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/docs/apis-tools/spring-zeebe-sdk/configuration.md
@@ -510,7 +510,7 @@ You could also provide a custom class that can customize the `JobWorker` configu
 
 Read more about this feature in the [job streaming documentation](/apis-tools/java-client/job-worker.md#job-streaming).
 
-Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, you can configure it:
+Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, configure it as follows:
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
@@ -497,7 +497,7 @@ You could also provide a custom class that can customize the `JobWorker` configu
 
 Read more about this feature in the [job streaming documentation](/apis-tools/java-client/job-worker.md#job-streaming).
 
-To enable job streaming on the Zeebe client, you can configure it:
+Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, you can configure it:
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
@@ -497,7 +497,7 @@ You could also provide a custom class that can customize the `JobWorker` configu
 
 Read more about this feature in the [job streaming documentation](/apis-tools/java-client/job-worker.md#job-streaming).
 
-Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, you can configure it:
+Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, configure it as follows:
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/configuration.md
@@ -510,7 +510,7 @@ You could also provide a custom class that can customize the `JobWorker` configu
 
 Read more about this feature in the [job streaming documentation](/apis-tools/java-client/job-worker.md#job-streaming).
 
-To enable job streaming on the Zeebe client, you can configure it:
+Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, you can configure it:
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/configuration.md
@@ -510,7 +510,7 @@ You could also provide a custom class that can customize the `JobWorker` configu
 
 Read more about this feature in the [job streaming documentation](/apis-tools/java-client/job-worker.md#job-streaming).
 
-Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, you can configure it:
+Job streaming is disabled by default for job workers. To enable job streaming on the Zeebe client, configure it as follows:
 
 ```yaml
 camunda:


### PR DESCRIPTION
- Job streaming should be is disabled by default for job workers.

## Description

Job streaming should be disabled by default for job workers.

Currently, job streaming is enabled by default for job workers and this can lead to 504 issues logged in the application if it's not configured correctly. Since it's not expected to be enabled by default, users are not aware that they need to configure it accordingly.

Related issue: https://github.com/camunda/camunda/issues/27502
Fix and backports: https://github.com/camunda/camunda/pull/28239

closes #5021

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
