### PR TITLE
Update configuration to match PKCS12 support

### DIFF
--- a/docs/self-managed/zeebe-deployment/configuration/broker.md
+++ b/docs/self-managed/zeebe-deployment/configuration/broker.md
@@ -160,11 +160,14 @@ network:
 
 ### zeebe.broker.network.security
 
-| Field                | Description                                                                                                                                                                                 | Example Value |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_ENABLED`. | false         |
-| certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                       |               |
-| privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                          |               |
+| Field                | Description                                                                                                                                                                                                  | Example Value |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_ENABLED`.                  | false         |
+| certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                                        |               |
+| privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                                           |               |
+| keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                               |               |
+| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet
 
@@ -173,6 +176,9 @@ security:
   enabled: false
   certificateChainPath:
   privateKeyPath:
+  keyStore:
+    filePath:
+    password:
 ```
 
 ### zeebe.broker.network.commandApi

--- a/docs/self-managed/zeebe-deployment/configuration/broker.md
+++ b/docs/self-managed/zeebe-deployment/configuration/broker.md
@@ -174,11 +174,11 @@ network:
 ```yaml
 security:
   enabled: false
-  certificateChainPath:
-  privateKeyPath:
+  certificateChainPath: null
+  privateKeyPath: null
   keyStore:
-    filePath:
-    password:
+    filePath: null
+    password: null
 ```
 
 ### zeebe.broker.network.commandApi

--- a/docs/self-managed/zeebe-deployment/configuration/broker.md
+++ b/docs/self-managed/zeebe-deployment/configuration/broker.md
@@ -166,7 +166,7 @@ network:
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                                        |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                                           |               |
 | keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                               |               |
-| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.filePath    | The path for keystore file; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                            | /path/key.pem |
 | keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -256,11 +256,11 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 ```yaml
 security:
   enabled: false
-  certificateChainPath:
-  privateKeyPath:
+  certificateChainPath: null
+  privateKeyPath: null
   keyStore:
-    filePath:
-    password:
+    filePath: null
+    password: null
 ```
 
 ### zeebe.gateway.cluster.security.authentication

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -248,7 +248,7 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                                        |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                                           |               |
 | keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                                |               |
-| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.filePath    | The path for keystore file; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                            | /path/key.pem |
 | keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet

--- a/docs/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/docs/self-managed/zeebe-deployment/configuration/gateway.md
@@ -242,19 +242,25 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 
 :::
 
-| Field                | Description                                                                                                                                                                                  | Example value |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED`. | false         |
-| certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                       |               |
-| privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                          |               |
+| Field                | Description                                                                                                                                                                                                   | Example value |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED`.                  | false         |
+| certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                                        |               |
+| privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                                           |               |
+| keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                                |               |
+| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet
 
 ```yaml
 security:
   enabled: false
-  certificateChainPath: null
-  privateKeyPath: null
+  certificateChainPath:
+  privateKeyPath:
+  keyStore:
+    filePath:
+    password:
 ```
 
 ### zeebe.gateway.cluster.security.authentication

--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -97,11 +97,11 @@ security:
   # Currently only supports PKCS#12 format.
   keyStore:
     # The path for the keystore file
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_PKCS12_FILEPATH
+    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH
     filePath:
 
     # Sets the password for the keystore file, if not set it is assumed there is no password
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_PKCS12_PASSWORD
+    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD
     password:
 ```
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/broker.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/broker.md
@@ -162,7 +162,7 @@ network:
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                          |               |
 | keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                               |               |
-| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.filePath    | The path for keystore file; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                            | /path/key.pem |
 | keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/broker.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/broker.md
@@ -161,14 +161,20 @@ network:
 | enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_ENABLED`. | false         |
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                          |               |
+| keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                               |               |
+| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet
 
 ```yaml
 security:
   enabled: false
-  certificateChainPath:
-  privateKeyPath:
+  certificateChainPath: null
+  privateKeyPath: null
+  keyStore:
+    filePath: null
+    password: null
 ```
 
 ### zeebe.broker.network.commandApi

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/gateway.md
@@ -223,6 +223,9 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 | enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED`. | false         |
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                          |               |
+| keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                                |               |
+| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet
 
@@ -231,6 +234,9 @@ security:
   enabled: false
   certificateChainPath: null
   privateKeyPath: null
+  keyStore:
+    filePath: null
+    password: null
 ```
 
 ### zeebe.gateway.cluster.security.authentication

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/gateway.md
@@ -224,7 +224,7 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                          |               |
 | keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                                |               |
-| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.filePath    | The path for keystore file; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                            | /path/key.pem |
 | keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -97,11 +97,11 @@ security:
   # Currently only supports PKCS#12 format.
   keyStore:
     # The path for the keystore file
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_PKCS12_FILEPATH
+    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH
     filePath:
 
     # Sets the password for the keystore file, if not set it is assumed there is no password
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_PKCS12_PASSWORD
+    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD
     password:
 ```
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/broker.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/broker.md
@@ -165,14 +165,20 @@ network:
 | enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_ENABLED`. | false         |
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                          |               |
+| keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                               |               |
+| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet
 
 ```yaml
 security:
   enabled: false
-  certificateChainPath:
-  privateKeyPath:
+  certificateChainPath: null
+  privateKeyPath: null
+  keyStore:
+    filePath: null
+    password: null
 ```
 
 ### zeebe.broker.network.commandApi

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/broker.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/broker.md
@@ -166,7 +166,7 @@ network:
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH`.                          |               |
 | keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                               |               |
-| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.filePath    | The path for keystore file; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH`.                                                            | /path/key.pem |
 | keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/gateway.md
@@ -247,6 +247,9 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 | enabled              | Enables TLS authentication between this gateway and other nodes in the cluster. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED`. | false         |
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                          |               |
+| keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                                |               |
+| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet
 
@@ -255,6 +258,9 @@ security:
   enabled: false
   certificateChainPath: null
   privateKeyPath: null
+  keyStore:
+    filePath: null
+    password: null
 ```
 
 ### zeebe.gateway.cluster.security.authentication

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/gateway.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/gateway.md
@@ -248,7 +248,7 @@ You can read more about intra-cluster security on [its dedicated page](../securi
 | certificateChainPath | Sets the path to the certificate chain file. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH`.                       |               |
 | privateKeyPath       | Sets the path to the private key file location. This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH`.                          |               |
 | keyStore             | Configures the keystore file containing both the certificate chain and the private key; currently only supports PKCS12 format.                                                                                |               |
-| keyStore.filePath    | The path for keystore file;  This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                           | /path/key.pem |
+| keyStore.filePath    | The path for keystore file; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_FILEPATH`.                                                            | /path/key.pem |
 | keyStore.password    | Sets the password for the keystore file, if not set it is assumed there is no password; This setting can also be overridden using the environment variable `ZEEBE_GATEWAY_CLUSTER_SECURITY_KEYSTORE_PASSWORD` | changeme      |
 
 #### YAML snippet

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -97,11 +97,11 @@ security:
   # Currently only supports PKCS#12 format.
   keyStore:
     # The path for the keystore file
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_PKCS12_FILEPATH
+    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_FILEPATH
     filePath:
 
     # Sets the password for the keystore file, if not set it is assumed there is no password
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_PKCS12_PASSWORD
+    # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_KEYSTORE_PASSWORD
     password:
 ```
 


### PR DESCRIPTION
## Description

This PR fixes the documentation around broker/gateway configuration support for PKCS12 keystores. Parts were missing in the general configuration overview, while in others we referenced the wrong environment variables.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.