### PR TITLE
Update orchestration cluster as defined in glossary, remove orchestration cluster core definition

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -169,11 +169,7 @@ A message contains information to be delivered to interested parties during exec
 
 ### Orchestration cluster
 
-An orchestration cluster includes Zeebe, Operate, Tasklist, Optimize, and Connectors. Previously [automation cluster](#automation-cluster).
-
-### Orchestration core
-
-An orchestration core or orchestration cluster core includes Zeebe, Operate, Tasklist, Optimize, and Identity.
+An orchestration cluster includes Zeebe, Operate, and Tasklist, but may include optional components like Optimize and Connectors. Previously [automation cluster](#automation-cluster).
 
 ### Outbound Connector
 


### PR DESCRIPTION
## Description

Internal conversations have gone back and forth on this, so I'm making a PR we can look at.

In our [reference architecture](https://docs.camunda.io/docs/next/self-managed/reference-architecture/#orchestration-cluster), we mention both cluster and cluster core, particularly in the architecture diagram, but for most of our users, they only need to understand "orchestration cluster." I've opened this PR to get alignment. 

I've marked this as "low prio" because we don't need to merge it as much as we need alignment across the 8.8 docs experience. This PR gets us closer to that.

FYI @camunda/tech-writers 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
