### PR TITLE
fix: make link to c8run release dynamic

### DIFF
--- a/docs/self-managed/setup/deploy/local/c8run.md
+++ b/docs/self-managed/setup/deploy/local/c8run.md
@@ -8,6 +8,7 @@ description: "Use the Camunda 8 Run single application script to set up a local 
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import {C8Run} from "@site/src/components/CamundaDistributions";
 
 :::note
 Camunda 8 Run is not supported for production use.
@@ -39,7 +40,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 
 ## Install and start Camunda 8 Run
 
-1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.8.0-alpha2) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
+1. Download the latest release of <C8Run/> for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
 2. Navigate to the new `c8run` directory.
 3. Start Camunda 8 Run by running one of the following in your terminal:
    - `./start.sh` (or `.\c8run.exe start` on Windows): start Camunda 8 Run as a Java application.

--- a/src/components/CamundaDistributions/C8Run.jsx
+++ b/src/components/CamundaDistributions/C8Run.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useActiveVersion } from "@docusaurus/plugin-content-docs/client";
+
+const C8RunBaseURL =
+  "https://github.com/camunda/camunda/releases/tag";
+
+const getVersion = () => {
+  const docsVersion = useActiveVersion();
+  if (docsVersion.label == "8.7 (unreleased)") {
+    return "8.7";
+  }
+  if (docsVersion.label == "8.8 (unreleased)") {
+    return "8.8"
+  }
+  return docsVersion.label;
+};
+
+const C8Run = () => {
+  const version = getVersion();
+  return (
+    <a
+      title={`${C8RunBaseURL}/c8run-${version}/`}
+      href={`${C8RunBaseURL}/c8run-${version}/`}
+    >
+      Camunda 8 Run
+    </a>
+  );
+};
+
+export default C8Run;

--- a/src/components/CamundaDistributions/C8Run.jsx
+++ b/src/components/CamundaDistributions/C8Run.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useActiveVersion } from "@docusaurus/plugin-content-docs/client";
 
 const C8RunBaseURL =
-  "https://github.com/camunda/camunda/releases/tag";
+"https://github.com/camunda/camunda/releases/tag";
 
 const getVersion = () => {
   const docsVersion = useActiveVersion();
@@ -10,7 +10,7 @@ const getVersion = () => {
     return "8.7";
   }
   if (docsVersion.label == "8.8 (unreleased)") {
-    return "8.8"
+    return "8.8";
   }
   return docsVersion.label;
 };

--- a/src/components/CamundaDistributions/C8Run.jsx
+++ b/src/components/CamundaDistributions/C8Run.jsx
@@ -6,13 +6,10 @@ const C8RunBaseURL =
 
 const getVersion = () => {
   const docsVersion = useActiveVersion();
-  if (docsVersion.label == "8.7 (unreleased)") {
-    return "8.7";
-  }
-  if (docsVersion.label == "8.8 (unreleased)") {
+  if (docsVersion.name == "current") {
     return "8.8";
   }
-  return docsVersion.label;
+  return docsVersion.name;
 };
 
 const C8Run = () => {

--- a/src/components/CamundaDistributions/index.jsx
+++ b/src/components/CamundaDistributions/index.jsx
@@ -1,1 +1,2 @@
 export { default as DockerCompose } from "./DockerCompose";
+export { default as C8Run } from "./C8Run";

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/local/c8run.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/local/c8run.md
@@ -8,6 +8,7 @@ description: "Use the Camunda 8 Run single application script to set up a local 
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import {C8Run} from "@site/src/components/CamundaDistributions";
 
 :::note
 Camunda 8 Run is not supported for production use.
@@ -37,7 +38,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 
 ## Install and start Camunda 8 Run
 
-1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.6.12) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
+1. Download the latest release of <C8Run/> for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
 2. Navigate to the new `c8run` directory.
 3. Start Camunda 8 Run by running `./start.sh` (or `.\c8run.exe start` on Windows) in your terminal.
 

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/local/c8run.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/local/c8run.md
@@ -8,6 +8,7 @@ description: "Use the Camunda 8 Run single application script to set up a local 
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import {C8Run} from "@site/src/components/CamundaDistributions";
 
 :::note
 Camunda 8 Run is not supported for production use.
@@ -39,7 +40,7 @@ If no version of Java is found, follow your chosen installation's instructions f
 
 ## Install and start Camunda 8 Run
 
-1. Download the [latest release of Camunda 8 Run](https://github.com/camunda/camunda/releases/tag/8.7.0-alpha5) for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
+1. Download the latest release of <C8Run/> for your operating system and architecture. Opening the .tgz file extracts the Camunda 8 Run script into a new directory.
 2. Navigate to the new `c8run` directory.
 3. Start Camunda 8 Run by running one of the following in your terminal:
    - `./start.sh` (or `.\c8run.exe start` on Windows): start Camunda 8 Run as a Java application.


### PR DESCRIPTION
## Description

Long gone are the cave-person days of updating manual links for c8run on every release. This PR introduces a jsx file which will  construct a URL pointing to the latest patch release of that minor version. We have a change like this for the DockerCompose link. I used the same code and adapted it to work for C8Run.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

No rush on this change.

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
