### PR TITLE
fix: use correct environment variable for proxy configuration in Web Modeler

### DIFF
--- a/docs/self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
+++ b/docs/self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
@@ -30,7 +30,7 @@ Ensure correct proxy configuration for both `webapp` and `restapi` components.
   ```properties
   http_proxy=http://proxy.example.com:8080 https_proxy=https://secureproxy.example.com:443 no_proxy=localhost,127.0.0.1,.example.com
   ```
-- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTS`.
+- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTIONS`.
   ```properties
-  JAVA_OPTS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
+  JAVA_OPTIONS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
   ```

--- a/versioned_docs/version-8.5/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
+++ b/versioned_docs/version-8.5/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
@@ -30,7 +30,7 @@ Ensure correct proxy configuration for both `webapp` and `restapi` components.
   ```properties
   http_proxy=http://proxy.example.com:8080 https_proxy=https://secureproxy.example.com:443 no_proxy=localhost,127.0.0.1,.example.com
   ```
-- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTS`.
+- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTIONS`.
   ```properties
-  JAVA_OPTS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
+  JAVA_OPTIONS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
   ```

--- a/versioned_docs/version-8.6/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
@@ -30,7 +30,7 @@ Ensure correct proxy configuration for both `webapp` and `restapi` components.
   ```properties
   http_proxy=http://proxy.example.com:8080 https_proxy=https://secureproxy.example.com:443 no_proxy=localhost,127.0.0.1,.example.com
   ```
-- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTS`.
+- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTIONS`.
   ```properties
-  JAVA_OPTS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
+  JAVA_OPTIONS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
   ```

--- a/versioned_docs/version-8.7/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/modeler/web-modeler/troubleshooting/troubleshoot-proxy-configuration.md
@@ -30,7 +30,7 @@ Ensure correct proxy configuration for both `webapp` and `restapi` components.
   ```properties
   http_proxy=http://proxy.example.com:8080 https_proxy=https://secureproxy.example.com:443 no_proxy=localhost,127.0.0.1,.example.com
   ```
-- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTS`.
+- For the `restapi` component, the proxy configuration is handled via JVM settings passed as the value of the environment variable `JAVA_OPTIONS`.
   ```properties
-  JAVA_OPTS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
+  JAVA_OPTIONS=-Dhttp.proxyHost=<host> -Dhttps.proxyPort=<port>
   ```


### PR DESCRIPTION
## Description
Fixes the name of the environment variable that can be used to configure a proxy for Web Modeler's `restapi` component (it's [`JAVA_OPTIONS`](https://github.com/camunda/web-modeler/blob/26b3454520b122f5b5921da1293bdd9d0150a639/restapi/docker-entrypoint.sh#L12) instead of `JAVA_OPTS`).

Related to https://github.com/camunda/web-modeler/issues/16044

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.