### PR TITLE
docs: extend update guide with OpenAPI changes

### DIFF
--- a/docs/self-managed/operational-guides/update-guide/860-to-870.md
+++ b/docs/self-managed/operational-guides/update-guide/860-to-870.md
@@ -36,7 +36,9 @@ If you have any logging based alerts configured, please update them accordingly.
 Configuring a non-existing bucket for backups will not prevent Zeebe to start up anymore and will only result
 in logs (at WARN) in the startup phase.
 
-## REST API key attributes change to `string`
+## Camunda 8 REST API
+
+### Key attributes change to `string`
 
 With 8.7, the default REST API key attribute type changes from `integer (int64)` to `string`.
 

--- a/docs/self-managed/operational-guides/update-guide/870-to-880.md
+++ b/docs/self-managed/operational-guides/update-guide/870-to-880.md
@@ -198,7 +198,9 @@ Using more than one isolated Elasticsearch/OpenSearch instance for exported Zeeb
 This step must be performed before all other migration steps.
 :::
 
-## Removed deprecated OpenAPI objects
+## Orchestration Cluster API
+
+### Removed deprecated OpenAPI objects
 
 :::warning
 With the Camunda 8.8 release, deprecated API objects containing number keys have been removed, including the
@@ -215,6 +217,15 @@ For more information about the key attribute type change, see
 the [8.7 API key attributes overview][camunda8-api-overview].
 
 [camunda8-api-overview]: /versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md#api-key-attributes
+
+### Streamlined variable OpenAPI objects
+
+The OpenAPI specification streamlines the objects used for variable filtering in search requests. The supported Camunda Java client handles those changes transparently. The affected API endpoints are alpha feature endpoints and thus already marked as subject to change in 8.6 and 8.7.
+
+If you are generating a custom REST client using the specification, consider the following changes: 
+
+* The unified `VariableValueFilterRequest` replaces the `ProcessInstanceVariableFilterRequest` and `UserTaskVariableFilterRequest` in the OpenAPI spec. 
+* For naming consistency, the `UserTaskVariableFilterRequest` replaces the `VariableUserTaskFilterRequest`.
 
 ## Exported records
 

--- a/docs/self-managed/operational-guides/update-guide/870-to-880.md
+++ b/docs/self-managed/operational-guides/update-guide/870-to-880.md
@@ -222,10 +222,10 @@ the [8.7 API key attributes overview][camunda8-api-overview].
 
 The OpenAPI specification streamlines the objects used for variable filtering in search requests. The supported Camunda Java client handles those changes transparently. The affected API endpoints are alpha feature endpoints and thus already marked as subject to change in 8.6 and 8.7.
 
-If you are generating a custom REST client using the specification, consider the following changes: 
+If you are generating a custom REST client using the specification, consider the following changes:
 
-* The unified `VariableValueFilterRequest` replaces the `ProcessInstanceVariableFilterRequest` and `UserTaskVariableFilterRequest` in the OpenAPI spec. 
-* For naming consistency, the `UserTaskVariableFilterRequest` replaces the `VariableUserTaskFilterRequest`.
+- The unified `VariableValueFilterRequest` replaces the `ProcessInstanceVariableFilterRequest` and `UserTaskVariableFilterRequest` in the OpenAPI spec.
+- For naming consistency, the `UserTaskVariableFilterRequest` replaces the `VariableUserTaskFilterRequest`.
 
 ## Exported records
 

--- a/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/860-to-870.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/update-guide/860-to-870.md
@@ -36,7 +36,9 @@ If you have any logging based alerts configured, please update them accordingly.
 Configuring a non-existing bucket for backups will not prevent Zeebe to start up anymore and will only result
 in logs (at WARN) in the startup phase.
 
-## REST API key attributes change to `string`
+## Camunda 8 REST API
+
+### Key attributes change to `string`
 
 With 8.7, the default REST API key attribute type changes from `integer (int64)` to `string`.
 


### PR DESCRIPTION
## Description

* Streamlines how V2 API changes are headlined.
* Hints at removed OpenAPI DTOs relevant for custom REST API client.

closes https://github.com/camunda/camunda-docs/issues/5623

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.