### PR TITLE
docs: update `CamundaClient` examples and JobResult gRPC docs

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -250,6 +250,7 @@ message JobResult{
   // In this example, the completion of a task is represented by a job that the worker can complete as denied.
   // As a result, the completion request is rejected and the task remains active.
   // Defaults to false.
+  // Only applicable for user task listener jobs.
   optional bool denied = 1;
   // Attributes that were corrected by the worker.
   // The following attributes can be corrected, additional attributes will be ignored:
@@ -259,8 +260,17 @@ message JobResult{
   //   * `candidateGroups` - clear by providing an empty list
   //   * `candidateUsers` - clear by providing an empty list
   //   * `priority` - minimum 0, maximum 100, default 50
-  //  Omitting any of the attributes will preserve the persisted attribute's value.
+  // Omitting any of the attributes will preserve the persisted attribute's value.
+  // Only applicable for user task listener jobs.
   optional JobResultCorrections corrections = 2;
+  // The reason provided by the user task listener for denying the work.
+  optional string deniedReason = 3;
+  // Identifies the type of job result. Must be either "userTask" or "adHocSubprocess".
+  // Defaults to "userTask" if not explicitly set.
+  optional string type = 4;
+  // The list of elements that should be activated after the job is completed.
+  // Only applicable for ad-hoc subprocesses.
+  repeated JobResultActivateElement activateElements = 5;
 }
 
 message JobResultCorrections {
@@ -276,6 +286,17 @@ message JobResultCorrections {
   optional StringList candidateGroups = 5;
   // The priority of the task.
   optional int32 priority = 6;
+}
+
+message JobResultActivateElement {
+  // The id of the element to activate
+  string elementId = 1;
+  // JSON document of variables that will be created on the scope of the activated element.
+  // It must be a JSON object, as variables will be mapped in a key-value fashion.
+  // e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+  // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+  // valid argument, as the root of the JSON document is an array and not an object.
+  string variables = 2;
 }
 
 message StringList {

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -106,7 +106,7 @@ final JobHandler userTaskListenerHandler =
             .newCompleteCommand(job)
             // highlight-start
             .withResult(
-                new CompleteJobResult()
+                r -> r.forUserTask()
                     .correctAssignee("john_doe")
                     .correctPriority(42)
                     .deny(shouldDeny)) // deny based on validation logic

--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -173,13 +173,13 @@ final JobHandler completeTaskListenerJobWithCorrectionsHandler =
             .newCompleteCommand(job)
             // highlight-start
             .withResult(
-                new CompleteJobResult()
-                    .correctAssignee("john_doe") // assigns the user task to 'john_doe'
-                    .correctDueDate(null) // preserves the current 'dueDate' of the user task
-                    .correctFollowUpDate("") // clears the 'followUpDate'
+                r -> r.forUserTask()
+                    .correctAssignee("john_doe")                    // assigns the user task to 'john_doe'
+                    .correctDueDate(null)                           // preserves the current 'dueDate'
+                    .correctFollowUpDate("")                        // clears the 'followUpDate'
                     .correctCandidateUsers(List.of("alice", "bob")) // sets candidate users
-                    .correctCandidateGroups(List.of()) // clears the candidate groups
-                    .correctPriority(80)) // sets the priority to 80
+                    .correctCandidateGroups(List.of())              // clears the candidate groups
+                    .correctPriority(80))                           // sets the priority to 80
             // highlight-end
             .send();
 
@@ -218,8 +218,7 @@ final JobHandler denyUserTaskLifecycleTransitionHandler =
         jobClient
             .newCompleteCommand(job)
             // highlight-start
-            .withResult()
-            .deny(true)
+            .withResult(r -> r.forUserTask().deny(true))
             // highlight-end
             .send();
 ```


### PR DESCRIPTION
## Description

This PR updates documentation to align with the API changes introduced in:
- Issue: camunda/camunda#34493
  - PR camunda/camunda#35466

Includes the following updates:
1. Updated code examples in `user-task-listeners.md` and `job-worker.md` to use the new lambda-based `.withResult(r -> r.forUserTask()...)` style instead of `new CompleteJobResult()`.
This reflects the new structure for completing user task listener jobs with corrections or denial flags.

3. Extended the `JobResult` gRPC message in `gateway-service.md` with new fields:
   - `type`: to distinguish between `userTask` and `adHocSubprocess`
   - `activateElements`: a list of elements that should be activated after the job is completed.
   - `JobResultActivateElement`: defines element ID and scoped variables
   - `deniedReason`: optional explanation when work is denied

Also updated existing field descriptions (`denied` and `corrections`) to clarify their applicability to user task jobs only.


---
closes camunda/camunda#35526

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
