### PR TITLE
fix: let vale print the problem and solution

### DIFF
--- a/styles/camunda/all/americanBritish.yml
+++ b/styles/camunda/all/americanBritish.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "British English writing style detected. Use American spelling instead."
+message: "British English writing style detected. Use `%s` instead of `%s`. Use American spelling instead."
 level: error
 ignorecase: true
 swap:

--- a/styles/camunda/all/codeBlocksAreOurs.yml
+++ b/styles/camunda/all/codeBlocksAreOurs.yml
@@ -1,8 +1,8 @@
 extends: existence
-message: "Improper codeblock source: '%s'. Please only reference codeblocks from Camunda GitHub orgs."
+message: "Improper codeblock source: `%s`. Please only reference codeblocks from Camunda GitHub orgs."
 level: error
 nonword: true
 scope: raw
 tokens:
   # Captures any referenced codeblocks that point at a non-Camunda github org.
-  - "`{3}.*\nhttps://github.com/(?!camunda|camunda-cloud).*\n`{3}"
+  - "`{3}.*\nhttps://github.com/(?!camunda/|camunda-cloud/).*\n`{3}"

--- a/styles/camunda/all/codeBlocksAreOurs.yml
+++ b/styles/camunda/all/codeBlocksAreOurs.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Improper codeblock source: `%s`. Please only reference codeblocks from Camunda GitHub orgs."
+message: "Improper codeblock source: '%s'. Please only reference codeblocks from Camunda GitHub orgs."
 level: error
 nonword: true
 scope: raw

--- a/styles/camunda/all/glossary.yml
+++ b/styles/camunda/all/glossary.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "This term is spelled, uppercased, lowercased, hyphenated, or used incorrectly. Review the WCoE glossary."
+message: "Inconsistent spelling detected. Use `%s` instead of `%s`. Review the WCoE glossary - https://confluence.camunda.com/x/b5RZBw ."
 level: error
 ignorecase: false
 swap:

--- a/styles/camunda/all/inclusiveLanguage.yml
+++ b/styles/camunda/all/inclusiveLanguage.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Non-inclusive terminology used. Review the WCoE for using inclusive language."
+message: "Non-inclusive terminology used. Use `%s` instead of `%s`. Review the WCoE for using inclusive language - https://confluence.camunda.com/x/VYNBCw ."
 level: error
 ignorecase: true
 swap:


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Related to the [slack thread](https://camunda.slack.com/archives/C026U8GBNSW/p1739976167023769)

Adds vale outputs for:
- technical glossary
- inclusive language
- American English

Adds confluence related pages for:
- technical glossary
- inclusive language

TBH with vale now printing error and solution, might even be able to drop the URL reference or just keep it as reference so people can get there quickly. I opted for just the URL as if you run vale cli locally it won't transform markdown but feel free to adjust.

Fixed the code block references.
The regex was too lash allowing something like `camundaluckyluke`, anything as long as it contains camunda.

Example outputs of vale:

```
 34:1  error  Improper codeblock                   all.codeBlocksAreOurs
              source: '```bash reference
              https://github.com/camundaluckyluke
              ```'. Please only reference
              codeblocks from Camunda GitHub
              orgs.
 40:1  error  British English writing style            all.americanBritish
              detected. Use `organize`
              instead of `organise`. Use
              American spelling instead.
 42:1  error  Inconsistent spelling detected.          all.glossary
              Use `Ingress` instead of `ingress`.
              Review the WCoE glossary -
              https://confluence.camunda.com/x/b5RZBw
              .
 44:1  error  Non-inclusive terminology used. Use      all.inclusiveLanguage
              `follower` instead of `slave`. Review
              the WCoE for using inclusive language -
              https://confluence.camunda.com/x/VYNBCw
              .
```


// edit: switched back the code block to be surrounded by single quotes, makes a lot more sense.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and:
  - [ ] are in the `/docs` directory (version 8.8).
  - [ ] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
