### PR TITLE
add diagnosis script

### DIFF
--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -29,7 +29,7 @@ The script outputs the following data from your namespace and creates a zip file
 chmod +x camunda-collect-diagnostics.sh
 ```
 
-3. Execute the script replacing `<namespace>` with the namespace of your Camunda deployment:
+3. Execute the script, replacing `<namespace>` with the namespace of your Camunda deployment:
 
 ```bash
 ./camunda-collect-diagnostics.sh --namespace <namespace>

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -22,7 +22,7 @@ The script outputs the following data from your namespace and creates a zip file
 
 ### Usage
 
-1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
+1. Save the following script as `camunda-collect-diagnostics.sh` for example.
 2. Make the script executable:
 
 ```bash

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -29,7 +29,7 @@ The script outputs the following data from your namespace and creates a :
 chmod +x camunda-collect-diagnostics.sh
 ```
 
-3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+3. Execute the script replacing `<namespace>` with the namespace of your Camunda deployment:
 
 ```bash
 ./camunda-collect-diagnostics.sh --namespace <namespace>

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -7,7 +7,7 @@ description: "Get diagnostics and logs from a Helm chart deployment."
 
 ## Diagnostics collection script
 
-This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. The script collects all relevant information (including pod logs, events, and resource details) into a single directory, and outputs it in a .zip file to make it easier to share this information with the Camunda Support team.
 
 ### What the script collects
 

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -23,16 +23,19 @@ The script outputs the following data from your namespace and creates a :
 ### Usage
 
 1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
-2. Replace <NAMESPACE> with the namespace of your Camunda deployment
+2. Replace <NAMESPACE> with the namespace of your Camunda deployment.
 3. Make the script executable.
+
 ```bash
 chmod +x camunda-collect-diagnostics.sh
 ```
+
 4. Run the script.
 ```bash
 ./camunda-collect-diagnostics.sh
 ```
-5. Share the generated `.zip` archive with Camunda Support
+
+5. Share the generated `.zip` archive with Camunda Support.
 
 ### Diagnostic collection script
 

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -2,12 +2,12 @@
 id: diagnostics
 title: "Diagnostics"
 sidebar_label: "Diagnostics"
-description: "Get diagnostics and logs from a helm chart deployment."
+description: "Get diagnostics and logs from a Helm chart deployment."
 ---
 
 ## Diagnostics collection script
 
-This script automates the process of gathering logs and diagnostics from a Camunda Helm Chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
 
 ### What the script collects
 
@@ -24,15 +24,15 @@ The script outputs the following data from your namespace and creates a :
 
 1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
 2. Replace <NAMESPACE> with the namespace of your Camunda deployment
-4. Make the script executable.
-   ```bash
-   chmod +x camunda-collect-diagnostics.sh
-  ```
-5. Run the script.
-  ```bash
-  ./camunda-collect-diagnostics.sh
-  ```
-6. Share the archive with Camunda Support
+3. Make the script executable.
+```bash
+chmod +x camunda-collect-diagnostics.sh
+```
+4. Run the script.
+```bash
+./camunda-collect-diagnostics.sh
+```
+5. Share the generated `.zip` archive with Camunda Support
 
 ### Diagnostic collection script
 

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -11,7 +11,7 @@ This script automates the process of gathering logs and diagnostics from a Camun
 
 ### What the script collects
 
-The script outputs the following data from your namespace and creates a :
+The script outputs the following data from your namespace and creates a zip file containing the following:
 
 - **Pod Information**: Current and previous logs and full pod descriptions.
 - **Cluster Events**: Sorted by time to help identify recent issues.

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -1,0 +1,138 @@
+---
+id: diagnostics
+title: "Diagnostics"
+sidebar_label: "Diagnostics"
+description: "Get diagnostics and logs from a helm chart deployment."
+---
+
+## Diagnostics collection script
+
+This script automates the process of gathering logs and diagnostics from a Camunda Helm Chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+
+### What the script collects
+
+The script outputs the following data from your namespace and creates a :
+
+- **Pod Information**: Current and previous logs and full pod descriptions.
+- **Cluster Events**: Sorted by time to help identify recent issues.
+- **Storage Details**: PV and PVC descriptions.
+- **Cluster Nodes**: Node descriptions.
+- **Network Resources**: Services, endpoints, and ingresses.
+- **Configuration**: Config map information.
+
+### Usage
+
+1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
+2. Replace <NAMESPACE> with the namespace of your Camunda deployment
+4. Make the script executable.
+   ```bash
+   chmod +x camunda-collect-diagnostics.sh
+  ```
+5. Run the script.
+  ```bash
+  ./camunda-collect-diagnostics.sh
+  ```
+6. Share the archive with Camunda Support
+
+### Diagnostic collection script
+
+```bash
+#!/bin/bash
+
+# Define namespace
+namespace=<NAMESPACE>
+
+# Check if NAMESPACE is set
+if [[ "$namespace" == "NAMESPACE" ]]; then
+  echo "ERROR: Please set the 'namespace' variable in the script before running it."
+  echo "Example:"
+  echo "  namespace=\"camunda-platform\""
+  exit 1
+fi
+
+# Set output directory with timestamp
+timestamp=$(date +"%Y%m%d-%H%M%S")
+output_dir="camunda-diagnostics-logs-$timestamp"
+
+# Start diagnostics collection
+echo "========================================"
+echo "Camunda Diagnostics Collection Script"
+echo "========================================"
+echo "Namespace: $namespace"
+echo "Output Directory: $output_dir"
+echo "Current kubectl context: $(kubectl config current-context)"
+echo "========================================"
+
+# Create output directory
+mkdir -p "$output_dir" && cd "$output_dir"
+
+# Collect general Kubernetes resources
+echo "Collecting resource information..."
+
+echo "  - Collecting pod information (current state of all pods in the namespace)."
+kubectl get pod -n "$namespace" -o wide > pods.txt
+
+echo "  - Collecting cluster events (recent events in the namespace)."
+kubectl get events -n "$namespace" --sort-by='.lastTimestamp' > events.txt
+
+echo "  - Collecting Persistent Volume Claims (PVCs) descriptions (storage claims in the namespace)."
+kubectl describe pvc -n "$namespace" > pvc-describe.txt
+
+echo "  - Collecting service information (list of services in the namespace)."
+kubectl get svc -n "$namespace" > services.txt
+
+echo "  - Collecting detailed service descriptions (configuration of services)."
+kubectl describe svc -n "$namespace" > services-describe.txt
+
+echo "  - Collecting endpoint information (list of endpoints in the namespace)."
+kubectl get ep -n "$namespace" > endpoints.txt
+
+echo "  - Collecting detailed endpoint descriptions (configuration of endpoints)."
+kubectl describe ep -n "$namespace" > endpoints-describe.txt
+
+echo "  - Collecting ingress descriptions (configuration of ingress resources)."
+kubectl describe ing -n "$namespace" > ingresses-describe.txt
+
+echo "  - Collecting config map information (configuration data stored in the namespace)."
+kubectl get cm -n "$namespace" -o yaml > configmaps.yaml
+
+# Collect Persistent Volumes (PVs) relevant to the namespace
+echo "  - Collecting Persistent Volumes (PVs):"
+for pvc in $(kubectl get pvc -n "$namespace" --no-headers -o custom-columns=":spec.volumeName"); do
+  echo "    - Collecting information for PV: $pvc"
+  kubectl describe pv "$pvc" >> pv-describe.txt
+done
+
+# Get nodes relevant to the namespace
+echo "  - Collecting node information:"
+for node in $(kubectl get pods -n "$namespace" -o wide --no-headers | awk '{print $7}' | sort | uniq); do
+  echo "    - Collecting information for node: $node"
+  kubectl describe node "$node" >> node-describe.txt
+  echo "" >> node-describe.txt
+done
+
+# Collect logs and descriptions for each pod
+echo "  - Collecting logs and descriptions for each pod..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  echo "    - Collecting logs for pod: $pod"
+  kubectl logs -n "$namespace" "$pod" > "$pod.log" 2>/dev/null
+  kubectl logs -n "$namespace" "$pod" -p > "${pod}-previous.log" 2>/dev/null
+  kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
+done
+echo "All logs and descriptions collected."
+
+# Compress the output directory
+echo "Compressing collected diagnostics into ${output_dir}.zip..."
+cd ..
+zip -r "${output_dir}.zip" "$output_dir" > /dev/null
+echo "Diagnostics collected and compressed into ${output_dir}.zip."
+
+# Final message
+echo "========================================"
+echo "Diagnostics collection completed."
+echo "Please share the file '${output_dir}.zip' with the Camunda Support team."
+echo ""
+echo "To clean up the generated files and folder, run the following command:"
+echo "  rm -rf $output_dir ${output_dir}.zip"
+echo "========================================"
+```

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -118,7 +118,7 @@ echo "  - Collecting config map information (configuration data stored in the na
 kubectl get cm -n "$namespace" -o yaml > configmaps.yaml
 
 echo "  - Collecting node information:"
-for node in $(kubectl get pods -n "$namespace" -o wide --no-headers | awk '{print $7}' | sort | uniq); do
+for node in $(kubectl get pods -n "$namespace" -o custom-columns=":spec.nodeName" --no-headers | sort | uniq); do
   echo "    - Collecting information for node: $node"
   kubectl describe node "$node" >> node-describe.txt
   echo "" >> node-describe.txt

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -23,7 +23,7 @@ The script outputs the following data from your namespace and creates a :
 ### Usage
 
 1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
-. Replace `<NAMESPACE>` &lt;NAMESPACE&gt; with the namespace of your Camunda deployment.
+2. Replace `<NAMESPACE>` with the namespace of your Camunda deployment.
 3. Make the script executable.
 
 ```bash

--- a/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/docs/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -23,7 +23,7 @@ The script outputs the following data from your namespace and creates a :
 ### Usage
 
 1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
-2. Replace <NAMESPACE> with the namespace of your Camunda deployment.
+. Replace `<NAMESPACE>` &lt;NAMESPACE&gt; with the namespace of your Camunda deployment.
 3. Make the script executable.
 
 ```bash
@@ -31,6 +31,7 @@ chmod +x camunda-collect-diagnostics.sh
 ```
 
 4. Run the script.
+
 ```bash
 ./camunda-collect-diagnostics.sh
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -1174,6 +1174,7 @@ module.exports = {
         {
           Troubleshooting: [
             "self-managed/operational-guides/troubleshooting/troubleshooting",
+            "self-managed/operational-guides/troubleshooting/diagnostics",
           ],
         },
       ],

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/diagnostics.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/diagnostics.md
@@ -29,7 +29,7 @@ The script outputs the following data from your namespace and creates a :
 chmod +x camunda-collect-diagnostics.sh
 ```
 
-3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+3. Execute the script replacing `<namespace>` with the namespace of your Camunda deployment:
 
 ```bash
 ./camunda-collect-diagnostics.sh --namespace <namespace>

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/diagnostics.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/diagnostics.md
@@ -1,0 +1,150 @@
+---
+id: diagnostics
+title: "Diagnostics"
+sidebar_label: "Diagnostics"
+description: "Get diagnostics and logs from a Helm chart deployment."
+---
+
+## Diagnostics collection script
+
+This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+
+### What the script collects
+
+The script outputs the following data from your namespace and creates a :
+
+- **Pod Information**: Current and previous logs and full pod descriptions.
+- **Cluster Events**: Sorted by time to help identify recent issues.
+- **Storage Details**: PV and PVC descriptions.
+- **Cluster Nodes**: Node descriptions.
+- **Network Resources**: Services, endpoints, and ingresses.
+- **Configuration**: Config map information.
+
+### Usage
+
+1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
+2. Make the script executable:
+
+```bash
+chmod +x camunda-collect-diagnostics.sh
+```
+
+3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+
+```bash
+./camunda-collect-diagnostics.sh --namespace <namespace>
+```
+
+4. Share the generated `.zip` archive with Camunda Support.
+
+### Diagnostic collection script
+
+```bash
+#!/bin/bash
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --namespace) namespace="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+# Check if namespace is provided
+if [[ -z "$namespace" ]]; then
+  echo "ERROR: Namespace not provided. Please run the script with the --namespace parameter."
+  echo "Example:"
+  echo "  ./camunda-collect-diagnostics.sh --namespace camunda-platform"
+  exit 1
+fi
+
+# Check if namespace exists
+if ! kubectl get namespace "$namespace" > /dev/null 2>&1; then
+  echo "ERROR: Namespace '$namespace' does not exist in the cluster."
+  exit 1
+fi
+
+# Set output directory with timestamp
+timestamp=$(date +"%Y%m%d-%H%M%S")
+output_dir="camunda-diagnostics-logs-$timestamp"
+
+# Start diagnostics collection
+echo "========================================"
+echo "Camunda Diagnostics Collection Script"
+echo "========================================"
+echo "Namespace: $namespace"
+echo "Output Directory: $output_dir"
+echo "Current kubectl context: $(kubectl config current-context)"
+echo "========================================"
+
+# Create output directory
+mkdir -p "$output_dir" && cd "$output_dir"
+
+# Collect general Kubernetes resources
+echo "Collecting resource information..."
+
+echo "  - Collecting pod information (current state of all pods in the namespace)."
+kubectl get pod -n "$namespace" -o wide > pods.txt
+
+echo "  - Collecting cluster events (recent events in the namespace)."
+kubectl get events -n "$namespace" --sort-by='.lastTimestamp' > events.txt
+
+echo "  - Collecting Persistent Volume Claims (PVCs) descriptions (storage claims in the namespace)."
+kubectl describe pvc -n "$namespace" > pvc-describe.txt
+
+echo "  - Collecting Persistent Volumes (PVs) descriptions (underlying storage volumes)."
+for pvc in $(kubectl get pvc -n "$namespace" --no-headers -o custom-columns=":spec.volumeName"); do
+  echo "    - Collecting information for PV: $pvc"
+  kubectl describe pv "$pvc" >> pv-describe.txt
+done
+
+echo "  - Collecting service information (list of services in the namespace)."
+kubectl get svc -n "$namespace" > services.txt
+
+echo "  - Collecting detailed service descriptions (configuration of services)."
+kubectl describe svc -n "$namespace" > services-describe.txt
+
+echo "  - Collecting endpoint information (list of endpoints in the namespace)."
+kubectl get ep -n "$namespace" > endpoints.txt
+
+echo "  - Collecting detailed endpoint descriptions (configuration of endpoints)."
+kubectl describe ep -n "$namespace" > endpoints-describe.txt
+
+echo "  - Collecting ingress descriptions (configuration of ingress resources)."
+kubectl describe ing -n "$namespace" > ingresses-describe.txt
+
+echo "  - Collecting config map information (configuration data stored in the namespace)."
+kubectl get cm -n "$namespace" -o yaml > configmaps.yaml
+
+echo "  - Collecting node information:"
+for node in $(kubectl get pods -n "$namespace" -o custom-columns=":spec.nodeName" --no-headers | sort | uniq); do
+  echo "    - Collecting information for node: $node"
+  kubectl describe node "$node" >> node-describe.txt
+  echo "" >> node-describe.txt
+done
+
+echo "  - Collecting logs and descriptions for each pod..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  echo "    - Collecting logs for pod: $pod"
+  kubectl logs -n "$namespace" "$pod" > "$pod.log" 2>/dev/null
+  kubectl logs -n "$namespace" "$pod" -p > "${pod}-previous.log" 2>/dev/null
+  kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
+done
+echo "All logs and descriptions collected."
+
+# Compress the output directory
+echo "Compressing collected diagnostics into ${output_dir}.zip..."
+cd ..
+zip -r "${output_dir}.zip" "$output_dir" > /dev/null
+echo "Diagnostics collected and compressed into ${output_dir}.zip."
+
+# Final message
+echo "========================================"
+echo "Diagnostics collection completed."
+echo "Please share the file '${output_dir}.zip' with the Camunda Support team."
+echo ""
+echo "To clean up the generated files and folder, run the following command:"
+echo "  rm -rf $output_dir ${output_dir}.zip"
+echo "========================================"
+```

--- a/versioned_docs/version-8.5/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -29,7 +29,7 @@ The script outputs the following data from your namespace and creates a :
 chmod +x camunda-collect-diagnostics.sh
 ```
 
-3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+3. Execute the script replacing `<namespace>` with the namespace of your Camunda deployment:
 
 ```bash
 ./camunda-collect-diagnostics.sh --namespace <namespace>

--- a/versioned_docs/version-8.5/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.5/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -1,0 +1,150 @@
+---
+id: diagnostics
+title: "Diagnostics"
+sidebar_label: "Diagnostics"
+description: "Get diagnostics and logs from a Helm chart deployment."
+---
+
+## Diagnostics collection script
+
+This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+
+### What the script collects
+
+The script outputs the following data from your namespace and creates a :
+
+- **Pod Information**: Current and previous logs and full pod descriptions.
+- **Cluster Events**: Sorted by time to help identify recent issues.
+- **Storage Details**: PV and PVC descriptions.
+- **Cluster Nodes**: Node descriptions.
+- **Network Resources**: Services, endpoints, and ingresses.
+- **Configuration**: Config map information.
+
+### Usage
+
+1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
+2. Make the script executable:
+
+```bash
+chmod +x camunda-collect-diagnostics.sh
+```
+
+3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+
+```bash
+./camunda-collect-diagnostics.sh --namespace <namespace>
+```
+
+4. Share the generated `.zip` archive with Camunda Support.
+
+### Diagnostic collection script
+
+```bash
+#!/bin/bash
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --namespace) namespace="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+# Check if namespace is provided
+if [[ -z "$namespace" ]]; then
+  echo "ERROR: Namespace not provided. Please run the script with the --namespace parameter."
+  echo "Example:"
+  echo "  ./camunda-collect-diagnostics.sh --namespace camunda-platform"
+  exit 1
+fi
+
+# Check if namespace exists
+if ! kubectl get namespace "$namespace" > /dev/null 2>&1; then
+  echo "ERROR: Namespace '$namespace' does not exist in the cluster."
+  exit 1
+fi
+
+# Set output directory with timestamp
+timestamp=$(date +"%Y%m%d-%H%M%S")
+output_dir="camunda-diagnostics-logs-$timestamp"
+
+# Start diagnostics collection
+echo "========================================"
+echo "Camunda Diagnostics Collection Script"
+echo "========================================"
+echo "Namespace: $namespace"
+echo "Output Directory: $output_dir"
+echo "Current kubectl context: $(kubectl config current-context)"
+echo "========================================"
+
+# Create output directory
+mkdir -p "$output_dir" && cd "$output_dir"
+
+# Collect general Kubernetes resources
+echo "Collecting resource information..."
+
+echo "  - Collecting pod information (current state of all pods in the namespace)."
+kubectl get pod -n "$namespace" -o wide > pods.txt
+
+echo "  - Collecting cluster events (recent events in the namespace)."
+kubectl get events -n "$namespace" --sort-by='.lastTimestamp' > events.txt
+
+echo "  - Collecting Persistent Volume Claims (PVCs) descriptions (storage claims in the namespace)."
+kubectl describe pvc -n "$namespace" > pvc-describe.txt
+
+echo "  - Collecting Persistent Volumes (PVs) descriptions (underlying storage volumes)."
+for pvc in $(kubectl get pvc -n "$namespace" --no-headers -o custom-columns=":spec.volumeName"); do
+  echo "    - Collecting information for PV: $pvc"
+  kubectl describe pv "$pvc" >> pv-describe.txt
+done
+
+echo "  - Collecting service information (list of services in the namespace)."
+kubectl get svc -n "$namespace" > services.txt
+
+echo "  - Collecting detailed service descriptions (configuration of services)."
+kubectl describe svc -n "$namespace" > services-describe.txt
+
+echo "  - Collecting endpoint information (list of endpoints in the namespace)."
+kubectl get ep -n "$namespace" > endpoints.txt
+
+echo "  - Collecting detailed endpoint descriptions (configuration of endpoints)."
+kubectl describe ep -n "$namespace" > endpoints-describe.txt
+
+echo "  - Collecting ingress descriptions (configuration of ingress resources)."
+kubectl describe ing -n "$namespace" > ingresses-describe.txt
+
+echo "  - Collecting config map information (configuration data stored in the namespace)."
+kubectl get cm -n "$namespace" -o yaml > configmaps.yaml
+
+echo "  - Collecting node information:"
+for node in $(kubectl get pods -n "$namespace" -o custom-columns=":spec.nodeName" --no-headers | sort | uniq); do
+  echo "    - Collecting information for node: $node"
+  kubectl describe node "$node" >> node-describe.txt
+  echo "" >> node-describe.txt
+done
+
+echo "  - Collecting logs and descriptions for each pod..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  echo "    - Collecting logs for pod: $pod"
+  kubectl logs -n "$namespace" "$pod" > "$pod.log" 2>/dev/null
+  kubectl logs -n "$namespace" "$pod" -p > "${pod}-previous.log" 2>/dev/null
+  kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
+done
+echo "All logs and descriptions collected."
+
+# Compress the output directory
+echo "Compressing collected diagnostics into ${output_dir}.zip..."
+cd ..
+zip -r "${output_dir}.zip" "$output_dir" > /dev/null
+echo "Diagnostics collected and compressed into ${output_dir}.zip."
+
+# Final message
+echo "========================================"
+echo "Diagnostics collection completed."
+echo "Please share the file '${output_dir}.zip' with the Camunda Support team."
+echo ""
+echo "To clean up the generated files and folder, run the following command:"
+echo "  rm -rf $output_dir ${output_dir}.zip"
+echo "========================================"
+```

--- a/versioned_docs/version-8.6/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -29,7 +29,7 @@ The script outputs the following data from your namespace and creates a :
 chmod +x camunda-collect-diagnostics.sh
 ```
 
-3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+3. Execute the script replacing `<namespace>` with the namespace of your Camunda deployment:
 
 ```bash
 ./camunda-collect-diagnostics.sh --namespace <namespace>

--- a/versioned_docs/version-8.6/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -1,0 +1,150 @@
+---
+id: diagnostics
+title: "Diagnostics"
+sidebar_label: "Diagnostics"
+description: "Get diagnostics and logs from a Helm chart deployment."
+---
+
+## Diagnostics collection script
+
+This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+
+### What the script collects
+
+The script outputs the following data from your namespace and creates a :
+
+- **Pod Information**: Current and previous logs and full pod descriptions.
+- **Cluster Events**: Sorted by time to help identify recent issues.
+- **Storage Details**: PV and PVC descriptions.
+- **Cluster Nodes**: Node descriptions.
+- **Network Resources**: Services, endpoints, and ingresses.
+- **Configuration**: Config map information.
+
+### Usage
+
+1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
+2. Make the script executable:
+
+```bash
+chmod +x camunda-collect-diagnostics.sh
+```
+
+3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+
+```bash
+./camunda-collect-diagnostics.sh --namespace <namespace>
+```
+
+4. Share the generated `.zip` archive with Camunda Support.
+
+### Diagnostic collection script
+
+```bash
+#!/bin/bash
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --namespace) namespace="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+# Check if namespace is provided
+if [[ -z "$namespace" ]]; then
+  echo "ERROR: Namespace not provided. Please run the script with the --namespace parameter."
+  echo "Example:"
+  echo "  ./camunda-collect-diagnostics.sh --namespace camunda-platform"
+  exit 1
+fi
+
+# Check if namespace exists
+if ! kubectl get namespace "$namespace" > /dev/null 2>&1; then
+  echo "ERROR: Namespace '$namespace' does not exist in the cluster."
+  exit 1
+fi
+
+# Set output directory with timestamp
+timestamp=$(date +"%Y%m%d-%H%M%S")
+output_dir="camunda-diagnostics-logs-$timestamp"
+
+# Start diagnostics collection
+echo "========================================"
+echo "Camunda Diagnostics Collection Script"
+echo "========================================"
+echo "Namespace: $namespace"
+echo "Output Directory: $output_dir"
+echo "Current kubectl context: $(kubectl config current-context)"
+echo "========================================"
+
+# Create output directory
+mkdir -p "$output_dir" && cd "$output_dir"
+
+# Collect general Kubernetes resources
+echo "Collecting resource information..."
+
+echo "  - Collecting pod information (current state of all pods in the namespace)."
+kubectl get pod -n "$namespace" -o wide > pods.txt
+
+echo "  - Collecting cluster events (recent events in the namespace)."
+kubectl get events -n "$namespace" --sort-by='.lastTimestamp' > events.txt
+
+echo "  - Collecting Persistent Volume Claims (PVCs) descriptions (storage claims in the namespace)."
+kubectl describe pvc -n "$namespace" > pvc-describe.txt
+
+echo "  - Collecting Persistent Volumes (PVs) descriptions (underlying storage volumes)."
+for pvc in $(kubectl get pvc -n "$namespace" --no-headers -o custom-columns=":spec.volumeName"); do
+  echo "    - Collecting information for PV: $pvc"
+  kubectl describe pv "$pvc" >> pv-describe.txt
+done
+
+echo "  - Collecting service information (list of services in the namespace)."
+kubectl get svc -n "$namespace" > services.txt
+
+echo "  - Collecting detailed service descriptions (configuration of services)."
+kubectl describe svc -n "$namespace" > services-describe.txt
+
+echo "  - Collecting endpoint information (list of endpoints in the namespace)."
+kubectl get ep -n "$namespace" > endpoints.txt
+
+echo "  - Collecting detailed endpoint descriptions (configuration of endpoints)."
+kubectl describe ep -n "$namespace" > endpoints-describe.txt
+
+echo "  - Collecting ingress descriptions (configuration of ingress resources)."
+kubectl describe ing -n "$namespace" > ingresses-describe.txt
+
+echo "  - Collecting config map information (configuration data stored in the namespace)."
+kubectl get cm -n "$namespace" -o yaml > configmaps.yaml
+
+echo "  - Collecting node information:"
+for node in $(kubectl get pods -n "$namespace" -o custom-columns=":spec.nodeName" --no-headers | sort | uniq); do
+  echo "    - Collecting information for node: $node"
+  kubectl describe node "$node" >> node-describe.txt
+  echo "" >> node-describe.txt
+done
+
+echo "  - Collecting logs and descriptions for each pod..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  echo "    - Collecting logs for pod: $pod"
+  kubectl logs -n "$namespace" "$pod" > "$pod.log" 2>/dev/null
+  kubectl logs -n "$namespace" "$pod" -p > "${pod}-previous.log" 2>/dev/null
+  kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
+done
+echo "All logs and descriptions collected."
+
+# Compress the output directory
+echo "Compressing collected diagnostics into ${output_dir}.zip..."
+cd ..
+zip -r "${output_dir}.zip" "$output_dir" > /dev/null
+echo "Diagnostics collected and compressed into ${output_dir}.zip."
+
+# Final message
+echo "========================================"
+echo "Diagnostics collection completed."
+echo "Please share the file '${output_dir}.zip' with the Camunda Support team."
+echo ""
+echo "To clean up the generated files and folder, run the following command:"
+echo "  rm -rf $output_dir ${output_dir}.zip"
+echo "========================================"
+```

--- a/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -29,7 +29,7 @@ The script outputs the following data from your namespace and creates a :
 chmod +x camunda-collect-diagnostics.sh
 ```
 
-3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+3. Execute the script replacing `<namespace>` with the namespace of your Camunda deployment:
 
 ```bash
 ./camunda-collect-diagnostics.sh --namespace <namespace>

--- a/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -1,0 +1,150 @@
+---
+id: diagnostics
+title: "Diagnostics"
+sidebar_label: "Diagnostics"
+description: "Get diagnostics and logs from a Helm chart deployment."
+---
+
+## Diagnostics collection script
+
+This script automates the process of gathering logs and diagnostics from a Camunda Helm chart deployment running in a Kubernetes cluster. It collects all relevant information—including pod logs, events, and resource details—into a single directory, and outputs it in a .zip file to make it easy sharing these information with the Camunda Support team.
+
+### What the script collects
+
+The script outputs the following data from your namespace and creates a :
+
+- **Pod Information**: Current and previous logs and full pod descriptions.
+- **Cluster Events**: Sorted by time to help identify recent issues.
+- **Storage Details**: PV and PVC descriptions.
+- **Cluster Nodes**: Node descriptions.
+- **Network Resources**: Services, endpoints, and ingresses.
+- **Configuration**: Config map information.
+
+### Usage
+
+1. Save the script below as e.g. `camunda-collect-diagnostics.sh`.
+2. Make the script executable:
+
+```bash
+chmod +x camunda-collect-diagnostics.sh
+```
+
+3. Execute the script replacing <namespace> with the namespace of your Camunda deployment:
+
+```bash
+./camunda-collect-diagnostics.sh --namespace <namespace>
+```
+
+4. Share the generated `.zip` archive with Camunda Support.
+
+### Diagnostic collection script
+
+```bash
+#!/bin/bash
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --namespace) namespace="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+# Check if namespace is provided
+if [[ -z "$namespace" ]]; then
+  echo "ERROR: Namespace not provided. Please run the script with the --namespace parameter."
+  echo "Example:"
+  echo "  ./camunda-collect-diagnostics.sh --namespace camunda-platform"
+  exit 1
+fi
+
+# Check if namespace exists
+if ! kubectl get namespace "$namespace" > /dev/null 2>&1; then
+  echo "ERROR: Namespace '$namespace' does not exist in the cluster."
+  exit 1
+fi
+
+# Set output directory with timestamp
+timestamp=$(date +"%Y%m%d-%H%M%S")
+output_dir="camunda-diagnostics-logs-$timestamp"
+
+# Start diagnostics collection
+echo "========================================"
+echo "Camunda Diagnostics Collection Script"
+echo "========================================"
+echo "Namespace: $namespace"
+echo "Output Directory: $output_dir"
+echo "Current kubectl context: $(kubectl config current-context)"
+echo "========================================"
+
+# Create output directory
+mkdir -p "$output_dir" && cd "$output_dir"
+
+# Collect general Kubernetes resources
+echo "Collecting resource information..."
+
+echo "  - Collecting pod information (current state of all pods in the namespace)."
+kubectl get pod -n "$namespace" -o wide > pods.txt
+
+echo "  - Collecting cluster events (recent events in the namespace)."
+kubectl get events -n "$namespace" --sort-by='.lastTimestamp' > events.txt
+
+echo "  - Collecting Persistent Volume Claims (PVCs) descriptions (storage claims in the namespace)."
+kubectl describe pvc -n "$namespace" > pvc-describe.txt
+
+echo "  - Collecting Persistent Volumes (PVs) descriptions (underlying storage volumes)."
+for pvc in $(kubectl get pvc -n "$namespace" --no-headers -o custom-columns=":spec.volumeName"); do
+  echo "    - Collecting information for PV: $pvc"
+  kubectl describe pv "$pvc" >> pv-describe.txt
+done
+
+echo "  - Collecting service information (list of services in the namespace)."
+kubectl get svc -n "$namespace" > services.txt
+
+echo "  - Collecting detailed service descriptions (configuration of services)."
+kubectl describe svc -n "$namespace" > services-describe.txt
+
+echo "  - Collecting endpoint information (list of endpoints in the namespace)."
+kubectl get ep -n "$namespace" > endpoints.txt
+
+echo "  - Collecting detailed endpoint descriptions (configuration of endpoints)."
+kubectl describe ep -n "$namespace" > endpoints-describe.txt
+
+echo "  - Collecting ingress descriptions (configuration of ingress resources)."
+kubectl describe ing -n "$namespace" > ingresses-describe.txt
+
+echo "  - Collecting config map information (configuration data stored in the namespace)."
+kubectl get cm -n "$namespace" -o yaml > configmaps.yaml
+
+echo "  - Collecting node information:"
+for node in $(kubectl get pods -n "$namespace" -o custom-columns=":spec.nodeName" --no-headers | sort | uniq); do
+  echo "    - Collecting information for node: $node"
+  kubectl describe node "$node" >> node-describe.txt
+  echo "" >> node-describe.txt
+done
+
+echo "  - Collecting logs and descriptions for each pod..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  echo "    - Collecting logs for pod: $pod"
+  kubectl logs -n "$namespace" "$pod" > "$pod.log" 2>/dev/null
+  kubectl logs -n "$namespace" "$pod" -p > "${pod}-previous.log" 2>/dev/null
+  kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
+done
+echo "All logs and descriptions collected."
+
+# Compress the output directory
+echo "Compressing collected diagnostics into ${output_dir}.zip..."
+cd ..
+zip -r "${output_dir}.zip" "$output_dir" > /dev/null
+echo "Diagnostics collected and compressed into ${output_dir}.zip."
+
+# Final message
+echo "========================================"
+echo "Diagnostics collection completed."
+echo "Please share the file '${output_dir}.zip' with the Camunda Support team."
+echo ""
+echo "To clean up the generated files and folder, run the following command:"
+echo "  rm -rf $output_dir ${output_dir}.zip"
+echo "========================================"
+```


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

closes https://github.com/camunda/team-distribution/issues/495

This script automates the collection of logs and diagnostics from a Camunda Helm Chart deployment in a Kubernetes cluster. It gathers relevant information from the specified namespace and outputs it in a .zip file for easy sharing with the Camunda Support team.

Once this change is approved, I will backport it to the other versions.

Example output file: [camunda-diagnostics-logs-20250501-082547.zip](https://github.com/user-attachments/files/19999492/camunda-diagnostics-logs-20250501-082547.zip)

Terminal output: 
```
========================================
Camunda Diagnostics Collection Script
========================================
Namespace: immi-test
Output Directory: camunda-diagnostics-logs-20250501-082547
Current kubectl context: gke_camunda-distribution_europe-west1-b_distro-ci
========================================
Collecting resource information...
  - Collecting pod information (current state of all pods in the namespace).
  - Collecting cluster events (recent events in the namespace).
  - Collecting Persistent Volume Claims (PVCs) descriptions (storage claims in the namespace).
  - Collecting service information (list of services in the namespace).
  - Collecting detailed service descriptions (configuration of services).
  - Collecting endpoint information (list of endpoints in the namespace).
  - Collecting detailed endpoint descriptions (configuration of endpoints).
  - Collecting ingress descriptions (configuration of ingress resources).
  - Collecting config map information (configuration data stored in the namespace).
  - Collecting Persistent Volumes (PVs)
    - Collecting information for PV: pvc-0264b211-65ec-43f9-984d-99979ebd75d7
    - Collecting information for PV: pvc-5969ec94-d963-4fc0-ad08-a871df01af79
    - Collecting information for PV: pvc-4b1e1971-fd13-4159-9d43-a8efa2bb56fb
    - Collecting information for PV: pvc-4c4f92cf-1d05-4640-8820-7db2394b44f9
  - Collecting node information for nodes...
    - Collecting information for node: gke-distro-ci-workflow-preemptible02-ba8c70c7-bkbp
    - Collecting information for node: gke-distro-ci-workflow-preemptible02-ba8c70c7-cpvf
    - Collecting information for node: gke-distro-ci-workflow-preemptible02-ba8c70c7-gc6n
    - Collecting information for node: gke-distro-ci-workflow-preemptible02-ba8c70c7-nnbk
    - Collecting information for node: gke-distro-ci-workflow-preemptible02-ba8c70c7-pbkp
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-2vqz
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-5wjh
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-8rbx
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-hr4x
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-mdxq
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-szx5
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-vs66
    - Collecting information for node: gke-distro-ci-workflow-spot02-001b92b6-wddz
  - Collecting logs and descriptions for each pod...
    - Collecting logs for pod: camunda-connectors-7fd4f6f6fd-lcls2
    - Collecting logs for pod: camunda-elasticsearch-master-0
    - Collecting logs for pod: camunda-identity-7bb4cc6dcc-cgbgl
    - Collecting logs for pod: camunda-keycloak-0
    - Collecting logs for pod: camunda-operate-d6b454f46-4nlmn
    - Collecting logs for pod: camunda-optimize-f99fdcd68-cns7q
    - Collecting logs for pod: camunda-postgresql-0
    - Collecting logs for pod: camunda-postgresql-web-modeler-0
    - Collecting logs for pod: camunda-tasklist-57765cd549-8cqdx
    - Collecting logs for pod: camunda-web-modeler-restapi-bf767b4b4-lmggt
    - Collecting logs for pod: camunda-web-modeler-webapp-97866d889-zm4xk
    - Collecting logs for pod: camunda-web-modeler-websockets-5cccddcf5f-lvlst
    - Collecting logs for pod: camunda-zeebe-0
    - Collecting logs for pod: camunda-zeebe-gateway-797bc6488f-qgkm7
All logs and descriptions collected.
Compressing collected diagnostics into camunda-diagnostics-logs-20250501-082547.zip...
Diagnostics collected and compressed into camunda-diagnostics-logs-20250501-082547.zip.
========================================
Diagnostics collection completed.
Please share the file 'camunda-diagnostics-logs-20250501-082547.zip' with the Camunda Support team.

To clean up the generated files and folder, run the following command:
  rm -rf camunda-diagnostics-logs-20250501-082547 camunda-diagnostics-logs-20250501-082547.zip
========================================
```
## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
