### PR TITLE
docs(helm): add release notes for Helm chart values templating

### DIFF
--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -31,26 +31,6 @@ These release notes identify the main new features included in the 8.9 minor rel
 
 </details>
 
-## 8.9.0-alpha5
-
-| Release date  | Changelog(s)                                                                                                                                                                               |
-| :------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 10 March 2026 | <ul><li>[ Camunda 8 core ](https://github.com/camunda/camunda/releases/tag/8.9.0-alpha5)</li><li>[ Connectors ](https://github.com/camunda/connectors/releases/tag/8.9.0-alpha5)</li></ul> |
-
-### Helm chart
-
-<div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Configuration">Configuration</span></div>
-
-#### Helm chart values templating
-
-<!-- https://github.com/camunda/product-hub/issues/3357 -->
-
-The Camunda 8 Self-Managed Helm chart now documents all values that support Go template expressions, with guidance on how `values.yaml` templating is evaluated.
-
-`podLabels`, `podAnnotations` (all components), and `global.ingress.host` now support templating via `{{ "{{" }} }}` expressions (for example, `{{ "{{" }} .Release.Name }}`), enabling dynamic configuration for multi-environment deployments and integrations like Datadog APM.
-
-<p class="link-arrow">[Helm chart parameters](/self-managed/deployment/helm/chart-parameters.md)</p>
-
 ## 8.9.0-alpha4
 
 | Release date     | Changelog(s)                                                                                                                                                                               |


### PR DESCRIPTION
## Description

Add 8.9.0-alpha5 release notes entry for Helm chart values templating support ([product-hub#3357](https://github.com/camunda/product-hub/issues/3357)).

PR [camunda-platform-helm#5064](https://github.com/camunda/camunda-platform-helm/pull/5064) added `tpl` support to `podLabels`, `podAnnotations`, and `global.ingress.host` across all components. This PR documents the change in the release notes and adds a templating tip to the chart parameters page.

Also relates to [camunda-platform-helm#4393](https://github.com/camunda/camunda-platform-helm/issues/4393).

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.