### PR TITLE
docs: multi-region 8.8 mention restarting importer if stuck

### DIFF
--- a/versioned_docs/version-8.8/self-managed/deployment/helm/upgrade/helm-870-880-dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/upgrade/helm-870-880-dual-region.md
@@ -119,6 +119,10 @@ Since every setup can differ, here are some edge cases to consider when upgradin
 - **During initial migration execution:**  
   If the importer deployment appears to be stuck processing the same import for an extended period and the data migration job does not complete, restarting the importer deployment may resolve the issue. If the importer has already completed successfully in the other region, this can be a good indicator that the importer is stuck, since both Elasticsearch instances are expected to contain the same data.
 
+  ```sh
+  kubectl delete pods -l "app.kubernetes.io/component=orchestration-importer"
+  ```
+
 Regardless, the regions must be upgraded **simultaneously**, though specific caveats may apply as outlined above.
 
 #### Post-migration


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Small addition to the dual-region migration.
A workaround that we noticed as the migration is quite flaky and restarting the importer has seemed to help us, at least in the tests.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
