### PR TITLE
docs: added recommendation for suppressing ES deprecation logs

### DIFF
--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -130,6 +130,20 @@ camunda.operate:
       selfSigned: true
 ```
 
+#### Disable Elasticsearch deprecation logging
+
+When using an Elasticsearch version 8.16.0+ it is recommended to turn off deprecation logging for the Elasticsearch cluster.
+
+```shell
+curl -X PUT "http://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "persistent": {
+      "logger.org.elasticsearch.deprecation": "OFF"
+    }
+  }'
+```
+
 ### Settings for OpenSearch
 
 #### Settings to connect to a secured OpenSearch instance

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -114,6 +114,20 @@ camunda.tasklist:
       selfSigned: true
 ```
 
+#### Disable Elasticsearch deprecation logging
+
+When using an Elasticsearch version ≥8.16.0 it is recommended to turn off deprecation logging for the Elasticsearch cluster.
+
+```shell
+curl -X PUT "http://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "persistent": {
+      "logger.org.elasticsearch.deprecation": "OFF"
+    }
+  }'
+```
+
 ## Zeebe Broker connection
 
 Tasklist needs a connection to the Zeebe Broker to start the import.

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/operate-configuration.md
@@ -152,6 +152,20 @@ camunda.operate:
       selfSigned: true
 ```
 
+#### Disable Elasticsearch deprecation logging
+
+When using an Elasticsearch version 8.16.0+ it is recommended to turn off deprecation logging for the Elasticsearch cluster.
+
+```shell
+curl -X PUT "http://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "persistent": {
+      "logger.org.elasticsearch.deprecation": "OFF"
+    }
+  }'
+```
+
 ### Settings for OpenSearch
 
 #### Settings to connect to a secured OpenSearch instance

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -136,6 +136,20 @@ camunda.tasklist:
       selfSigned: true
 ```
 
+#### Disable Elasticsearch deprecation logging
+
+When using an Elasticsearch version ≥8.16.0 it is recommended to turn off deprecation logging for the Elasticsearch cluster.
+
+```shell
+curl -X PUT "http://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "persistent": {
+      "logger.org.elasticsearch.deprecation": "OFF"
+    }
+  }'
+```
+
 ## Zeebe Broker connection
 
 Tasklist needs a connection to the Zeebe Broker to start the import.


### PR DESCRIPTION
Added workaround for the logs of Operate and Tasklist being flooded with deprecation warnings from Elasticsearch when newer Elasticsearch versions (>=8.16.0) are used as recommendation to the documentation.

I added this to current and 8.7. because the default Elasticsearch version from 8.7 onwards will be 8.17.3.

Please let me know if you think it makes more sense to put this elsewhere.

I'm also unsure if this should be added to the update guidelines for 8.7 (this workaround will also be put as [default to the Helm charts for 8.7 and 8.8](https://github.com/camunda/camunda-platform-helm/issues/3243))

relates to: https://github.com/camunda/camunda/issues/26285

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and:
  - [x] are in the `/docs` directory (version 8.8).
  - [x] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
