### PR TITLE
chore: add visual aspect to tabs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1175,6 +1175,23 @@ ul ol {
   border-bottom: none;
 }
 
+div[role="tabpanel"]:not(div[role="tabpanel"] div[role="tabpanel"]) {
+  background-color: #fff;
+  padding: 1.25rem;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05);
+  margin-top: 1rem;
+}
+
+html[data-theme="dark"]
+  div[role="tabpanel"]:not(div[role="tabpanel"] div[role="tabpanel"]) {
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.5);
+  color: #ddd;
+}
+
 /* Reset all menu items to default styling */
 .menu__link {
   color: inherit; /* Default text color */


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

The following is a proposal that helps to showcase tabs within long text blocks where they start and stop.
I've noticed myself a couple of times already when using tabs that when going `viewer mode` I don't know where they stop and potentially dabble already into chapters that come afterwards.

This is just a proposal to visually indicate a tab.
It also only affects the outermost tabs, using tabs in tabs won't create weird embedded visuals.

It looks like the following:

Starting point (current status quo):
<img width="1008" height="487" alt="image" src="https://github.com/user-attachments/assets/762b6ea9-e23d-4aa0-b3be-e9740856d7ad" />

Added CSS: (light mode)
<img width="991" height="498" alt="image" src="https://github.com/user-attachments/assets/956ba819-f64d-4d89-b363-9b794e451884" />

dark mode
<img width="991" height="498" alt="image" src="https://github.com/user-attachments/assets/b550429c-8f87-4c59-8317-e15a397c6a8a" />

I don't think the `dx` process is up2date anymore, as said it's just a proposal to quickly showcase visually. We can iterate on it or we can also drop it.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

- [x] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label)
