### PR TITLE
fix(cpt): Correct code snippet for the CPT assertion `hasLocalVariableNames()`  

### DIFF
--- a/docs/apis-tools/testing/assertions.md
+++ b/docs/apis-tools/testing/assertions.md
@@ -321,7 +321,7 @@ Assert that the process instance has the local variables in the scope of the giv
 doesn't exist.
 
 ```java
-assertThat(processInstance).hasVariableNames(ElementSelectors.byId("task_A"), "var1", "var2");
+assertThat(processInstance).hasLocalVariableNames(ElementSelectors.byId("task_A"), "var1", "var2");
 ```
 
 ### hasLocalVariable

--- a/versioned_docs/version-8.8/apis-tools/testing/assertions.md
+++ b/versioned_docs/version-8.8/apis-tools/testing/assertions.md
@@ -340,7 +340,7 @@ Assert that the process instance has the local variables in the scope of the giv
 `ElementSelector` to identify the element. The assertion fails if at least one variable doesn't exist.
 
 ```java
-assertThat(processInstance).hasVariableNames(byId("task_A"), "var1", "var2");
+assertThat(processInstance).hasLocalVariableNames(byId("task_A"), "var1", "var2");
 ```
 
 ### hasLocalVariable


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

This PR corrects the code snippet for the CPT assertion: `hasLocalVariableNames()`.

Before:
```
assertThat(processInstance).hasVariableNames(ElementSelectors.byId("task_A"), "var1", "var2");
```

After:
```
assertThat(processInstance).hasLocalVariableNames(ElementSelectors.byId("task_A"), "var1", "var2");
``` 

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
