### PR TITLE
fix(self-managed): correct wrong auth method env var and stale Helm/app versions in 8.9 docs

### DIFF
--- a/docs/self-managed/components/connectors/connectors-configuration.md
+++ b/docs/self-managed/components/connectors/connectors-configuration.md
@@ -120,7 +120,7 @@ To activate basic authentication:
 **Environment variables**
 
 ```bash
-CAMUNDA_CLIENT_AUTH_METHOD=oidc
+CAMUNDA_CLIENT_AUTH_METHOD=basic
 CAMUNDA_CLIENT_AUTH_USERNAME=<your username>
 CAMUNDA_CLIENT_AUTH_PASSWORD=<your password>
 ```

--- a/docs/self-managed/deployment/helm/install/production/index.md
+++ b/docs/self-managed/deployment/helm/install/production/index.md
@@ -538,51 +538,51 @@ console:
           releases:
             - name: camunda
               namespace: management-and-modeling
-              version: 13.x.x
+              version: 14.x.x
               components:
                 - name: Console
                   id: console
-                  version: 8.8.x
+                  version: 8.9.x
                   url: https://management-and-modeling-host.com/
                   readiness: http://camunda-console.oidc:9100/health/readiness
                   metrics: http://camunda-console.oidc:9100/prometheus
                 - name: Identity
                   id: identity
-                  version: 8.8.x
+                  version: 8.9.x
                   url: https://management-and-modeling-host.com/identity
                   readiness: http://camunda-identity.oidc:82/actuator/health
                   metrics: http://camunda-identity.oidc:82/actuator/prometheus
                 - name: WebModeler WebApp
                   id: webModelerWebApp
-                  version: 8.8.x
+                  version: 8.9.x
                   url: https://management-and-modeling-host.com/modeler
                   readiness: http://camunda-web-modeler-webapp.oidc:8071/health/readiness
                   metrics: http://camunda-web-modeler-webapp.oidc:8071/metrics
             - name: camunda
               namespace: orchestration
-              version: 13.x
+              version: 14.x
               components:
                 - name: Operate
                   id: operate
-                  version: 8.8.x
+                  version: 8.9.x
                   url: https://orchestration-host.com/orchestration/operate
                   readiness: http://camunda-zeebe.orchestration:9600/operate/actuator/health/readiness
                   metrics: http://camunda-zeebe.orchestration:9600/operate/actuator/prometheus
                 - name: Optimize
                   id: optimize
-                  version: 8.8.x
+                  version: 8.9.x
                   url: https://orchestration-host.com/optimize
                   readiness: http://camunda-optimize.orchestration:80/optimize/api/readyz
                   metrics: http://camunda-optimize.orchestration:8092/actuator/prometheus
                 - name: Tasklist
                   id: tasklist
-                  version: 8.8.x
+                  version: 8.9.x
                   url: https://orchestration-host.com/orchestration/tasklist
                   readiness: http://camunda-zeebe.orchestration:9600/tasklist/actuator/health/readiness
                   metrics: http://camunda-zeebe.orchestration:9600/tasklist/actuator/prometheus
                 - name: Orchestration Cluster
                   id: orchestration
-                  version: 8.8.x
+                  version: 8.9.x
                   urls:
                     grpc: https://zeebe-orchestration-host.com
                     http: https://orchestration-host.com/orchestration


### PR DESCRIPTION
## Summary

Fixes two incorrect code samples in the self-managed 8.9 documentation.

### 1. Wrong `CAMUNDA_CLIENT_AUTH_METHOD` value in Basic Authentication tab

**File:** `docs/self-managed/components/connectors/connectors-configuration.md`

The Basic Authentication tab showed `CAMUNDA_CLIENT_AUTH_METHOD=oidc` in the environment variables example, which is the value for OIDC authentication, not basic. The correct value is `basic`.

The `Application.yaml` block in the same tab was already correct (`method: basic`), making this a copy-paste error in the env var block only.

### 2. Stale Helm chart and application versions in production Console example

**File:** `docs/self-managed/deployment/helm/install/production/index.md`

The example Console YAML configuration block referenced 8.8 versions instead of 8.9:

| Field | Old value | Correct value |
|---|---|---|
| Helm chart version (management cluster) | `13.x.x` | `14.x.x` |
| Helm chart version (orchestration cluster) | `13.x` | `14.x` |
| Component app versions (Console, Identity, WebModeler, Operate, Optimize, Tasklist, Orchestration Cluster) | `8.8.x` | `8.9.x` |

Verified against the Helm chart version matrix and other 8.9 docs confirming chart 14.x = Camunda 8.9.