### PR TITLE
fix: remove mention of removed bpmn embedding feature

### DIFF
--- a/docs/components/modeler/web-modeler/modeling/advanced-modeling/process-documentation-with-readme-files.md
+++ b/docs/components/modeler/web-modeler/modeling/advanced-modeling/process-documentation-with-readme-files.md
@@ -23,7 +23,6 @@ With README support in Web Modeler, you can:
 
 - Project goals, scope, and stakeholders
 - Links to related assets
-- Embedded BPMN diagrams
 - Go-live dates, status updates, and project health
 - Requirements, process owners, and change logs
 

--- a/versioned_docs/version-8.7/components/modeler/web-modeler/advanced-modeling/process-documentation-with-readme-files.md
+++ b/versioned_docs/version-8.7/components/modeler/web-modeler/advanced-modeling/process-documentation-with-readme-files.md
@@ -23,7 +23,6 @@ With README support in Web Modeler, you can:
 
 - Project goals, scope, and stakeholders
 - Links to related assets
-- Embedded BPMN diagrams
 - Go-live dates, status updates, and project health
 - Requirements, process owners, and change logs
 

--- a/versioned_docs/version-8.8/components/modeler/web-modeler/advanced-modeling/process-documentation-with-readme-files.md
+++ b/versioned_docs/version-8.8/components/modeler/web-modeler/advanced-modeling/process-documentation-with-readme-files.md
@@ -23,7 +23,6 @@ With README support in Web Modeler, you can:
 
 - Project goals, scope, and stakeholders
 - Links to related assets
-- Embedded BPMN diagrams
 - Go-live dates, status updates, and project health
 - Requirements, process owners, and change logs
 


### PR DESCRIPTION
## Description

This PR removes a mention of a diagram embedding functionality which was removed due to security concerns. 

Was raised here: https://camunda.slack.com/archives/C0693F1NFK5/p1771850368699969.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
