### PR TITLE
docs: rework V1 API migration doc to include Tasklist

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-component-apis.md
+++ b/docs/apis-tools/migration-manuals/migrate-component-apis.md
@@ -25,8 +25,6 @@ Users now require wildcard (`*`) permissions for the resource type and permissio
 
 For guidance on assigning permissions in Identity, see the [Identity authorization guide](../../components/identity/authorization.md).
 
-<Tabs>
-<TabItem value="Operate" default>
 ### Mapping Operate permissions to new authorizations
 
 To maintain the same access level for the Operate V1 API, apply the following authorizations:
@@ -41,9 +39,9 @@ To maintain the same access level for the Operate V1 API, apply the following au
 
 - `PROCESS_DEFINITION:*:DELETE_PROCESS_INSTANCES`
 
-### Complete list of resource permissions
+### Operate V1 API permission matrix
 
-To enable more fine-grained access control, the matrix below details the required permissions for each Operate V1 API endpoint.  
+To enable more fine-grained access control, the matrix below details the required permissions for each Operate V1 API endpoint.
 Ensure the user has general access (resource ID `*`) for each listed resource and permission type.
 
 | Endpoint                                                                                                       | Resource Type                    | Permission type          |
@@ -70,9 +68,6 @@ Ensure the user has general access (resource ID `*`) for each listed resource an
 | [`POST /v1/incidents/search`](../operate-api/specifications/search-3.api.mdx)                                  | PROCESS_DEFINITION               | READ_PROCESS_INSTANCE    |
 | [`GET /v1/incidents/:key`](../operate-api/specifications/by-key-3.api.mdx)                                     | PROCESS_DEFINITION               | READ_PROCESS_INSTANCE    |
 
-</TabItem>
-
-<TabItem value="Tasklist">
 ### Mapping Tasklist permissions to new authorizations
 
 To maintain the same access level for the Tasklist V1 API, apply the following authorizations:
@@ -85,7 +80,7 @@ To maintain the same access level for the Tasklist V1 API, apply the following a
 
 - `PROCESS_DEFINITION:*:UPDATE_USER_TASK`
 
-### Complete list of resource permissions
+### Tasklist V1 API permission matrix
 
 To enable more fine-grained access control, the matrix below details the required permissions for each Tasklist V1 API endpoint.  
 Ensure the user has general access (resource ID `*`) for each listed resource and permission type.
@@ -101,7 +96,3 @@ Ensure the user has general access (resource ID `*`) for each listed resource an
 | [`POST /v1/tasks/:taskId/variables`](../tasklist-api-rest/specifications/save-draft-task-variables.api.mdx)    | PROCESS_DEFINTION  | UPDATE_USER_TASK |
 | [`POST /v1/tasks/:taskId/variables/search`](../tasklist-api-rest/specifications/search-task-variables.api.mdx) | PROCESS_DEFINITION | READ_USER_TASK   |
 | [`GET /v1/variables/:variableId`](../tasklist-api-rest/specifications/get-variable-by-id.api.mdx)              | PROCESS_DEFINITION | READ_USER_TASK   |
-
-</TabItem>
-
-</Tabs>

--- a/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-component-apis.md
+++ b/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-component-apis.md
@@ -25,8 +25,6 @@ Users now require wildcard (`*`) permissions for the resource type and permissio
 
 For guidance on assigning permissions in Identity, see the [Identity authorization guide](../../components/identity/authorization.md).
 
-<Tabs>
-<TabItem value="Operate" default>
 ### Mapping Operate permissions to new authorizations
 
 To maintain the same access level for the Operate V1 API, apply the following authorizations:
@@ -41,7 +39,7 @@ To maintain the same access level for the Operate V1 API, apply the following au
 
 - `PROCESS_DEFINITION:*:DELETE_PROCESS_INSTANCES`
 
-### Complete list of resource permissions
+### Operate V1 API permission matrix
 
 To enable more fine-grained access control, the matrix below details the required permissions for each Operate V1 API endpoint.
 Ensure the user has general access (resource ID `*`) for each listed resource and permission type.
@@ -70,9 +68,6 @@ Ensure the user has general access (resource ID `*`) for each listed resource an
 | [`POST /v1/incidents/search`](../operate-api/specifications/search-3.api.mdx)                                  | PROCESS_DEFINITION               | READ_PROCESS_INSTANCE    |
 | [`GET /v1/incidents/:key`](../operate-api/specifications/by-key-3.api.mdx)                                     | PROCESS_DEFINITION               | READ_PROCESS_INSTANCE    |
 
-</TabItem>
-
-<TabItem value="Tasklist">
 ### Mapping Tasklist permissions to new authorizations
 
 To maintain the same access level for the Tasklist V1 API, apply the following authorizations:
@@ -85,7 +80,7 @@ To maintain the same access level for the Tasklist V1 API, apply the following a
 
 - `PROCESS_DEFINITION:*:UPDATE_USER_TASK`
 
-### Complete list of resource permissions
+### Tasklist V1 API permission matrix
 
 To enable more fine-grained access control, the matrix below details the required permissions for each Tasklist V1 API endpoint.  
 Ensure the user has general access (resource ID `*`) for each listed resource and permission type.
@@ -101,7 +96,3 @@ Ensure the user has general access (resource ID `*`) for each listed resource an
 | [`POST /v1/tasks/:taskId/variables`](../tasklist-api-rest/specifications/save-draft-task-variables.api.mdx)    | PROCESS_DEFINTION  | UPDATE_USER_TASK |
 | [`POST /v1/tasks/:taskId/variables/search`](../tasklist-api-rest/specifications/search-task-variables.api.mdx) | PROCESS_DEFINITION | READ_USER_TASK   |
 | [`GET /v1/variables/:variableId`](../tasklist-api-rest/specifications/get-variable-by-id.api.mdx)              | PROCESS_DEFINITION | READ_USER_TASK   |
-
-</TabItem>
-
-</Tabs>


### PR DESCRIPTION
**_Will create a conflict with https://github.com/camunda/camunda-docs/pull/6427_**

Related to https://github.com/camunda/camunda/issues/36536

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

This PR achieves two core tasks:
1. Rework the V1 API migration one-pager to allow a general view of the work followed by specific component tabs/needs
2. Adds in the Tasklist V1 API permission changes that are being delivered with [this PR](https://github.com/camunda/camunda/pull/36742)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)
