### PR TITLE
fix: Camunda process test

### DIFF
--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -126,7 +126,7 @@ public class MyProcessTest {
                 .join();
 
         // then
-        CamundaAssert.assertThat(processInstance).isCompleted();
+        CamundaAssert.assertThat(processInstance).isActive();
     }
 }
 ```
@@ -178,7 +178,7 @@ public class MyProcessTest {
                 .join();
 
         // then
-        CamundaAssert.assertThat(processInstance).isCompleted();
+        CamundaAssert.assertThat(processInstance).isActive();
     }
 }
 ```

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -58,6 +58,7 @@ Add the following dependency to your Maven project:
 <dependency>
   <groupId>io.camunda</groupId>
   <artifactId>camunda-process-test-spring</artifactId>
+  <version>${camunda.version}</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -72,6 +73,7 @@ Add the following dependency to your Maven project:
 <dependency>
   <groupId>io.camunda</groupId>
   <artifactId>camunda-process-test-java</artifactId>
+  <version>${camunda.version}</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -113,8 +113,13 @@ public class MyProcessTest {
     @Autowired private CamundaProcessTestContext processTestContext;
 
     @Test
-    void shouldCompleteProcessInstance() {
-        // given: the processes are deployed
+    void shouldCreateProcessInstance() {
+        // given
+        client
+                .newDeployResourceCommand()
+                .addResourceFromClasspath("my-process.bpmn")
+                .send()
+                .join();
 
         // when
         final ProcessInstanceEvent processInstance =
@@ -160,7 +165,7 @@ public class MyProcessTest {
     private CamundaProcessTestContext processTestContext;
 
     @Test
-    void shouldCompleteProcessInstance() {
+    void shouldCreateProcessInstance() {
         // given
         client
             .newDeployResourceCommand()

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -107,6 +107,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @CamundaSpringProcessTest
+@Deployment(resources = "classpath:my-process.bpmn")
 public class MyProcessTest {
 
     @Autowired private CamundaClient client;
@@ -114,12 +115,7 @@ public class MyProcessTest {
 
     @Test
     void shouldCreateProcessInstance() {
-        // given
-        client
-                .newDeployResourceCommand()
-                .addResourceFromClasspath("my-process.bpmn")
-                .send()
-                .join();
+        // given process definition is deployed
 
         // when
         final ProcessInstanceEvent processInstance =

--- a/docs/apis-tools/testing/getting-started.md
+++ b/docs/apis-tools/testing/getting-started.md
@@ -107,7 +107,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @CamundaSpringProcessTest
-@Deployment(resources = "classpath:my-process.bpmn")
 public class MyProcessTest {
 
     @Autowired private CamundaClient client;
@@ -138,6 +137,18 @@ public class MyProcessTest {
 - (_optional_) Inject a preconfigured `CamundaClient` to interact with the Camunda runtime.
 - (_optional_) Inject a `CamundaProcessTestContext` to interact with the test runtime.
 - (_optional_) Use `CamundaAssert` to verify the process instance state.
+
+The Spring test requires a Spring Boot process application in the same package. Usually, the process
+application [deploys the process resources](/apis-tools/camunda-spring-boot-starter/getting-started.md#deploy-process-models)
+using the annotation `@Deployment`.
+
+If you have no process application yet, you can add a minimal one inside the test class as follows:
+
+```java
+@SpringBootApplication
+@Deployment(resources = "classpath*:/bpmn/**/*.bpmn")
+static class TestProcessApplication {}
+```
 
 </TabItem>
 


### PR DESCRIPTION
This pull request updates the `getting-started.md` documentation for process testing tools. The main changes clarify dependency configuration for Maven (to align with Java Client docs) and change the example test assertions to check if the process instance is active.

**Dependency configuration improvements:**

* Added explicit `<version>${camunda.version}</version>` tags to both the `camunda-process-test-spring` and `camunda-process-test-java` Maven dependency examples to ensure users specify the correct version. [[1]](diffhunk://#diff-74867037373dcaa0bcd94147e2fc1bc2657f8a17c4df7599f8d2673ed896c8e1R61) [[2]](diffhunk://#diff-74867037373dcaa0bcd94147e2fc1bc2657f8a17c4df7599f8d2673ed896c8e1R76)

**Test example corrections:**

* Updated the example test assertions from `isCompleted()` to `isActive()` to more accurately demonstrate the expected process instance state in the sample test code. [[1]](diffhunk://#diff-74867037373dcaa0bcd94147e2fc1bc2657f8a17c4df7599f8d2673ed896c8e1L127-R129) [[2]](diffhunk://#diff-74867037373dcaa0bcd94147e2fc1bc2657f8a17c4df7599f8d2673ed896c8e1L179-R181)

**Spring Test requirements:**

Add a hint that the Spring test requires a Spring Boot application. 

Related to https://github.com/camunda/camunda/issues/38255.

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
