### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,5 +1,9 @@
 name: Auto Assign
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/camunda/camunda-docs/security/code-scanning/23](https://github.com/camunda/camunda-docs/security/code-scanning/23)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it likely needs `contents: read` to access repository metadata and `pull-requests: write` to assign users to pull requests. These permissions will be added to the root of the workflow file, ensuring all jobs inherit them unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
