### PR TITLE
docs: document intra cluster tls config

### DIFF
--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -224,6 +224,21 @@ camunda.operate:
     gatewayAddress: localhost:26500
 ```
 
+### Intra-cluster secure connection
+
+You can enable intra-cluster TLS secured connections between Operate and Zeebe by applying the following configuration properties.
+
+| Name                                                | Description                                                                                                         | Example value                     |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ | :-------------------------------- |
+| zeebe.gateway.cluster.initialContactPoints          | Zeebe Gateway initial contact points.                                                                               | [gateway-0:26502,gateway-1:26502] |
+| zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
+| zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
+| zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | operate                           |
+| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | operate                           |
+
+For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+
 ## Zeebe Elasticsearch or OpenSearch exporter
 
 :::note

--- a/docs/self-managed/operate-deployment/operate-configuration.md
+++ b/docs/self-managed/operate-deployment/operate-configuration.md
@@ -234,10 +234,10 @@ You can enable intra-cluster TLS secured connections between Operate and Zeebe b
 | zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
 | zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
 | zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
-| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | operate                           |
-| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | operate                           |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster.                                                                                 | operate                           |
+| zeebe.gateway.cluster.memberId                      | Member ID for the cluster.                                                                                          | operate                           |
 
-For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+For extended configuration and guidelines, refer to [secure cluster communication](../zeebe-deployment/security/secure-cluster-communication.md) and [gateway configuration](../zeebe-deployment/configuration/gateway.md).
 
 ## Zeebe Elasticsearch or OpenSearch exporter
 

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -152,6 +152,21 @@ camunda.tasklist:
     gatewayAddress: localhost:26500
 ```
 
+### Intra-cluster secure connection
+
+You can enable intra-cluster TLS secured connections between Tasklist and Zeebe by applying the following configuration properties.
+
+| Name                                                | Description                                                                                                         | Example value                     |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ | :-------------------------------- |
+| zeebe.gateway.cluster.initialContactPoints          | Zeebe Gateway initial contact points.                                                                               | [gateway-0:26502,gateway-1:26502] |
+| zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
+| zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
+| zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | tasklist                          |
+| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | tasklist                          |
+
+For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+
 ## Zeebe Elasticsearch or OpenSearch exporter
 
 :::note

--- a/docs/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/docs/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -162,10 +162,10 @@ You can enable intra-cluster TLS secured connections between Tasklist and Zeebe 
 | zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
 | zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
 | zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
-| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | tasklist                          |
-| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | tasklist                          |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster.                                                                                 | tasklist                          |
+| zeebe.gateway.cluster.memberId                      | Member ID for the cluster.                                                                                          | tasklist                          |
 
-For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+For extended configuration and guidelines, refer to [secure cluster communication](../zeebe-deployment/security/secure-cluster-communication.md) and [gateway configuration](../zeebe-deployment/configuration/gateway.md).
 
 ## Zeebe Elasticsearch or OpenSearch exporter
 

--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -145,7 +145,7 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 ## Tasklist & Operate
 
-In a similar fashion you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster, refer to
+In a similar fashion, using the same set of configuration properties, you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster. Refer to the respective guides for further details
 [Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
 
 ## How it works

--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -143,6 +143,11 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 :::
 
+## Tasklist & Operate
+
+In a similar fashion you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster, refer to
+[Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
+
 ## How it works
 
 When enabled for each node, communication over TCP between these is securely encrypted using the provided certificates in a client-server model.

--- a/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -143,10 +143,9 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 :::
 
-## Tasklist & Operate
+## Tasklist and Operate
 
-In a similar fashion, using the same set of configuration properties, you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster. Refer to the respective guides for further details
-[Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
+Using the same set of configuration properties, you can configure Tasklist and Operate to enable TLS-secured connectivity within a Camunda 8 cluster. Refer to the documentation on [Tasklist configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection) for additional details.
 
 ## How it works
 

--- a/versioned_docs/version-8.6/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/operate-deployment/operate-configuration.md
@@ -242,10 +242,10 @@ You can enable intra-cluster TLS secured connections between Operate and Zeebe b
 | zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
 | zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
 | zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
-| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | operate                           |
-| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | operate                           |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster.                                                                                 | operate                           |
+| zeebe.gateway.cluster.memberId                      | Member ID for the cluster.                                                                                          | operate                           |
 
-For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+For extended configuration and guidelines, refer to [secure cluster communication](../zeebe-deployment/security/secure-cluster-communication.md) and [gateway configuration](../zeebe-deployment/configuration/gateway.md).
 
 :::note
 Intra-cluster TLS secured connections are available from Operate 8.6.14.

--- a/versioned_docs/version-8.6/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/operate-deployment/operate-configuration.md
@@ -232,6 +232,25 @@ camunda.operate:
     gatewayAddress: localhost:26500
 ```
 
+### Intra-cluster secure connection
+
+You can enable intra-cluster TLS secured connections between Operate and Zeebe by applying the following configuration properties.
+
+| Name                                                | Description                                                                                                         | Example value                     |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ | :-------------------------------- |
+| zeebe.gateway.cluster.initialContactPoints          | Zeebe Gateway initial contact points.                                                                               | [gateway-0:26502,gateway-1:26502] |
+| zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
+| zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
+| zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | operate                           |
+| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | operate                           |
+
+For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+
+:::note
+Intra-cluster TLS secured connections are available from Operate 8.6.14.
+:::
+
 ## Zeebe Elasticsearch or OpenSearch exporter
 
 :::note

--- a/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
@@ -78,6 +78,10 @@ With this change, there is no need to do extra steps with the post-renderer. You
 
 We have introduced a new base path for both the Operate and Tasklist web applications. The new base path for Operate is `/operate`, and for Tasklist, it is `/tasklist`. For more information, see the 8.6 [announcements](/reference/announcements-release-notes/860/860-announcements.md#new-base-path-for-operate-and-tasklist-web-applications).
 
+### Intra-cluster secure connection
+
+Starting from `8.6.14` you can now enable intra-cluster TLS secured connections for Tasklist & Operate as well. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).
+
 ## Zeebe
 
 ### Potential issue leading to stopped processing after update

--- a/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/update-guide/850-to-860.md
@@ -78,9 +78,9 @@ With this change, there is no need to do extra steps with the post-renderer. You
 
 We have introduced a new base path for both the Operate and Tasklist web applications. The new base path for Operate is `/operate`, and for Tasklist, it is `/tasklist`. For more information, see the 8.6 [announcements](/reference/announcements-release-notes/860/860-announcements.md#new-base-path-for-operate-and-tasklist-web-applications).
 
-### Intra-cluster secure connection
+### Intra-cluster communication
 
-Starting from `8.6.14` you can now enable intra-cluster TLS secured connections for Tasklist & Operate as well. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).
+Operate and Tasklist are now both part of the orchestration cluster. You can enable TLS encryption for intra-cluster connections as well starting from `8.6.14`. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).
 
 ## Zeebe
 

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -170,10 +170,10 @@ You can enable intra-cluster TLS secured connections between Tasklist and Zeebe 
 | zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
 | zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
 | zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
-| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | tasklist                          |
-| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | tasklist                          |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster.                                                                                 | tasklist                          |
+| zeebe.gateway.cluster.memberId                      | Member ID for the cluster.                                                                                          | tasklist                          |
 
-For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+For extended configuration and guidelines, refer to [secure cluster communication](../zeebe-deployment/security/secure-cluster-communication.md) and [gateway configuration](../zeebe-deployment/configuration/gateway.md).
 
 :::note
 Intra-cluster TLS secured connections are available from Tasklist 8.6.14.

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -160,6 +160,25 @@ camunda.tasklist:
     gatewayAddress: localhost:26500
 ```
 
+### Intra-cluster secure connection
+
+You can enable intra-cluster TLS secured connections between Tasklist and Zeebe by applying the following configuration properties.
+
+| Name                                                | Description                                                                                                         | Example value                     |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ | :-------------------------------- |
+| zeebe.gateway.cluster.initialContactPoints          | Zeebe Gateway initial contact points.                                                                               | [gateway-0:26502,gateway-1:26502] |
+| zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
+| zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
+| zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | tasklist                          |
+| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | tasklist                          |
+
+For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+
+:::note
+Intra-cluster TLS secured connections are available from Tasklist 8.6.14.
+:::
+
 ## Zeebe Elasticsearch or OpenSearch exporter
 
 :::note

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -145,7 +145,7 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 ## Tasklist & Operate
 
-In a similar fashion you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster, refer to
+In a similar fashion, using the same set of configuration properties, you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster. Refer to the respective guides for further details
 [Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
 
 ## How it works

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -143,6 +143,11 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 :::
 
+## Tasklist & Operate
+
+In a similar fashion you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster, refer to
+[Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
+
 ## How it works
 
 When enabled for each node, communication over TCP between these is securely encrypted using the provided certificates in a client-server model.

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -143,10 +143,9 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 :::
 
-## Tasklist & Operate
+## Tasklist and Operate
 
-In a similar fashion, using the same set of configuration properties, you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster. Refer to the respective guides for further details
-[Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
+Using the same set of configuration properties, you can configure Tasklist and Operate to enable TLS-secured connectivity within a Camunda 8 cluster. Refer to the documentation on [Tasklist configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection) for additional details.
 
 ## How it works
 

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/operate-configuration.md
@@ -256,10 +256,10 @@ You can enable intra-cluster TLS secured connections between Operate and Zeebe b
 | zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
 | zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
 | zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
-| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | operate                           |
-| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | operate                           |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster.                                                                                 | operate                           |
+| zeebe.gateway.cluster.memberId                      | Member ID for the cluster.                                                                                          | operate                           |
 
-For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+For extended configuration and guidelines, refer to [secure cluster communication](../zeebe-deployment/security/secure-cluster-communication.md) and [gateway configuration](../zeebe-deployment/configuration/gateway.md).
 
 :::note
 Intra-cluster TLS secured connections are available from Operate 8.7.2.

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/operate-configuration.md
@@ -246,6 +246,25 @@ camunda.operate:
     gatewayAddress: localhost:26500
 ```
 
+### Intra-cluster secure connection
+
+You can enable intra-cluster TLS secured connections between Operate and Zeebe by applying the following configuration properties.
+
+| Name                                                | Description                                                                                                         | Example value                     |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ | :-------------------------------- |
+| zeebe.gateway.cluster.initialContactPoints          | Zeebe Gateway initial contact points.                                                                               | [gateway-0:26502,gateway-1:26502] |
+| zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
+| zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
+| zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | operate                           |
+| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | operate                           |
+
+For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+
+:::note
+Intra-cluster TLS secured connections are available from Operate 8.7.2.
+:::
+
 ## Zeebe Elasticsearch or OpenSearch exporter
 
 :::note

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
@@ -78,6 +78,10 @@ With this change, there is no need to do extra steps with the post-renderer. You
 
 We have introduced a new base path for both the Operate and Tasklist web applications. The new base path for Operate is `/operate`, and for Tasklist, it is `/tasklist`. For more information, see the 8.6 [announcements](/reference/announcements-release-notes/860/860-announcements.md#new-base-path-for-operate-and-tasklist-web-applications).
 
+### Intra-cluster secure connection
+
+Starting from `8.6.14` you can now enable intra-cluster TLS secured connections for Tasklist & Operate as well. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).
+
 ## Zeebe
 
 ### Potential issue leading to stopped processing after update

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/850-to-860.md
@@ -78,9 +78,9 @@ With this change, there is no need to do extra steps with the post-renderer. You
 
 We have introduced a new base path for both the Operate and Tasklist web applications. The new base path for Operate is `/operate`, and for Tasklist, it is `/tasklist`. For more information, see the 8.6 [announcements](/reference/announcements-release-notes/860/860-announcements.md#new-base-path-for-operate-and-tasklist-web-applications).
 
-### Intra-cluster secure connection
+### Intra-cluster communication
 
-Starting from `8.6.14` you can now enable intra-cluster TLS secured connections for Tasklist & Operate as well. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).
+Operate and Tasklist are now both part of the orchestration cluster. You can enable TLS encryption for intra-cluster connections as well starting from `8.6.14`. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).
 
 ## Zeebe
 

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/860-to-870.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/860-to-870.md
@@ -122,3 +122,9 @@ For more information, see the [Connectors configuration guide](/self-managed/con
 ### Potential issue leading to stopped processing after update
 
 When updating from `8.6.13` to `8.7.0`, Zeebe processing can stop after the update in some situations, where multi-instance elements are used. This issue is fixed in `8.7.1`. When affected, going to `8.7.1` fully mitigates the issue. There is no risk of data loss.
+
+## Operate and Tasklist
+
+### Intra-cluster secure connection
+
+Starting from `8.7.2` you can now enable intra-cluster TLS secured connections for Tasklist & Operate as well. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/860-to-870.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/860-to-870.md
@@ -122,9 +122,3 @@ For more information, see the [Connectors configuration guide](/self-managed/con
 ### Potential issue leading to stopped processing after update
 
 When updating from `8.6.13` to `8.7.0`, Zeebe processing can stop after the update in some situations, where multi-instance elements are used. This issue is fixed in `8.7.1`. When affected, going to `8.7.1` fully mitigates the issue. There is no risk of data loss.
-
-## Operate and Tasklist
-
-### Intra-cluster secure connection
-
-Starting from `8.7.2` you can now enable intra-cluster TLS secured connections for Tasklist & Operate as well. For detailed information refer to [secure cluster configuration](../../zeebe-deployment/security/secure-cluster-communication.md).

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -184,10 +184,10 @@ You can enable intra-cluster TLS secured connections between Tasklist and Zeebe 
 | zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
 | zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
 | zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
-| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | tasklist                          |
-| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | tasklist                          |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster.                                                                                 | tasklist                          |
+| zeebe.gateway.cluster.memberId                      | Member ID for the cluster.                                                                                          | tasklist                          |
 
-For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+For extended configuration and guidelines, refer to [secure cluster communication](../zeebe-deployment/security/secure-cluster-communication.md) and [gateway configuration](../zeebe-deployment/configuration/gateway.md).
 
 :::note
 Intra-cluster TLS secured connections are available from Tasklist 8.7.2.

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -174,6 +174,25 @@ camunda.tasklist:
     gatewayAddress: localhost:26500
 ```
 
+### Intra-cluster secure connection
+
+You can enable intra-cluster TLS secured connections between Tasklist and Zeebe by applying the following configuration properties.
+
+| Name                                                | Description                                                                                                         | Example value                     |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ | :-------------------------------- |
+| zeebe.gateway.cluster.initialContactPoints          | Zeebe Gateway initial contact points.                                                                               | [gateway-0:26502,gateway-1:26502] |
+| zeebe.gateway.cluster.security.enabled              | Connection should be secure via Transport Layer Security (TLS).                                                     | true                              |
+| zeebe.gateway.cluster.security.certificateChainPath | Path to certificate used by Zeebe. This is necessary when the certificate isn't registered in the operating system. | /path/to/cert.pem                 |
+| zeebe.gateway.cluster.security.privateKeyPath       | Path to certificate's key used by Zeebe.                                                                            | /path/to/private.key              |
+| zeebe.gateway.cluster.advertisedHost                | Advertised hostname in the cluster                                                                                  | tasklist                          |
+| zeebe.gateway.cluster.memberId                      | Member id for the cluster                                                                                           | tasklist                          |
+
+For extended configuration and guidelines refer to [Secure Cluster Communication](../zeebe-deployment/security/secure-cluster-communication.md) and [Gateway Configuration](../zeebe-deployment/configuration/gateway.md)
+
+:::note
+Intra-cluster TLS secured connections are available from Tasklist 8.7.2.
+:::
+
 ## Zeebe Elasticsearch or OpenSearch exporter
 
 :::note

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -143,10 +143,9 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 :::
 
-## Tasklist & Operate
+## Tasklist and Operate
 
-In a similar fashion, using the same set of configuration properties, you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster. Refer to the respective guides for further details
-[Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
+Using the same set of configuration properties, you can configure Tasklist and Operate to enable TLS-secured connectivity within a Camunda 8 cluster. Refer to the documentation on [Tasklist configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection) for additional details.
 
 ## How it works
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -143,6 +143,11 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 :::
 
+## Tasklist & Operate
+
+In a similar fashion you can configure Tasklist & Operate to support TLS secured connectivity within a Camunda 8 cluster, refer to
+[Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
+
 ## How it works
 
 When enabled for each node, communication over TCP between these is securely encrypted using the provided certificates in a client-server model.

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/security/secure-cluster-communication.md
@@ -145,7 +145,7 @@ The `certificateChainPath`, `privateKeyPath`, and `keyStore.filePath` can be rel
 
 ## Tasklist & Operate
 
-In a similar fashion you can configure Tasklist & Operate to support TLS secured connectivity within a Camunda 8 cluster, refer to
+In a similar fashion, using the same set of configuration properties, you can configure Tasklist & Operate to enable TLS secured connectivity within a Camunda 8 cluster. Refer to the respective guides for further details
 [Tasklist Configuration](../../tasklist-deployment/tasklist-configuration.md#intra-cluster-secure-connection) and [Operate Configuration](../../operate-deployment/operate-configuration.md#intra-cluster-secure-connection)
 
 ## How it works


### PR DESCRIPTION
## Description
Document Intra cluster TLS configuration for Tasklist & Operate for versions 8.6, 8.7 and 8.8.

To be released alongside May's scheduled patch releases.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

#### Tasklist
Version _note_ for 8.7.2 and 8.6.14
- docs/8.6/self-managed/tasklist-deployment/tasklist-configuration/#intra-cluster-secure-connection
- docs/8.7/self-managed/tasklist-deployment/tasklist-configuration/#intra-cluster-secure-connection
- docs/next/self-managed/tasklist-deployment/tasklist-configuration/#intra-cluster-secure-connection

![image](https://github.com/user-attachments/assets/00848773-5c16-42c5-b809-2db8d6ccc218)

#### Operate
Version _note_ for 8.7.2 and 8.6.14
- docs/8.6/self-managed/operate-deployment/operate-configuration/#intra-cluster-secure-connection
- docs/8.7/self-managed/operate-deployment/operate-configuration/#intra-cluster-secure-connection
- docs/next/self-managed/operate-deployment/operate-configuration/#intra-cluster-secure-connection

![image](https://github.com/user-attachments/assets/bae1a23f-cc90-4773-a18c-d1bc798acbc7)


#### Security Config
- docs/8.6/self-managed/zeebe-deployment/security/secure-cluster-communication/#tasklist--operate
- docs/8.7/self-managed/zeebe-deployment/security/secure-cluster-communication/#tasklist--operate
- docs/next/self-managed/zeebe-deployment/security/secure-cluster-communication/#tasklist--operate

![image](https://github.com/user-attachments/assets/86edd79b-657f-4d5d-83fb-8ee8e7f7833b)

#### Update guides

- 8.5 -> 8.6
  -  docs/8.6/self-managed/operational-guides/update-guide/850-to-860/
  - /docs/self-managed/operational-guides/update-guide/850-to-860/
![image](https://github.com/user-attachments/assets/3230409d-5dd9-4720-b461-622d9d3a7e55)


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->

closes: #5674