### PR TITLE
docs(data-purge): fix note formatting

### DIFF
--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -179,9 +179,13 @@ When the purge cluster operation is executed, the following steps are taken:
   - The exporter is closed via `Exporter#close`.
 - Partitions are bootstrapped and nodes rejoin the partitions with the same configuration as before the purge.
 
-:::note `Exporter#open(Context)` is not called during the purge operation. :::
+:::note 
+`Exporter#open(Context)` is not called during the purge operation. 
+:::
 
 When an exporter is purged, it is expected to delete all data, but not schemas.
 In the case that an exporter exports to a database, only the records are deleted, not the tables themselves.
 
-:::note All resources required for purging need to be closed afterwards to avoid memory leaks. :::
+:::note 
+All resources required for purging need to be closed afterwards to avoid memory leaks. 
+:::

--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -179,13 +179,13 @@ When the purge cluster operation is executed, the following steps are taken:
   - The exporter is closed via `Exporter#close`.
 - Partitions are bootstrapped and nodes rejoin the partitions with the same configuration as before the purge.
 
-:::note 
-`Exporter#open(Context)` is not called during the purge operation. 
+:::note
+`Exporter#open(Context)` is not called during the purge operation.
 :::
 
 When an exporter is purged, it is expected to delete all data, but not schemas.
 In the case that an exporter exports to a database, only the records are deleted, not the tables themselves.
 
-:::note 
-All resources required for purging need to be closed afterwards to avoid memory leaks. 
+:::note
+All resources required for purging need to be closed afterwards to avoid memory leaks.
 :::


### PR DESCRIPTION
## Description

Notes were shown incorrectly:
![image](https://github.com/user-attachments/assets/55108fac-5d93-4704-8776-213ffb700160)


## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

