### PR TITLE
docs(connectors): Add timeout section to agentic ai model providers

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_model-provider.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_model-provider.md
@@ -18,16 +18,16 @@ Select and configure authentication for the LLM model **Provider** you want to u
 
 #### Timeout handling
 
-The default timeout for model API calls is set by the runtime to 3 minutes. Self-managed Spring connector runtime instances provide the ability to override this value by setting the `camunda.connector.agenticai.aiagent.chat-model.api.default-timeout` property in the Spring application properties file.
+The default timeout for model API calls is set to three minutes by the runtime. Self-managed Spring connector runtime instances allow you to override this value by setting the `camunda.connector.agenticai.aiagent.chat-model.api.default-timeout` property in the Spring application properties file.
 
-Furthermore, you can specify a custom timeout per provider in the **Timeout** field below. Setting this value will take precedence over the default timeout.
+You can also specify a custom timeout per provider in the **Timeout** field below. This value takes precedence over the default timeout.
 
-All values must be provided in the [ISO-8601 Duration Format](https://en.wikipedia.org/wiki/ISO_8601#Durations), for example, `PT60S` for a 60-second timeout.
+All values must be provided in the [ISO-8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations), for example, `PT60S` for a 60-second timeout.
 
-Check the individual provider sections below for more details, especially if there are any provider-specific limitations.
+For more details, see the individual provider sections below, especially for any provider-specific limitations.
 
-:::note
-The timeout setting must not be greater than the job worker timeout, otherwise the job might be reassigned by the engine while the model call is still in progress.
+:::important
+The timeout setting must not exceed the job worker timeout; otherwise, the job may be reassigned by the engine while the model call is still in progress.
 :::
 
 #### Anthropic


### PR DESCRIPTION
## Description

Added a timeout section to the Agentic AI connectors model provider blocks. It describes the default timeout setting of the connector runtime and how to override it. Furthermore, a small info is added that the element template provides an individual task override that takes precedence.

relates to https://github.com/camunda/connectors/pull/5965 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
