### PR TITLE
Update renovate automerge config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,75 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended", "schedule:weekends"],
+  extends: [
+    "config:recommended",
+    "schedule:weekends",
+    ":automergeDisabled",
+    ":semanticCommits",
+  ],
   lockFileMaintenance: {
     enabled: true,
+    automerge: true
   },
+  prBodyNotes: [
+    "{{#if isMajor}}:warning: THIS IS A MAJOR VERSION UPDATE :warning:{{/if}}",
+    "Before merging, *always* check with the release notes if any other changes need to be done.",
+  ],
+  {
+    packageRules: [
+      {
+        groupName: "docusaurus",
+        matchPackageNames: [
+          "/docusaurus/",
+        ],
+      },
+      {
+        // Automerge dev dependencies
+        matchPackageNames: [
+          "@playwright/test",
+          "@types/jest",
+          "husky",
+          "jest",
+          "lint-staged",
+          "playwright",
+          "prettier",
+        ],
+        groupName: "dev dependencies",
+        automerge: true,
+      },
+      {
+        // Require Docs team review for minor updates of docusaurus
+        matchPackageNames: [ "/docusaurus/" ],
+        matchUpdateTypes: [
+          "minor",
+        ],
+        reviewers: ["@camunda/docs-api-reviewers"],
+        automerge: false,
+      },
+      {
+        // Automerge docusaurus patches
+        matchPackageNames: [ "/docusaurus/" ],
+        matchUpdateTypes: [ "patch" ],
+        automerge: true,
+      },
+      {
+        // Automerge patches and minor updates of GitHub Actions
+        matchManagers: ["github-actions"],
+        matchUpdateTypes: [
+          "patch",
+          "minor",
+        ],
+        automerge: true,
+        groupName: "GitHub Actions",
+      },
+      // Use only stable/LTS versions of NodeJS (even numbers): 18, 20, ...
+      {
+        matchPackageNames: ["node"],
+        matchUpdateTypes: [
+          "patch", "minor"
+        ],
+        groupName: "node",
+        automerge: true,
+      }
+    ]
+  }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,68 +8,57 @@
   ],
   lockFileMaintenance: {
     enabled: true,
-    automerge: true
+    automerge: true,
   },
   prBodyNotes: [
     "{{#if isMajor}}:warning: THIS IS A MAJOR VERSION UPDATE :warning:{{/if}}",
     "Before merging, *always* check with the release notes if any other changes need to be done.",
   ],
-  {
-    packageRules: [
-      {
-        groupName: "docusaurus",
-        matchPackageNames: [
-          "/docusaurus/",
-        ],
-      },
-      {
-        // Automerge dev dependencies
-        matchPackageNames: [
-          "@playwright/test",
-          "@types/jest",
-          "husky",
-          "jest",
-          "lint-staged",
-          "playwright",
-          "prettier",
-        ],
-        groupName: "dev dependencies",
-        automerge: true,
-      },
-      {
-        // Require Docs team review for minor updates of docusaurus
-        matchPackageNames: [ "/docusaurus/" ],
-        matchUpdateTypes: [
-          "minor",
-        ],
-        reviewers: ["@camunda/docs-api-reviewers"],
-        automerge: false,
-      },
-      {
-        // Automerge docusaurus patches
-        matchPackageNames: [ "/docusaurus/" ],
-        matchUpdateTypes: [ "patch" ],
-        automerge: true,
-      },
-      {
-        // Automerge patches and minor updates of GitHub Actions
-        matchManagers: ["github-actions"],
-        matchUpdateTypes: [
-          "patch",
-          "minor",
-        ],
-        automerge: true,
-        groupName: "GitHub Actions",
-      },
-      // Use only stable/LTS versions of NodeJS (even numbers): 18, 20, ...
-      {
-        matchPackageNames: ["node"],
-        matchUpdateTypes: [
-          "patch", "minor"
-        ],
-        groupName: "node",
-        automerge: true,
-      }
-    ]
-  }
+  packageRules: [
+    {
+      groupName: "docusaurus",
+      matchPackageNames: ["/docusaurus/"],
+    },
+    {
+      // Automerge dev dependencies
+      matchPackageNames: [
+        "@playwright/test",
+        "@types/jest",
+        "husky",
+        "jest",
+        "lint-staged",
+        "playwright",
+        "prettier",
+      ],
+      groupName: "dev dependencies",
+      automerge: true,
+    },
+    {
+      // Require Docs team review for minor updates of docusaurus
+      matchPackageNames: ["/docusaurus/"],
+      matchUpdateTypes: ["minor"],
+      reviewers: ["@camunda/docs-api-reviewers"],
+      automerge: false,
+    },
+    {
+      // Automerge docusaurus patches
+      matchPackageNames: ["/docusaurus/"],
+      matchUpdateTypes: ["patch"],
+      automerge: true,
+    },
+    {
+      // Automerge patches and minor updates of GitHub Actions
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["patch", "minor"],
+      automerge: true,
+      groupName: "GitHub Actions",
+    },
+    // Use only stable/LTS versions of NodeJS (even numbers): 18, 20, ...
+    {
+      matchPackageNames: ["node"],
+      matchUpdateTypes: ["patch", "minor"],
+      groupName: "node",
+      automerge: true,
+    },
+  ],
 }


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->
This PR is to configure Renovate's automerge for most dependencies, based on the conversation on this [#ask-infra question on slack](https://camunda.slack.com/archives/C5AHF1D8T/p1752568821040499)

In particular, here the suggested automerge policies:


* devDependencies (like jest, playwright, prettier etc.) -> we can automerge any version (major-minor-patch)
consider also grouping all devDeps into a single upgrade PR to simplify the flow
* docusaurus dependencies
  * patch versions are fine to auto-merge
  * minor versions should go through a review via the Docs team first -> we've had examples in the past when the minor versions of the plugins were misbehaving and needed adjustment. Docs team will be able to verify with the preview environments that all works well and approve the rollout
  * major - no automerge (e.g. Docusaurus v4 upgrade will be a separate epic, where EM Docs will need to decide how to move forward there)
* service dependencies (e.g. github actions) -> patch+minor fine to auto-merge; major better keep manual
* meta dependencies (e.g. nodejs version) -> patch+minor fine to auto-merge; major should be fine to keep automated (but maybe better keep manual for now)
* lockFile upgrades -> always auto-merge


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
