### PR TITLE
docs on docs: tip for generating numbered versions of API docs

### DIFF
--- a/howtos/interactive-api-explorers.md
+++ b/howtos/interactive-api-explorers.md
@@ -40,7 +40,7 @@ If you've made changes to the upstream `main` branch and require urgent document
 1. Replace the OpenAPI spec file at `/api/[apiName]/[version]/[apiName]-openapi.yaml`.
 2. Regenerate the docs with this command:
    `npm run api:generate:[apiName] [version]`
-3. If changes affect the sidebars (e.g. the name or method of an endpoint), manually move the changes from the generated `sidebar.ts` into the version's top-level `version-x-sidebars.json` file.
+3. If changes affect the sidebars (for example, the name or method of an endpoint), manually move the changes from the generated `sidebar.ts` into the version's top-level `version-x-sidebars.json` file.
 4. Commit the changes, and open a PR.
 
 ## Code languages

--- a/howtos/interactive-api-explorers.md
+++ b/howtos/interactive-api-explorers.md
@@ -40,7 +40,7 @@ If you've made changes to the upstream `main` branch and require urgent document
 1. Replace the OpenAPI spec file at `/api/[apiName]/[version]/[apiName]-openapi.yaml`.
 2. Regenerate the docs with this command:
    `npm run api:generate:[apiName] [version]`
-3. If changes include affect the sidebars (e.g. the name or method of an endpoint), manually move the changes from the generated `sidebar.ts` into the version's top-level `version-x-sidebars.json` file.
+3. If changes affect the sidebars (e.g. the name or method of an endpoint), manually move the changes from the generated `sidebar.ts` into the version's top-level `version-x-sidebars.json` file.
 4. Commit the changes, and open a PR.
 
 ## Code languages

--- a/howtos/interactive-api-explorers.md
+++ b/howtos/interactive-api-explorers.md
@@ -40,7 +40,8 @@ If you've made changes to the upstream `main` branch and require urgent document
 1. Replace the OpenAPI spec file at `/api/[apiName]/[version]/[apiName]-openapi.yaml`.
 2. Regenerate the docs with this command:
    `npm run api:generate:[apiName] [version]`
-3. Commit the changes, and open a PR.
+3. If changes include affect the sidebars (e.g. the name or method of an endpoint), manually move the changes from the generated `sidebar.ts` into the version's top-level `version-x-sidebars.json` file.
+4. Commit the changes, and open a PR.
 
 ## Code languages
 


### PR DESCRIPTION
## Description

Describes a very annoying manual step in generating back-versions of API docs.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and:
  - [ ] are in the `/docs` directory (version 8.8).
  - [ ] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
