### PR TITLE
Improvements to the user task listener documentation

### DIFF
--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -114,8 +114,8 @@ The following user task attributes can be accessed from the activated job's `use
 
 | Attribute           | Description                                                                                                                                                                                   |
 | :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `action`            | A custom action value provided along with the request that triggered this event. If none was provided, it defaults to one of `assign`, `claim`, `update`, or `complete`.                     |
-| `assignee`          | The user assigned to the task. If not specified, the task is unassigned. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.             |
+| `action`            | A custom action value provided along with the request that triggered this event. If none was provided, it defaults to one of `assign`, `claim`, `update`, or `complete`.                      |
+| `assignee`          | The user assigned to the task. If not specified, the task is unassigned. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.              |
 | `candidateGroups`   | Specifies the groups of users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                       |
 | `candidateUsers`    | Specifies the users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                                 |
 | `changedAttributes` | Lists the user task attributes that have changed with the event. Refer to the [changed attributes](#changed-attributes) section below for more details.                                       |

--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -109,21 +109,21 @@ See [open a job worker](/apis-tools/java-client-examples/job-worker-open.md) for
 
 ### Accessing user task data
 
-User task-specific data, such as `assignee` and `priority`, are accessible through the `userTask` property of the user task listener job.
-The following user task attributes can be accessed from the activated job's user task property:
+User task-specific data, such as `assignee` and `priority`, are accessible through the `userTask` property of the user task listener job.  
+The following user task attributes can be accessed from the activated job's `userTask` property:
 
-| Attribute           | Decription                                                                                                                                                                                   |
-| :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `action`            | A custom action value provided along with the request that triggered this event. If none was provided, it defaults to one of `assign`, `claim`, `update`, `complete`.                        |
-| `assignee`          | The user assigned to the task. If not specified, then the task is unassigned. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.        |
-| `candidateGroups`   | Specifies the groups of users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                      |
-| `candidateUsers`    | Specifies the users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                                |
-| `changedAttributes` | Lists which user task attributes have changed with the event. Refer to [changed attributes](#changed-attributes) section below for more details.                                             |
-| `dueDate`           | Specifies the due date of the task. Refer to [scheduling](/components/modeler/bpmn/user-tasks/user-tasks.md#scheduling) for more details.                                                    |
-| `followUpDate`      | Specifies the follow up date of the task. Refer to [scheduling](/components/modeler/bpmn/user-tasks/user-tasks.md#scheduling) for more details.                                              |
-| `formKey`           | The form linked to the user task referenced by its uniquely identifying key. Refer to [user task forms](/components/modeler/bpmn/user-tasks/user-tasks.md#user-task-forms) for more details. |
-| `priority`          | Refer to [priority](/components/modeler/bpmn/user-tasks/user-tasks.md#define-user-task-priority) for more details.                                                                           |
-| `userTaskKey`       | The unique key identifying the user task.                                                                                                                                                    |
+| Attribute           | Description                                                                                                                                                                                   |
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `action`            | A custom action value provided along with the request that triggered this event. If none was provided, it defaults to one of `assign`, `claim`, `update`, or `complete`.                     |
+| `assignee`          | The user assigned to the task. If not specified, the task is unassigned. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.             |
+| `candidateGroups`   | Specifies the groups of users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                       |
+| `candidateUsers`    | Specifies the users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                                 |
+| `changedAttributes` | Lists the user task attributes that have changed with the event. Refer to the [changed attributes](#changed-attributes) section below for more details.                                       |
+| `dueDate`           | Specifies the due date of the task. Refer to [scheduling](/components/modeler/bpmn/user-tasks/user-tasks.md#scheduling) for more details.                                                     |
+| `followUpDate`      | Specifies the follow-up date of the task. Refer to [scheduling](/components/modeler/bpmn/user-tasks/user-tasks.md#scheduling) for more details.                                               |
+| `formKey`           | The form linked to the user task, referenced by its uniquely identifying key. Refer to [user task forms](/components/modeler/bpmn/user-tasks/user-tasks.md#user-task-forms) for more details. |
+| `priority`          | The task’s priority level. Refer to [priority](/components/modeler/bpmn/user-tasks/user-tasks.md#define-user-task-priority) for more details.                                                 |
+| `userTaskKey`       | The unique key identifying the user task.                                                                                                                                                     |
 
 Below is an example of accessing the `assignee` value from the activated job in Java:
 

--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -156,6 +156,10 @@ Now, this second listener corrects the priority back to the value it had before 
 The third listener sees only the `assignee` attribute as changed attribute, because the priority is no longer changed with the event.
 :::
 
+#### Task headers
+
+Configured [task headers](/components/modeler/bpmn/user-tasks/user-tasks.md#task-headers) on the user task are available in the job's custom headers.
+
 ### Correcting user task data
 
 User task listeners can correct user task data before the lifecycle transition is finalized. Corrections allow user task listeners to update specific attributes of the user task, such as the assignee, due date, follow-up date, candidate users, candidate groups, and priority. These corrections are immediately available to any subsequent task listeners and are applied to the user task when the lifecycle transition is finalized, without triggering the `UPDATING` lifecycle event.

--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -91,11 +91,11 @@ You can configure user task listeners per BPMN user task element.
 
 Each user task listener has the following properties:
 
-| Property    | Description                                                                                                                                        |
-| :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eventType` | Specifies the user task event that triggers the listener. Supported values are `creating`, `assigning`, `updating`, `completing`, and `canceling`. |
-| `type`      | The name of the job type.                                                                                                                          |
-| `retries`   | The number of retries for the user task listener job.                                                                                              |
+| Property    | Description                                                                                                                                                                                                                                                                                                                              |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eventType` | (Required) Specifies the user task event type that triggers the listener. Supported values are `creating`, `assigning`, `updating`, `completing`, and `canceling`.                                                                                                                                                                       |
+| `type`      | (Required) The name of the job type. Used as a reference to specify which job workers request the respective task listener job. For example, `order-items`. `type` can be specified as any static value (`myType`) or as a FEEL expression prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`. |
+| `retries`   | (Optional) The number of retries for the user task listener job (defaults to 3 if omitted).                                                                                                                                                                                                                                              |
 
 :::note
 If multiple user task listeners of the same `eventType` (such as multiple `assigning` listeners) are defined on the same user task, they are executed sequentially, one after the other, in the order they are defined in the BPMN model.

--- a/docs/components/concepts/user-task-listeners.md
+++ b/docs/components/concepts/user-task-listeners.md
@@ -109,32 +109,30 @@ See [open a job worker](/apis-tools/java-client-examples/job-worker-open.md) for
 
 ### Accessing user task data
 
-User task-specific data, such as `assignee` and `priority`, is accessible through the job headers of the user task listener job.
-These are merged together with the user task's [task headers](/components/modeler/bpmn/user-tasks/user-tasks.md#task-headers).
-The following attributes can be retrieved using reserved header names:
+User task-specific data, such as `assignee` and `priority`, are accessible through the `userTask` property of the user task listener job.
+The following user task attributes can be accessed from the activated job's user task property:
 
-| Attribute           | Header name                          |
-| :------------------ | :----------------------------------- |
-| `action`            | `io.camunda.zeebe:action`            |
-| `assignee`          | `io.camunda.zeebe:assignee`          |
-| `candidateGroups`   | `io.camunda.zeebe:candidateGroups`   |
-| `candidateUsers`    | `io.camunda.zeebe:candidateUsers`    |
-| `changedAttributes` | `io.camunda.zeebe:changedAttributes` |
-| `dueDate`           | `io.camunda.zeebe:dueDate`           |
-| `followUpDate`      | `io.camunda.zeebe:followUpDate`      |
-| `formKey`           | `io.camunda.zeebe:formKey`           |
-| `priority`          | `io.camunda.zeebe:priority`          |
-| `userTaskKey`       | `io.camunda.zeebe:userTaskKey`       |
+| Attribute           | Decription                                                                                                                                                                                   |
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `action`            | A custom action value provided along with the request that triggered this event. If none was provided, it defaults to one of `assign`, `claim`, `update`, `complete`.                        |
+| `assignee`          | The user assigned to the task. If not specified, then the task is unassigned. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.        |
+| `candidateGroups`   | Specifies the groups of users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                      |
+| `candidateUsers`    | Specifies the users that the task can be assigned to. Refer to [assignments](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments) for more details.                                |
+| `changedAttributes` | Lists which user task attributes have changed with the event. Refer to [changed attributes](#changed-attributes) section below for more details.                                             |
+| `dueDate`           | Specifies the due date of the task. Refer to [scheduling](/components/modeler/bpmn/user-tasks/user-tasks.md#scheduling) for more details.                                                    |
+| `followUpDate`      | Specifies the follow up date of the task. Refer to [scheduling](/components/modeler/bpmn/user-tasks/user-tasks.md#scheduling) for more details.                                              |
+| `formKey`           | The form linked to the user task referenced by its uniquely identifying key. Refer to [user task forms](/components/modeler/bpmn/user-tasks/user-tasks.md#user-task-forms) for more details. |
+| `priority`          | Refer to [priority](/components/modeler/bpmn/user-tasks/user-tasks.md#define-user-task-priority) for more details.                                                                           |
+| `userTaskKey`       | The unique key identifying the user task.                                                                                                                                                    |
 
-Below is an example of accessing the `assignee` value from the headers in Java:
+Below is an example of accessing the `assignee` value from the activated job in Java:
 
 ```java
 final JobHandler userTaskListenerHandler =
     (jobClient, job) -> {
-        // Access the 'assignee' from the job headers
+        // Access the 'assignee' from the job's user task property
         // highlight-start
-        final String assignee = job.getCustomHeaders()
-            .get("io.camunda.zeebe:assignee");
+        final String assignee = job.getUserTask().getAssignee();
         // highlight-end
 
         System.out.println("The assignee for this user task is: " + assignee);
@@ -143,7 +141,7 @@ final JobHandler userTaskListenerHandler =
     };
 ```
 
-Each header provides user task metadata that can be leveraged to customize the behavior of the user task listener job. Use these headers to retrieve necessary information about the user task in your job handler implementation.
+This user task data can be leveraged to customize the behavior of the user task listener job worker.
 
 #### Changed attributes
 

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -167,15 +167,6 @@ configuration parameters for tasklist applications.
 
 User tasks support **user task listeners**, which allow you to react to user task lifecycle events.
 
-#### Supported events
-
-Currently, user task listeners can react to the following events:
-
-- **Assigning**: Triggered while assigning a user task.
-- **Completing**: Triggered while completing a user task.
-
-#### Configuration
-
 To define a user task listener, include the `zeebe:taskListeners` extension element within the user task in your BPMN model. This element can contain one or more `zeebe:taskListener` elements, each specifying the following attributes:
 
 - The `eventType` that triggers the listener (possible values: `creating`, `assigning`, `updating`, `completing`, `canceling`).

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -169,9 +169,9 @@ User tasks support **user task listeners**, which allow you to react to user tas
 
 To define a user task listener, include the `zeebe:taskListeners` extension element within the user task in your BPMN model. This element can contain one or more `zeebe:taskListener` elements, each specifying the following attributes:
 
-- The `eventType` that triggers the listener (possible values: `creating`, `assigning`, `updating`, `completing`, `canceling`).
-- The `type` of the listener (job type used by the external worker).
-- The number of `retries` for the user task listener job (defaults to 3 if omitted).
+- The `eventType` (required) that triggers the listener. Possible values are: `creating`, `assigning`, `updating`, `completing`, `canceling`.
+- The `type` (required) of the listener. Used as a reference to specify which job workers request the respective task listener job. For example, `order-items`. `type` can be specified as any static value (`myType`) or as a FEEL expression prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
+- The number of `retries` (optional) for the user task listener job (defaults to 3 if omitted).
 
 For more details, see [user task listeners](components/concepts/user-task-listeners.md).
 

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -178,7 +178,7 @@ Currently, user task listeners can react to the following events:
 
 To define a user task listener, include the `zeebe:taskListeners` extension element within the user task in your BPMN model. This element can contain one or more `zeebe:taskListener` elements, each specifying the following attributes:
 
-- The `eventType` that triggers the listener (`"assigning"` or `"completing"`).
+- The `eventType` that triggers the listener (possible values: `creating`, `assigning`, `updating`, `completing`, `canceling`).
 - The `type` of the listener (job type used by the external worker).
 - The number of `retries` for the user task listener job (defaults to 3 if omitted).
 


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

This changes the documentation about user task listeners across a few pages applying previously received feedback:
- the [User tasks](https://docs.camunda.io/docs/next/components/modeler/bpmn/user-tasks/#user-task-listeners) page
- the [User task listeners](https://docs.camunda.io/docs/next/components/concepts/user-task-listeners/) page

<details><summary>Changes to the User tasks page</summary>
<p>

- Removed the section on supported events, as these are much nicer documented in the concept page (which is referenced at the end of this section)
- Added more detail to the definitions of a listener like the `type`, including examples. Aligning it to the task definition section of the service tasks page.

| Before | After |
|--------|--------|
| <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 13 50" src="https://github.com/user-attachments/assets/43cf029f-2691-4a1e-a893-0c6d1a2d1051" /> | <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 18 00" src="https://github.com/user-attachments/assets/63919f29-417d-41f1-9cd7-95d8944f6047" /> |

</p>
</details> 



<details><summary>Changes to the User task listeners page</summary>
<p>

- Aligned the listener definition section to the same section on the user task page
- Adjusted how user task data can be accessed, and clarified the attributes

| Before | After |
|--------|--------|
| <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 23 52" src="https://github.com/user-attachments/assets/bc8c8d3a-eb79-48a5-880a-9a34d2cf9c35" /> | <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 24 08" src="https://github.com/user-attachments/assets/33718f5d-04d3-4dfc-90ff-39757bd6eebe" /> | 
| <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 25 12" src="https://github.com/user-attachments/assets/640910c1-512e-434d-b1a0-fba107a6c5d8" /> | <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 25 29" src="https://github.com/user-attachments/assets/51455aba-b1ab-49e2-a174-4e3d50c2a981" /> |
| <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 26 08" src="https://github.com/user-attachments/assets/23a8aee4-2dff-4d83-8761-c1ea1508a474" /> | <img width="1264" height="1191" alt="Screenshot 2025-07-21 at 11 26 30" src="https://github.com/user-attachments/assets/8599ef3b-6642-4061-bc00-49e38a68817b" /> |

</p>
</details> 

closes camunda/camunda#30527

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
