### PR TITLE
docs(consume-unmatched-events): Document how Consume unmatched events works

### DIFF
--- a/docs/components/connectors/use-connectors/inbound.md
+++ b/docs/components/connectors/use-connectors/inbound.md
@@ -129,6 +129,57 @@ For example, given that your correlation key is defined with `requestIdValue` pr
 
 See the [webhook documentation](/components/connectors/protocol/http-webhook.md) or the documentation of [other connector types](/components/connectors/out-of-the-box-connectors/available-connectors-overview.md) for more details.
 
+## Consume unmatched events
+
+You can configure a connector to consume all unmatched events from the event source by enabling the **Consume unmatched events** checkbox in the **Activation** section of the connector properties.
+
+- When this option is enabled, the connector will consume all events that do not match the activation condition of any other connector with the same deduplication ID.
+  This is useful in scenarios where you want to ensure that all events are processed, even if they do not match any specific activation condition.
+
+- When this option is disabled, the connector will only consume events that match its activation condition. Events that do not match any activation condition will lead to an error.
+
+Here are some examples of how this option will affect the behavior of the connector when enabled or disabled, when the activation conditions of all the connectors with the same deduplication ID do not match the incoming event:
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2" style={{ verticalAlign: "middle", textAlign: "center" }}>Connector</th>
+      <th colspan="2">Consume unmatched events</th>
+    </tr>
+    <tr>
+      <th>✅ Enabled</th>
+      <th>◻️ Disabled</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Webhook Connectors</td>
+      <td>Return a success response (200)</td>
+      <td>Return an error response (422, or specific HTTP status code depending on the error)</td>
+    </tr>
+    <tr>
+      <td>Kafka Connector</td>
+      <td>Commit the message offset</td>
+      <td>Do not commit the message offset</td>
+    </tr>
+    <tr>
+      <td>RabbitMQ Connector</td>
+      <td>Acknowledge the message</td>
+      <td>Reject the message</td>
+    </tr>
+    <tr>
+      <td>SQS Connector</td>
+      <td>Delete the message from the queue</td>
+      <td>Do not delete the message from the queue</td>
+    </tr>
+    <tr>
+      <td>Email Connector</td>
+      <td>Mark the email as processed (e.g. marked as read, deleted, or moved)</td>
+      <td>Do not mark the email as processed</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Connector deduplication
 
 In the simplest case, each inbound connector element in a BPMN diagram corresponds to a unique endpoint, event consumer, or a polling task.

--- a/versioned_docs/version-8.6/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.6/components/connectors/use-connectors/inbound.md
@@ -125,6 +125,57 @@ For example, given that your correlation key is defined with `requestIdValue` pr
 
 See the [webhook documentation](/components/connectors/protocol/http-webhook.md) or the documentation of [other Connector types](/components/connectors/out-of-the-box-connectors/available-connectors-overview.md) for more details.
 
+### Consume unmatched events
+
+You can configure a connector to consume all unmatched events from the event source by enabling the **Consume unmatched events** checkbox in the **Activation** section of the connector properties.
+
+- When this option is enabled, the connector will consume all events that do not match the activation condition of any other connector with the same deduplication ID.
+  This is useful in scenarios where you want to ensure that all events are processed, even if they do not match any specific activation condition.
+
+- When this option is disabled, the connector will only consume events that match its activation condition. Events that do not match any activation condition will lead to an error.
+
+Here are some examples of how this option will affect the behavior of the connector when enabled or disabled, when the activation conditions of all the connectors with the same deduplication ID do not match the incoming event:
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2" style={{ verticalAlign: "middle", textAlign: "center" }}>Connector</th>
+      <th colspan="2">Consume unmatched events</th>
+    </tr>
+    <tr>
+      <th>✅ Enabled</th>
+      <th>◻️ Disabled</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Webhook Connectors</td>
+      <td>Return a success response (200)</td>
+      <td>Return an error response (422, or specific HTTP status code depending on the error)</td>
+    </tr>
+    <tr>
+      <td>Kafka Connector</td>
+      <td>Commit the message offset</td>
+      <td>Do not commit the message offset</td>
+    </tr>
+    <tr>
+      <td>RabbitMQ Connector</td>
+      <td>Acknowledge the message</td>
+      <td>Reject the message</td>
+    </tr>
+    <tr>
+      <td>SQS Connector</td>
+      <td>Delete the message from the queue</td>
+      <td>Do not delete the message from the queue</td>
+    </tr>
+    <tr>
+      <td>Email Connector</td>
+      <td>Mark the email as processed (e.g. marked as read, deleted, or moved)</td>
+      <td>Do not mark the email as processed</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Connector deduplication
 
 In the simplest case, each inbound Connector element in a BPMN diagram corresponds to a unique endpoint, event consumer, or a polling task.

--- a/versioned_docs/version-8.7/components/connectors/use-connectors/inbound.md
+++ b/versioned_docs/version-8.7/components/connectors/use-connectors/inbound.md
@@ -125,6 +125,57 @@ For example, given that your correlation key is defined with `requestIdValue` pr
 
 See the [webhook documentation](/components/connectors/protocol/http-webhook.md) or the documentation of [other connector types](/components/connectors/out-of-the-box-connectors/available-connectors-overview.md) for more details.
 
+### Consume unmatched events
+
+You can configure a connector to consume all unmatched events from the event source by enabling the **Consume unmatched events** checkbox in the **Activation** section of the connector properties.
+
+- When this option is enabled, the connector will consume all events that do not match the activation condition of any other connector with the same deduplication ID.
+  This is useful in scenarios where you want to ensure that all events are processed, even if they do not match any specific activation condition.
+
+- When this option is disabled, the connector will only consume events that match its activation condition. Events that do not match any activation condition will lead to an error.
+
+Here are some examples of how this option will affect the behavior of the connector when enabled or disabled, when the activation conditions of all the connectors with the same deduplication ID do not match the incoming event:
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2" style={{ verticalAlign: "middle", textAlign: "center" }}>Connector</th>
+      <th colspan="2">Consume unmatched events</th>
+    </tr>
+    <tr>
+      <th>✅ Enabled</th>
+      <th>◻️ Disabled</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Webhook Connectors</td>
+      <td>Return a success response (200)</td>
+      <td>Return an error response (422, or specific HTTP status code depending on the error)</td>
+    </tr>
+    <tr>
+      <td>Kafka Connector</td>
+      <td>Commit the message offset</td>
+      <td>Do not commit the message offset</td>
+    </tr>
+    <tr>
+      <td>RabbitMQ Connector</td>
+      <td>Acknowledge the message</td>
+      <td>Reject the message</td>
+    </tr>
+    <tr>
+      <td>SQS Connector</td>
+      <td>Delete the message from the queue</td>
+      <td>Do not delete the message from the queue</td>
+    </tr>
+    <tr>
+      <td>Email Connector</td>
+      <td>Mark the email as processed (e.g. marked as read, deleted, or moved)</td>
+      <td>Do not mark the email as processed</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Connector deduplication
 
 In the simplest case, each inbound connector element in a BPMN diagram corresponds to a unique endpoint, event consumer, or a polling task.


### PR DESCRIPTION
## Description

This pull request updates the inbound connector documentation across multiple versions to introduce and explain the new "Consume unmatched events" option. This option allows connectors to process events that do not match any activation condition, improving event handling flexibility. The documentation now includes a detailed table showing how enabling or disabling this feature affects the behavior of different connector types.

<img width="1012" height="756" alt="Screenshot 2025-09-25 at 14 47 21" src="https://github.com/user-attachments/assets/efc4aab5-75c1-440d-bfc2-56107e534c11" />


**Documentation updates for new connector feature:**

* Added a section describing the **Consume unmatched events** option in the inbound connector documentation for `docs/components/connectors/use-connectors/inbound.md`, `versioned_docs/version-8.6/components/connectors/use-connectors/inbound.md`, and `versioned_docs/version-8.7/components/connectors/use-connectors/inbound.md`. [[1]](diffhunk://#diff-83b75495886e0569a03038cf165ef640918f251a16ed64e681c01195e73a327aR132-R182) [[2]](diffhunk://#diff-501f464ddd863d76f6f86aede0f5c89b2f1a888bca66bf7848789cdbc3c0a715R128-R178) [[3]](diffhunk://#diff-1f87c9dbb6724ea94e321da1f35ccf25beade8bd7f560e1145f325606c970f59R128-R178)

**Behavioral details for connectors:**

* Provided a comparison table illustrating the behavior of Webhook, Kafka, RabbitMQ, SQS, and Email connectors when the option is enabled or disabled, clarifying the effects on event consumption and error handling. [[1]](diffhunk://#diff-83b75495886e0569a03038cf165ef640918f251a16ed64e681c01195e73a327aR132-R182) [[2]](diffhunk://#diff-501f464ddd863d76f6f86aede0f5c89b2f1a888bca66bf7848789cdbc3c0a715R128-R178) [[3]](diffhunk://#diff-1f87c9dbb6724ea94e321da1f35ccf25beade8bd7f560e1145f325606c970f59R128-R178)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
