### PR TITLE
docs(logging) Refactored rdbms and general logging

### DIFF
--- a/docs/self-managed/components/components-upgrade/870-to-880.md
+++ b/docs/self-managed/components/components-upgrade/870-to-880.md
@@ -690,7 +690,7 @@ Starting with the 8.8 release, angle brackets (`<` and `>`) are no longer remove
 ### Default configuration
 
 The default logging configuration is included inline for quick reference.  
-See the [full logging documentation](../orchestration-cluster/core-settings/configuration/logging.md#default-logging-configuration) for advanced settings and details.
+See the [full logging documentation](/self-managed/components/orchestration-cluster/core-settings/configuration/logging.md) for advanced settings and details.
 
 ### Rolling file appender
 

--- a/docs/self-managed/components/orchestration-cluster/core-settings/configuration/logging.md
+++ b/docs/self-managed/components/orchestration-cluster/core-settings/configuration/logging.md
@@ -76,7 +76,7 @@ The default `log4j2.xml` (Zeebe, Operate, Tasklist, Identity) representation:
 
 :::note
 This is a simplified example. The actual `log4j2.xml` may include additional appenders, different file paths, or slightly different patterns.  
-See the full [logging documentation](../orchestration-cluster/core-settings/configuration/logging.md#default-logging-configuration) for the official default file and additional settings.
+See the full [logging documentation](/self-managed/components/orchestration-cluster/core-settings/configuration/logging.md#default-logging-configuration) for the official default file and additional settings.
 :::
 
 ## Environment variables


### PR DESCRIPTION
## Description

Updated the logging sections for changes which come with https://github.com/camunda/camunda/issues/35258:

- RollingFile appender is now disabled by default
- Pattern Layout changed
- Added a hint to configure RDBMS Logging to show sensitive data. (+ a warning what that means)

<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

With 8.8.0-alpha8

