### PR TITLE
docs: document Optimize proxy authentication and OpenSearch proxy support

### DIFF
--- a/docs/self-managed/components/optimize/configuration/system-configuration.md
+++ b/docs/self-managed/components/optimize/configuration/system-configuration.md
@@ -161,6 +161,8 @@ if one node fails, Optimize is still able to talk to the cluster.
 | es.connection.proxy.host                      |                                                                      | null          | The proxy host to use, must be set if es.connection.proxy.enabled = true.                                                                                                 |
 | es.connection.proxy.port                      |                                                                      | null          | The proxy port to use, must be set if es.connection.proxy.enabled = true.                                                                                                 |
 | es.connection.proxy.sslEnabled                |                                                                      | false         | Whether this proxy is using a secured connection (HTTPS).                                                                                                                 |
+| es.connection.proxy.username                  |                                                                      | null          | Optional username for HTTP Basic proxy authentication. If both username and password are set, a preemptive `Proxy-Authorization` header is sent with each request.        |
+| es.connection.proxy.password                  |                                                                      | null          | Optional password for HTTP Basic proxy authentication.                                                                                                                    |
 | es.connection.skipHostnameVerification        | CAMUNDA_OPTIMIZE_ELASTICSEARCH_CONNECTION_SKIP_HOSTNAME_VERIFICATION | false         | Determines whether the hostname verification should be skipped.                                                                                                           |
 
 #### Elasticsearch index settings
@@ -213,6 +215,12 @@ You can define a number of connection points in a cluster. Therefore, everything
 | opensearch.connection.nodes[*].httpPort        | CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT                             | 9200            | A port number used by OpenSearch to accept HTTP connections.                                      |
 | opensearch.connection.skipHostnameVerification | CAMUNDA_OPTIMIZE_OPENSEARCH_CONNECTION_SKIP_HOSTNAME_VERIFICATION | false           | Determines whether the hostname verification should be skipped.                                   |
 | opensearch.connection.awsEnabled               | CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED                           | false           | Determines if AWS credentials shall be used for authentication                                    |
+| opensearch.connection.proxy.enabled            |                                                                   | false           | Whether an HTTP proxy should be used for requests to OpenSearch.                                  |
+| opensearch.connection.proxy.host               |                                                                   | null            | The proxy host to use, must be set if opensearch.connection.proxy.enabled = true.                 |
+| opensearch.connection.proxy.port               |                                                                   | null            | The proxy port to use, must be set if opensearch.connection.proxy.enabled = true.                 |
+| opensearch.connection.proxy.sslEnabled         |                                                                   | false           | Whether this proxy is using a secured connection (HTTPS).                                         |
+| opensearch.connection.proxy.username           |                                                                   | null            | Optional username for HTTP Basic proxy authentication. If both username and password are set, a preemptive `Proxy-Authorization` header is sent with each request. |
+| opensearch.connection.proxy.password           |                                                                   | null            | Optional password for HTTP Basic proxy authentication.                                            |
 
 #### OpenSearch index settings
 


### PR DESCRIPTION
## Description

### Summary

- Adds `username` and `password` proxy authentication properties to the Elasticsearch connection settings in the Optimize system configuration reference.
- Adds the full proxy configuration block (`enabled`, `host`, `port`, `sslEnabled`, `username`, `password`) to OpenSearch connection settings, which previously had no proxy support documented.
- Documents that when both `username` and `password` are configured, a preemptive `Proxy-Authorization` header with HTTP Basic credentials is sent with each request to the database.

### Related

This documents the code changes from the `el-optimize-proxy-support` branch in the main `camunda/camunda` repository, which added:
- Proxy authentication (username/password) for Elasticsearch and OpenSearch connectors
- Full proxy support for OpenSearch (previously only Elasticsearch had it)
- Preemptive `Proxy-Authorization` header injection via HTTP request interceptor

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.