### PR TITLE
fix: rename `camunda.version` to `camunda.dockerImageVersion`

### DIFF
--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -201,7 +201,7 @@ io:
     process:
       test:
         # Change the version of the Camunda Docker image
-        camunda-version: 8.8.0
+        camunda-docker-image-version: 8.8.0
         # Change the Camunda Docker image
         camunda-docker-image-name: camunda/camunda
         # Set additional Camunda environment variables
@@ -231,7 +231,7 @@ io:
 You can change the version by setting the following properties in a `/camunda-container-runtime.properties` file:
 
 ```properties
-camunda.version=8.8.0
+camunda.dockerImageVersion=8.8.0
 ```
 
 For more configuration options, you can register the JUnit extension manually and use the fluent builder to override the defaults:
@@ -249,7 +249,7 @@ public class MyProcessTest {
     private static final CamundaProcessTestExtension EXTENSION =
         new CamundaProcessTestExtension()
             // Change the version of the Camunda Docker image
-            .withCamundaVersion("8.8.0")
+            .withCamundaDockerImageVersion("8.8.0")
             // Change the Camunda Docker image
             .withCamundaDockerImageName("camunda/camunda")
             // Set additional Camunda environment variables


### PR DESCRIPTION
## Description

As part of the changes in renaming the property `camunda.version` in favor of `camunda.dockerImageVersion` (see here: https://github.com/camunda/camunda/pull/33515), the documentation also needed to be updated.