### PR TITLE
Disabled Operate/Tasklist importers in 8.8

### DIFF
--- a/docs/self-managed/components/components-upgrade/870-to-880.md
+++ b/docs/self-managed/components/components-upgrade/870-to-880.md
@@ -124,7 +124,7 @@ When upgrading, enable them by setting:
 
 - `camunda.operate.importerEnabled=true`
 - `camunda.tasklist.importerEnabled=true`
-  :::
+:::
 
 Importers are only necessary at the start of the migration. Once complete, they can be safely turned off.
 

--- a/docs/self-managed/components/components-upgrade/870-to-880.md
+++ b/docs/self-managed/components/components-upgrade/870-to-880.md
@@ -118,6 +118,11 @@ When using the Camunda 8 Helm charts, the migration application will automatical
 
 ### Turn off importers after completion
 
+:::note
+The configuration for 8.8 by default disables importers, ensure when upgrading `camunda.operate.importerEnabled=true`
+and `camunda.tasklist.importerEnabled=true`
+:::
+
 Importers are only necessary at the start of the migration. Once complete, they can be safely turned off.
 
 To detect whether importers are done, users can validate the state in the Elasticsearch/OpenSearch index:
@@ -168,6 +173,7 @@ Complete the following steps to migrate any custom prefixes:
 1. Shut down your Camunda 8.7 cluster (for example, reduce the replicas to zero). No traffic can be executed against your to-be-migrated ES/OS prefixes.
 2. In the `camunda/bin` directory, the `prefix-migration` script will execute the prefix migration, which can be executed locally.
    Pass the desired prefix using the `CAMUNDA_DATABASE_INDEXPREFIX` environment variable.
+
    1. Make sure that your configuration in `camunda/config` has set the previous custom prefixes, and your configuration is made public to the script (for example, using `SPRING_CONFIG_ADDITIONALLOCATION=/path/to/application.yaml ./camunda/bin/prefix-migration`).
    2. Alternatively, you can set the configuration via environment variables:
 

--- a/docs/self-managed/components/components-upgrade/870-to-880.md
+++ b/docs/self-managed/components/components-upgrade/870-to-880.md
@@ -119,8 +119,8 @@ When using the Camunda 8 Helm charts, the migration application will automatical
 ### Turn off importers after completion
 
 :::note
-The configuration for 8.8 by default disables importers, ensure when upgrading `camunda.operate.importerEnabled=true`
-and `camunda.tasklist.importerEnabled=true`
+In 8.8, the Tasklist and Operate importers are disabled by default. When upgrading, please ensure that they are enabled via the `camunda.operate.importerEnabled=true`
+and `camunda.tasklist.importerEnabled=true` properties
 :::
 
 Importers are only necessary at the start of the migration. Once complete, they can be safely turned off.
@@ -173,7 +173,6 @@ Complete the following steps to migrate any custom prefixes:
 1. Shut down your Camunda 8.7 cluster (for example, reduce the replicas to zero). No traffic can be executed against your to-be-migrated ES/OS prefixes.
 2. In the `camunda/bin` directory, the `prefix-migration` script will execute the prefix migration, which can be executed locally.
    Pass the desired prefix using the `CAMUNDA_DATABASE_INDEXPREFIX` environment variable.
-
    1. Make sure that your configuration in `camunda/config` has set the previous custom prefixes, and your configuration is made public to the script (for example, using `SPRING_CONFIG_ADDITIONALLOCATION=/path/to/application.yaml ./camunda/bin/prefix-migration`).
    2. Alternatively, you can set the configuration via environment variables:
 

--- a/docs/self-managed/components/components-upgrade/870-to-880.md
+++ b/docs/self-managed/components/components-upgrade/870-to-880.md
@@ -119,9 +119,12 @@ When using the Camunda 8 Helm charts, the migration application will automatical
 ### Turn off importers after completion
 
 :::note
-In 8.8, the Tasklist and Operate importers are disabled by default. When upgrading, please ensure that they are enabled via the `camunda.operate.importerEnabled=true`
-and `camunda.tasklist.importerEnabled=true` properties
-:::
+In 8.8, the Operate and Tasklist importers are disabled by default.  
+When upgrading, enable them by setting:
+
+- `camunda.operate.importerEnabled=true`
+- `camunda.tasklist.importerEnabled=true`
+  :::
 
 Importers are only necessary at the start of the migration. Once complete, they can be safely turned off.
 

--- a/docs/self-managed/components/orchestration-cluster/operate/importer-and-archiver.md
+++ b/docs/self-managed/components/orchestration-cluster/operate/importer-and-archiver.md
@@ -16,7 +16,7 @@ Modules can be run together or separately in any combination and can be scaled. 
 
 | Configuration parameter         | Description                            | Default value |
 | ------------------------------- | -------------------------------------- | ------------- |
-| camunda.operate.importerEnabled | When true, Importer module is enabled. | true          |
+| camunda.operate.importerEnabled | When true, Importer module is enabled. | false         |
 | camunda.operate.archiverEnabled | When true, Archiver module is enabled. | true          |
 | camunda.operate.webappEnabled   | When true, Webapp module is enabled.   | true          |
 

--- a/docs/self-managed/components/orchestration-cluster/tasklist/importer-and-archiver.md
+++ b/docs/self-managed/components/orchestration-cluster/tasklist/importer-and-archiver.md
@@ -16,7 +16,7 @@ Modules can be run together or separately in any combination and can be scaled. 
 
 | Configuration parameter          | Description                            | Default value |
 | -------------------------------- | -------------------------------------- | ------------- |
-| camunda.tasklist.importerEnabled | When true, Importer module is enabled. | true          |
+| camunda.tasklist.importerEnabled | When true, Importer module is enabled. | false         |
 | camunda.tasklist.archiverEnabled | When true, Archiver module is enabled. | true          |
 | camunda.tasklist.webappEnabled   | When true, Webapp module is enabled.   | true          |
 

--- a/docs/self-managed/installation-methods/helm/upgrade/helm-870-880.md
+++ b/docs/self-managed/installation-methods/helm/upgrade/helm-870-880.md
@@ -105,9 +105,8 @@ Enable or disable the required Camunda components for your use case:
 
 #### 2.2.1 Operate and Tasklist importers.
 
-By default, starting in 8.8 the Operate and Tasklist importers will be disabled as they are not needed for normal execution.
-However the importers must be running during the upgrade from `8.7.x` to process any left over data, if these importers are
-not enabled the update will stall. Ensure that:
+In 8.8, the Operate and Tasklist importers will be disabled by default, as they are not needed for normal execution.
+During the upgrade from `8.7.x`, they must be enabled to process any left over data to ensure that the upgrade can execute successfully. Ensure that:
 
 - `camunda.operate.importerEnabled=true`
 - `camunda.tasklist.importerEnabled=true`

--- a/docs/self-managed/installation-methods/helm/upgrade/helm-870-880.md
+++ b/docs/self-managed/installation-methods/helm/upgrade/helm-870-880.md
@@ -103,6 +103,15 @@ Enable or disable the required Camunda components for your use case:
 - Web Modeler
 - Optimize
 
+#### 2.2.1 Operate and Tasklist importers.
+
+By default, starting in 8.8 the Operate and Tasklist importers will be disabled as they are not needed for normal execution.
+However the importers must be running during the upgrade from `8.7.x` to process any left over data, if these importers are
+not enabled the update will stall. Ensure that:
+
+- `camunda.operate.importerEnabled=true`
+- `camunda.tasklist.importerEnabled=true`
+
 #### 2.3 Authentication
 
 Depending on your authentication setup, you may need to run the **Identity Migration App** to migrate users, groups, roles, and tenants to the new Orchestration Cluster's Elasticsearch index.

--- a/docs/self-managed/installation-methods/helm/upgrade/helm-870-880.md
+++ b/docs/self-managed/installation-methods/helm/upgrade/helm-870-880.md
@@ -103,10 +103,12 @@ Enable or disable the required Camunda components for your use case:
 - Web Modeler
 - Optimize
 
-#### 2.2.1 Operate and Tasklist importers.
+##### 2.2.1 Enable Operate and Tasklist importers
 
-In 8.8, the Operate and Tasklist importers will be disabled by default, as they are not needed for normal execution.
-During the upgrade from `8.7.x`, they must be enabled to process any left over data to ensure that the upgrade can execute successfully. Ensure that:
+In 8.8, the Operate and Tasklist importers are disabled by default because they are not required for normal execution.  
+When upgrading from `8.7.x`, you must enable them to process any remaining data so that the upgrade can complete successfully.
+
+To enable the importers, set:
 
 - `camunda.operate.importerEnabled=true`
 - `camunda.tasklist.importerEnabled=true`


### PR DESCRIPTION
## Description

By default in 8.8 the Operate/Tasklist importers will be disabled, however they are still required for the update from 8.7 -> 8.8. 

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

relates to https://github.com/camunda/camunda/issues/37080