### PR TITLE
docs(assert): add docs for newly implemented asserts

### DIFF
--- a/docs/apis-tools/testing/assertions.md
+++ b/docs/apis-tools/testing/assertions.md
@@ -140,6 +140,22 @@ Assert that the process instance is created and either active, completed, or ter
 assertThat(processInstance).isCreated();
 ```
 
+### hasActiveIncidents
+
+Assert that the process instance has at least one active incident. The assertion fails if there is no active incident.
+
+```java
+assertThat(processInstance).hasActiveIncidents();
+```
+
+### hasNoActiveIncidents
+
+Assert that the process instance has no active incidents. The assertion fails if there is any active incident.
+
+```java
+assertThat(processInstance).hasNoActiveIncidents();
+```
+
 ## Element instance assertions
 
 You can verify the element instance states and other properties using `CamundaAssert.assertThat(processInstance)`. Use the BPMN element ID or a `ElementSelector` to identify the elements.
@@ -177,12 +193,47 @@ Assert that the given BPMN elements of the process instance are active. The asse
 assertThat(processInstance).hasActiveElements("task_A", "task_B");
 ```
 
+### hasActiveElementsExactly
+
+Assert that only the given BPMN elements are active. The assertion fails if at least one element is not active, or other elements are active.
+
+```java
+assertThat(processInstance).hasActiveElementsExactly("task_A", "task_B");
+```
+
+### hasNoActiveElements
+
+Assert that the given BPMN elements are not active. The assertion fails if at least one element is active.
+
+```java
+assertThat(processInstance).hasNoActiveElements("task_A", "task_B");
+```
+
+### hasNotActivatedElements
+
+Assert that the given BPMN elements are not activated (i.e. not entered). The assertion fails if at least one element is active, completed, or terminated.
+
+This assertion does not wait for the given activities.
+
+```java
+assertThat(processInstance).hasNotActivatedElements("task_A", "task_B");
+```
+
 ### hasCompletedElements
 
 Assert that the given BPMN elements of the process instance are completed. The assertion fails if at least one element is active, terminated, or not entered.
 
 ```java
 assertThat(processInstance).hasCompletedElements("task_A", "task_B");
+```
+
+### hasCompletedElementsInOrder
+
+Assert that the given BPMN elements are completed in order. Elements that do not match any of the given element IDs are ignored. The assertion fails if at least one of the elements is not completed,
+or the order is not correct.
+
+```java
+assertThat(processInstance).hasCompletedElementsInOrder("task_A", "task_B");
 ```
 
 ### hasTerminatedElements

--- a/docs/apis-tools/testing/assertions.md
+++ b/docs/apis-tools/testing/assertions.md
@@ -193,6 +193,14 @@ Assert that the given BPMN elements of the process instance are active. The asse
 assertThat(processInstance).hasActiveElements("task_A", "task_B");
 ```
 
+### hasActiveElement
+
+Assert that the BPMN element of the process instance is active the given amount of times. The assertion fails if the element is not active or not exactly the given amount of times.
+
+```java
+assertThat(processInstance).hasActiveElement("task_A", 2);
+```
+
 ### hasActiveElementsExactly
 
 Assert that only the given BPMN elements are active. The assertion fails if at least one element is not active, or other elements are active.
@@ -227,6 +235,14 @@ Assert that the given BPMN elements of the process instance are completed. The a
 assertThat(processInstance).hasCompletedElements("task_A", "task_B");
 ```
 
+### hasCompletedElement
+
+Assert that the BPMN element of the process instance is completed the given amount of times. The assertion fails if the element is not completed or not exactly the given amount of times.
+
+```java
+assertThat(processInstance).hasCompletedElement("task_A", 2);
+```
+
 ### hasCompletedElementsInOrder
 
 Assert that the given BPMN elements are completed in order. Elements that do not match any of the given element IDs are ignored. The assertion fails if at least one of the elements is not completed,
@@ -242,22 +258,6 @@ Assert that the given BPMN elements of the process instance are terminated. The 
 
 ```java
 assertThat(processInstance).hasTerminatedElements("task_A", "task_B");
-```
-
-### hasActiveElement
-
-Assert that the BPMN element of the process instance is active the given amount of times. The assertion fails if the element is not active or not exactly the given amount of times.
-
-```java
-assertThat(processInstance).hasActiveElement("task_A", 2);
-```
-
-### hasCompletedElement
-
-Assert that the BPMN element of the process instance is completed the given amount of times. The assertion fails if the element is not completed or not exactly the given amount of times.
-
-```java
-assertThat(processInstance).hasCompletedElement("task_A", 2);
 ```
 
 ### hasTerminatedElement


### PR DESCRIPTION
## Description

Adds documentation for 

```
assertThat(processInstance).hasActiveIncidents();
assertThat(processInstance).hasNoActiveIncidents();
assertThat(processInstance).hasActiveElementsExactly("task_A", "task_B");
assertThat(processInstance).hasNoActiveElements("task_A", "task_B");
assertThat(processInstance).hasNotActivatedElements("task_A", "task_B");
assertThat(processInstance).hasCompletedElementsInOrder("task_A", "task_B");
```

Closes #5320, #5374, #5375, #5472, #5223, #5299

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

