### PR TITLE
fix(docs/8.8): fix expectedTopology typo in data-purge and cluster-scaling

### DIFF
--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md
@@ -814,7 +814,7 @@ The response is a JSON object. See detailed specs [here](https://github.com/camu
 - `changeId`: The ID of the changes initiated to scale the cluster. This can be used to monitor the progress of the scaling operation. The ID typically increases so new requests get a higher ID than the previous one.
 - `currentTopology`: A list of current brokers and the partition distribution.
 - `plannedChanges`: A sequence of operations that has to be executed to achieve scaling.
-- `expectedToplogy`: The expected list of brokers and the partition distribution once the scaling is completed.
+- `expectedTopology`: The expected list of brokers and the partition distribution once the scaling is completed.
 
 <details>
   <summary>Example response</summary>

--- a/versioned_docs/version-8.8/self-managed/operational-guides/data-purge.md
+++ b/versioned_docs/version-8.8/self-managed/operational-guides/data-purge.md
@@ -126,7 +126,7 @@ The response is a [JSON object](https://github.com/camunda/camunda/blob/main/dis
 - `changeId`: The ID of the changes initiated to scale the cluster. This can be used to monitor the progress of the scaling operation. The ID typically increases, so new requests have a higher ID than previous requests.
 - `currentTopology`: A list of current brokers and the partition distribution.
 - `plannedChanges`: A sequence of operations that has to be executed to achieve scaling.
-- `expectedToplogy`: The expected list of brokers and the partition distribution once the scaling is completed. For the purge feature, the expected topology will be the same as the current topology.
+- `expectedTopology`: The expected list of brokers and the partition distribution once the scaling is completed. For the purge feature, the expected topology will be the same as the current topology.
 
 <details>
   <summary>Example response</summary>


### PR DESCRIPTION
## Summary

Fixes a misspelling of `expectedToplogy` → `expectedTopology` in two files where the field name appears in prose descriptions of the cluster topology response.

The JSON code blocks in both files already use the correct spelling; only the bullet-point descriptions had the typo.

## Files changed

| File | Line | Change |
|------|------|--------|
| `operational-guides/data-purge.md` | 129 | `expectedToplogy` → `expectedTopology` |
| `components/orchestration-cluster/zeebe/operations/cluster-scaling.md` | 817 | `expectedToplogy` → `expectedTopology` |