### PR TITLE
Clarifying form rendering in ms teams

### DIFF
--- a/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -69,7 +69,7 @@ Adaptive cards support only a subset of Camunda form elements. Forms with any of
 - Group
 - Table
 - Dynamic list
-- iFrame
+- iframe
 - HTML viewer
 - Button
 - Expression field


### PR DESCRIPTION
## Description                                                                                                                                                                                                 
   
  Documents the rules for when a Camunda form is considered too complex to render as an adaptive card in the Microsoft Teams bot chat, and is instead opened in a pop-up dialog.                                 
                  
  Two conditions trigger the pop-up dialog:
  1. The form contains element types not supported by adaptive cards (Group, Table, Dynamic list, iFrame, HTML viewer, Button, Expression field, Document preview).
  2. Any field uses a FEEL expression (value starting with `=`) in a supported property such as label, default value, read-only, etc.

  Added as a subsection under the existing **Pop-up dialog** section in the Chatbot page.

  <!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

  ## When should this change go live?

  - [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
  - [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
  - [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
  - [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
  - [ ] There is **no urgency** with this change (add `low prio` label)

  ## PR Checklist

  - [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

  - [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
  - [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

  - [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
    - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
    - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.