### PR TITLE
docs: add bitname repo change to the announcements

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -31,7 +31,7 @@ jobs:
           sed -i '/SERVER_PORT/d;/SERVER_NAME/d' build/.htaccess
       - name: Run a web server for link checking
         run: |
-          docker run -d --name webserver -v "$PWD/build":/app -p 8888:8080 bitnami/apache:2.4.54
+          docker run -d --name webserver -v "$PWD/build":/app -p 8888:8080 bitnamilegacy/apache:2.4.54
           container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' webserver)
           echo "container_ip=${container_ip}" >> $GITHUB_ENV
           echo "domain_to_test=http://${container_ip}:8080" >> $GITHUB_ENV

--- a/docs/reference/announcements-release-notes/850/850-announcements.md
+++ b/docs/reference/announcements-release-notes/850/850-announcements.md
@@ -96,6 +96,10 @@ The number of replicas for the Web Modeler REST API and web app deployments can 
 | :------------- | :----------------- |
 | 9 January 2024 | 9 July 2025        |
 
+##### Bitnami Docker repository migration
+
+The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+
 ### Changes in supported environments
 
 #### Versioning changes in Helm chart

--- a/docs/reference/announcements-release-notes/850/850-announcements.md
+++ b/docs/reference/announcements-release-notes/850/850-announcements.md
@@ -90,16 +90,16 @@ A new `commonLabels` value is now available and integrates with `camundaPlatform
 
 The number of replicas for the Web Modeler REST API and web app deployments can be set with new configuration properties: `webModeler.restapi.replicas` and `webModeler.webapp.replicas`, respectively.
 
+##### Bitnami Docker repository migration
+
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.
+See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
+
 ## Camunda 8.4
 
 | Release date   | End of maintenance |
 | :------------- | :----------------- |
 | 9 January 2024 | 9 July 2025        |
-
-##### Bitnami Docker repository migration
-
-The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
-See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 ### Changes in supported environments
 

--- a/docs/reference/announcements-release-notes/850/850-announcements.md
+++ b/docs/reference/announcements-release-notes/850/850-announcements.md
@@ -98,7 +98,8 @@ The number of replicas for the Web Modeler REST API and web app deployments can 
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 ### Changes in supported environments
 

--- a/docs/reference/announcements-release-notes/860/860-announcements.md
+++ b/docs/reference/announcements-release-notes/860/860-announcements.md
@@ -168,7 +168,8 @@ The number of replicas for the Web Modeler REST API and web app deployments can 
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 ### New base path for Operate and Tasklist web applications
 

--- a/docs/reference/announcements-release-notes/860/860-announcements.md
+++ b/docs/reference/announcements-release-notes/860/860-announcements.md
@@ -166,6 +166,10 @@ A new `commonLabels` value is now available and integrates with `camundaPlatform
 
 The number of replicas for the Web Modeler REST API and web app deployments can be set with new configuration properties: `webModeler.restapi.replicas` and `webModeler.webapp.replicas`, respectively.
 
+##### Bitnami Docker repository migration
+
+The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+
 ### New base path for Operate and Tasklist web applications
 
 We are introducing a new base path for both the Operate and Tasklist **web applications**. This change applies to both Self-Managed and SaaS environments.

--- a/docs/reference/announcements-release-notes/860/860-announcements.md
+++ b/docs/reference/announcements-release-notes/860/860-announcements.md
@@ -168,7 +168,7 @@ The number of replicas for the Web Modeler REST API and web app deployments can 
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.
 See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 ### New base path for Operate and Tasklist web applications

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -135,7 +135,7 @@ The configuration for the external database used by the Web Modeler REST API has
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.
 See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 #### Adjustments

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -133,6 +133,10 @@ The number of replicas for the Web Modeler REST API and web app deployments can 
 
 The configuration for the external database used by the Web Modeler REST API has been updated to align with the Identity component's database configuration. A new value, `webModeler.restapi.externalDatabase`, is now available and mirrors the structure of `identity.externalDatabase`. To ensure backward compatibility, the existing `webModeler.restapi.externalDatabase.url` field is retained and will take precedence if set.
 
+##### Bitnami Docker repository migration
+
+The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+
 #### Adjustments
 
 - **New package structure**:

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -135,7 +135,8 @@ The configuration for the external database used by the Web Modeler REST API has
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 #### Adjustments
 

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -73,14 +73,14 @@ The configuration for the external database used by the Web Modeler REST API has
 The default ID token claim that Web Modeler uses to assign usernames has changed from `name` to `preferred_username`. This change aligns the configuration with other Camunda 8 components for consistency across the platform.
 To continue using the `name` claim, explicitly set `CAMUNDA_IDENTITY_USERNAMECLAIM=name` as an environment variable for the Web Modeler `webapp`. See [Identity / Keycloak](/self-managed/components/modeler/web-modeler/configuration/configuration.md#identity--keycloak-1).
 
-#### Deprecation of Self-Managed AWS Marketplace offering
+##### Deprecation of Self-Managed AWS Marketplace offering
 
 As of **October 2025**, the **Self-Managed AWS Marketplace** offering will be **deprecated** and no longer publicly available.  
 Existing customers may continue to use the product until their contracts expire.
 
 For future use, refer to our [new AWS Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-6y664fcnydiqg?sr=0-1&ref_=beagle&applicationId=AWSMPContessa) for more information.
 
-#### Separated Ingress deprecation
+##### Separated Ingress deprecation
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed has been deprecated in 8.6, and will be removed from the Helm chart in 8.8. Only the combined Ingress configuration is officially supported. See the [Ingress guide](/self-managed/installation-methods/helm/configure/ingress-setup.md) for more information on configuring a combined Ingress setup.
 
@@ -91,6 +91,10 @@ New migration guides will also be provided to support you when migrating from a 
 :::caution
 Additional upgrade considerations are necessary for deployments that use custom scripts, such as Docker containers, manual installations, or custom-developed Kubernetes deployments. For these deployments, customers can either continue to deploy with their original 8.7 topology and upgrade each component independently, or adopt our Helm chart approach for the upgrade, which allows for unifying the deployment into a single JAR or container executable.
 :::
+
+##### Bitnami Docker repository migration
+
+The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
 
 #### Alternative container images
 

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -94,7 +94,7 @@ Additional upgrade considerations are necessary for deployments that use custom 
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.
 See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 #### Alternative container images

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -94,7 +94,8 @@ Additional upgrade considerations are necessary for deployments that use custom 
 
 ##### Bitnami Docker repository migration
 
-The Camunda Helm charts have been updated to use the new [Bitnami Docker repository](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration).
+The Camunda Helm charts have been updated to use the new Bitnami Docker repository.  
+See [Bitnami Docker repository migration](/self-managed/installation-methods/helm/upgrade/index.md#bitnami-docker-repository-migration) for migration details.
 
 #### Alternative container images
 

--- a/docs/self-managed/installation-methods/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/installation-methods/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -431,17 +431,17 @@ From Keycloak versions 21+, the default JDBC driver can be overwritten, allowing
 
 The [official Keycloak documentation](https://www.keycloak.org/server/db#preparing-keycloak-for-amazon-aurora-postgresql) also provides detailed instructions for utilizing Amazon Aurora PostgreSQL.
 
-A custom Keycloak container image containing necessary configurations is accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak), incorporates the required wrapper for seamless integration.
+A custom Keycloak container image containing necessary configurations is accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak), incorporates the required wrapper for seamless integration.
 
 #### Container image sources
 
 The sources of the [Camunda Keycloak images](https://hub.docker.com/r/camunda/keycloak) can be found on [GitHub](https://github.com/camunda/keycloak). In this repository, the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) is assembled in the `Dockerfile`.
 
-Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnami/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
+Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnamilegacy/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
 
 ##### Keycloak image configuration
 
-Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak).
+Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak).
 
 ##### Identity
 

--- a/docs/self-managed/installation-methods/helm/configure/air-gapped-installation.md
+++ b/docs/self-managed/installation-methods/helm/configure/air-gapped-installation.md
@@ -26,10 +26,10 @@ The following images must be available in your air-gapped environment:
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
 - [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
-- [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql)
-- [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
-- [bitnami/os-shell](https://hub.docker.com/r/bitnami/os-shell/)
-- [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch/)
+- [bitnami/postgresql](https://hub.docker.com/r/bitnamilegacy/postgresql)
+- [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak)
+- [bitnami/os-shell](https://hub.docker.com/r/bitnamilegacy/os-shell/)
+- [bitnami/elasticsearch](https://hub.docker.com/r/bitnamilegacy/elasticsearch/)
 - [Web Modeler images](/self-managed/installation-methods/docker/docker.md#component-images):
   - [camunda/web-modeler-restapi](https://hub.docker.com/r/camunda/web-modeler-restapi)
   - [camunda/web-modeler-webapp](https://hub.docker.com/r/camunda/web-modeler-webapp)
@@ -49,7 +49,7 @@ For example, the Docker image of Zeebe and PostgreSQL can be pulled via DockerHu
 docker pull camunda/zeebe:latest
 docker pull registry.camunda.cloud/camunda/zeebe:latest
 
-docker pull bitnami/postgresql:latest
+docker pull bitnamilegacy/postgresql:latest
 docker pull registry.camunda.cloud/bitnami/postgresql:latest
 ```
 
@@ -166,10 +166,10 @@ zeebeGateway:
 elasticsearch:
   image:
     registry: example.jfrog.io
-    repository: bitnami/os-shell
+    repository: bitnamilegacy/os-shell
   sysctlImage:
     registry: example.jfrog.io
-    repository: bitnami/elasticsearch
+    repository: bitnamilegacy/elasticsearch
 identity:
   image:
     repository: camunda/identity
@@ -177,12 +177,12 @@ identity:
 identityKeycloak:
   image:
     registry: example.jfrog.io
-    repository: bitnami/keycloak
+    repository: bitnamilegacy/keycloak
     ...
   postgresql:
     image:
       registry: example.jfrog.io
-      repository: bitnami/postgresql
+      repository: bitnamilegacy/postgresql
 
       ...
 operate:
@@ -218,7 +218,7 @@ webModeler:
 postgresql:
   image:
     registry: example.jfrog.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
   ...
 ```
 

--- a/docs/self-managed/installation-methods/helm/upgrade/helm-820-830.md
+++ b/docs/self-managed/installation-methods/helm/upgrade/helm-820-830.md
@@ -105,7 +105,7 @@ If you have a custom `values.yaml`, change the image repository and tag:
 
 ```yaml
 image:
-  repository: bitnami/elasticsearch
+  repository: bitnamilegacy/elasticsearch
   tag: 8.8.2
 ```
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/guides/air-gapped-installation.md
@@ -25,10 +25,10 @@ The following images must be available in your air-gapped environment:
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
 - [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
-- [bitnami/postgres](https://hub.docker.com/r/bitnami/postgresql)
-- [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
-- [bitnami/os-shell](https://hub.docker.com/r/bitnami/os-shell/)
-- [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch/)
+- [bitnami/postgres](https://hub.docker.com/r/bitnamilegacy/postgresql)
+- [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak)
+- [bitnami/os-shell](https://hub.docker.com/r/bitnamilegacy/os-shell/)
+- [bitnami/elasticsearch](https://hub.docker.com/r/bitnamilegacy/elasticsearch/)
 - Web Modeler images (only available from [Camunda's private registry](../../docker.md#web-modeler)):
   - `web-modeler-ee/modeler-restapi`
   - `web-modeler-ee/modeler-webapp`

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/platforms/amazon-eks/irsa.md
@@ -104,17 +104,17 @@ From Keycloak versions 21+, the default JDBC driver can be overwritten, allowing
 
 Furthermore, the [official Keycloak documentation](https://www.keycloak.org/server/db#preparing-keycloak-for-amazon-aurora-postgresql) also provides detailed instructions for utilizing Amazon Aurora PostgreSQL.
 
-A custom Keycloak container image containing necessary configurations is conveniently accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak), incorporates the required wrapper for seamless integration.
+A custom Keycloak container image containing necessary configurations is conveniently accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak), incorporates the required wrapper for seamless integration.
 
 #### Container image sources
 
 The sources of the [Camunda Keycloak images](https://hub.docker.com/r/camunda/keycloak) can be found on [GitHub](https://github.com/camunda/keycloak). In this repository, the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) is assembled in the `Dockerfile`.
 
-Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnami/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
+Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnamilegacy/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
 
 #### Keycloak image configuration
 
-Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak).
+Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak).
 
 #### Kubernetes configuration
 

--- a/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
+++ b/versioned_docs/version-8.4/self-managed/platform-deployment/helm-kubernetes/upgrade.md
@@ -230,7 +230,7 @@ If you have a custom `values.yaml`, change the image repository and tag:
 
 ```yaml
 image:
-  repository: bitnami/elasticsearch
+  repository: bitnamilegacy/elasticsearch
   tag: 8.8.2
 ```
 

--- a/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.5/self-managed/setup/deploy/amazon/amazon-eks/irsa.md
@@ -187,17 +187,17 @@ From Keycloak versions 21+, the default JDBC driver can be overwritten, allowing
 
 Furthermore, the [official Keycloak documentation](https://www.keycloak.org/server/db#preparing-keycloak-for-amazon-aurora-postgresql) also provides detailed instructions for utilizing Amazon Aurora PostgreSQL.
 
-A custom Keycloak container image containing necessary configurations is conveniently accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak), incorporates the required wrapper for seamless integration.
+A custom Keycloak container image containing necessary configurations is conveniently accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak), incorporates the required wrapper for seamless integration.
 
 #### Container image sources
 
 The sources of the [Camunda Keycloak images](https://hub.docker.com/r/camunda/keycloak) can be found on [GitHub](https://github.com/camunda/keycloak). In this repository, the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) is assembled in the `Dockerfile`.
 
-Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnami/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
+Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnamilegacy/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
 
 #### Keycloak image configuration
 
-Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak).
+Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak).
 
 #### Kubernetes configuration
 

--- a/versioned_docs/version-8.5/self-managed/setup/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.5/self-managed/setup/guides/air-gapped-installation.md
@@ -25,10 +25,10 @@ The following images must be available in your air-gapped environment:
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
 - [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
-- [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql)
-- [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
-- [bitnami/os-shell](https://hub.docker.com/r/bitnami/os-shell/)
-- [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch/)
+- [bitnami/postgresql](https://hub.docker.com/r/bitnamilegacy/postgresql)
+- [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak)
+- [bitnami/os-shell](https://hub.docker.com/r/bitnamilegacy/os-shell/)
+- [bitnami/elasticsearch](https://hub.docker.com/r/bitnamilegacy/elasticsearch/)
 - Web Modeler images (only available from [Camunda's private registry](/self-managed/setup/deploy/other/docker.md#web-modeler)):
   - `web-modeler-ee/modeler-restapi`
   - `web-modeler-ee/modeler-webapp`
@@ -48,7 +48,7 @@ For example, the Docker image of Zeebe and PostgreSQL can be pulled via DockerHu
 docker pull camunda/zeebe:latest
 docker pull registry.camunda.cloud/camunda/zeebe:latest
 
-docker pull bitnami/postgresql:latest
+docker pull bitnamilegacy/postgresql:latest
 docker pull registry.camunda.cloud/bitnami/postgresql:latest
 ```
 
@@ -174,10 +174,10 @@ zeebeGateway:
 elasticsearch:
   image:
     registry: example.jfrog.io
-    repository: bitnami/os-shell
+    repository: bitnamilegacy/os-shell
   sysctlImage:
     registry: example.jfrog.io
-    repository: bitnami/elasticsearch
+    repository: bitnamilegacy/elasticsearch
 identity:
   image:
     repository: camunda/identity
@@ -185,12 +185,12 @@ identity:
 identityKeycloak:
   image:
     registry: example.jfrog.io
-    repository: bitnami/keycloak
+    repository: bitnamilegacy/keycloak
     ...
   postgresql:
     image:
       registry: example.jfrog.io
-      repository: bitnami/postgresql
+      repository: bitnamilegacy/postgresql
 
       ...
 operate:
@@ -226,7 +226,7 @@ webModeler:
 postgresql:
   image:
     registry: example.jfrog.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
   ...
 ```
 

--- a/versioned_docs/version-8.5/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.5/self-managed/setup/upgrade.md
@@ -306,7 +306,7 @@ If you have a custom `values.yaml`, change the image repository and tag:
 
 ```yaml
 image:
-  repository: bitnami/elasticsearch
+  repository: bitnamilegacy/elasticsearch
   tag: 8.8.2
 ```
 

--- a/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.6/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -475,17 +475,17 @@ From Keycloak versions 21+, the default JDBC driver can be overwritten, allowing
 
 The [official Keycloak documentation](https://www.keycloak.org/server/db#preparing-keycloak-for-amazon-aurora-postgresql) also provides detailed instructions for utilizing Amazon Aurora PostgreSQL.
 
-A custom Keycloak container image containing necessary configurations is accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak), incorporates the required wrapper for seamless integration.
+A custom Keycloak container image containing necessary configurations is accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak), incorporates the required wrapper for seamless integration.
 
 #### Container image sources
 
 The sources of the [Camunda Keycloak images](https://hub.docker.com/r/camunda/keycloak) can be found on [GitHub](https://github.com/camunda/keycloak). In this repository, the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) is assembled in the `Dockerfile`.
 
-Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnami/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
+Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnamilegacy/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
 
 ##### Keycloak image configuration
 
-Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak).
+Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak).
 
 ##### Identity
 

--- a/versioned_docs/version-8.6/self-managed/setup/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.6/self-managed/setup/guides/air-gapped-installation.md
@@ -25,10 +25,10 @@ The following images must be available in your air-gapped environment:
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
 - [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
-- [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql)
-- [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
-- [bitnami/os-shell](https://hub.docker.com/r/bitnami/os-shell/)
-- [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch/)
+- [bitnami/postgresql](https://hub.docker.com/r/bitnamilegacy/postgresql)
+- [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak)
+- [bitnami/os-shell](https://hub.docker.com/r/bitnamilegacy/os-shell/)
+- [bitnami/elasticsearch](https://hub.docker.com/r/bitnamilegacy/elasticsearch/)
 - [Web Modeler images](/self-managed/setup/deploy/other/docker.md#component-images):
   - [camunda/web-modeler-restapi](https://hub.docker.com/r/camunda/web-modeler-restapi)
   - [camunda/web-modeler-webapp](https://hub.docker.com/r/camunda/web-modeler-webapp)
@@ -48,7 +48,7 @@ For example, the Docker image of Zeebe and PostgreSQL can be pulled via DockerHu
 docker pull camunda/zeebe:latest
 docker pull registry.camunda.cloud/camunda/zeebe:latest
 
-docker pull bitnami/postgresql:latest
+docker pull bitnamilegacy/postgresql:latest
 docker pull registry.camunda.cloud/bitnami/postgresql:latest
 ```
 
@@ -165,10 +165,10 @@ zeebeGateway:
 elasticsearch:
   image:
     registry: example.jfrog.io
-    repository: bitnami/os-shell
+    repository: bitnamilegacy/os-shell
   sysctlImage:
     registry: example.jfrog.io
-    repository: bitnami/elasticsearch
+    repository: bitnamilegacy/elasticsearch
 identity:
   image:
     repository: camunda/identity
@@ -176,12 +176,12 @@ identity:
 identityKeycloak:
   image:
     registry: example.jfrog.io
-    repository: bitnami/keycloak
+    repository: bitnamilegacy/keycloak
     ...
   postgresql:
     image:
       registry: example.jfrog.io
-      repository: bitnami/postgresql
+      repository: bitnamilegacy/postgresql
 
       ...
 operate:
@@ -217,7 +217,7 @@ webModeler:
 postgresql:
   image:
     registry: example.jfrog.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
   ...
 ```
 

--- a/versioned_docs/version-8.6/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.6/self-managed/setup/upgrade.md
@@ -363,7 +363,7 @@ If you have a custom `values.yaml`, change the image repository and tag:
 
 ```yaml
 image:
-  repository: bitnami/elasticsearch
+  repository: bitnamilegacy/elasticsearch
   tag: 8.8.2
 ```
 

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/eks-helm.md
@@ -431,17 +431,17 @@ From Keycloak versions 21+, the default JDBC driver can be overwritten, allowing
 
 The [official Keycloak documentation](https://www.keycloak.org/server/db#preparing-keycloak-for-amazon-aurora-postgresql) also provides detailed instructions for utilizing Amazon Aurora PostgreSQL.
 
-A custom Keycloak container image containing necessary configurations is accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak), incorporates the required wrapper for seamless integration.
+A custom Keycloak container image containing necessary configurations is accessible on Docker Hub at [camunda/keycloak](https://hub.docker.com/r/camunda/keycloak). This image, built upon the base image [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak), incorporates the required wrapper for seamless integration.
 
 #### Container image sources
 
 The sources of the [Camunda Keycloak images](https://hub.docker.com/r/camunda/keycloak) can be found on [GitHub](https://github.com/camunda/keycloak). In this repository, the [aws-advanced-jdbc-wrapper](https://github.com/awslabs/aws-advanced-jdbc-wrapper) is assembled in the `Dockerfile`.
 
-Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnami/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
+Maintenance of these images is based on the upstream [Bitnami Keycloak images](https://hub.docker.com/r/bitnamilegacy/keycloak), ensuring they are always up-to-date with the latest Keycloak releases. The lifecycle details for Keycloak can be found on [endoflife.date](https://endoflife.date/keycloak).
 
 ##### Keycloak image configuration
 
-Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak).
+Bitnami Keycloak container image configuration is available at [hub.docker.com/bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak).
 
 ##### Identity
 

--- a/versioned_docs/version-8.7/self-managed/setup/guides/air-gapped-installation.md
+++ b/versioned_docs/version-8.7/self-managed/setup/guides/air-gapped-installation.md
@@ -25,10 +25,10 @@ The following images must be available in your air-gapped environment:
 - [camunda/optimize](https://hub.docker.com/r/camunda/optimize)
 - [camunda/connectors-bundle](https://hub.docker.com/r/camunda/connectors-bundle)
 - [camunda/identity](https://hub.docker.com/r/camunda/identity)
-- [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql)
-- [bitnami/keycloak](https://hub.docker.com/r/bitnami/keycloak)
-- [bitnami/os-shell](https://hub.docker.com/r/bitnami/os-shell/)
-- [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch/)
+- [bitnami/postgresql](https://hub.docker.com/r/bitnamilegacy/postgresql)
+- [bitnami/keycloak](https://hub.docker.com/r/bitnamilegacy/keycloak)
+- [bitnami/os-shell](https://hub.docker.com/r/bitnamilegacy/os-shell/)
+- [bitnami/elasticsearch](https://hub.docker.com/r/bitnamilegacy/elasticsearch/)
 - [Web Modeler images](/self-managed/setup/deploy/other/docker.md#component-images):
   - [camunda/web-modeler-restapi](https://hub.docker.com/r/camunda/web-modeler-restapi)
   - [camunda/web-modeler-webapp](https://hub.docker.com/r/camunda/web-modeler-webapp)
@@ -48,7 +48,7 @@ For example, the Docker image of Zeebe and PostgreSQL can be pulled via DockerHu
 docker pull camunda/zeebe:latest
 docker pull registry.camunda.cloud/camunda/zeebe:latest
 
-docker pull bitnami/postgresql:latest
+docker pull bitnamilegacy/postgresql:latest
 docker pull registry.camunda.cloud/bitnami/postgresql:latest
 ```
 
@@ -165,10 +165,10 @@ zeebeGateway:
 elasticsearch:
   image:
     registry: example.jfrog.io
-    repository: bitnami/os-shell
+    repository: bitnamilegacy/os-shell
   sysctlImage:
     registry: example.jfrog.io
-    repository: bitnami/elasticsearch
+    repository: bitnamilegacy/elasticsearch
 identity:
   image:
     repository: camunda/identity
@@ -176,12 +176,12 @@ identity:
 identityKeycloak:
   image:
     registry: example.jfrog.io
-    repository: bitnami/keycloak
+    repository: bitnamilegacy/keycloak
     ...
   postgresql:
     image:
       registry: example.jfrog.io
-      repository: bitnami/postgresql
+      repository: bitnamilegacy/postgresql
 
       ...
 operate:
@@ -217,7 +217,7 @@ webModeler:
 postgresql:
   image:
     registry: example.jfrog.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
   ...
 ```
 

--- a/versioned_docs/version-8.7/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.7/self-managed/setup/upgrade.md
@@ -376,7 +376,7 @@ If you have a custom `values.yaml`, change the image repository and tag:
 
 ```yaml
 image:
-  repository: bitnami/elasticsearch
+  repository: bitnamilegacy/elasticsearch
   tag: 8.8.2
 ```
 


### PR DESCRIPTION
## Description

Task: https://github.com/camunda/camunda-platform-helm/issues/3999

Add Bitname Docker repo change to the announcements.

Note: I'm not sure if I should make the changes the older versions dir (I've added to other versions announcements in latest).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.


- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

