### PR TITLE
docs: add minimum supported version for rollover interval

### DIFF
--- a/versioned_docs/version-8.6/self-managed/operate-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.6/self-managed/operate-deployment/importer-and-archiver.md
@@ -130,5 +130,5 @@ or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/
 for more information on possible values and their effects.
 
 :::note
-This feature is only officially supported from version >= 8.6.29.
+This feature is officially supported from version >= 8.6.29.
 :::

--- a/versioned_docs/version-8.6/self-managed/operate-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.6/self-managed/operate-deployment/importer-and-archiver.md
@@ -128,3 +128,7 @@ therefore it would be archived into a historical index with a suffix of `yyyy-mm
 Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
 or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
 for more information on possible values and their effects.
+
+:::note
+This feature is only officially supported from version >= 8.6.29.
+:::

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -122,7 +122,7 @@ value of `1w` would archive based on weekly intervals so a process instance whic
 therefore it would be archived into a historical index with a suffix of `yyyy-mm-07`
 
 | Configuration parameter                    | Description                            | Default value |
-|--------------------------------------------|----------------------------------------|---------------|
+| ------------------------------------------ | -------------------------------------- | ------------- |
 | camunda.tasklist.archiver.rolloverInterval | Interval for size of archived indices. | 1d            |
 
 Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
@@ -130,5 +130,5 @@ or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/
 for more information on possible values and their effects.
 
 :::note
-This feature is only officially supported from version >= 8.6.29.
+This feature is officially supported from version >= 8.6.29.
 :::

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -128,3 +128,7 @@ therefore it would be archived into a historical index with a suffix of `yyyy-mm
 Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
 or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
 for more information on possible values and their effects.
+
+:::note
+This feature is only officially supported from version >= 8.6.29.
+:::

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
@@ -130,5 +130,5 @@ or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/
 for more information on possible values and their effects.
 
 :::note
-This feature is only officially supported from version >= 8.7.15.
+This feature is officially supported from version >= 8.7.15.
 :::

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
@@ -128,3 +128,7 @@ therefore it would be archived into a historical index with a suffix of `yyyy-mm
 Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
 or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
 for more information on possible values and their effects.
+
+:::note
+This feature is only officially supported from version >= 8.7.15.
+:::

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -128,3 +128,7 @@ therefore it would be archived into a historical index with a suffix of `yyyy-mm
 Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
 or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
 for more information on possible values and their effects.
+
+:::note
+This feature is only officially supported from version >= 8.7.15.
+:::

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -122,7 +122,7 @@ value of `1w` would archive based on weekly intervals so a process instance whic
 therefore it would be archived into a historical index with a suffix of `yyyy-mm-07`
 
 | Configuration parameter                    | Description                            | Default value |
-|--------------------------------------------|----------------------------------------|---------------|
+| ------------------------------------------ | -------------------------------------- | ------------- |
 | camunda.tasklist.archiver.rolloverInterval | Interval for size of archived indices. | 1d            |
 
 Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
@@ -130,5 +130,5 @@ or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/
 for more information on possible values and their effects.
 
 :::note
-This feature is only officially supported from version >= 8.7.15.
+This feature is officially supported from version >= 8.7.15.
 :::


### PR DESCRIPTION
## Description

Adds a min officially supported version for rollover interval

addition to https://github.com/camunda/camunda-docs/pull/6850 as it was merged

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist
- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.


- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.


