### PR TITLE
Document processing metrics availability

### DIFF
--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -200,6 +200,8 @@ Camunda also exposes several custom metrics, most of them under the `zeebe`, `at
 :::note
 While all nodes in a Camunda cluster expose metrics, they will expose relevant metrics based on their role. For example, brokers will expose processing related metrics,
 while gateways will expose REST API relevant metrics.
+
+Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
 :::
 
 ### Process processing metrics

--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -200,8 +200,10 @@ Camunda also exposes several custom metrics, most of them under the `zeebe`, `at
 :::note
 While all nodes in a Camunda cluster expose metrics, they will expose relevant metrics based on their role. For example, brokers will expose processing related metrics,
 while gateways will expose REST API relevant metrics.
+:::
 
-Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
+:::note
+**Not all metrics are available at all times.** This can apply to various metrics, but is especially noticeable for **processing-related metrics**, which are recorded on events that can occur infrequently. For example, the `zeebe_incident_events_total` metric is only recorded when an incident is **created** or **resolved**.
 :::
 
 ### Process processing metrics

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/metrics.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/metrics.md
@@ -55,8 +55,10 @@ Most metrics have the following common label:
 
 :::note
 Both brokers and gateways expose their respective metrics. The brokers have an optional metrics exporter that can be enabled for maximum insight.
+:::
 
-Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
+:::note
+**Not all metrics are available at all times.** This can apply to various metrics, but is especially noticeable for **processing-related metrics**, which are recorded on events that can occur infrequently. For example, the `zeebe_incident_events_total` metric is only recorded when an incident is **created** or **resolved**.
 :::
 
 **Metrics related to process processing:**

--- a/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/metrics.md
+++ b/versioned_docs/version-8.4/self-managed/zeebe-deployment/operations/metrics.md
@@ -55,6 +55,8 @@ Most metrics have the following common label:
 
 :::note
 Both brokers and gateways expose their respective metrics. The brokers have an optional metrics exporter that can be enabled for maximum insight.
+
+Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
 :::
 
 **Metrics related to process processing:**

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/metrics.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/metrics.md
@@ -55,8 +55,10 @@ Most metrics have the following common label:
 
 :::note
 Both brokers and gateways expose their respective metrics. The brokers have an optional metrics exporter that can be enabled for maximum insight.
+:::
 
-Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
+:::note
+**Not all metrics are available at all times.** This can apply to various metrics, but is especially noticeable for **processing-related metrics**, which are recorded on events that can occur infrequently. For example, the `zeebe_incident_events_total` metric is only recorded when an incident is **created** or **resolved**.
 :::
 
 **Metrics related to process processing:**

--- a/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/metrics.md
+++ b/versioned_docs/version-8.5/self-managed/zeebe-deployment/operations/metrics.md
@@ -55,6 +55,8 @@ Most metrics have the following common label:
 
 :::note
 Both brokers and gateways expose their respective metrics. The brokers have an optional metrics exporter that can be enabled for maximum insight.
+
+Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
 :::
 
 **Metrics related to process processing:**

--- a/versioned_docs/version-8.6/self-managed/operational-guides/monitoring/metrics.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/monitoring/metrics.md
@@ -200,6 +200,8 @@ Camunda also exposes several custom metrics, most of them under the `zeebe`, `at
 :::note
 While all nodes in a Camunda cluster expose metrics, they will expose relevant metrics based on their role. For example, brokers will expose processing related metrics,
 while gateways will expose REST API relevant metrics.
+
+Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
 :::
 
 ### Process processing metrics

--- a/versioned_docs/version-8.6/self-managed/operational-guides/monitoring/metrics.md
+++ b/versioned_docs/version-8.6/self-managed/operational-guides/monitoring/metrics.md
@@ -200,8 +200,10 @@ Camunda also exposes several custom metrics, most of them under the `zeebe`, `at
 :::note
 While all nodes in a Camunda cluster expose metrics, they will expose relevant metrics based on their role. For example, brokers will expose processing related metrics,
 while gateways will expose REST API relevant metrics.
+:::
 
-Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
+:::note
+**Not all metrics are available at all times.** This can apply to various metrics, but is especially noticeable for **processing-related metrics**, which are recorded on events that can occur infrequently. For example, the `zeebe_incident_events_total` metric is only recorded when an incident is **created** or **resolved**.
 :::
 
 ### Process processing metrics

--- a/versioned_docs/version-8.7/self-managed/operational-guides/monitoring/metrics.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/monitoring/metrics.md
@@ -200,6 +200,8 @@ Camunda also exposes several custom metrics, most of them under the `zeebe`, `at
 :::note
 While all nodes in a Camunda cluster expose metrics, they will expose relevant metrics based on their role. For example, brokers will expose processing related metrics,
 while gateways will expose REST API relevant metrics.
+
+Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
 :::
 
 ### Process processing metrics

--- a/versioned_docs/version-8.7/self-managed/operational-guides/monitoring/metrics.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/monitoring/metrics.md
@@ -200,8 +200,10 @@ Camunda also exposes several custom metrics, most of them under the `zeebe`, `at
 :::note
 While all nodes in a Camunda cluster expose metrics, they will expose relevant metrics based on their role. For example, brokers will expose processing related metrics,
 while gateways will expose REST API relevant metrics.
+:::
 
-Also note that not all metrics are available at all times. Specifically, processing related metrics are affected by this because not all events occur frequently. For example, `zeebe_incident_events_total` is only recorded for the first time when an incident is created or resolved.
+:::note
+**Not all metrics are available at all times.** This can apply to various metrics, but is especially noticeable for **processing-related metrics**, which are recorded on events that can occur infrequently. For example, the `zeebe_incident_events_total` metric is only recorded when an incident is **created** or **resolved**.
 :::
 
 ### Process processing metrics


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

This came up in a support case [#inc-support-27804-questions-about-process-processing-metrics](https://camunda.slack.com/archives/C092SJEQ6M9), where it was not clear to the customer that in order to see the
zeebe_process_instance_creations_total or the
zeebe_incident_events_total, there needs to be some activity on the cluster that causes the recording of these metric events.

To avoid this in the future, I've added a note to the page in the Available metrics section.

Please note that the example `zeebe_incident_events_total`, currently has a known bug where it is called `zeebe_incidents_events_total` instead (https://github.com/camunda/camunda/issues/34342). But, I still think it's a good example so I prefer to use it even though that bug is not yet resolved.

<img width="1584" alt="Screenshot after changes" src="https://github.com/user-attachments/assets/db9ba763-5501-4f6b-b221-aee52b2aa259" />

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
