### PR TITLE
Algolia crawler now runs daily

### DIFF
--- a/howtos/release-procedure.md
+++ b/howtos/release-procedure.md
@@ -131,10 +131,8 @@ The build process for [publish-prod](https://github.com/camunda/camunda-docs/act
 
 Search not working for a new minor version? A specific document, published recently, not showing up in the internal search results?
 
-Our twice yearly minor releases usually line up nicely with the scheduled Algolia crawl - Tuesday early US morning.
+The Algolia crawler runs **daily** between the end of the US day and the beginning of the next European working day.
 
-If the minor version docs are deployed after Tuesday early US morning, the Algolia crawler should be manually triggered, or the internal search (DocSearch) will not work for the new minor version.
-
-Patch releases with significant or urgent updates may also require a manually triggered crawler.
+Patch releases with significant or urgent updates may require a manually triggered crawler.
 
 This requires [admin access](https://crawler.algolia.com/admin/users/login). Contact @pepopowitz or @akeller for assistance.


### PR DESCRIPTION
## Description

This is the docs-on-docs update to state the Algolia crawler now runs daily. The change to the Algolia config has already happened.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

Does not apply. These are unversioned docs-on-docs.
