### PR TITLE
chore(dataMigrator): update limitations

### DIFF
--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/limitations.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/limitations.md
@@ -173,7 +173,7 @@ The history migration has the following limitations.
 - As a result, you cannot query for the history of a subprocess or call activity using the
   parent process instance key.
   - See https://github.com/camunda/camunda-bpm-platform/issues/5359
-- When migrating models including subprocesses, it is possible that during the first migration round the start event inside the subprocess is skipped. Simply rerun the migration with the `--retry-skipped` flag to ensure complete migration
+- When migrating models including subprocesses, it is possible that during the migration flow nodes inside the subprocess are skipped due to dependencies. Simply rerun the migration with the `--retry-skipped` flag to ensure complete migration.
 
 ### DMN
 


### PR DESCRIPTION
related to [AP7#829](https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/829)

## Description

Update data migrator docs:

- when migrating models including subprocesses, its possible that during the first migration round the startEvent is skipped. Must be rerun with retry-skipped flag to ensure complete migration
- DMN version 1.1 cannot be displayed in operate (slack [convo](https://camunda.slack.com/archives/CL5PTD6AJ/p1767878475436719?thread_ts=1753106285.379249&cid=CL5PTD6AJ))

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
