### PR TITLE
docs(connectors): add refresh token expiry note to Microsoft Teams connector

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/microsoft-teams.md
+++ b/docs/components/connectors/out-of-the-box-connectors/microsoft-teams.md
@@ -53,6 +53,10 @@ For a **Bearer Token** type authentication, take the following steps:
 
 Visit [Microsoft Teams Access Token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for more information.
 
+:::note
+Bearer tokens expire after **60–90 minutes**. The connector cannot refresh them automatically, so you must provide a new valid access token before expiry.
+:::
+
 #### Options to obtain an access token
 
 - Via the Graph Explorer:
@@ -75,6 +79,10 @@ For a **Refresh Token** type authentication, take the following steps:
 3. Set **Tenant ID** to `Tenant ID`. Your Microsoft Teams tenant ID is a unique identifier. Read more on [how to find a tenant ID](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant).
 4. Set the **Client ID** field: the application ID that the [Azure app registration portal](https://go.microsoft.com/fwlink/?linkid=2083908) assigned to your app.
 5. Set the **Secret ID** field: the client secret that you created in the app registration portal for your app.
+
+:::note
+Refresh tokens expire after **90 days** by default. The connector cannot persist updated refresh tokens when stored as a secret or hardcoded value, so the originally configured token will expire regardless of usage. You must obtain and configure a new refresh token before the 90-day expiry. See [Microsoft's documentation on refresh token lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#token-lifetime) for details.
+:::
 
 ### Client credentials type authentication
 

--- a/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/microsoft-teams.md
+++ b/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/microsoft-teams.md
@@ -53,6 +53,10 @@ For a **Bearer Token** type authentication, take the following steps:
 
 Visit [Microsoft Teams Access Token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for more information.
 
+:::note
+Bearer tokens expire after **60–90 minutes**. The connector cannot refresh them automatically, so you must provide a new valid access token before expiry.
+:::
+
 #### Options to obtain an access token
 
 - Via the Graph Explorer:
@@ -75,6 +79,10 @@ For a **Refresh Token** type authentication, take the following steps:
 3. Set **Tenant ID** to `Tenant ID`. Your Microsoft Teams tenant ID is a unique identifier. Read more on [how to find a tenant ID](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant).
 4. Set the **Client ID** field: the application ID that the [Azure app registration portal](https://go.microsoft.com/fwlink/?linkid=2083908) assigned to your app.
 5. Set the **Secret ID** field: the client secret that you created in the app registration portal for your app.
+
+:::note
+Refresh tokens expire after **90 days** by default. The connector cannot persist updated refresh tokens when stored as a secret or hardcoded value, so the originally configured token will expire regardless of usage. You must obtain and configure a new refresh token before the 90-day expiry. See [Microsoft's documentation on refresh token lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#token-lifetime) for details.
+:::
 
 ### Client credentials type authentication
 

--- a/versioned_docs/version-8.7/components/connectors/out-of-the-box-connectors/microsoft-teams.md
+++ b/versioned_docs/version-8.7/components/connectors/out-of-the-box-connectors/microsoft-teams.md
@@ -53,6 +53,10 @@ For a **Bearer Token** type authentication, take the following steps:
 
 Visit [Microsoft Teams Access Token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for more information.
 
+:::note
+Bearer tokens expire after **60–90 minutes**. The connector cannot refresh them automatically, so you must provide a new valid access token before expiry.
+:::
+
 #### Options to obtain an access token
 
 - Via the Graph Explorer:
@@ -75,6 +79,10 @@ For a **Refresh Token** type authentication, take the following steps:
 3. Set **Tenant ID** to `Tenant ID`. Your Microsoft Teams tenant ID is a unique identifier. Read more on [how to find a tenant ID](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant).
 4. Set the **Client ID** field: the application ID that the [Azure app registration portal](https://go.microsoft.com/fwlink/?linkid=2083908) assigned to your app.
 5. Set the **Secret ID** field: the client secret that you created in the app registration portal for your app.
+
+:::note
+Refresh tokens expire after **90 days** by default. The connector cannot persist updated refresh tokens when stored as a secret or hardcoded value, so the originally configured token will expire regardless of usage. You must obtain and configure a new refresh token before the 90-day expiry. See [Microsoft's documentation on refresh token lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#token-lifetime) for details.
+:::
 
 ### Client credentials type authentication
 

--- a/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/microsoft-teams.md
+++ b/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/microsoft-teams.md
@@ -53,6 +53,10 @@ For a **Bearer Token** type authentication, take the following steps:
 
 Visit [Microsoft Teams Access Token](https://learn.microsoft.com/azure/active-directory/develop/access-tokens) for more information.
 
+:::note
+Bearer tokens expire after **60–90 minutes**. The connector cannot refresh them automatically, so you must provide a new valid access token before expiry.
+:::
+
 #### Options to obtain an access token
 
 - Via the Graph Explorer:
@@ -74,6 +78,10 @@ For a **Refresh Token** type authentication, take the following steps:
 3. Set **Tenant ID** to `Tenant ID`. Your Microsoft Teams tenant ID is a unique identifier. Read more on [how to find a tenant ID](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant).
 4. Set the **Client ID** field: the application ID that the [Azure app registration portal](https://go.microsoft.com/fwlink/?linkid=2083908) assigned to your app.
 5. Set the **Secret ID** field: the client secret that you created in the app registration portal for your app.
+
+:::note
+Refresh tokens expire after **90 days** by default. The connector cannot persist updated refresh tokens when stored as a secret or hardcoded value, so the originally configured token will expire regardless of usage. You must obtain and configure a new refresh token before the 90-day expiry. See [Microsoft's documentation on refresh token lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#token-lifetime) for details.
+:::
 
 ### Client credentials type authentication
 


### PR DESCRIPTION
## Description

Adds a note to the Microsoft Teams connector's "Refresh Token type authentication" section warning users about refresh token expiry limitations.

Key points documented:
- Microsoft Entra ID refresh tokens expire after **90 days** by default ([source](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens#token-lifetime)).
- Although Microsoft returns a new refresh token on each use, the Camunda connector **cannot automatically persist the updated token** when it is stored as a secret or hardcoded value. The originally configured token will therefore expire 90 days after issuance regardless of usage frequency.
- It is the **customer's responsibility** to obtain and configure a new refresh token before the 90-day expiry.
- Access (bearer) tokens are short-lived (~60–90 minutes) and are refreshed automatically by the connector.

The note is added to all maintained versions: next (8.9), 8.8, 8.7, and 8.6.

## When should this change go live?

- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.