### PR TITLE
Document internal linking lint error workaround

### DIFF
--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -63,10 +63,15 @@ As such, when a new version is cut, it results in unused sidebar sub-tree `.js` 
 
 When linking internally from one document to another, follow these guidelines:
 
+- Always include the `.md` extension in the path.
 - Use a relative path to the target markdown file if it is in the same subtree as the source file. [See example](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/components/console/introduction-to-console.md?plain=1#L10).
 - Use an absolute path to the target markdown file if it is in a different subtree than the source file. [See example](https://github.com/camunda/camunda-docs/blob/930a0c384b48be27d0bc66216015404f67716f61/docs/apis-clients/community-clients/spring.md?plain=1#L8).
-  - Refrain from using `/docs/<version>` when using an absolute path. For example, use `/components/components-overview.md` rather than `/docs/components/components-overview.md`. The latter will force Docusaurus to link to the vNext documentation, instead of the current version.
-- Always include the `.md` extension in the path.
+  - Refrain from using `/docs/<version>` when using an absolute path. See note below.
+
+> [!NOTE]
+> If you add/edit a link that goes to `docs/path/file.md`, and you see the error `[all.markdownLinksDontCrossVersions] Exclude the docs/ prefix in markdown links, unless you intend to link only to vNext. Consider using [...](/path/file.md) instead of [...](docs/path/file.md).` ([example](https://github.com/camunda/camunda-docs/pull/5606#discussion_r2052977180)), you have two options:
+> 1. Consider using `[...](/path/file.md)` instead of `[...](docs/path/file.md)`. For example, `/components/components-overview.md` rather than `/docs/components/components-overview.md`. The latter will force Docusaurus to link to the _vNext_ documentation, instead of the current version.
+> 2. If you're linking to vNext on purpose, just ignore the linting error. It won't prevent a green PR.
 
 ## Adding a new documentation page
 

--- a/howtos/documentation-guidelines.md
+++ b/howtos/documentation-guidelines.md
@@ -70,6 +70,7 @@ When linking internally from one document to another, follow these guidelines:
 
 > [!NOTE]
 > If you add/edit a link that goes to `docs/path/file.md`, and you see the error `[all.markdownLinksDontCrossVersions] Exclude the docs/ prefix in markdown links, unless you intend to link only to vNext. Consider using [...](/path/file.md) instead of [...](docs/path/file.md).` ([example](https://github.com/camunda/camunda-docs/pull/5606#discussion_r2052977180)), you have two options:
+>
 > 1. Consider using `[...](/path/file.md)` instead of `[...](docs/path/file.md)`. For example, `/components/components-overview.md` rather than `/docs/components/components-overview.md`. The latter will force Docusaurus to link to the _vNext_ documentation, instead of the current version.
 > 2. If you're linking to vNext on purpose, just ignore the linting error. It won't prevent a green PR.
 


### PR DESCRIPTION


## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

The internal links section already document what we should do. However, there is also a linter that checks against this. Contributors are likely to encounter this, and may be looking for advice on what to do.

This adds a note to the internal links section of the documentation guidelines to help users that encounter this linting error.

I've re-ordered the guidelines to highlight what we should always do first.

This came up in Slack [here](https://camunda.slack.com/archives/C01H4NG9XDY/p1745945897036719?thread_ts=1745876798.510449&cid=C01H4NG9XDY).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
