### PR TITLE
docs: remove mention of `variableNames` in template properties

### DIFF
--- a/docs/components/modeler/element-templates/template-properties.md
+++ b/docs/components/modeler/element-templates/template-properties.md
@@ -615,25 +615,16 @@ The `condition` property requires a FEEL expression. When using `String` or `Tex
 
 ### Conditional filter: `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property`
 
-| **Binding `type`**         | `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property`                                |
-| -------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Valid property `type`s** | `String`<br />`Text`<br />`Hidden`                                                                |
-| **Binding parameters**     | `name`: The name of the property.<br/>Supported properties: `variableNames` and `variableEvents`. |
-| **Mapping result**         | `<zeebe:conditionalFilter [name]="[userInput]" />`                                                |
+| **Binding `type`**         | `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property`            |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| **Valid property `type`s** | `String`<br />`Text`<br />`Hidden`                                            |
+| **Binding parameters**     | `name`: The name of the property.<br/>Supported properties: `variableEvents`. |
+| **Mapping result**         | `<zeebe:conditionalFilter [name]="[userInput]" />`                            |
 
 The `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property` binding allows you to configure the conditional filter for [conditional events](../bpmn/conditional-events/conditional-events.md). The conditional filter controls which variable changes trigger the condition evaluation.
 
 ```json
 [
-  {
-    "label": "Variable Names",
-    "type": "String",
-    "value": "orderTotal,discount",
-    "binding": {
-      "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-      "name": "variableNames"
-    }
-  },
   {
     "label": "Variable Events",
     "type": "String",
@@ -650,7 +641,6 @@ The `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property` binding a
 
 **Property descriptions:**
 
-- **`variableNames`**: A comma-separated list of variable names that trigger condition evaluation when changed.
 - **`variableEvents`**: A comma-separated list of variable events (`create`, `update`) that trigger condition evaluation.
 
 When `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property` is used, `bpmn:ConditionalEventDefinition#property` with `condition` should also be set on the same element.


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Follow up to https://github.com/camunda/camunda-docs/pull/7833

Remove info about `variableNames` mapping, as this property is being removed from element templates.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
