### PR TITLE
docs: renamed archiver to history and removed enable setting

### DIFF
--- a/docs/self-managed/zeebe-deployment/exporters/camunda-exporter.md
+++ b/docs/self-managed/zeebe-deployment/exporters/camunda-exporter.md
@@ -35,13 +35,13 @@ As the exporter is packaged with Zeebe, it is not necessary to specify a `jarPat
 
 Configure the exporter by providing `args`. See the tables below for configuration options and default values, or review the [example YAML configuration](#example).
 
-| Option       | Description                                                                                                        | Default |
-| ------------ | ------------------------------------------------------------------------------------------------------------------ | ------- |
-| connect      | Refer to [Connect](./camunda-exporter.md?configuration=connect#options) for the connection configuration options.  |         |
-| index        | Refer to [Index](./camunda-exporter.md?configuration=index#options) for the index configuration options.           |         |
-| bulk         | Refer to [Bulk](./camunda-exporter.md?configuration=bulk#options) for the bulk configuration options.              |         |
-| archiver     | Refer to [Archiver](./camunda-exporter.md?configuration=archiver#options) for the retention configuration options. |         |
-| createSchema | If `true` missing indexes will be created automatically.                                                           | true    |
+| Option       | Description                                                                                                       | Default |
+| ------------ | ----------------------------------------------------------------------------------------------------------------- | ------- |
+| connect      | Refer to [Connect](./camunda-exporter.md?configuration=connect#options) for the connection configuration options. |         |
+| index        | Refer to [Index](./camunda-exporter.md?configuration=index#options) for the index configuration options.          |         |
+| bulk         | Refer to [Bulk](./camunda-exporter.md?configuration=bulk#options) for the bulk configuration options.             |         |
+| history      | Refer to [History](./camunda-exporter.md?configuration=history#options) for the retention configuration options.  |         |
+| createSchema | If `true` missing indexes will be created automatically.                                                          | true    |
 
 ### Options
 
@@ -135,14 +135,13 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 
 </TabItem>
 
-<TabItem value="archiver">
+<TabItem value="history">
 
-To keep the main runtime index performant, the archiver periodically moves documents into historical
-indices. The archiver can be configured as follows:
+To keep the main runtime index performant, documents are periodically moved into historical
+indices. The history can be configured as follows:
 
 | Option                    | Description                                                                                                                                                                                                   | Default |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| enabled                   | If `true` archiver is enabled.                                                                                                                                                                                | `true`  |
 | elsRolloverDateFormat     | Defines how the date values are formatted for historical indices using Java DateTimeFormatter syntax, if no format is specified the first date format specified in teh field mapping is used.                 | `date`  |
 | rolloverInterval          | The time range for groups captured by the historical indices.                                                                                                                                                 | `1d`    |
 | rolloverBatchSize         | The max number of instances for each batch that is being archived.                                                                                                                                            | `100`   |
@@ -196,8 +195,7 @@ exporters:
         numberOfShards: 3
         numberOfReplicas: 0
 
-      archiver:
-        enabled: true
+      history:
         elsRolloverDateFormat: "date"
         rolloverInterval: "1d"
         rolloverBatchSize: 100


### PR DESCRIPTION
## Description

- The archiver properties will be renamed to history.
- Remove the disabling of the archiver e.g. remove `archiver.enable`

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [ ] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
