### PR TITLE
update full helm config example

### DIFF
--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/internal-keycloak.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/internal-keycloak.md
@@ -158,11 +158,17 @@ Add the section under `global.identity.auth` to the existing section you created
 
 #### Configure Web Modeler
 
-Web Modeler configures a second PostgreSQL instance.
+Web Modeler configures a second PostgreSQL instance and requires a redirect URL for OIDC authentication.
 
 Web Modeler component configuration:
 
 ```yaml
+global:
+  identity:
+    auth:
+      webModeler:
+        redirectUrl: "http://localhost:8070" # Change this when using a domain
+
 webModeler:
   enabled: true
   restapi:
@@ -177,6 +183,17 @@ webModelerPostgresql:
       adminPasswordKey: "webmodeler-postgresql-admin-password"
       userPasswordKey: "webmodeler-postgresql-user-password"
 ```
+
+:::important Redirect URL configuration
+The `redirectUrl` parameter is **required** for Web Modeler authentication. The default value is `http://localhost:8070`, which works for local port-forwarding setups.
+
+If you're using a domain or Ingress to expose Web Modeler, you **must** update this value to match your Web Modeler URL:
+
+- With Ingress: `https://your-domain.com/modeler` (if using a context path)
+- Without context path: `https://modeler.your-domain.com`
+
+Mismatched redirect URLs will cause authentication failures that are difficult to debug.
+:::
 
 You can update `webModeler.restapi.mail.fromAddress` with an address suitable for your environment.
 This address appears as the sender in emails sent by Web Modeler.
@@ -206,6 +223,10 @@ global:
         secret:
           existingSecret: "camunda-credentials"
           existingSecretKey: "identity-optimize-client-token"
+      webModeler:
+        # Default: http://localhost:8070
+        # Update this when using a domain/Ingress, e.g., https://your-domain.com/modeler
+        redirectUrl: "http://localhost:8070"
   security:
     authentication:
       method: oidc
@@ -275,6 +296,8 @@ To review how each component is configured and which OIDC clients are used:
 
 ## Connect to the cluster
 
+### Local access with port forwarding
+
 After applying this configuration, use the following `kubectl port-forward` commands to access the APIs and UIs from your localhost. If you use [Keycloak deployed via the Keycloak Operator](/self-managed/deployment/helm/configure/operator-based-infrastructure.md), also port-forward the Keycloak service:
 
 ```bash
@@ -306,9 +329,31 @@ Once port forwarding is active, access each component through `http://localhost:
 For example:
 
 - Keycloak: `http://localhost:18080`
+- Web Modeler: `http://localhost:8070`
 - Orchestration Cluster: `http://localhost:8080`
 
 Log in with username `demo` and the password you defined under `identity-firstuser-password`.
+
+:::note Default URLs and port forwarding
+The configuration shown above uses default `redirectUrl` values that match the port-forwarding setup (`http://localhost:8070` for Web Modeler, `http://localhost:18080` for Keycloak). These defaults work automatically when using `kubectl port-forward`.
+
+If you don't use port forwarding and instead expose components via Ingress or a domain, you **must** update the `redirectUrl` parameters under `global.identity.auth` to match your actual URLs. See [Ingress setup](/self-managed/deployment/helm/configure/ingress/ingress-setup.md) for domain-based configuration examples.
+:::
+
+### Domain-based access with Ingress
+
+If you're using Ingress to expose components via a domain (instead of port forwarding), update the redirect URLs in your Helm values:
+
+```yaml
+global:
+  identity:
+    auth:
+      webModeler:
+        redirectUrl: "https://your-domain.com/modeler" # Or https://modeler.your-domain.com
+      # Update other component URLs as needed
+```
+
+For complete Ingress configuration, see [Ingress setup](/self-managed/deployment/helm/configure/ingress/ingress-setup.md).
 
 ## External identity provider
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/internal-keycloak.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/internal-keycloak.md
@@ -158,11 +158,17 @@ Add the section under `global.identity.auth` to the existing section you created
 
 #### Configure Web Modeler
 
-Web Modeler configures a second PostgreSQL instance.
+Web Modeler configures a second PostgreSQL instance and requires a redirect URL for OIDC authentication.
 
 Web Modeler component configuration:
 
 ```yaml
+global:
+  identity:
+    auth:
+      webModeler:
+        redirectUrl: "http://localhost:8070" # Change this when using a domain
+
 webModeler:
   enabled: true
   restapi:
@@ -177,6 +183,17 @@ webModelerPostgresql:
       adminPasswordKey: "webmodeler-postgresql-admin-password"
       userPasswordKey: "webmodeler-postgresql-user-password"
 ```
+
+:::important Redirect URL configuration
+The `redirectUrl` parameter is **required** for Web Modeler authentication. The default value is `http://localhost:8070`, which works for local port-forwarding setups.
+
+If you're using a domain or Ingress to expose Web Modeler, you **must** update this value to match your Web Modeler URL:
+
+- With Ingress: `https://your-domain.com/modeler` (if using a context path)
+- Without context path: `https://modeler.your-domain.com`
+
+Mismatched redirect URLs will cause authentication failures that are difficult to debug.
+:::
 
 You can update `webModeler.restapi.mail.fromAddress` with an address suitable for your environment.
 This address appears as the sender in emails sent by Web Modeler.
@@ -210,6 +227,10 @@ global:
         secret:
           existingSecret: "camunda-credentials"
           existingSecretKey: "identity-optimize-client-token"
+      webModeler:
+        # Default: http://localhost:8070
+        # Update this when using a domain/Ingress, e.g., https://your-domain.com/modeler
+        redirectUrl: "http://localhost:8070"
   security:
     authentication:
       method: oidc
@@ -279,6 +300,8 @@ To review how each component is configured and which OIDC clients are used:
 
 ## Connect to the cluster
 
+### Local access with port forwarding
+
 After applying this configuration, use the following `kubectl port-forward` commands to access the APIs and UIs from your localhost:
 
 ```bash
@@ -310,9 +333,31 @@ Once port forwarding is active, access each component through `http://localhost:
 For example:
 
 - Keycloak: `http://localhost:18080`
+- Web Modeler: `http://localhost:8070`
 - Orchestration Cluster: `http://localhost:8080`
 
 Log in with username `demo` and the password you defined under `identity-firstuser-password`.
+
+:::note Default URLs and port forwarding
+The configuration shown above uses default `redirectUrl` values that match the port-forwarding setup (`http://localhost:8070` for Web Modeler, `http://localhost:18080` for Keycloak). These defaults work automatically when using `kubectl port-forward`.
+
+If you don't use port forwarding and instead expose components via Ingress or a domain, you **must** update the `redirectUrl` parameters under `global.identity.auth` to match your actual URLs. See [Ingress setup](/self-managed/deployment/helm/configure/ingress/ingress-setup.md) for domain-based configuration examples.
+:::
+
+### Domain-based access with Ingress
+
+If you're using Ingress to expose components via a domain (instead of port forwarding), update the redirect URLs in your Helm values:
+
+```yaml
+global:
+  identity:
+    auth:
+      webModeler:
+        redirectUrl: "https://your-domain.com/modeler" # Or https://modeler.your-domain.com
+      # Update other component URLs as needed
+```
+
+For complete Ingress configuration, see [Ingress setup](/self-managed/deployment/helm/configure/ingress/ingress-setup.md).
 
 ## External identity provider
 


### PR DESCRIPTION
## Description

PushFeedback on https://docs.camunda.io/docs/self-managed/deployment/helm/configure/authentication-and-authorization/internal-keycloak/#full-configuration-example. Enhances internal Keycloak configuration documentation to explicitly show the `webModeler.redirectUrl` parameter and clarify when it needs to be changed.

The Web Modeler `redirectUrl` parameter defaults to `http://localhost:8070`, which works for local port-forwarding setups but causes authentication failures when users deploy with domains or Ingress. Because this parameter wasn't explicitly shown in configuration examples, users encountered hard-to-debug authentication issues when their deployment didn't match the implicit default.

## Changes

- Added explicit `redirectUrl` parameter to Web Modeler configuration sections with inline comments indicating when it needs customization
- Added warning callout explaining:
  - The parameter is required for Web Modeler authentication
  - Default value works for port-forwarding scenarios
  - Must be updated to match your domain when using Ingress (`https://your-domain.com/modeler`)
  - Mismatched URLs cause authentication failures
- Reorganized "Connect to cluster" section with subsections distinguishing:
  - Local access with port forwarding (defaults work here)
  - Domain-based access with Ingress (requires overriding defaults)
- Updated full configuration example to include `redirectUrl` with helpful comments

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
