### PR TITLE
docs(api): tomcat multipart max-part-count

### DIFF
--- a/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
+++ b/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
@@ -51,6 +51,18 @@ spring.servlet.multipart.max-request-size=4MB
 
 For example, if you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
 
+Additionally, if you're uploading multiple files as part of a multipart request, be aware that Tomcat limits the number of parts per request via the `server.tomcat.max-part-count` property. By default, this is set to 50 in our orchestration API. You can increase it to allow more files:
+
+```properties
+server.tomcat.max-part-count=100
+```
+
+This can also be configured via the environment variable:
+
+```properties
+SERVER_TOMCAT_MAX_PART_COUNT=100
+```
+
 [camunda-api-explorer]: ./specifications/camunda-8-rest-api.info.mdx
 
 ## Naming conventions

--- a/versioned_docs/version-8.6/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.6/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -43,6 +43,18 @@ spring.servlet.multipart.max-request-size=4MB
 
 For example, if you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
 
+Additionally, if you're uploading multiple files as part of a multipart request, be aware that Tomcat limits the number of parts per request via the `server.tomcat.max-part-count` property. By default, this is set to 50 in our orchestration API. You can increase it to allow more files:
+
+```properties
+server.tomcat.max-part-count=100
+```
+
+This can also be configured via the environment variable:
+
+```properties
+SERVER_TOMCAT_MAX_PART_COUNT=100
+```
+
 ### Query API
 
 :::danger

--- a/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -43,6 +43,18 @@ spring.servlet.multipart.max-request-size=4MB
 
 For example, if you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
 
+Additionally, if you're uploading multiple files as part of a multipart request, be aware that Tomcat limits the number of parts per request via the `server.tomcat.max-part-count` property. By default, this is set to 50 in our orchestration API. You can increase it to allow more files:
+
+```properties
+server.tomcat.max-part-count=100
+```
+
+This can also be configured via the environment variable:
+
+```properties
+SERVER_TOMCAT_MAX_PART_COUNT=100
+```
+
 ### Query API
 
 :::danger


### PR DESCRIPTION
## Description

When deploying resources via the Zeebe client to the `/v2/deployments` endpoint, the request fails with a 500 Internal Server Error if more than 10 files are included in the multipart request.
This happens because [Tomcat has a maxPartCount](https://tomcat.apache.org/tomcat-9.0-doc/changelog.html) parameter that limits the total number of parts in a multipart requests. In our version, the default is set to 10. This PR is documenting how to configure this limit.

Related issue : https://github.com/camunda/camunda/issues/34322
Related fix PR : https://github.com/camunda/camunda/pull/35068

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
