### PR TITLE
fix(workflow): lychee cache

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,16 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - name: Get Current Timestamp
-        id: timestamp
-        run: echo "TIMESTAMP=$(date +%s)" >> "$GITHUB_ENV"
+      - name: Get Current Date
+        id: dateofday
+        run: echo "DATEOFDAY=$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Restore lychee cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: .lycheecache
-          key: "cache-lychee-${{ env.TIMESTAMP }}"
-          restore-keys: cache-lychee-
+          key: cache-lychee-${{ env.DATEOFDAY }}
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.9.0
@@ -29,6 +28,12 @@ jobs:
           fail: true
           args: -c ./lychee-external-links.toml --base . --cache --max-cache-age 1d . --verbose --no-progress 'docs/**/*.md' 'versioned_docs/**/*.md'
           token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Cache links
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ env.DATEOFDAY }}
 
       - name: Create Issue From File
         if: ${{ github.event_name == 'schedule' && env.lychee_exit_code != 0 }}


### PR DESCRIPTION
## Description

The current implement of the cache mechanism in lychee workflow does not work as it uses the current timestamp and will never hit the cache.

By using the day, the cache will last 1 day.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and:
  - [ ] are in the `/docs` directory (version 8.8).
  - [ ] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
