### PR TITLE
Reduced default bulk delay

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -90,13 +90,13 @@ size) can be controlled by configuration.
 
 | Option | Description                                                                                                                                                    | Default |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| delay  | Delay, in seconds, before force flush of the current batch. This ensures that even when we have low traffic of records, we still export every once in a while. | `5`     |
+| delay  | Delay, in seconds, before force flush of the current batch. This ensures that even when we have low traffic of records, we still export every once in a while. | `1`     |
 | size   | The amount of records a batch should have before we flush the batch.                                                                                           | `1000`  |
 
 With the default configuration, the exporter will aggregate records and flush them to Elasticsearch/OpenSearch:
 
 1. When it has aggregated 1000 records.
-2. Five seconds have elapsed since the last flush (regardless of how many
+2. One seconds have elapsed since the last flush (regardless of how many
    records were aggregated).
 
 </TabItem>


### PR DESCRIPTION
## Description

Reduce the bulk delay from 5s to 1s. Implementation PR here https://github.com/camunda/camunda/pull/40299

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.8).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
