### PR TITLE
feat: change sdk default for maxMessageSize

### DIFF
--- a/docs/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/docs/apis-tools/spring-zeebe-sdk/configuration.md
@@ -325,7 +325,7 @@ camunda:
 
 #### Max message size
 
-A custom `maxMessageSize` allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the `maxInboundMessageSize` of the gRPC channel (default 4MB):
+A custom `maxMessageSize` allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the `maxInboundMessageSize` of the gRPC channel (default 5MB):
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.5/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.5/apis-tools/spring-zeebe-sdk/configuration.md
@@ -381,7 +381,7 @@ zeebe.client.message.timeToLive=PT2H
 
 ### Max message size
 
-A custom maxMessageSize (in bytes) allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the maxInboundMessageSize of the gRPC channel (default 4MB):
+A custom maxMessageSize (in bytes) allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the maxInboundMessageSize of the gRPC channel (default 5MB):
 
 ```properties
 zeebe.client.message.maxMessage-size=3145728

--- a/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.6/apis-tools/spring-zeebe-sdk/configuration.md
@@ -298,7 +298,7 @@ camunda:
 
 #### Max message size
 
-A custom maxMessageSize allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the maxInboundMessageSize of the gRPC channel (default 4MB):
+A custom maxMessageSize allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the maxInboundMessageSize of the gRPC channel (default 5MB):
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/configuration.md
+++ b/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/configuration.md
@@ -298,7 +298,7 @@ camunda:
 
 #### Max message size
 
-A custom `maxMessageSize` allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the `maxInboundMessageSize` of the gRPC channel (default 4MB):
+A custom `maxMessageSize` allows the client to receive larger or smaller responses from Zeebe. Technically, it specifies the `maxInboundMessageSize` of the gRPC channel (default 5MB):
 
 ```yaml
 camunda:


### PR DESCRIPTION
Changed and backported the default settings for maxInboundMessageSize. The server does just an approximation and thus sometimes even though rarely it might send a payload that is slightly larger than 4MB (old default) and the client would have denied this before. Thus we are increasing the size on the client side to not be overly rigorous.

(for more details check out the SDK PR https://github.com/camunda/camunda/pull/29608)

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
