### PR TITLE
fix(docs/8.8): fix broken anchor and missing leading slashes in self-managed links

### DIFF
--- a/versioned_docs/version-8.8/self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
+++ b/versioned_docs/version-8.8/self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md
@@ -7,7 +7,7 @@ sidebar_label: "Zeebe connection"
 You try to connect (i.e., to deploy) to a remote Zeebe cluster and Web Modeler reports an error.
 
 To resolve this issue, check if you can connect to Zeebe through another client.
-If that doesn't work, resolve the general connection issue first (see [the platform deployment troubleshooting section](self-managed/operational-guides/troubleshooting.md), for example.)
+If that doesn't work, resolve the general connection issue first (see [the platform deployment troubleshooting section](/self-managed/operational-guides/troubleshooting.md), for example.)
 
 If that works, further debug your Zeebe connection with the help of the information stated below. Enabling [debug logging in `modeler-restapi`](#how-can-i-debug-log-grpc--zeebe-communication) may also help to understand the issue.
 
@@ -46,7 +46,7 @@ for additional information.
 by the server.
 
 Secure connections to Zeebe require an Ingress controller that supports HTTP/2 over TLS with protocol negotiation via ALPN.
-Ensure you properly [configured your Zeebe Ingress to support ALPN](self-managed/operational-guides/troubleshooting.md#zeebe-ingress-grpc).
+Ensure you properly [configured your Zeebe Ingress to support ALPN](/self-managed/operational-guides/troubleshooting.md#zeebe-ingress-grpc).
 
 ### Configure `modeler-restapi` to trust a custom Zeebe SSL certificate
 

--- a/versioned_docs/version-8.8/self-managed/concepts/elasticsearch-without-cluster-privileges.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/elasticsearch-without-cluster-privileges.md
@@ -472,7 +472,7 @@ camunda_webapps_123_8.8.0_part_6_of_7
 camunda_webapps_123_8.8.0_part_7_of_7
 ```
 
-Once completed, you can proceed with step 7 of the [backup procedure](self-managed/operational-guides/backup-restore/backup-and-restore.md#backup-process).
+Once completed, you can proceed with step 7 of the [backup procedure](/self-managed/operational-guides/backup-restore/backup-and-restore.md#backup-process).
 
 ### Limitations
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/openshift/dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/openshift/dual-region.md
@@ -552,4 +552,4 @@ Consult the generic [dual-region failover procedure](/self-managed/deployment/he
 
 ## Pitfalls to avoid
 
-For general deployment pitfalls, visit the [deployment troubleshooting guide](self-managed/operational-guides/troubleshooting.md).
+For general deployment pitfalls, visit the [deployment troubleshooting guide](/self-managed/operational-guides/troubleshooting.md).

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -552,7 +552,7 @@ The following values are required for OAuth authentication:
 
 ## Pitfalls to avoid
 
-For general deployment pitfalls, visit the [deployment troubleshooting guide](self-managed/operational-guides/troubleshooting.md).
+For general deployment pitfalls, visit the [deployment troubleshooting guide](/self-managed/operational-guides/troubleshooting.md).
 
 ### Persistent volume reclaim policy
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/application-configs.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/application-configs.md
@@ -102,7 +102,7 @@ operate:
 
 ### Default properties
 
-The `helm template` command generates the application's default configuration. Keep the original `values.yaml` unchanged and maintain a separate file with your custom settings. For details, see [Creating your own values files](self-managed/deployment/helm/chart-parameters.md#creating-your-own-values-files). To generate the default configuration, replace `<your-release-name>` with your release name and run:
+The `helm template` command generates the application's default configuration. Keep the original `values.yaml` unchanged and maintain a separate file with your custom settings. For details, see [Creating your own values files](/self-managed/deployment/helm/chart-parameters.md#creating-your-own-values-files). To generate the default configuration, replace `<your-release-name>` with your release name and run:
 
 ```bash
 helm template <your-release-name> \

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/enable-additional-components.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/enable-additional-components.md
@@ -27,7 +27,7 @@ Starting with Camunda 8.8, the Helm chart reflects a new architecture where Zeeb
 :::note Upgrading from 8.7?
 In Camunda 8.7, more components were enabled by default. If you're upgrading from 8.7 and used any of the components listed above, you must explicitly enable them in your 8.8 `values.yaml`.
 
-See the [8.7 to 8.8 upgrade guide](/self-managed/upgrade/helm/870-to-880.md#ensure-required-components) for upgrade-specific instructions.
+See the [8.7 to 8.8 upgrade guide](/self-managed/upgrade/helm/870-to-880.md#changes-to-the-default-deployment-setup) for upgrade-specific instructions.
 :::
 
 ## Management Identity

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/ingress/ingress-setup.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/ingress/ingress-setup.md
@@ -195,4 +195,4 @@ helm install -f ingress_nginx_values.yml \
 
 ## Troubleshooting
 
-If Ingress is not working as expected, see [Camunda components troubleshooting](self-managed/operational-guides/troubleshooting.md).
+If Ingress is not working as expected, see [Camunda components troubleshooting](/self-managed/operational-guides/troubleshooting.md).

--- a/versioned_docs/version-8.8/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
+++ b/versioned_docs/version-8.8/self-managed/operational-guides/backup-restore/modeler-backup-and-restore.md
@@ -37,7 +37,7 @@ After the database has been restored, you can start Web Modeler again.
 
 :::danger
 When restoring Web Modeler data from a backup, ensure that the ids of the users stored in your OIDC provider (e.g. Keycloak) do not change in between the backup and restore.
-Otherwise, users may not be able to access their projects after the restore (see [Web Modeler's troubleshooting guide](self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-missing-data.md)).
+Otherwise, users may not be able to access their projects after the restore (see [Web Modeler's troubleshooting guide](/self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-missing-data.md)).
 :::
 
 :::tip

--- a/versioned_docs/version-8.8/self-managed/operational-guides/data-purge.md
+++ b/versioned_docs/version-8.8/self-managed/operational-guides/data-purge.md
@@ -22,7 +22,7 @@ The data purge feature can be used to:
 
 ## Purge data
 
-You will need access to the Cluster API as described in the [Cluster scaling guide](self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md) to perform the purge.
+You will need access to the Cluster API as described in the [Cluster scaling guide](/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md) to perform the purge.
 
 :::danger
 The purge operation is irreversible. It will delete the runtime data in the cluster and the historical data in the exporters! Make sure to back up your data before proceeding.

--- a/versioned_docs/version-8.8/self-managed/upgrade/components/keycloak/keycloak-compatibility.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/components/keycloak/keycloak-compatibility.md
@@ -20,5 +20,5 @@ When upgrading Keycloak, you must reuse the existing Keycloak database.
 
 **Do not** upgrade by creating a new Keycloak instance and re-importing users from external identity providers (for example, LDAP).
 
-Doing so will generate new internal Keycloak IDs, which can prevent users from accessing existing data such as Optimize collections and [Web Modeler projects](self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-missing-data.md).
+Doing so will generate new internal Keycloak IDs, which can prevent users from accessing existing data such as Optimize collections and [Web Modeler projects](/self-managed/components/modeler/web-modeler/troubleshooting/troubleshoot-missing-data.md).
 :::

--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/index.md
@@ -12,7 +12,7 @@ import '../react-components/\_card.css';
 Upgrade a Camunda 8 Self-Managed deployment installation using the official Camunda Helm charts.
 
 :::caution earlier versions
-If you are upgrading from a version earlier than 8.7, see [upgrading from an earlier version](self-managed/upgrade/index.md#upgrading-from-an-earlier-version).
+If you are upgrading from a version earlier than 8.7, see [upgrading from an earlier version](/self-managed/upgrade/index.md#upgrading-from-an-earlier-version).
 :::
 
 ## Upgrade guides
@@ -45,4 +45,4 @@ See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issu
 ## Related resources
 
 - [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)
-- [Component upgrade from 8.7 to 8.8](self-managed/upgrade/components/870-to-880.md)
+- [Component upgrade from 8.7 to 8.8](/self-managed/upgrade/components/870-to-880.md)


### PR DESCRIPTION
## Summary

Fixes broken and malformed links in the Camunda 8.8 self-managed versioned docs.

- **Broken anchor** in `enable-additional-components.md`: `#ensure-required-components` did not exist in the upgrade guide; corrected to `#changes-to-the-default-deployment-setup`
- **Missing leading `/`** on 12 `self-managed/*` links across 10 files — without the leading slash these resolve relative to the current page instead of the docs root

## Files changed

| File | Change |
|------|--------|
| `deployment/helm/configure/enable-additional-components.md` | Fix broken anchor |
| `upgrade/helm/index.md` | Fix 2 missing leading slashes |
| `upgrade/components/keycloak/keycloak-compatibility.md` | Fix 1 missing leading slash |
| `operational-guides/data-purge.md` | Fix 1 missing leading slash |
| `operational-guides/backup-restore/modeler-backup-and-restore.md` | Fix 1 missing leading slash |
| `components/modeler/web-modeler/troubleshooting/troubleshoot-zeebe-connection.md` | Fix 2 missing leading slashes |
| `deployment/helm/cloud-providers/openshift/dual-region.md` | Fix 1 missing leading slash |
| `deployment/helm/cloud-providers/openshift/redhat-openshift.md` | Fix 1 missing leading slash |
| `deployment/helm/configure/application-configs.md` | Fix 1 missing leading slash |
| `deployment/helm/configure/ingress/ingress-setup.md` | Fix 1 missing leading slash |
| `concepts/elasticsearch-without-cluster-privileges.md` | Fix 1 missing leading slash |