### PR TITLE
fix: include note that the section applies to other components as well

### DIFF
--- a/docs/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md
@@ -44,6 +44,12 @@ Choose one of the three approaches below. **Init container is recommended for pr
 
 ## Loading JDBC drivers into pods
 
+:::note
+
+The following applies to each of the components that require JDBC drivers: Orchestration Cluster, Identity, and Web Modeler, though examples may only reference Orchestration Cluster.
+
+:::
+
 Some databases—such as Oracle and MySQL—require JDBC drivers that cannot be included in the Camunda image due to licensing restrictions. You must provide these drivers at runtime using one of the following approaches.
 
 ### Option 1: Using an init container


### PR DESCRIPTION
## Description

I'm thinking that it might not be clear from the sections written on 
self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers/#loading-jdbc-drivers-into-pods

that the overall idea applies to all components, not just orchestration cluster. The snippets only include orchestration cluster configuration for extra drivers, but the general idea of loading JDBC drivers is just general java knowledge, not a specific feature to orchestration cluster or the helm chart.

The following snippet works for modeler configuring a oracle db connection:

```yaml
webModeler:
  restapi:
    externalDatabase:
      url: jdbc:oracle:thin:@//IP_ADDR:1521/FREEPDB1
      username: USERNAME
      secret:
        inlineSecret: PASSWORD
    extraVolumeMounts:
      - name: jdbcdrivers
        mountPath: /driver-lib
    extraVolumes:
      - name: jdbcdrivers
        emptyDir: {}
    initContainers:
      - name: fetch-jdbc-drivers
        image: alpine:3.19
        imagePullPolicy: "Always"
        command:
          [
            "sh",
            "-c",
            "wget https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.9.0.25.07/ojdbc11-23.9.0.25.07.jar -O /driver-lib/ojdbc.jar",
          ]
        volumeMounts:
          - name: jdbcdrivers
            mountPath: /driver-lib
        securityContext:
          runAsUser: 1001
```


<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
