### PR TITLE
docs(operate): update guide on modifying existing variables

### DIFF
--- a/docs/components/operate/userguide/process-instance-modification.md
+++ b/docs/components/operate/userguide/process-instance-modification.md
@@ -75,11 +75,12 @@ During the modification mode, if there are new scopes generated it will be possi
 
 ## Edit variable on existing scopes
 
-During modification mode it is possible to edit existing variables in existing scopes by following these steps:
+During modification mode it is not possible to edit existing variables in existing local scopes. Only variables in global scope can be edited by following these steps:
 
-1. Select the existing scope from the **Instance History** panel you want to edit variables on.
-2. Edit the variable value from the **Variables** panel.
-3. Once you blur out of the field (click anywhere in the screen other than the last edited variable field), assuming the new value is valid, the **Edit Variable** modification will be added to the [pending modifications](#view-summary-of-pending-modifications).
+1. Plan at least one **Add** or **Move** modification.
+2. Select the global scope from the **Instance History** panel.
+3. Edit the variable value from the **Variables** panel.
+4. Once you blur out of the field (click anywhere in the screen other than the last edited variable field), assuming the new value is valid, the **Edit Variable** modification will be added to the [pending modifications](#view-summary-of-pending-modifications).
 
 ## View summary of pending modifications
 


### PR DESCRIPTION
## Description

In https://github.com/camunda/camunda/issues/41143 we updated the behavior of single process-instance variable modifications. The changes have been described [here](https://github.com/camunda/camunda/issues/41143#issuecomment-3811184816) and [here](https://github.com/camunda/camunda/issues/41143#issuecomment-3841962338). This PR adjust the user-guide section on editing existing variables, which has been limited with the linked changes.

### Open Question

Should further sections be adjusted? I am mainly thinking about [limitations](https://docs.camunda.io/docs/next/components/concepts/process-instance-modification/#limitations) and [unsupported modifications](https://docs.camunda.io/docs/next/components/concepts/process-instance-modification/#limitations), although they mainly focus on unsupported token modifications.


<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [X] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [X] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [X] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [X] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [X] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [X] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [X] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
