### PR TITLE
fix: do not invoke scrollToHash if no diagrams are present in the page

### DIFF
--- a/static/js/render-diagrams.js
+++ b/static/js/render-diagrams.js
@@ -277,6 +277,13 @@ async function renderDiagrams() {
     ...Array.from(document.querySelectorAll("div[dmn]")),
   ];
 
+  // Minimal guard: if the page has no BPMN/DMN diagrams, skip processing and
+  // do not invoke scrollToHash (avoids errors for numeric-start anchors when
+  // querySelector would be used elsewhere or future changes reintroduce it).
+  if (diagramElements.length === 0) {
+    return;
+  }
+
   Promise.all(
     diagramElements.map(async (element) => {
       try {


### PR DESCRIPTION
## Description
When running the docs in dev mode with `npm start` I noticed that for some sections with a name starting with a number it would throw a runtime error. 

I checked in the released version of the docs and I noticed that the error is thrown, but it's not visible to the user, just in the console.

Screenshot of the errors thrown in the console from the `main`:
<img width="1776" height="1255" alt="image" src="https://github.com/user-attachments/assets/f460b038-ca3e-4fd5-ab40-fe7aa5b6d49d" />

## Cause 
The function renderDiagrams would call scrollToHash on every render even if no bpmn diagrams are present in the page.
The function scrollToHash would throw an error if the location.hash starts with a number like '#1-example'.

## Fix
If no diagrams are present in the page, renderDiagrams now just return immediately instead.


@mesellings please assign to whoever is best fit for this review, I was not sure who to assign it to 

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [X] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
