### PR TITLE
feat: Document potential issues during task migration

### DIFF
--- a/docs/self-managed/components/components-upgrade/870-to-880.md
+++ b/docs/self-managed/components/components-upgrade/870-to-880.md
@@ -88,15 +88,15 @@ Useful metrics are:
 
 #### Platform behavior during migration
 
-While the data migration is in progress, you might observe the following:
+During data migration, you may observe the following temporary behaviors:
 
-- Some tasks do not appear in the Tasklist UI and are not returned by the Tasklist API
-- While using v1 of the Tasklist API, some tasks cannot be (un)assigned or completed. Instead, a Not Found (404) response will be returned
-- While using v2 of the Tasklist API, tasks can be (un)assigned or completed but retrieving them (e.g. via search) can lead to API responses indicating an Internal Server Error (500)
-- Refreshing the Tasklist UI while a task is selected can lead to Not Found (404) API responses if that task is in the process of being migrated.
-- Refreshing the Tasklist UI while a task is selected can lead to Internal Server Error (500) API responses if that task was completed or (un)assigned via the v2 API but not fully migrated yet.
+- Some tasks may not appear in the Tasklist UI or be returned by the Tasklist API.
+- When using **Tasklist API v1**, some tasks cannot be assigned, unassigned, or completed. These requests return a `404 Not Found` response.
+- When using **Tasklist API v2**, tasks can be assigned, unassigned, or completed, but attempts to retrieve them (e.g., via search) may return a `500 Internal Server Error` response.
+- Refreshing the Tasklist UI while a task is selected may return `404 Not Found` if the task is still being migrated.
+- Refreshing the Tasklist UI while a task is selected may return `500 Internal Server Error` if the task was completed or reassigned via API v2 but not yet fully migrated.
 
-All of the above will be temporary and should be resolved once the migration is completed.
+All issues above are temporary and resolve automatically once migration is complete.
 
 #### Standalone Migration (locally)
 
@@ -188,7 +188,6 @@ Complete the following steps to migrate any custom prefixes:
 1. Shut down your Camunda 8.7 cluster (for example, reduce the replicas to zero). No traffic can be executed against your to-be-migrated ES/OS prefixes.
 2. In the `camunda/bin` directory, the `prefix-migration` script will execute the prefix migration, which can be executed locally.
    Pass the desired prefix using the `CAMUNDA_DATABASE_INDEXPREFIX` environment variable.
-
    1. Make sure that your configuration in `camunda/config` has set the previous custom prefixes, and your configuration is made public to the script (for example, using `SPRING_CONFIG_ADDITIONALLOCATION=/path/to/application.yaml ./camunda/bin/prefix-migration`).
    2. Alternatively, you can set the configuration via environment variables:
 


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

The purpose of this PR is to provide some information on issues customer could potentially observe during the task migration that will take place when upgrading from 8.7 to 8.8.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
