### PR TITLE
chore: sync bugs with quality board project

### DIFF
--- a/.github/workflows/add-bugs-to-quality-board.yaml
+++ b/.github/workflows/add-bugs-to-quality-board.yaml
@@ -1,0 +1,31 @@
+name: Add bug issues to Quality Board
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled]
+
+jobs:
+  add-to-quality-board:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_API_SYNC_ID }}
+          private-key: ${{ secrets.GH_APP_API_SYNC_KEY }}
+      - id: add-bug-to-quality-board
+        name: Add issue to Quality Board
+        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@main
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          project-number: "187"
+          component-label: "component/documentation"
+        if: >
+          contains(github.event.issue.labels.*.name, 'kind/bug') &&
+          (
+              github.event.action == 'opened' ||
+              github.event.action == 'reopened' ||
+              github.event.action == 'transferred' ||
+              (github.event.action == 'labeled' && github.event.label.name == 'kind/bug')
+          )


### PR DESCRIPTION
Closes #7711

This PR adds a GitHub workflow that automatically adds bug issues to the Quality Board (project #187) when they are opened, reopened, transferred, or labeled with 'kind/bug'. The action automatically adds a component label to the issue component/documentation.