### PR TITLE
Correct user task restirciton

### DIFF
--- a/docs/self-managed/concepts/access-control/user-task-access-restrictions.md
+++ b/docs/self-managed/concepts/access-control/user-task-access-restrictions.md
@@ -6,18 +6,13 @@ description: "Control the level of access a user or group has to perform tasks i
 ---
 
 :::caution
-User task access restrictions are enabled by default and can be disabled using environment variables. This feature is controlled in the required component, see [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags).
+User task access restrictions are enabled by default and can be disabled using the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity).
 This configuration does not affect API users. When retrieving tasks using the APIs, all tasks are returned.
 :::
 
-User task access restrictions allow you to control the level of access a [user](/self-managed/identity/user-guide/roles/manage-roles.md) or
-[group](self-managed/identity/user-guide/groups/manage-groups.md) has to perform BPMN user tasks where they are candidates.
+User task access restrictions are used in Tasklist to control task access for a
+user or a [group](/self-managed/identity/user-guide/groups/manage-groups.md). The currently logged-in user needs to be either in the `Assignee` field, in the `Candidate users` field, or a member of the `Candidate groups` as defined in the BPMN definition to see the task in the Tasklist.
 
-### User task access restrictions
+For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the users that belong to `Team A` and the user `example` will have access to the task.
 
-[User task access restrictions](self-managed/tasklist-deployment/tasklist-authentication.md#user-restrictions) are used in Tasklist to control task access for a
-user or [group](/self-managed/identity/user-guide/groups/manage-groups.md). The restrictions are
-related to the candidate users or groups set up on user task definitions.
-
-For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the
-users that belong to `Team A` and the user `example` will have access to the task.
+See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailled description.

--- a/docs/self-managed/identity/deployment/configuration-variables.md
+++ b/docs/self-managed/identity/deployment/configuration-variables.md
@@ -116,10 +116,9 @@ steps:
 
 Identity uses feature flag environment variables to enable and disable features; the supported flags are:
 
-| Environment variable         | Description                                                     | Default value |
-| ---------------------------- | --------------------------------------------------------------- | ------------- |
-| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature.                   | false         |
-| USER_RESTRICTIONS_ENABLED    | Controls the user task access restrictions feature in Tasklist. | true          |
+| Environment variable         | Description                                   | Default value |
+| ---------------------------- | --------------------------------------------- | ------------- |
+| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -162,7 +162,7 @@ curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKE
 
 ### User task access restrictions
 
-To use this resource, the **User Task Access Restrictions** feature must be [enabled on Identity](/self-managed/concepts/access-control/user-task-access-restrictions.md). When it is active, Tasklist applies additional security measures to filter tasks based on user identity and authorization. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
+User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 
 - Enhanced security: Users only see tasks for which they have the necessary permissions, improving security and preventing unauthorized access.
 - Tasklist customization: The Tasklist interface is tailored to display only relevant tasks for each user, providing a personalized and streamlined experience.

--- a/docs/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -160,7 +160,7 @@ Take the `access_token` value from the response object and store it as your toke
 curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKEN>" http://localhost:8080/v1/tasks/search
 ```
 
-### User task access restrictions
+## User task access restrictions
 
 User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 

--- a/versioned_docs/version-8.4/self-managed/concepts/access-control/user-task-access-restrictions.md
+++ b/versioned_docs/version-8.4/self-managed/concepts/access-control/user-task-access-restrictions.md
@@ -6,17 +6,13 @@ description: "Control the level of access a user or group has to perform tasks i
 ---
 
 :::caution
-User task access restrictions are enabled by default and can be disabled using environment variables. This feature is controlled in the required component, see [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags).
+User task access restrictions are enabled by default and can be disabled using the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity).
+This configuration does not affect API users. When retrieving tasks using the APIs, all tasks are returned.
 :::
 
-User task access restrictions allow you to control the level of access a [user](/self-managed/identity/user-guide/roles/add-assign-role.md) or
-[group](self-managed/identity/user-guide/groups/create-group.md) has to perform BPMN user tasks where they are candidates.
+User task access restrictions are used in Tasklist to control task access for a
+user or a [group](/self-managed/identity/user-guide/groups/create-group.md). The currently logged-in user needs to be either in the `Assignee` field, in the `Candidate users` field, or a member of the `Candidate groups` as defined in the BPMN definition to see the task in the Tasklist.
 
-### User task access restrictions
+For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the users that belong to `Team A` and the user `example` will have access to the task.
 
-[User task access restrictions](self-managed/tasklist-deployment/tasklist-authentication.md#user-restrictions) are used in Tasklist to control task access for a
-user or [group](/self-managed/identity/user-guide/groups/create-group.md). The restrictions are
-related to the candidate users or groups set up on user task definitions.
-
-For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the
-users that belong to `Team A` and the user `example` will have access to the task.
+See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailled description.

--- a/versioned_docs/version-8.4/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.4/self-managed/identity/deployment/configuration-variables.md
@@ -106,7 +106,7 @@ Identity uses feature flag environment variables to enable and disable features;
 | Environment variable         | Description                                   | Default value |
 | ---------------------------- | --------------------------------------------- | ------------- |
 | RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
+| MULTITENANCY_ENABLED         | Controls the multi-tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.4/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.4/self-managed/identity/deployment/configuration-variables.md
@@ -103,11 +103,10 @@ instance, in addition to the adjustments described [above](#running-identity-on-
 
 Identity uses feature flag environment variables to enable and disable features; the supported flags are:
 
-| Environment variable         | Description                                                     | Default value |
-| ---------------------------- | --------------------------------------------------------------- | ------------- |
-| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature.                   | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.                             | false         |
-| USER_RESTRICTIONS_ENABLED    | Controls the user task access restrictions feature in Tasklist. | true          |
+| Environment variable         | Description                                   | Default value |
+| ---------------------------- | --------------------------------------------- | ------------- |
+| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
+| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -162,7 +162,7 @@ curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKE
 
 ### User task access restrictions
 
-To use this resource, the **User Task Access Restrictions** feature must be [enabled on Identity](/self-managed/concepts/access-control/user-task-access-restrictions.md). When it is active, Tasklist applies additional security measures to filter tasks based on user identity and authorization. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
+User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 
 - Enhanced security: Users only see tasks for which they have the necessary permissions, improving security and preventing unauthorized access.
 - Tasklist customization: The Tasklist interface is tailored to display only relevant tasks for each user, providing a personalized and streamlined experience.

--- a/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.4/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -160,7 +160,7 @@ Take the `access_token` value from the response object and store it as your toke
 curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKEN>" -d '{"query": "{tasks(query:{}){id name}}"}' http://localhost:8080/graphql
 ```
 
-### User task access restrictions
+## User task access restrictions
 
 User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 

--- a/versioned_docs/version-8.5/self-managed/concepts/access-control/user-task-access-restrictions.md
+++ b/versioned_docs/version-8.5/self-managed/concepts/access-control/user-task-access-restrictions.md
@@ -6,18 +6,13 @@ description: "Control the level of access a user or group has to perform tasks i
 ---
 
 :::caution
-User task access restrictions are enabled by default and can be disabled using environment variables. This feature is controlled in the required component, see [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags).
+User task access restrictions are enabled by default and can be disabled using the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity).
 This configuration does not affect API users. When retrieving tasks using the APIs, all tasks are returned.
 :::
 
-User task access restrictions allow you to control the level of access a [user](/self-managed/identity/user-guide/roles/add-assign-role.md) or
-[group](self-managed/identity/user-guide/groups/create-group.md) has to perform BPMN user tasks where they are candidates.
+User task access restrictions are used in Tasklist to control task access for a
+user or a [group](/self-managed/identity/user-guide/groups/create-group.md). The currently logged-in user needs to be either in the `Assignee` field, in the `Candidate users` field, or a member of the `Candidate groups` as defined in the BPMN definition to see the task in the Tasklist.
 
-### User task access restrictions
+For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the users that belong to `Team A` and the user `example` will have access to the task.
 
-[User task access restrictions](self-managed/tasklist-deployment/tasklist-authentication.md#user-restrictions) are used in Tasklist to control task access for a
-user or [group](/self-managed/identity/user-guide/groups/create-group.md). The restrictions are
-related to the candidate users or groups set up on user task definitions.
-
-For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the
-users that belong to `Team A` and the user `example` will have access to the task.
+See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailled description.

--- a/versioned_docs/version-8.5/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.5/self-managed/identity/deployment/configuration-variables.md
@@ -120,11 +120,10 @@ steps:
 
 Identity uses feature flag environment variables to enable and disable features; the supported flags are:
 
-| Environment variable         | Description                                                     | Default value |
-| ---------------------------- | --------------------------------------------------------------- | ------------- |
-| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature.                   | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.                             | false         |
-| USER_RESTRICTIONS_ENABLED    | Controls the user task access restrictions feature in Tasklist. | true          |
+| Environment variable         | Description                                   | Default value |
+| ---------------------------- | --------------------------------------------- | ------------- |
+| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
+| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.5/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.5/self-managed/identity/deployment/configuration-variables.md
@@ -123,7 +123,7 @@ Identity uses feature flag environment variables to enable and disable features;
 | Environment variable         | Description                                   | Default value |
 | ---------------------------- | --------------------------------------------- | ------------- |
 | RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
+| MULTITENANCY_ENABLED         | Controls the multi-tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -162,7 +162,7 @@ curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKE
 
 ### User task access restrictions
 
-To use this resource, the **User Task Access Restrictions** feature must be [enabled on Identity](/self-managed/concepts/access-control/user-task-access-restrictions.md). When it is active, Tasklist applies additional security measures to filter tasks based on user identity and authorization. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
+User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 
 - Enhanced security: Users only see tasks for which they have the necessary permissions, improving security and preventing unauthorized access.
 - Tasklist customization: The Tasklist interface is tailored to display only relevant tasks for each user, providing a personalized and streamlined experience.

--- a/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.5/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -160,7 +160,7 @@ Take the `access_token` value from the response object and store it as your toke
 curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKEN>" -d '{"query": "{tasks(query:{}){id name}}"}' http://localhost:8080/graphql
 ```
 
-### User task access restrictions
+## User task access restrictions
 
 User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 

--- a/versioned_docs/version-8.6/self-managed/concepts/access-control/user-task-access-restrictions.md
+++ b/versioned_docs/version-8.6/self-managed/concepts/access-control/user-task-access-restrictions.md
@@ -6,18 +6,13 @@ description: "Control the level of access a user or group has to perform tasks i
 ---
 
 :::caution
-User task access restrictions are enabled by default and can be disabled using environment variables. This feature is controlled in the required component, see [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags).
+User task access restrictions are enabled by default and can be disabled using the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity).
 This configuration does not affect API users. When retrieving tasks using the APIs, all tasks are returned.
 :::
 
-User task access restrictions allow you to control the level of access a [user](/self-managed/identity/user-guide/roles/manage-roles.md) or
-[group](self-managed/identity/user-guide/groups/manage-groups.md) has to perform BPMN user tasks where they are candidates.
+User task access restrictions are used in Tasklist to control task access for a
+user or a [group](/self-managed/identity/user-guide/groups/manage-groups.md). The currently logged-in user needs to be either in the `Assignee` field, in the `Candidate users` field, or a member of the `Candidate groups` as defined in the BPMN definition to see the task in the Tasklist.
 
-### User task access restrictions
+For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the users that belong to `Team A` and the user `example` will have access to the task.
 
-[User task access restrictions](self-managed/tasklist-deployment/tasklist-authentication.md#user-restrictions) are used in Tasklist to control task access for a
-user or [group](/self-managed/identity/user-guide/groups/manage-groups.md). The restrictions are
-related to the candidate users or groups set up on user task definitions.
-
-For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the
-users that belong to `Team A` and the user `example` will have access to the task.
+See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailled description.

--- a/versioned_docs/version-8.6/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.6/self-managed/identity/deployment/configuration-variables.md
@@ -132,11 +132,10 @@ steps:
 
 Identity uses feature flag environment variables to enable and disable features; the supported flags are:
 
-| Environment variable         | Description                                                     | Default value |
-| ---------------------------- | --------------------------------------------------------------- | ------------- |
-| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature.                   | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.                             | false         |
-| USER_RESTRICTIONS_ENABLED    | Controls the user task access restrictions feature in Tasklist. | true          |
+| Environment variable         | Description                                   | Default value |
+| ---------------------------- | --------------------------------------------- | ------------- |
+| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
+| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.6/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.6/self-managed/identity/deployment/configuration-variables.md
@@ -135,7 +135,7 @@ Identity uses feature flag environment variables to enable and disable features;
 | Environment variable         | Description                                   | Default value |
 | ---------------------------- | --------------------------------------------- | ------------- |
 | RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
+| MULTITENANCY_ENABLED         | Controls the multi-tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -162,7 +162,7 @@ curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKE
 
 ### User task access restrictions
 
-To use this resource, the **User Task Access Restrictions** feature must be [enabled on Identity](/self-managed/concepts/access-control/user-task-access-restrictions.md). When it is active, Tasklist applies additional security measures to filter tasks based on user identity and authorization. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
+User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 
 - Enhanced security: Users only see tasks for which they have the necessary permissions, improving security and preventing unauthorized access.
 - Tasklist customization: The Tasklist interface is tailored to display only relevant tasks for each user, providing a personalized and streamlined experience.

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -160,7 +160,7 @@ Take the `access_token` value from the response object and store it as your toke
 curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKEN>" http://localhost:8080/v1/tasks/search
 ```
 
-### User task access restrictions
+## User task access restrictions
 
 User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 

--- a/versioned_docs/version-8.7/self-managed/concepts/access-control/user-task-access-restrictions.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/access-control/user-task-access-restrictions.md
@@ -6,18 +6,13 @@ description: "Control the level of access a user or group has to perform tasks i
 ---
 
 :::caution
-User task access restrictions are enabled by default and can be disabled using environment variables. This feature is controlled in the required component, see [Identity feature flags](../../../../self-managed/identity/deployment/configuration-variables/#feature-flags).
+User task access restrictions are enabled by default and can be disabled using the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity).
 This configuration does not affect API users. When retrieving tasks using the APIs, all tasks are returned.
 :::
 
-User task access restrictions allow you to control the level of access a [user](/self-managed/identity/user-guide/roles/manage-roles.md) or
-[group](self-managed/identity/user-guide/groups/manage-groups.md) has to perform BPMN user tasks where they are candidates.
+User task access restrictions are used in Tasklist to control task access for a
+user or a [group](/self-managed/identity/user-guide/groups/manage-groups.md). The currently logged-in user needs to be either in the `Assignee` field, in the `Candidate users` field, or a member of the `Candidate groups` as defined in the BPMN definition to see the task in the Tasklist.
 
-### User task access restrictions
+For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the users that belong to `Team A` and the user `example` will have access to the task.
 
-[User task access restrictions](self-managed/tasklist-deployment/tasklist-authentication.md#user-restrictions) are used in Tasklist to control task access for a
-user or [group](/self-managed/identity/user-guide/groups/manage-groups.md). The restrictions are
-related to the candidate users or groups set up on user task definitions.
-
-For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the
-users that belong to `Team A` and the user `example` will have access to the task.
+See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailled description.

--- a/versioned_docs/version-8.7/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.7/self-managed/identity/deployment/configuration-variables.md
@@ -132,11 +132,10 @@ steps:
 
 Identity uses feature flag environment variables to enable and disable features; the supported flags are:
 
-| Environment variable         | Description                                                     | Default value |
-| ---------------------------- | --------------------------------------------------------------- | ------------- |
-| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature.                   | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.                             | false         |
-| USER_RESTRICTIONS_ENABLED    | Controls the user task access restrictions feature in Tasklist. | true          |
+| Environment variable         | Description                                   | Default value |
+| ---------------------------- | --------------------------------------------- | ------------- |
+| RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
+| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.7/self-managed/identity/deployment/configuration-variables.md
+++ b/versioned_docs/version-8.7/self-managed/identity/deployment/configuration-variables.md
@@ -135,7 +135,7 @@ Identity uses feature flag environment variables to enable and disable features;
 | Environment variable         | Description                                   | Default value |
 | ---------------------------- | --------------------------------------------- | ------------- |
 | RESOURCE_PERMISSIONS_ENABLED | Controls the resource authorizations feature. | false         |
-| MULTITENANCY_ENABLED         | Controls the multi tenancy feature.           | false         |
+| MULTITENANCY_ENABLED         | Controls the multi-tenancy feature.           | false         |
 
 :::note
 Setting either of the feature flags to `true` requires a database connection. To configure a database

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -162,7 +162,7 @@ curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKE
 
 ### User task access restrictions
 
-To use this resource, the **User Task Access Restrictions** feature must be [enabled on Identity](/self-managed/concepts/access-control/user-task-access-restrictions.md). When it is active, Tasklist applies additional security measures to filter tasks based on user identity and authorization. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
+User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 
 - Enhanced security: Users only see tasks for which they have the necessary permissions, improving security and preventing unauthorized access.
 - Tasklist customization: The Tasklist interface is tailored to display only relevant tasks for each user, providing a personalized and streamlined experience.

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-authentication.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-authentication.md
@@ -160,7 +160,7 @@ Take the `access_token` value from the response object and store it as your toke
 curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKEN>" http://localhost:8080/v1/tasks/search
 ```
 
-### User task access restrictions
+## User task access restrictions
 
 User task access restrictions are enabled by default. To disable, set the [`userAccessRestrictionsEnabled` Tasklist environment variable](/self-managed/tasklist-deployment/tasklist-authentication.md?authentication=identity#configure-identity) to `false`. When enabled, Tasklist applies additional security measures to only show tasks based on the logged-in users identity. The tasks displayed are restricted based on the candidate groups, candidate users, and assignee associated with the logged-in user. The benefits of this resource are:
 


### PR DESCRIPTION
Context of this PR: 
@romansmirnov  and myself went through docs, and Roman verified code. 

Basic rationale of this change:
* The status-quo of the docs refer to a `USER_RESTRICTIONS_ENABLED` flag in the Identity application that controls whether tasks in Tasklists are shown or not based on set properties (assignee, candidate, ...).
* Checking code, Roman found that this flag in Identity is not used. Instead, another flag in tasklist seems to be used.
* This PR adjusts the documentation accordingly. 

My ask for the reviewers:
* @marcosgvieira  - can you please verify that our findings and corrections are correct - in particular for how Tasklist handles the check for user task access restrictions?
* @ThorbenLindhauer - can you please verify that our findings and corrections are correct - in particular removing the `USER_RESTRICTIONS_ENABLED` flag?

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the DevEx team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and:
  - [ ] are in the `/docs` directory (version 8.8).
  - [ ] are in the `/versioned_docs/version-8.7/` directory (version 8.7).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
