### PR TITLE
Document differences in variables handling between Tasklist V1 and V2

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -235,7 +235,7 @@ Response structure changes as outlined in [general changes][].
 | `isValueTruncated` | Renamed         | Now `isTruncated` (see get variable endpoint for full value if needed).  |
 | `draft`            | Removed         | Draft variables not supported in V2 (see save draft variables endpoint). |
 
-Note that for completed tasks the V1 API returned snapshot variables representing their value as they were at completion time, while the V2 API always returns the current runtime value of the variables.
+For completed tasks, the V1 API returned snapshot variable values as they existed at completion time. The V2 API always returns the current runtime value of variables.
 
 </TabItem>
 </Tabs>

--- a/docs/components/tasklist/api-versions.md
+++ b/docs/components/tasklist/api-versions.md
@@ -68,18 +68,17 @@ fine-grained access at the process-definition level.
 
 ### Variable semantics
 
-Tasklist V1 represents variables for completed tasks as they were at completion time.
-When a task is completed via the V1 API, Tasklist persists a snapshot of all visible variables and V1 task search reads only this snapshot for completed tasks.
+Tasklist V1 returns variables for completed tasks as they were at completion time. When a task is completed via the V1 API, Tasklist persists a snapshot of all visible variables. V1 task search for completed tasks reads only this snapshot.
 
-Tasklist V2, on the other hand, represents variables as runtime state.
-User task variable search endpoints always reflect the latest values and do not store an immutable “value at completion” snapshot.
+Tasklist V2 returns variables as runtime state. User task variable search endpoints always reflect the latest values and do not store an immutable “value at completion” snapshot.
 
-For compatibility purposes, when a task is completed via the V2 API Tasklist persists a snapshot of just the variables explicitly sent in the completion request.
-Because of this, mixing APIs for the same user task leads to unexpected results:
-if you complete a Camunda user task via Tasklist V2 and then query it via Tasklist V1, only the variables explicitly sent in the V2 completion request are visible in V1 results.
-Other process variables in scope are not included.
+For compatibility, when a task is completed via the V2 API, Tasklist persists a snapshot of only the variables explicitly included in the completion request.
 
-For this reason it is strongly recommended to avoid mixing Tasklist V1 and V2 APIs for the same tasks during migration.
+Because of this, mixing APIs for the same user task can lead to unexpected results. For example, if you complete a task via Tasklist V2 and then query it via Tasklist V1, V1 results show only the variables explicitly sent in the V2 completion request. Other in-scope process variables are not included.
+
+:::warning Avoid mixing Tasklist V1 and V2 APIs during migration
+To prevent unexpected variable results, avoid using Tasklist V1 and V2 APIs on the same tasks during migration.
+:::
 
 ## Switching between V1 and V2 modes
 

--- a/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-to-camunda-api.md
+++ b/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-to-camunda-api.md
@@ -235,7 +235,7 @@ Response structure changes as outlined in [general changes][].
 | `isValueTruncated` | Renamed         | Now `isTruncated` (see get variable endpoint for full value if needed).  |
 | `draft`            | Removed         | Draft variables not supported in V2 (see save draft variables endpoint). |
 
-Note that for completed tasks the V1 API returned snapshot variables representing their value as they were at completion time, while the V2 API always returns the current runtime value of the variables.
+For completed tasks, the V1 API returned snapshot variable values as they existed at completion time. The V2 API always returns the current runtime value of variables.
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-8.8/components/tasklist/api-versions.md
+++ b/versioned_docs/version-8.8/components/tasklist/api-versions.md
@@ -68,18 +68,17 @@ fine-grained access at the process-definition level.
 
 ### Variable semantics
 
-Tasklist V1 represents variables for completed tasks as they were at completion time.
-When a task is completed via the V1 API, Tasklist persists a snapshot of all visible variables and V1 task search reads only this snapshot for completed tasks.
+Tasklist V1 returns variables for completed tasks as they were at completion time. When a task is completed via the V1 API, Tasklist persists a snapshot of all visible variables. V1 task search for completed tasks reads only this snapshot.
 
-Tasklist V2, on the other hand, represents variables as runtime state.
-User task variable search endpoints always reflect the latest values and do not store an immutable “value at completion” snapshot.
+Tasklist V2 returns variables as runtime state. User task variable search endpoints always reflect the latest values and do not store an immutable “value at completion” snapshot.
 
-For compatibility purposes, when a task is completed via the V2 API Tasklist persists a snapshot of just the variables explicitly sent in the completion request.
-Because of this, mixing APIs for the same user task leads to unexpected results:
-if you complete a Camunda user task via Tasklist V2 and then query it via Tasklist V1, only the variables explicitly sent in the V2 completion request are visible in V1 results.
-Other process variables in scope are not included.
+For compatibility, when a task is completed via the V2 API, Tasklist persists a snapshot of only the variables explicitly included in the completion request.
 
-For this reason it is strongly recommended to avoid mixing Tasklist V1 and V2 APIs for the same tasks during migration.
+Because of this, mixing APIs for the same user task can lead to unexpected results. For example, if you complete a task via Tasklist V2 and then query it via Tasklist V1, V1 results show only the variables explicitly sent in the V2 completion request. Other in-scope process variables are not included.
+
+:::warning Avoid mixing Tasklist V1 and V2 APIs during migration
+To prevent unexpected variable results, avoid using Tasklist V1 and V2 APIs on the same tasks during migration.
+:::
 
 ## Switching between V1 and V2 modes
 


### PR DESCRIPTION
Tasklist V1 keeps track of completion-time snaphots of user task variables, while this is not supported in Tasklist V2. This can lead to counter-intuitive results when mixing the two APIs (using V2 to complete a task and V1 to query it).

This led to https://github.com/camunda/camunda/issues/40231 to be opened as a bug.  [PM confirmed this is the expected behaviour](https://github.com/camunda/camunda/issues/40231#issuecomment-3749407722), but it should still be properly documented in order to prevent other users from incurring in the same problem.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
