### PR TITLE
docs: document default log configuration

### DIFF
--- a/docs/self-managed/zeebe-deployment/configuration/logging.md
+++ b/docs/self-managed/zeebe-deployment/configuration/logging.md
@@ -3,7 +3,8 @@ id: logging
 title: "Logging"
 ---
 
-Zeebe uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file in `config/log4j2.xml`.
+The Camunda 8 orchestration cluster uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file
+in `config/log4j2.xml`.
 
 ## Google Stackdriver (JSON) logging
 
@@ -11,57 +12,44 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-- `config/log4j2.xml` (applied by default)
+[You can find the default log4j2.xml used by the application here](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" shutdownHook="disable">
+It will configure the default [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to be `WARN` for all except for the
+following as `INFO`:
 
-  <Properties>
-    <Property name="log.path">${sys:app.home}/logs</Property>
-    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n</Property>
-    <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-}</Property>
-    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}</Property>
-  </Properties>
+- Camunda 8 (anything under `io.camunda` and `io.atomix`)
+- Spring and Spring Boot (anything under `org.springframework`)
 
-  <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout
-        pattern="${log.pattern}"/>
-    </Console>
+:::note
+[See our documentation on log levels to understand what the various log levels mean.](../../operational-guides/monitoring/log-levels.md)
+:::
 
-    <Console name="Stackdriver" target="SYSTEM_OUT">
-      <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
-        serviceVersion="${log.stackdriver.serviceVersion}" />
-    </Console>
+You can control the log level for the orchestration cluster via the `CAMUNDA_LOG_LEVEL` environment variable, e.g. `CAMUNDA_LOG_LEVEL=DEBUG`, or
+`CAMUNDA_LOG_LEVEL=ERROR`.
 
-    <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
-      filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
-      <PatternLayout>
-        <Pattern>${log.pattern}</Pattern>
-      </PatternLayout>
-      <Policies>
-        <TimeBasedTriggeringPolicy/>
-        <SizeBasedTriggeringPolicy size="250 MB"/>
-      </Policies>
-    </RollingFile>
-  </Appenders>
+:::note
+You can further use the following environment variables to set the log level for certain components of the application, but we recommend using the general
+`CAMUNDA_LOG_LEVEL` unless you really know what you're doing.
 
-  <Loggers>
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-info}"/>
+- `ZEEBE_LOG_LEVEL`: will set the level for anything under `io.camunda.zeebe`, i.e. Zeebe related.
+- `ATOMIX_LOG_LEVEL`: will set the level for anything clustering or raft related.
+- `OPTIMIZE_LOG_LEVEL`: will set the level for anything under `io.camunda.optimize`.
+- `ES_LOG_LEVEL`: will set the level for anything under `org.elasticsearch`.
+  :::
 
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-warn}"/>
+Additionally, it will configure three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (aka outputs):
 
-    <Root level="info">
-      <AppenderRef ref="RollingFile"/>
-
-      <!-- remove to disable console logging -->
-      <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-Console}"/>
-    </Root>
-  </Loggers>
-
-</Configuration>
-```
+- `RollingFile`: [A rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html) which prints out to a file
+  (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
+  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
+  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
+- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
+  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
+  `ZEEBE_LOG_APPENDER=Stackdriver`.**
+- `Stackdriver`: another console appender, but configured to print out JSON logs which conform to the
+  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). **This is not enabled by default, and you can
+  select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
 
 ## Change log level dynamically
 

--- a/docs/self-managed/zeebe-deployment/configuration/logging.md
+++ b/docs/self-managed/zeebe-deployment/configuration/logging.md
@@ -6,10 +6,6 @@ title: "Logging"
 The Camunda 8 orchestration cluster uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file
 in `config/log4j2.xml`.
 
-## Google Stackdriver (JSON) logging
-
-To enable Google Stackdriver compatible JSON logging, set the environment variable `ZEEBE_LOG_APPENDER=Stackdriver` before starting Zeebe.
-
 ## Default logging configuration
 
 You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
@@ -29,16 +25,15 @@ The log level for the Orchestration cluster is controlled via the `CAMUNDA_LOG_L
 Additionally, it configures three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (outputs):
 
 - `RollingFile`: A [rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html), which prints out to a file
-  (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
-  compressed archive, and a new one is started.
-  - **This is enabled by default.** Disable the rolling file appender by setting the environment variable
-    `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`.
-- `Console`: Uses [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
-  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html) to output directly to standard out.
-  - **This is enabled by default,** and is mutually exclusive with the `Stackdriver` appender. Select one or the other using the environment variable `ZEEBE_LOG_APPENDER` (for example, `ZEEBE_LOG_APPENDER=Console` or `ZEEBE_LOG_APPENDER=Stackdriver`).
-- `Stackdriver`: A console appender configured to print out JSON logs which conform to the
-  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
-  - **This is not enabled by default.** Select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.
+  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
+  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
+- `Stackdriver`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender), configured to
+  print out JSON logs which conform to the [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+  **This is not enabled by default, and you can select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
+- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
+  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
+  `ZEEBE_LOG_APPENDER=Stackdriver`.**
 
 ### Component log levels
 
@@ -47,7 +42,6 @@ The following environment variables can be used to set the log level for individ
 
 - `ZEEBE_LOG_LEVEL`: Sets the level for anything under `io.camunda.zeebe` (Zeebe related logs).
 - `ATOMIX_LOG_LEVEL`: Sets the level for anything clustering or raft related.
-- `OPTIMIZE_LOG_LEVEL`: Sets the level for anything under `io.camunda.optimize`.
 - `ES_LOG_LEVEL`: Sets the level for anything under `org.elasticsearch`.
 
 ## Change log level dynamically

--- a/docs/self-managed/zeebe-deployment/configuration/logging.md
+++ b/docs/self-managed/zeebe-deployment/configuration/logging.md
@@ -12,7 +12,7 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-You can find the default log4j2.xml used by the application in the [Github repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
 
 It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 

--- a/docs/self-managed/zeebe-deployment/configuration/logging.md
+++ b/docs/self-managed/zeebe-deployment/configuration/logging.md
@@ -12,44 +12,43 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-[You can find the default log4j2.xml used by the application here](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [Github repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
 
-It will configure the default [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to be `WARN` for all except for the
-following as `INFO`:
+It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 
 - Camunda 8 (anything under `io.camunda` and `io.atomix`)
 - Spring and Spring Boot (anything under `org.springframework`)
 
 :::note
-[See our documentation on log levels to understand what the various log levels mean.](../../operational-guides/monitoring/log-levels.md)
+For more information, see the documentation on [log levels](../../operational-guides/monitoring/log-levels.md).
 :::
 
-You can control the log level for the orchestration cluster via the `CAMUNDA_LOG_LEVEL` environment variable, e.g. `CAMUNDA_LOG_LEVEL=DEBUG`, or
-`CAMUNDA_LOG_LEVEL=ERROR`.
+The log level for the Orchestration cluster is controlled via the `CAMUNDA_LOG_LEVEL` environment variable (for example, `CAMUNDA_LOG_LEVEL=DEBUG`, or
+`CAMUNDA_LOG_LEVEL=ERROR`). The log levels for individual components can be set using additional [environment variables](#component-log-levels).
 
-:::note
-You can further use the following environment variables to set the log level for certain components of the application, but we recommend using the general
-`CAMUNDA_LOG_LEVEL` unless you really know what you're doing.
+Additionally, it configures three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (outputs):
 
-- `ZEEBE_LOG_LEVEL`: will set the level for anything under `io.camunda.zeebe`, i.e. Zeebe related.
-- `ATOMIX_LOG_LEVEL`: will set the level for anything clustering or raft related.
-- `OPTIMIZE_LOG_LEVEL`: will set the level for anything under `io.camunda.optimize`.
-- `ES_LOG_LEVEL`: will set the level for anything under `org.elasticsearch`.
-  :::
-
-Additionally, it will configure three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (aka outputs):
-
-- `RollingFile`: [A rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html) which prints out to a file
+- `RollingFile`: A [rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html), which prints out to a file
   (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
-  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
-  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
-- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
-  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
-  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
-  `ZEEBE_LOG_APPENDER=Stackdriver`.**
-- `Stackdriver`: another console appender, but configured to print out JSON logs which conform to the
-  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). **This is not enabled by default, and you can
-  select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
+  compressed archive, and a new one is started.
+  - **This is enabled by default.** Disable the rolling file appender by setting the environment variable
+    `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`.
+- `Console`: Uses [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html) to output directly to standard out.
+  - **This is enabled by default,** and is mutually exclusive with the `Stackdriver` appender. Select one or the other using the environment variable `ZEEBE_LOG_APPENDER` (for example, `ZEEBE_LOG_APPENDER=Console` or `ZEEBE_LOG_APPENDER=Stackdriver`).
+- `Stackdriver`: A console appender configured to print out JSON logs which conform to the
+  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+  - **This is not enabled by default.** Select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.
+
+### Component log levels
+
+The following environment variables can be used to set the log level for individual components of the application. However, using the general
+`CAMUNDA_LOG_LEVEL` is recommended unless these components are fully understood.
+
+- `ZEEBE_LOG_LEVEL`: Sets the level for anything under `io.camunda.zeebe` (Zeebe related logs).
+- `ATOMIX_LOG_LEVEL`: Sets the level for anything clustering or raft related.
+- `OPTIMIZE_LOG_LEVEL`: Sets the level for anything under `io.camunda.optimize`.
+- `ES_LOG_LEVEL`: Sets the level for anything under `org.elasticsearch`.
 
 ## Change log level dynamically
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
@@ -12,44 +12,45 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-[You can find the default log4j2.xml used by the application here](https://github.com/camunda/camunda/blob/stable/8.6/dist/src/main/config/log4j2.xml).
+## Default logging configuration
 
-It will configure the default [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to be `WARN` for all except for the
-following as `INFO`:
+You can find the default log4j2.xml used by the application in the [Github repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+
+It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 
 - Camunda 8 (anything under `io.camunda` and `io.atomix`)
 - Spring and Spring Boot (anything under `org.springframework`)
 
 :::note
-[See our documentation on log levels to understand what the various log levels mean.](../../operational-guides/monitoring/log-levels.md)
+For more information, see the documentation on [log levels](../../operational-guides/monitoring/log-levels.md).
 :::
 
-You can control the log level for the orchestration cluster via the `CAMUNDA_LOG_LEVEL` environment variable, e.g. `CAMUNDA_LOG_LEVEL=DEBUG`, or
-`CAMUNDA_LOG_LEVEL=ERROR`.
+The log level for the Orchestration cluster is controlled via the `CAMUNDA_LOG_LEVEL` environment variable (for example, `CAMUNDA_LOG_LEVEL=DEBUG`, or
+`CAMUNDA_LOG_LEVEL=ERROR`). The log levels for individual components can be set using additional [environment variables](#component-log-levels).
 
-:::note
-You can further use the following environment variables to set the log level for certain components of the application, but we recommend using the general
-`CAMUNDA_LOG_LEVEL` unless you really know what you're doing.
+Additionally, it configures three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (outputs):
 
-- `ZEEBE_LOG_LEVEL`: will set the level for anything under `io.camunda.zeebe`, i.e. Zeebe related.
-- `ATOMIX_LOG_LEVEL`: will set the level for anything clustering or raft related.
-- `OPTIMIZE_LOG_LEVEL`: will set the level for anything under `io.camunda.optimize`.
-- `ES_LOG_LEVEL`: will set the level for anything under `org.elasticsearch`.
-  :::
-
-Additionally, it will configure three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (aka outputs):
-
-- `RollingFile`: [A rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html) which prints out to a file
+- `RollingFile`: A [rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html), which prints out to a file
   (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
-  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
-  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
-- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
-  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
-  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
-  `ZEEBE_LOG_APPENDER=Stackdriver`.**
-- `Stackdriver`: another console appender, but configured to print out JSON logs which conform to the
-  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). **This is not enabled by default, and you can
-  select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
+  compressed archive, and a new one is started.
+  - **This is enabled by default.** Disable the rolling file appender by setting the environment variable
+    `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`.
+- `Console`: Uses [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html) to output directly to standard out.
+  - **This is enabled by default,** and is mutually exclusive with the `Stackdriver` appender. Select one or the other using the environment variable `ZEEBE_LOG_APPENDER` (for example, `ZEEBE_LOG_APPENDER=Console` or `ZEEBE_LOG_APPENDER=Stackdriver`).
+- `Stackdriver`: A console appender configured to print out JSON logs which conform to the
+  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+  - **This is not enabled by default.** Select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.
+
+### Component log levels
+
+The following environment variables can be used to set the log level for individual components of the application. However, using the general
+`CAMUNDA_LOG_LEVEL` is recommended unless these components are fully understood.
+
+- `ZEEBE_LOG_LEVEL`: Sets the level for anything under `io.camunda.zeebe` (Zeebe related logs).
+- `ATOMIX_LOG_LEVEL`: Sets the level for anything clustering or raft related.
+- `OPTIMIZE_LOG_LEVEL`: Sets the level for anything under `io.camunda.optimize`.
+- `ES_LOG_LEVEL`: Sets the level for anything under `org.elasticsearch`.
 
 ## Change log level dynamically
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
@@ -3,7 +3,8 @@ id: logging
 title: "Logging"
 ---
 
-Zeebe uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file in `config/log4j2.xml`.
+The Camunda 8 orchestration cluster uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file
+in `config/log4j2.xml`.
 
 ## Google Stackdriver (JSON) logging
 
@@ -11,57 +12,44 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-- `config/log4j2.xml` (applied by default)
+[You can find the default log4j2.xml used by the application here](https://github.com/camunda/camunda/blob/stable/8.6/dist/src/main/config/log4j2.xml).
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" shutdownHook="disable">
+It will configure the default [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to be `WARN` for all except for the
+following as `INFO`:
 
-  <Properties>
-    <Property name="log.path">${sys:app.home}/logs</Property>
-    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n</Property>
-    <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-}</Property>
-    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}</Property>
-  </Properties>
+- Camunda 8 (anything under `io.camunda` and `io.atomix`)
+- Spring and Spring Boot (anything under `org.springframework`)
 
-  <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout
-        pattern="${log.pattern}"/>
-    </Console>
+:::note
+[See our documentation on log levels to understand what the various log levels mean.](../../operational-guides/monitoring/log-levels.md)
+:::
 
-    <Console name="Stackdriver" target="SYSTEM_OUT">
-      <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
-        serviceVersion="${log.stackdriver.serviceVersion}" />
-    </Console>
+You can control the log level for the orchestration cluster via the `CAMUNDA_LOG_LEVEL` environment variable, e.g. `CAMUNDA_LOG_LEVEL=DEBUG`, or
+`CAMUNDA_LOG_LEVEL=ERROR`.
 
-    <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
-      filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
-      <PatternLayout>
-        <Pattern>${log.pattern}</Pattern>
-      </PatternLayout>
-      <Policies>
-        <TimeBasedTriggeringPolicy/>
-        <SizeBasedTriggeringPolicy size="250 MB"/>
-      </Policies>
-    </RollingFile>
-  </Appenders>
+:::note
+You can further use the following environment variables to set the log level for certain components of the application, but we recommend using the general
+`CAMUNDA_LOG_LEVEL` unless you really know what you're doing.
 
-  <Loggers>
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-info}"/>
+- `ZEEBE_LOG_LEVEL`: will set the level for anything under `io.camunda.zeebe`, i.e. Zeebe related.
+- `ATOMIX_LOG_LEVEL`: will set the level for anything clustering or raft related.
+- `OPTIMIZE_LOG_LEVEL`: will set the level for anything under `io.camunda.optimize`.
+- `ES_LOG_LEVEL`: will set the level for anything under `org.elasticsearch`.
+  :::
 
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-warn}"/>
+Additionally, it will configure three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (aka outputs):
 
-    <Root level="info">
-      <AppenderRef ref="RollingFile"/>
-
-      <!-- remove to disable console logging -->
-      <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-Console}"/>
-    </Root>
-  </Loggers>
-
-</Configuration>
-```
+- `RollingFile`: [A rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html) which prints out to a file
+  (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
+  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
+  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
+- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
+  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
+  `ZEEBE_LOG_APPENDER=Stackdriver`.**
+- `Stackdriver`: another console appender, but configured to print out JSON logs which conform to the
+  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). **This is not enabled by default, and you can
+  select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
 
 ## Change log level dynamically
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
@@ -6,15 +6,9 @@ title: "Logging"
 The Camunda 8 orchestration cluster uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file
 in `config/log4j2.xml`.
 
-## Google Stackdriver (JSON) logging
-
-To enable Google Stackdriver compatible JSON logging, set the environment variable `ZEEBE_LOG_APPENDER=Stackdriver` before starting Zeebe.
-
 ## Default logging configuration
 
-## Default logging configuration
-
-You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/stable/8.7/dist/src/main/config/log4j2.xml).
 
 It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 
@@ -31,16 +25,15 @@ The log level for the Orchestration cluster is controlled via the `CAMUNDA_LOG_L
 Additionally, it configures three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (outputs):
 
 - `RollingFile`: A [rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html), which prints out to a file
-  (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
-  compressed archive, and a new one is started.
-  - **This is enabled by default.** Disable the rolling file appender by setting the environment variable
-    `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`.
-- `Console`: Uses [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
-  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html) to output directly to standard out.
-  - **This is enabled by default,** and is mutually exclusive with the `Stackdriver` appender. Select one or the other using the environment variable `ZEEBE_LOG_APPENDER` (for example, `ZEEBE_LOG_APPENDER=Console` or `ZEEBE_LOG_APPENDER=Stackdriver`).
-- `Stackdriver`: A console appender configured to print out JSON logs which conform to the
-  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
-  - **This is not enabled by default.** Select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.
+  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
+  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
+- `Stackdriver`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender), configured to
+  print out JSON logs which conform to the [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+  **This is not enabled by default, and you can select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
+- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
+  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
+  `ZEEBE_LOG_APPENDER=Stackdriver`.**
 
 ### Component log levels
 
@@ -49,7 +42,6 @@ The following environment variables can be used to set the log level for individ
 
 - `ZEEBE_LOG_LEVEL`: Sets the level for anything under `io.camunda.zeebe` (Zeebe related logs).
 - `ATOMIX_LOG_LEVEL`: Sets the level for anything clustering or raft related.
-- `OPTIMIZE_LOG_LEVEL`: Sets the level for anything under `io.camunda.optimize`.
 - `ES_LOG_LEVEL`: Sets the level for anything under `org.elasticsearch`.
 
 ## Change log level dynamically

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
@@ -14,7 +14,7 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-You can find the default log4j2.xml used by the application in the [Github repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
 
 It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
@@ -6,15 +6,9 @@ title: "Logging"
 The Camunda 8 orchestration cluster uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file
 in `config/log4j2.xml`.
 
-## Google Stackdriver (JSON) logging
-
-To enable Google Stackdriver compatible JSON logging, set the environment variable `ZEEBE_LOG_APPENDER=Stackdriver` before starting Zeebe.
-
 ## Default logging configuration
 
-## Default logging configuration
-
-You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/stable/8.7/dist/src/main/config/log4j2.xml).
 
 It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 
@@ -31,16 +25,15 @@ The log level for the Orchestration cluster is controlled via the `CAMUNDA_LOG_L
 Additionally, it configures three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (outputs):
 
 - `RollingFile`: A [rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html), which prints out to a file
-  (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
-  compressed archive, and a new one is started.
-  - **This is enabled by default.** Disable the rolling file appender by setting the environment variable
-    `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`.
-- `Console`: Uses [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
-  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html) to output directly to standard out.
-  - **This is enabled by default,** and is mutually exclusive with the `Stackdriver` appender. Select one or the other using the environment variable `ZEEBE_LOG_APPENDER` (for example, `ZEEBE_LOG_APPENDER=Console` or `ZEEBE_LOG_APPENDER=Stackdriver`).
-- `Stackdriver`: A console appender configured to print out JSON logs which conform to the
-  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
-  - **This is not enabled by default.** Select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.
+  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
+  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
+- `Stackdriver`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender), configured to
+  print out JSON logs which conform to the [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+  **This is not enabled by default, and you can select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
+- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
+  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
+  `ZEEBE_LOG_APPENDER=Stackdriver`.**
 
 ### Component log levels
 
@@ -49,7 +42,6 @@ The following environment variables can be used to set the log level for individ
 
 - `ZEEBE_LOG_LEVEL`: Sets the level for anything under `io.camunda.zeebe` (Zeebe related logs).
 - `ATOMIX_LOG_LEVEL`: Sets the level for anything clustering or raft related.
-- `OPTIMIZE_LOG_LEVEL`: Sets the level for anything under `io.camunda.optimize`.
 - `ES_LOG_LEVEL`: Sets the level for anything under `org.elasticsearch`.
 
 ## Change log level dynamically

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
@@ -14,7 +14,7 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-You can find the default log4j2.xml used by the application in the [Github repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
 
 It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
@@ -12,44 +12,45 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-[You can find the default log4j2.xml used by the application here](https://github.com/camunda/camunda/blob/stable/8.7/dist/src/main/config/log4j2.xml).
+## Default logging configuration
 
-It will configure the default [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to be `WARN` for all except for the
-following as `INFO`:
+You can find the default log4j2.xml used by the application in the [Github repository](https://github.com/camunda/camunda/blob/main/dist/src/main/config/log4j2.xml).
+
+It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 
 - Camunda 8 (anything under `io.camunda` and `io.atomix`)
 - Spring and Spring Boot (anything under `org.springframework`)
 
 :::note
-[See our documentation on log levels to understand what the various log levels mean.](../../operational-guides/monitoring/log-levels.md)
+For more information, see the documentation on [log levels](../../operational-guides/monitoring/log-levels.md).
 :::
 
-You can control the log level for the orchestration cluster via the `CAMUNDA_LOG_LEVEL` environment variable, e.g. `CAMUNDA_LOG_LEVEL=DEBUG`, or
-`CAMUNDA_LOG_LEVEL=ERROR`.
+The log level for the Orchestration cluster is controlled via the `CAMUNDA_LOG_LEVEL` environment variable (for example, `CAMUNDA_LOG_LEVEL=DEBUG`, or
+`CAMUNDA_LOG_LEVEL=ERROR`). The log levels for individual components can be set using additional [environment variables](#component-log-levels).
 
-:::note
-You can further use the following environment variables to set the log level for certain components of the application, but we recommend using the general
-`CAMUNDA_LOG_LEVEL` unless you really know what you're doing.
+Additionally, it configures three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (outputs):
 
-- `ZEEBE_LOG_LEVEL`: will set the level for anything under `io.camunda.zeebe`, i.e. Zeebe related.
-- `ATOMIX_LOG_LEVEL`: will set the level for anything clustering or raft related.
-- `OPTIMIZE_LOG_LEVEL`: will set the level for anything under `io.camunda.optimize`.
-- `ES_LOG_LEVEL`: will set the level for anything under `org.elasticsearch`.
-  :::
-
-Additionally, it will configure three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (aka outputs):
-
-- `RollingFile`: [A rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html) which prints out to a file
+- `RollingFile`: A [rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html), which prints out to a file
   (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
-  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
-  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
-- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
-  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
-  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
-  `ZEEBE_LOG_APPENDER=Stackdriver`.**
-- `Stackdriver`: another console appender, but configured to print out JSON logs which conform to the
-  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). **This is not enabled by default, and you can
-  select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
+  compressed archive, and a new one is started.
+  - **This is enabled by default.** Disable the rolling file appender by setting the environment variable
+    `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`.
+- `Console`: Uses [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html) to output directly to standard out.
+  - **This is enabled by default,** and is mutually exclusive with the `Stackdriver` appender. Select one or the other using the environment variable `ZEEBE_LOG_APPENDER` (for example, `ZEEBE_LOG_APPENDER=Console` or `ZEEBE_LOG_APPENDER=Stackdriver`).
+- `Stackdriver`: A console appender configured to print out JSON logs which conform to the
+  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+  - **This is not enabled by default.** Select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.
+
+### Component log levels
+
+The following environment variables can be used to set the log level for individual components of the application. However, using the general
+`CAMUNDA_LOG_LEVEL` is recommended unless these components are fully understood.
+
+- `ZEEBE_LOG_LEVEL`: Sets the level for anything under `io.camunda.zeebe` (Zeebe related logs).
+- `ATOMIX_LOG_LEVEL`: Sets the level for anything clustering or raft related.
+- `OPTIMIZE_LOG_LEVEL`: Sets the level for anything under `io.camunda.optimize`.
+- `ES_LOG_LEVEL`: Sets the level for anything under `org.elasticsearch`.
 
 ## Change log level dynamically
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/configuration/logging.md
@@ -3,7 +3,8 @@ id: logging
 title: "Logging"
 ---
 
-Zeebe uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file in `config/log4j2.xml`.
+The Camunda 8 orchestration cluster uses Log4j2 framework for logging. In the distribution and the Docker image, find the default log configuration file
+in `config/log4j2.xml`.
 
 ## Google Stackdriver (JSON) logging
 
@@ -11,57 +12,44 @@ To enable Google Stackdriver compatible JSON logging, set the environment variab
 
 ## Default logging configuration
 
-- `config/log4j2.xml` (applied by default)
+[You can find the default log4j2.xml used by the application here](https://github.com/camunda/camunda/blob/stable/8.7/dist/src/main/config/log4j2.xml).
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" shutdownHook="disable">
+It will configure the default [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to be `WARN` for all except for the
+following as `INFO`:
 
-  <Properties>
-    <Property name="log.path">${sys:app.home}/logs</Property>
-    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n</Property>
-    <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-}</Property>
-    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}</Property>
-  </Properties>
+- Camunda 8 (anything under `io.camunda` and `io.atomix`)
+- Spring and Spring Boot (anything under `org.springframework`)
 
-  <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout
-        pattern="${log.pattern}"/>
-    </Console>
+:::note
+[See our documentation on log levels to understand what the various log levels mean.](../../operational-guides/monitoring/log-levels.md)
+:::
 
-    <Console name="Stackdriver" target="SYSTEM_OUT">
-      <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
-        serviceVersion="${log.stackdriver.serviceVersion}" />
-    </Console>
+You can control the log level for the orchestration cluster via the `CAMUNDA_LOG_LEVEL` environment variable, e.g. `CAMUNDA_LOG_LEVEL=DEBUG`, or
+`CAMUNDA_LOG_LEVEL=ERROR`.
 
-    <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
-      filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
-      <PatternLayout>
-        <Pattern>${log.pattern}</Pattern>
-      </PatternLayout>
-      <Policies>
-        <TimeBasedTriggeringPolicy/>
-        <SizeBasedTriggeringPolicy size="250 MB"/>
-      </Policies>
-    </RollingFile>
-  </Appenders>
+:::note
+You can further use the following environment variables to set the log level for certain components of the application, but we recommend using the general
+`CAMUNDA_LOG_LEVEL` unless you really know what you're doing.
 
-  <Loggers>
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-info}"/>
+- `ZEEBE_LOG_LEVEL`: will set the level for anything under `io.camunda.zeebe`, i.e. Zeebe related.
+- `ATOMIX_LOG_LEVEL`: will set the level for anything clustering or raft related.
+- `OPTIMIZE_LOG_LEVEL`: will set the level for anything under `io.camunda.optimize`.
+- `ES_LOG_LEVEL`: will set the level for anything under `org.elasticsearch`.
+  :::
 
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-warn}"/>
+Additionally, it will configure three possible [appenders](https://logging.apache.org/log4j/2.x/manual/appenders.html) (aka outputs):
 
-    <Root level="info">
-      <AppenderRef ref="RollingFile"/>
-
-      <!-- remove to disable console logging -->
-      <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-Console}"/>
-    </Root>
-  </Loggers>
-
-</Configuration>
-```
+- `RollingFile`: [A rolling file appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html) which prints out to a file
+  (by default, `logs/zeebe.log` relative from the distribution root). After a day, or once that file reaches 250MB, the file is "rolled" into a
+  compressed archive, and a new one is started. **This is enabled by default. You can disable it by setting the environment variable
+  `CAMUNDA_LOG_FILE_APPENDER_ENABLED=false`**.
+- `Console`: will output using the [Console Appender](https://logging.apache.org/log4j/2.x/manual/appenders.html#ConsoleAppender) and a
+  [pattern layout](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html), directly to standard out. **This is enabled by default, and is
+  mutually exclusive with the `Stackdriver` appender. You can select one them via `ZEEBE_LOG_APPENDER`, e.g. `ZEEBE_LOG_APPENDER=Console` or
+  `ZEEBE_LOG_APPENDER=Stackdriver`.**
+- `Stackdriver`: another console appender, but configured to print out JSON logs which conform to the
+  [expected Stackdriver format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). **This is not enabled by default, and you can
+  select it by setting `ZEEBE_LOG_APPENDER=Stackdriver`.**
 
 ## Change log level dynamically
 


### PR DESCRIPTION
## Description

This PR documents the logging configuration used by the C8 orchestration cluster.

I've opted to link to the configuration instead of pasting its contents, since this is more likely to get out of sync. I then focused mostly on the ways the user can re-configure it without providing their own `log4j2.xml` file.

Note that since 8.6, this applies not just to Zeebe, but to C8 as a whole. However, we have no "general" or "streamlined" configuration section, everything is by components =/

I think it would be good to have this, but it may be a bit out of scope here, and a bigger refactoring/rewrite.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
