### PR TITLE
docs: clarify how to configure nodb mode

### DIFF
--- a/docs/self-managed/concepts/no-secondary-storage.md
+++ b/docs/self-managed/concepts/no-secondary-storage.md
@@ -4,6 +4,9 @@ title: "No secondary storage"
 description: "Run Zeebe clusters with only the engine and primary storage components, without secondary storage dependencies."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 The `noSecondaryStorage` mode allows you to run Zeebe clusters with only the engine and primary storage components, disabling all components that depend on secondary storage.
 
 ## No secondary storage mode
@@ -41,6 +44,64 @@ In addition to using Helm charts, you can enable `noSecondaryStorage` mode throu
 
 - **Docker Compose**: Modify your `docker-compose` file to exclude secondary storage services.
 - **Manual deployment**: Start Zeebe without Elasticsearch/OpenSearch or any services that rely on them.
+
+As you are running in headless mode, you will need to configure your brokers with the following:
+
+<Tabs groupId="brokerConfig" defaultValue="env" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<TabItem value="yaml">
+
+```yaml
+spring:
+  profiles:
+    active: broker,standalone
+
+camunda:
+  data:
+    secondary-storage:
+      type: none
+```
+
+</TabItem>
+
+<TabItem value="env">
+
+```
+SPRING_PROFILES_ACTIVE=broker,standalone
+CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=none
+```
+
+</TabItem>
+
+</Tabs>
+
+Similarly, if you're running gateways and brokers separately, you will need to also configure your gateways:
+
+<Tabs groupId="gatewayConfig" defaultValue="env" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<TabItem value="yaml">
+
+```yaml
+spring:
+  profiles:
+    active: gateway,standalone
+
+camunda:
+  data:
+    secondary-storage:
+      type: none
+```
+
+</TabItem>
+
+<TabItem value="env">
+
+```
+SPRING_PROFILES_ACTIVE=gateway,standalone
+CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=none
+```
+
+</TabItem>
+
+</Tabs>
 
 ## Components and features disabled in `noSecondaryStorage` mode
 


### PR DESCRIPTION
## Description

This PR adds the required configuration to start brokers/gateways without a secondary storage, as the Helm configuration is not enough, and we do not tell users how to start in Docker Compose or bare metal mode.

For example, you cannot have the authentication profile enabled - as it's on by default, and there is no configuration to disable Identity, you need to set some profiles explicitly.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
