### PR TITLE
Use correct path to example task listener in camunda-platform-tutorials

### DIFF
--- a/docs/components/concepts/user-task-listeners-guide.md
+++ b/docs/components/concepts/user-task-listeners-guide.md
@@ -40,7 +40,7 @@ Additionally, you need the following:
 - Maven
 - IDE (IntelliJ, VSCode, or similar)
 - Download and unzip or clone the [repository](https://github.com/camunda/camunda-platform-tutorials), then navigate to:  
-  `camunda-platform-tutorials/quick-start/task-listeners/task-listener-java`
+  `camunda-platform-tutorials/quick-start/task-listeners/worker-java`
 
 ## Step 1: Create a process with a user task in Modeler
 
@@ -51,7 +51,7 @@ Additionally, you need the following:
 ![Web modeler showing a process with user task](./assets/user-task-listeners-guide/1-process-with-user-task.png)
 
 :::note
-In this guide, you can also use the example BPMN from the repo located in `camunda-platform-tutorials/quick-start/task-listeners/task-listener-java/src/main/resources/Quick_Start_Task_Listeners.bpmn`.
+In this guide, you can also use the example BPMN from the repo located in `camunda-platform-tutorials/quick-start/task-listeners/worker-java/src/main/resources/Quick_Start_Task_Listeners.bpmn`.
 In that case, just explore the BPMN using the steps below, but do not adjust the model in steps 2-4.
 :::
 
@@ -124,7 +124,7 @@ Next, we'll run the listener application to execute our external logic, and comp
 
 Next, we’ll create a worker that listens to the user task's events by associating it with the **Listener type** we specified on the task listener in the BPMN diagram.
 
-1. Open the downloaded or cloned project ([repo](https://github.com/camunda/camunda-platform-tutorials), then `cd` into `camunda-platform-tutorials/quick-start/task-listeners/task-listener-java`) in your IDE.
+1. Open the downloaded or cloned project ([repo](https://github.com/camunda/camunda-platform-tutorials), then `cd` into `camunda-platform-tutorials/quick-start/task-listeners/worker-java`) in your IDE.
 2. Add your credentials to `application.properties`. Your client ID and client secret are available from the previous section in the credential text file you downloaded or copied. Go to the cluster overview page to find your **region Id** and **cluster Id** (in your client credentials under the **API** tab within your cluster).
 3. In the `Listener.java` file, change the type to match what you specified in the BPMN diagram. If you followed the previous steps for this guide and entered “assign_new_task”, no action is required.
 4. After making these changes, perform a Maven install, then run the Listener.java `main` method via your favorite IDE. If you prefer using a terminal, run `mvn package exec:java`.


### PR DESCRIPTION
## Description

A tutorial about User Task Listeners was introduced to the documentation in #6040, with its code counterpart in camunda/camunda-platform-tutorials#75. There is a small misalignment in the two PRs regarding the path of the user task listener implementation:
- docs: `camunda-platform-tutorials/quick-start/task-listeners/task-listener-java`
- code: `camunda-platform-tutorials/quick-start/task-listeners/worker-java`

This PR fixes the misalignment.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
