### PR TITLE
feat: docs update related to docker with other rdbms

### DIFF
--- a/docs/self-managed/quickstart/developer-quickstart/c8run.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run.md
@@ -86,7 +86,7 @@ Use the CLI command:
 
 If startup is successful, a browser window for Operate will open automatically. Alternatively, you can access Operate at [http://localhost:8080/operate](http://localhost:8080/operate).
 
-To start Camunda 8 in Docker Compose using Camunda 8 Run you can use the following option. It is equivalent of running `docker compose up -d`:
+To start Camunda 8 in Docker Compose using Camunda 8 Run you can use the following options. They map to `docker compose up -d` under the hood and now include presets for each supported relational database.
 
 <Tabs groupId="os" defaultValue="maclinux" values={
 [
@@ -95,16 +95,134 @@ To start Camunda 8 in Docker Compose using Camunda 8 Run you can use the followi
 ] }>
 <TabItem value="maclinux">
 
+<Tabs groupId="docker-db-mac" defaultValue="h2" values={[
+{label: 'H2 (default)', value: 'h2'},
+{label: 'PostgreSQL', value: 'postgresql'},
+{label: 'MariaDB', value: 'mariadb'},
+{label: 'MySQL', value: 'mysql'},
+{label: 'Oracle', value: 'oracle'},
+{label: 'Microsoft SQL Server', value: 'mssql'},
+]}>
+<TabItem value="h2">
+
 ```bash
 ./start.sh --docker
+# or
+./c8run start -docker
 ```
+
+</TabItem>
+<TabItem value="postgresql">
+
+```bash
+ORCHESTRATION_CONFIG_FILE=application-postgresql.yaml ./c8run start -docker
+# or pass the config directly to c8run
+# ./c8run start -docker --config configuration/application-postgresql.yaml
+```
+
+</TabItem>
+<TabItem value="mariadb">
+
+```bash
+ORCHESTRATION_CONFIG_FILE=application-mariadb.yaml ./c8run start -docker
+# or
+# ./c8run start -docker --config configuration/application-mariadb.yaml
+```
+
+</TabItem>
+<TabItem value="mysql">
+
+```bash
+ORCHESTRATION_CONFIG_FILE=application-mysql.yaml ./c8run start -docker
+# or
+# ./c8run start -docker --config configuration/application-mysql.yaml
+```
+
+</TabItem>
+<TabItem value="oracle">
+
+```bash
+ORCHESTRATION_CONFIG_FILE=application-oracle.yaml ./c8run start -docker
+# or
+# ./c8run start -docker --config configuration/application-oracle.yaml
+```
+
+</TabItem>
+<TabItem value="mssql">
+
+```bash
+ORCHESTRATION_CONFIG_FILE=application-mssql.yaml ./c8run start -docker
+# or
+# ./c8run start -docker --config configuration/application-mssql.yaml
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 <TabItem value="windows">
 
-```bash
+<Tabs groupId="docker-db-win" defaultValue="h2" values={[
+{label: 'H2 (default)', value: 'h2'},
+{label: 'PostgreSQL', value: 'postgresql'},
+{label: 'MariaDB', value: 'mariadb'},
+{label: 'MySQL', value: 'mysql'},
+{label: 'Oracle', value: 'oracle'},
+{label: 'Microsoft SQL Server', value: 'mssql'},
+]}>
+<TabItem value="h2">
+
+```powershell
 .\c8run.exe start --docker
 ```
+
+</TabItem>
+<TabItem value="postgresql">
+
+```powershell
+set ORCHESTRATION_CONFIG_FILE=application-postgresql.yaml .\c8run.exe start --docker
+# or
+# .\c8run.exe start --docker --config configuration\application-postgresql.yaml
+```
+
+</TabItem>
+<TabItem value="mariadb">
+
+```powershell
+set ORCHESTRATION_CONFIG_FILE=application-mariadb.yaml .\c8run.exe start --docker
+# or
+# .\c8run.exe start --docker --config configuration\application-mariadb.yaml
+```
+
+</TabItem>
+<TabItem value="mysql">
+
+```powershell
+set ORCHESTRATION_CONFIG_FILE=application-mysql.yaml .\c8run.exe start --docker
+# or
+# .\c8run.exe start --docker --config configuration\application-mysql.yaml
+```
+
+</TabItem>
+<TabItem value="oracle">
+
+```powershell
+set ORCHESTRATION_CONFIG_FILE=application-oracle.yaml .\c8run.exe start --docker
+# or
+# .\c8run.exe start --docker --config configuration\application-oracle.yaml
+```
+
+</TabItem>
+<TabItem value="mssql">
+
+```powershell
+set ORCHESTRATION_CONFIG_FILE=application-mssql.yaml .\c8run.exe start --docker
+# or
+# .\c8run.exe start --docker --config configuration\application-mssql.yaml
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>
@@ -118,19 +236,19 @@ If Camunda 8 Run fails to start, run the [shutdown script](#shut-down-camunda-8-
 The following options provide a convenient way to override settings for quick tests and interactions in Camunda 8 Run.  
 For more advanced or permanent configuration, modify the default `configuration/application.yaml` or supply a custom file using the `--config` flag (e.g., [to enable authentication and authorization](#enable-authentication-and-authorization)).
 
-| Argument                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--config <path>`          | Applies the specified Zeebe [`application.yaml`](/self-managed/components/orchestration-cluster/zeebe/configuration/configuration.md).                                                                                                                                                                                                                                                                                                 |
-| `--extra-driver <path>`    | Copies an external JDBC driver into `camunda-zeebe-<version>/lib` before startup. Use this when running against Oracle, MySQL, or other databases that require a driver that is not bundled with Camunda 8 Run. Repeat the flag to copy multiple jars.                                                                                                                                                                                 |
-| `--username <arg>`         | Configures the first user’s username as `<arg>`.                                                                                                                                                                                                                                                                                                                                                                                       |
-| `--password <arg>`         | Configures the first user’s password as `<arg>`.                                                                                                                                                                                                                                                                                                                                                                                       |
-| `--keystore <arg>`         | Configures the TLS certificate for HTTPS. If not specified, HTTP is used. For more information, see [enabling TLS](#enable-tls).                                                                                                                                                                                                                                                                                                       |
-| `--keystorePassword <arg>` | Provides the password for the JKS keystore file.                                                                                                                                                                                                                                                                                                                                                                                       |
-| `--port <arg>`             | Sets the Camunda core port (default: `8080`).                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--log-level <arg>`        | Sets the log level for the Camunda core.                                                                                                                                                                                                                                                                                                                                                                                               |
-| `--docker`                 | Downloads and runs the Camunda Docker Compose distribution. This option provides an easy shortcut to run Camunda in Docker Compose. However, additional Camunda 8 Run options are not supported and will be ignored. For more information on running Camunda with Docker Compose see the [documentation](./docker-compose.md). See the [shutdown script](#shut-down-camunda-8-run) for information on stopping the Docker application. |
-| `--disable-elasticsearch`  | Prevents the built-in Elasticsearch from starting. Ensure another Elasticsearch instance is provided via `--config`. See the [external Elasticsearch](#start-external-elasticsearch) section for details.                                                                                                                                                                                                                              |
-| `--startup-url`            | The URL to open after startup (e.g., `'http://localhost:8080/operate'`). By default, Operate is opened.                                                                                                                                                                                                                                                                                                                                |
+| Argument                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--config <path>`          | Applies the specified Zeebe [`application.yaml`](/self-managed/components/orchestration-cluster/zeebe/configuration/configuration.md).                                                                                                                                                                                                                                                                                                                                                                                   |
+| `--extra-driver <path>`    | Copies an external JDBC driver into `camunda-zeebe-<version>/lib` before startup. Use this when running against Oracle, MySQL, or other databases that require a driver that is not bundled with Camunda 8 Run. Repeat the flag to copy multiple jars.                                                                                                                                                                                                                                                                   |
+| `--username <arg>`         | Configures the first user’s username as `<arg>`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `--password <arg>`         | Configures the first user’s password as `<arg>`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `--keystore <arg>`         | Configures the TLS certificate for HTTPS. If not specified, HTTP is used. For more information, see [enabling TLS](#enable-tls).                                                                                                                                                                                                                                                                                                                                                                                         |
+| `--keystorePassword <arg>` | Provides the password for the JKS keystore file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `--port <arg>`             | Sets the Camunda core port (default: `8080`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `--log-level <arg>`        | Sets the log level for the Camunda core.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `--docker`                 | Downloads and runs the Camunda Docker Compose distribution. This option provides an easy shortcut to run Camunda in Docker Compose. Most other Camunda 8 Run flags are ignored, but you can combine `--docker` with `--config` to supply an alternative RDBMS configuration (for example, PostgreSQL). For more information on running Camunda with Docker Compose see the [documentation](./docker-compose.md). See the [shutdown script](#shut-down-camunda-8-run) for information on stopping the Docker application. |
+| `--disable-elasticsearch`  | Prevents the built-in Elasticsearch from starting. Ensure another Elasticsearch instance is provided via `--config`. See the [external Elasticsearch](#start-external-elasticsearch) section for details.                                                                                                                                                                                                                                                                                                                |
+| `--startup-url`            | The URL to open after startup (e.g., `'http://localhost:8080/operate'`). By default, Operate is opened.                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### Configure or switch secondary storage (H2 or Elasticsearch)
 


### PR DESCRIPTION
 ## Description

  Documented the two supported ways to select non-default RDBMS configs when running `./c8run start -docker`, reorganized the start commands into nested OS/DB tabs, and added inline instructions for PostgreSQL, MariaDB, MySQL, Oracle, and MSSQL. This work ties into
  task 43986 to make Docker usage with different secondary storage backends clearer.

  ## When should this change go live?

  - [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
  - [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
  - [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
  - [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
  - [x] There is **no urgency** with this change (add `low prio` label)

  ## PR Checklist

  - [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

  - [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
  - [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

  - [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
    - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
    - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.