### PR TITLE
dx(rest-docs): Use stable branch if it exists

### DIFF
--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -30,10 +30,9 @@ jobs:
           # Get the latest docs tag, and increment the minor version to store the next minor release.
           cd docs
           next_minor_release=$(
-            git ls-remote --tags origin \
+            git ls-remote --tags origin '*.*.*'  \
                 | awk '{print $2}' \
                 | sed 's#refs/tags/##' \
-                | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
                 | sort -V \
                 | tail -n1 \
                 | awk -F. '{printf "%d.%d", $1, $2+1}'


### PR DESCRIPTION
## Description

During development of a minor release, updates are going into the `camunda` repo's `main` branch, so we need to use `main` during this time to keep the docs up to date with the alpha releases. However, toward the end of the dev cycle for the minor version, engineering cuts a stable version branch `stable/8.x` and starts including code for the next version in `main`. At this point, we need to stop using `main` and switch to the stable branch until the minor version ships. After that, we need to switch back to using `main`.

In this PR, we added some code that does the following:

- Get the latest docs release tag (for example, 8.8.123)
- From that, increment the minor version to calculate the next minor (8.9)
- Next, we use that to check if there is a stable `camunda` branch for the next minor (stable/8.9)
- If there is a stable branch, we checkout that branch locally and use those specs to generate the docs
- If there isn't a stable branch, we use `main`

## Testing

### Used stable branch when tested against 8.9 ✅

https://github.com/camunda/camunda-docs/actions/runs/22615986169/job/65528871080

```
Found a stable branch: origin/stable/8.9

/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --filter=blob:none --depth=1 origin +refs/heads/stable/8.9*:refs/remotes/origin/stable/8.9* +refs/tags/stable/8.9*:refs/tags/stable/8.9*

From https://github.com/camunda/camunda
  * [new branch]      stable/8.9 -> origin/stable/8.9
```

###  Used main when tested against 8.10 ✅
https://github.com/camunda/camunda-docs/actions/runs/22616567338/job/65530819477

```
No stable branch for version 8.10, using main

/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --filter=blob:none --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*

From https://github.com/camunda/camunda
  * [new branch]      main          -> origin/main
  * [new branch]      main-20240716 -> origin/main-20240716
```

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
