### PR TITLE
fix(rest-connector): Add hints about breaking changes for pre encoded…

### DIFF
--- a/docs/reference/announcements/860.md
+++ b/docs/reference/announcements/860.md
@@ -101,6 +101,8 @@ Message start event element templates are better suited for the message-based co
 
 If one of your endpoints returns multiple Set-Cookie headers and you need to capture all of them, set `groupSetCookieHeaders` to `true` in the element template XML. This aggregates the headers into a list. This feature is available since version 8.6.7. The grouping is enabled by default since version 8.6.11.
 
+If one of your endpoints requires pre-encoded URL elements, this behavior will change in version 8.6.0. Since 8.6.10, the element template includes the skipEncoding property, which can be set to "true". This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+
 ### Breaking changes in the Connector SDK
 
 The `void correlate(Object variables)` method in the `InboundConnectorContext` interface has been removed, following the deprecation in 8.4.0. Use the `CorrelationResult correlateWithResult(Object variables)` method instead.

--- a/docs/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/docs/self-managed/operational-guides/update-guide/850-to-860.md
@@ -31,7 +31,7 @@ If one of your endpoints returns multiple Set-Cookie headers and you need to cap
 :::
 
 :::caution Breaking change
-If one of your endpoints require pre-encoded URL elements this will break with 8.6.0. Since 8.6.12. the `skipEncoding` in the XML value can be set to `"true"`. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+If one of your endpoints requires pre-encoded URL elements, this behavior will change in version 8.6.0. Since 8.6.10, the element template includes the skipEncoding property, which can be set to "true". This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
 :::
 
 ### Kafka Connector supports Avro schema

--- a/docs/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/docs/self-managed/operational-guides/update-guide/850-to-860.md
@@ -30,6 +30,10 @@ The default value of Elasticsearch deployment pods has changed from 2 to 3, and 
 If one of your endpoints returns multiple Set-Cookie headers and you need to capture all of them, set `groupSetCookieHeaders` to `true` in the element template XML. This aggregates the headers into a list. This feature is available since version 8.6.7. The grouping is enabled by default since version 8.6.11.
 :::
 
+:::caution Breaking change
+If one of your endpoints require pre-encoded URL elements this will break with 8.6.0. Since 8.6.12. the `skipEncoding` in the XML value can be set to `"true"`. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+:::
+
 ### Kafka Connector supports Avro schema
 
 :::caution Breaking change

--- a/versioned_docs/version-8.6/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.6/components/connectors/protocol/rest.md
@@ -207,7 +207,7 @@ Secrets are currently not supported in the body of a **REST Connector**.
 
 In certain scenarios, such as when working with APIs that require pre-encoded URL elements, the REST Connector's default behavior may inadvertently modify encoded segments.
 
-To avoid this, set the `skipEncoding` value to `"true"` in the XML. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided. This flag is available since 8.6.12.
+To avoid this, set the `skipEncoding` value to `"true"` in the element template XML. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided. This flag is available since 8.6.10.
 
 ### Network communication timeouts
 

--- a/versioned_docs/version-8.6/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.6/components/connectors/protocol/rest.md
@@ -203,6 +203,12 @@ Secrets are currently not supported in the body of a **REST Connector**.
 }
 ```
 
+### Encoding
+
+In certain scenarios, such as when working with APIs that require pre-encoded URL elements, the REST Connector's default behavior may inadvertently modify encoded segments.
+
+To avoid this, set the `skipEncoding` value to `"true"` in the XML. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided. This flag is available since 8.6.12.
+
 ### Network communication timeouts
 
 - **Connection timeout in seconds** determines the time frame in which the client will try to establish a connection with the server. If you do not specify a value, the system uses the default of 20 seconds. For cases where you need to wait indefinitely, set this value to 0.

--- a/versioned_docs/version-8.6/reference/announcements.md
+++ b/versioned_docs/version-8.6/reference/announcements.md
@@ -101,6 +101,8 @@ Message start event element templates are better suited for the message-based co
 
 If one of your endpoints returns multiple Set-Cookie headers and you need to capture all of them, set `groupSetCookieHeaders` to `true` in the element template XML. This aggregates the headers into a list. This feature is available since version 8.6.7. The grouping is enabled by default since version 8.6.11.
 
+If one of your endpoints requires pre-encoded URL elements, this behavior will change in version 8.6.0. Since 8.6.10, the element template includes the skipEncoding property, which can be set to "true". This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+
 #### Breaking changes in the Connector SDK
 
 The `void correlate(Object variables)` method in the `InboundConnectorContext` interface has been removed, following the deprecation in 8.4.0. Use the `CorrelationResult correlateWithResult(Object variables)` method instead.

--- a/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
@@ -31,7 +31,7 @@ If one of your endpoints returns multiple Set-Cookie headers and you need to cap
 :::
 
 :::caution Breaking change
-If one of your endpoints require pre-encoded URL elements this will break with 8.6.0. Since 8.6.12. the `skipEncoding` in the XML value can be set to `"true"`. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+If one of your endpoints requires pre-encoded URL elements, this behavior will change in version 8.6.0. Since 8.6.10, the element template includes the skipEncoding property, which can be set to "true". This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
 :::
 
 ### Kafka Connector supports Avro schema

--- a/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
@@ -30,6 +30,10 @@ The default value of Elasticsearch deployment pods has changed from 2 to 3, and 
 If one of your endpoints returns multiple Set-Cookie headers and you need to capture all of them, set `groupSetCookieHeaders` to `true` in the element template XML. This aggregates the headers into a list. This feature is available since version 8.6.7. The grouping is enabled by default since version 8.6.11.
 :::
 
+:::caution Breaking change
+If one of your endpoints require pre-encoded URL elements this will break with 8.6.0. Since 8.6.12. the `skipEncoding` in the XML value can be set to `"true"`. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+:::
+
 ### Kafka Connector supports Avro schema
 
 :::caution Breaking change

--- a/versioned_docs/version-8.7/reference/announcements/860.md
+++ b/versioned_docs/version-8.7/reference/announcements/860.md
@@ -101,6 +101,8 @@ Message start event element templates are better suited for the message-based co
 
 If one of your endpoints returns multiple Set-Cookie headers and you need to capture all of them, set `groupSetCookieHeaders` to `true` in the element template XML. This aggregates the headers into a list. This feature is available since version 8.6.7. The grouping is enabled by default since version 8.6.11.
 
+If one of your endpoints requires pre-encoded URL elements, this behavior will change in version 8.6.0. Since 8.6.10, the element template includes the skipEncoding property, which can be set to "true". This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+
 ### Breaking changes in the Connector SDK
 
 The `void correlate(Object variables)` method in the `InboundConnectorContext` interface has been removed, following the deprecation in 8.4.0. Use the `CorrelationResult correlateWithResult(Object variables)` method instead.

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
@@ -31,7 +31,7 @@ If one of your endpoints returns multiple Set-Cookie headers and you need to cap
 :::
 
 :::caution Breaking change
-If one of your endpoints require pre-encoded URL elements this will break with 8.6.0. Since 8.6.12. the `skipEncoding` in the XML value can be set to `"true"`. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+If one of your endpoints requires pre-encoded URL elements, this behavior will change in version 8.6.0. Since 8.6.10, the element template includes the skipEncoding property, which can be set to "true". This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
 :::
 
 ### Kafka Connector supports Avro schema

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
@@ -30,6 +30,10 @@ The default value of Elasticsearch deployment pods has changed from 2 to 3, and 
 If one of your endpoints returns multiple Set-Cookie headers and you need to capture all of them, set `groupSetCookieHeaders` to `true` in the element template XML. This aggregates the headers into a list. This feature is available since version 8.6.7. The grouping is enabled by default since version 8.6.11.
 :::
 
+:::caution Breaking change
+If one of your endpoints require pre-encoded URL elements this will break with 8.6.0. Since 8.6.12. the `skipEncoding` in the XML value can be set to `"true"`. This disables the automatic decoding and re-encoding process, ensuring the URL is sent to the server exactly as provided.
+:::
+
 ### Kafka Connector supports Avro schema
 
 :::caution Breaking change


### PR DESCRIPTION
… urls in rest connector

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

The rest connector does decode and endocde urls leading to pre encoded urls to break.
This was fixed [here](https://github.com/camunda/connectors/pull/3840) and documented [here](https://github.com/camunda/camunda-docs/pull/4837/)
With this PR i document the backport of this feature to 8.6. done [here](https://github.com/camunda/connectors/pull/4274) and add hints about the breaking change, when updating from 8.5 to 8.6. 
This breaking change only happens on self-managed, while on SaaS this was never working and therefore no breaking change was introduced with 8.6. Please verify this is reflected properly with the changes I made here, as I was not super sure where these changes need to be done, if only self manage is affected.
The new feature flag is available on SaaS and SM.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
