### PR TITLE
docs(pim): add new section for user task implementation migration

### DIFF
--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -10,7 +10,7 @@ import ProcessInstanceAfterMigration from './assets/process-instance-migration/m
 Process instance migration fits a running process instance to a different process definition.
 This can be useful when the process definition of a running process instance needs changes due to bugs or updated requirements.
 While doing so, we aim to interfere as little as possible with the process instance state during the migration.
-For example, a migrated active user task remains assigned to the same user (if there is no implementation migration).
+For example, a migrated active user task remains assigned to the same user if no implementation migration occurs.
 This principle applies to all parts of the process instance.
 
 :::tip
@@ -165,21 +165,20 @@ To migrate ad-hoc subprocesses, you must provide a mapping instruction from the 
 Changing the scope of ad-hoc subprocesses during migration is not possible.
 :::
 
-## Migrate job-worker user tasks to Camunda user tasks
+## Migrate job worker user tasks to Camunda user tasks
 
-User tasks with job worker implementation can be migrated to user tasks with Camunda user task implementation by providing mapping instructions between the source and the target user task.
+You can migrate user tasks with a job worker implementation to Camunda user tasks by providing mapping instructions between the source and target user tasks.
 
-The target Camunda user task will preserve the `candidate groups`, `candidate users`, `due date`, `follow-up date`, and `form id`/`form key` of the source task.
+The target Camunda user task preserves `candidate groups`, `candidate users`, `due date`, `follow-up date`, and the `form id` or `form key` from the source task.
 
-The target user task will set the priority as defined in the target user task definition, or set a default value if none is defined.
-
-:::important
-Camunda user tasks do not support embedded forms. When migrating a job-worker user task with embedded form to a Camunda user task, the form defined in the target user task definition will be used.
-:::
+The target user task uses the priority defined in the target user task definition, or a default value if none is defined.
 
 :::important
-For the migration between different user task implementations the current `assignee` is not preserved. The target user task will be assigned to the initial assignee defined in the target user task definition.
-:::
+When you migrate a job worker user task to a Camunda user task:
+
+- Embedded forms are not supported. The form defined in the target user task definition is used.
+- The current `assignee` is not preserved. The task is assigned to the initial assignee defined in the target user task definition.
+  :::
 
 ## Deal with catch events
 
@@ -302,7 +301,7 @@ The target process definition contains a compensation boundary event attached to
 
 If the process instance is migrated by providing mapping instruction between service tasks `A` -> `A`, the compensation subscription will be created on completion of the element `A`.
 
-However, if the process instance is migrated by providing mapping instruction between service tasks `A` -> `B`, then triggering compensation throw event afterward will **not** compensate `A`. This is because the subscription is only opened when completing a task with a compensation boundary event.
+However, if the process instance is migrated by providing mapping instruction between service tasks `A` -> `B`, then triggering compensation throw event afterward will not compensate `A`. This is because the subscription is only opened when completing a task with a compensation boundary event.
 
 ## Deal with gateways
 


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->
Add documentation for the new feature that allows for process instance migration between user task implementations.

closes https://github.com/camunda/camunda/issues/29273

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
