### PR TITLE
refactor: drop unused ports

### DIFF
--- a/docs/self-managed/quickstart/administrator-quickstart.md
+++ b/docs/self-managed/quickstart/administrator-quickstart.md
@@ -142,10 +142,6 @@ nodes:
         hostPort: 80
       - containerPort: 443
         hostPort: 443
-      - containerPort: 26500
-        hostPort: 26500
-      - containerPort: 18080
-        hostPort: 18080
 ```
 
 Modify the `kind create cluster` command to use the configuration file above. You might need to delete and re-create this cluster if you are planning to enable Ingress (see [delete kind cluster](#clean)):

--- a/versioned_docs/version-8.8/self-managed/quickstart/administrator-quickstart.md
+++ b/versioned_docs/version-8.8/self-managed/quickstart/administrator-quickstart.md
@@ -142,10 +142,6 @@ nodes:
         hostPort: 80
       - containerPort: 443
         hostPort: 443
-      - containerPort: 26500
-        hostPort: 26500
-      - containerPort: 18080
-        hostPort: 18080
 ```
 
 Modify the `kind create cluster` command to use the configuration file above. You might need to delete and re-create this cluster if you are planning to enable Ingress (see [delete kind cluster](#clean)):


### PR DESCRIPTION


## Description

The ports 26500 and 18080 do not need to be mapped from the container of the KIND cluster to the host because these ports are mapped via Ingress. These 2 ports are unnecessarily mapped, which means that it is problematic if you were running a KIND cluster as well as an instance of C8Run.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
