### PR TITLE
docs: formalise no schema migrations in Camunda 8.8<=

### DIFF
--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -370,9 +370,9 @@ The following **breaking changes** require data migrations and must be avoided:
 
 #### Safe schema evolution
 
-The following changes are considered **backward compatible** and do **not** require data migrations:
+The following changes are considered **backwards compatible** and do **not** require data migrations:
 
-- **Additive changes**: Adding optional fields or columns with default values
+- **Additive changes**: Adding optional fields with default values
 - **New indices**: Creating new indices for new features
 - **Index settings**: Updating index settings in ways that do not affect existing data
 


### PR DESCRIPTION
## Description

This formalises the fact that no more data migrations are required for upgrades between minor versions in camunda 8.8>=

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

relates to https://github.com/camunda/product-hub/issues/1707
