### PR TITLE
fix: prettier check

### DIFF
--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -11,12 +11,12 @@ jobs:
           node-version: 22
       - name: Install Dependencies
         run: npm ci
-      - name: Verify format with Vale
-        uses: errata-ai/vale-action@v2.1.1
-        with:
-          filter_mode: added
-          reporter: github-pr-review
-          version: 3.9.6
+      # - name: Verify format with Vale
+      #   uses: errata-ai/vale-action@v2.1.1
+      #   with:
+      #     filter_mode: added
+      #     reporter: github-pr-review
+      #     version: 3.9.6
       - name: Verify format with Prettier
         uses: camunda/reviewdog-action-prettier@main
         with:

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -18,7 +18,7 @@ jobs:
           reporter: github-pr-review
           version: 3.9.6
       - name: Verify format with Prettier
-        uses: EPMatt/reviewdog-action-prettier@v1
+        uses: camunda/reviewdog-action-prettier
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -11,12 +11,12 @@ jobs:
           node-version: 22
       - name: Install Dependencies
         run: npm ci
-      # - name: Verify format with Vale
-      #   uses: errata-ai/vale-action@v2.1.1
-      #   with:
-      #     filter_mode: added
-      #     reporter: github-pr-review
-      #     version: 3.9.6
+      - name: Verify format with Vale
+        uses: errata-ai/vale-action@v2.1.1
+        with:
+          filter_mode: added
+          reporter: github-pr-review
+          version: 3.9.6
       - name: Verify format with Prettier
         uses: camunda/reviewdog-action-prettier@main
         with:

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -18,7 +18,7 @@ jobs:
           reporter: github-pr-review
           version: 3.9.6
       - name: Verify format with Prettier
-        uses: camunda/reviewdog-action-prettier
+        uses: camunda/reviewdog-action-prettier@main
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review


### PR DESCRIPTION
## Description

Makeshift solution to fix prettier check.
We forked the action repo as it got abandoned and went back to an older reviewdog version to reinstate known behavior.

We will also create a follow-up issue. 

See details in this [ask-infra question](https://camunda.slack.com/archives/C5AHF1D8T/p1756973496578219).

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
