### PR TITLE
Update Algolia crawler instructions for manual triggers

### DIFF
--- a/howtos/release-procedure.md
+++ b/howtos/release-procedure.md
@@ -144,8 +144,8 @@ This requires [admin access](https://crawler.algolia.com/admin/users/login). Con
 Manually triggering the Algolia crawler is not intuitive(!!!) and requires [admin access](https://crawler.algolia.com/admin/users/login). Contact @pepopowitz or @akeller for assistance.
 
 1. Login to the [Algolia dashboard](https://dashboard.algolia.com/apps/6KYF3VMCXZ/dashboard).
-2. In the bottom left corner, click ** Data sources **, and after the UI loads, click ** Crawler **. If the sidebar is collapsed, you may only see a database icon (it looks like a barrel) instead of **Data sources**. 
-3. Click **camunda**, which should show the status _Idle_. 
+2. In the bottom left corner, click ** Data sources **, and after the UI loads, click ** Crawler **. If the sidebar is collapsed, you may only see a database icon (it looks like a barrel) instead of **Data sources**.
+3. Click **camunda**, which should show the status _Idle_.
 4. Click **Resume crawling** in the upper right corner. It will change to **Cancel crawl**, and the UI should update.
 
-Once the crawl is complete, you should see the updates you expected as search results. 
+Once the crawl is complete, you should see the updates you expected as search results.

--- a/howtos/release-procedure.md
+++ b/howtos/release-procedure.md
@@ -127,7 +127,7 @@ Use the GitHub UI and follow the instructions below:
 
 The build process for [publish-prod](https://github.com/camunda/camunda-docs/actions/workflows/publish-prod.yaml) will kick off which could take around 30 min to finish. If publish-prod is successful, the updates will appear on [docs.camunda.io](https://docs.camunda.io).
 
-## Manually Trigger the Algolia crawler (DocSearch)
+## Algolia crawler (DocSearch)
 
 Search not working for a new minor version? A specific document, published recently, not showing up in the internal search results?
 
@@ -138,3 +138,14 @@ If the minor version docs are deployed after Tuesday early US morning, the Algol
 Patch releases with significant or urgent updates may also require a manually triggered crawler.
 
 This requires [admin access](https://crawler.algolia.com/admin/users/login). Contact @pepopowitz or @akeller for assistance.
+
+### How to trigger Algolia crawler
+
+Manually triggering the Algolia crawler is not intuitive(!!!) and requires [admin access](https://crawler.algolia.com/admin/users/login). Contact @pepopowitz or @akeller for assistance.
+
+1. Login to the [Algolia dashboard](https://dashboard.algolia.com/apps/6KYF3VMCXZ/dashboard).
+2. In the bottom left corner, click ** Data sources **, and after the UI loads, click ** Crawler **. If the sidebar is collapsed, you may only see a database icon (it looks like a barrel) instead of **Data sources**. 
+3. Click **camunda**, which should show the status _Idle_. 
+4. Click **Resume crawling** in the upper right corner. It will change to **Cancel crawl**, and the UI should update.
+
+Once the crawl is complete, you should see the updates you expected as search results. 


### PR DESCRIPTION
## Description

As discussed in the backlog review.

I've also verified that all Docs Team members have the right access and should be able to trigger crawls manually. 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

These changes are for the docs-on-docs. 
