### PR TITLE
docs: usage metrics make example visible

### DIFF
--- a/docs/apis-tools/orchestration-cluster-api-rest/specifications/get-usage-metrics.api.mdx
+++ b/docs/apis-tools/orchestration-cluster-api-rest/specifications/get-usage-metrics.api.mdx
@@ -53,10 +53,10 @@ Retrieve the usage metrics based on given criteria.
       in: "query",
       required: true,
       description: "The start date for usage metrics, including this date.",
+      example: "2025-06-07T13:14:15Z",
       schema: {
         type: "string",
         format: "date-time",
-        example: "2025-06-07T13:14:15Z",
       },
     },
     {
@@ -64,10 +64,10 @@ Retrieve the usage metrics based on given criteria.
       in: "query",
       required: true,
       description: "The end date for usage metrics, including this date.",
+      example: "2026-07-08T13:14:15Z",
       schema: {
         type: "string",
         format: "date-time",
-        example: "2025-06-07T13:14:15Z",
       },
     },
     {


### PR DESCRIPTION
## Description

For Docusaurus visibility, it seems that `example` should be at the parameter level.

<img width="811" height="469" alt="image" src="https://github.com/user-attachments/assets/1153a1b8-aecc-4941-8bd8-f764ee2fa150" />


relates to [#37997](https://github.com/camunda/camunda/issues/37997)
