### PR TITLE
fix(docs/8.7): remove stale internal comments from self-managed setup guides

### DIFF
--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/dual-region.md
@@ -41,9 +41,6 @@ Following this guide will incur costs on your Cloud provider account, namely for
 
 ## Outcome
 
-<!-- The following diagram should be exported as an image and as a PDF from the sources https://miro.com/app/board/uXjVL-6SrPc=/ --->
-<!-- To export: click on the frame > "Export Image" > as PDF and as JPG (low res), then save it in the ./assets/ folder --->
-
 _Infrastructure diagram for a dual-region EKS setup (click on the image to open the PDF version)_
 [![Infrastructure Diagram EKS Dual-Region](./assets/eks-dual-region.jpg)](./assets/eks-dual-region.pdf)
 

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/terraform-setup.md
@@ -94,9 +94,6 @@ Both can be set up with or without a **Domain** ([ingress](https://kubernetes.io
 
 ### Outcome
 
-<!-- The following diagram should be exported as an image and as a PDF from the sources https://miro.com/app/board/uXjVL-6SrPc=/ --->
-<!-- To export: click on the frame > "Export Image" > as PDF and as JPG (low res), then save it in the ./assets/ folder --->
-
 _Infrastructure diagram for a single region EKS setup (click on the image to open the PDF version)_
 [![Infrastructure Diagram EKS Single-Region](./assets/eks-single-region.jpg)](./assets/eks-single-region.pdf)
 

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/openshift/terraform-setup-dual-region.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/openshift/terraform-setup-dual-region.md
@@ -49,9 +49,6 @@ Following this guide will incur costs on your cloud provider account and your Re
 
 ### Outcome
 
-<!-- The following diagram should be exported as an image and as a PDF from the sources https://miro.com/app/board/uXjVL-6SrPc=/ --->
-<!-- To export: click on the frame > "Export Image" > as PDF and as JPG (low res), then save it in the ./assets/ folder --->
-
 _Infrastructure diagram for a dual region ROSA setup (click on the image to open the PDF version)_
 [![Infrastructure Diagram ROSA Dual-Region](./assets/rosa-dual-region.jpg)](./assets/rosa-dual-region.pdf)
 

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/openshift/terraform-setup.md
@@ -63,11 +63,6 @@ Unlike the [EKS Terraform setup](../amazon-eks/terraform-setup.md), we currently
 
 ### Outcome
 
-<!-- TODO: before merge, replace  => stable/8.7 >
-
-<!-- The following diagram should be exported as an image and as a PDF from the sources https://miro.com/app/board/uXjVL-6SrPc=/ --->
-<!-- To export: click on the frame > "Export Image" > as PDF and as JPG (low res), then save it in the ./assets/ folder --->
-
 _Infrastructure diagram for a single region ROSA setup (click on the image to open the PDF version)_
 [![Infrastructure Diagram ROSA Single-Region](./assets/rosa-single-region.jpg)](./assets/rosa-single-region.pdf)
 
@@ -307,9 +302,6 @@ This section guides you through setting up an AWS VPN Endpoint to access a priva
 This step is **optional** and only necessary if you have configured a **private cluster**.
 
 Using a VPN offers a flexible and secure way to connect to the private subnets within your VPC. It can be used either by a user to access cluster resources or to enable cross-site communications via [PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/what-is-privatelink.html). This module focuses on user access.
-
-<!-- The following diagram should be exported as an image and as a PDF from the sources https://miro.com/app/board/uXjVL-6SrPc=/ --->
-<!-- To export: click on the frame > "Export Image" > as PDF and as JPG (low res), then save it in the ./assets/ folder --->
 
 _Infrastructure diagram for a single region ROSA setup with VPN (click on the image to open the PDF version)_
 [![Infrastructure Diagram ROSA Single-Region VPN](./assets/rosa-single-region-vpn.jpg)](./assets/rosa-single-region-vpn.pdf)

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/openshift/dual-region.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/openshift/dual-region.md
@@ -24,9 +24,6 @@ Please review our [dual-region concept documentation](./../../../concepts/multi-
 
 ## High Level Design
 
-<!-- The following diagram should be exported as an image and as a PDF from the sources https://miro.com/app/board/uXjVL-6SrPc=/ --->
-<!-- To export: click on the frame > "Export Image" > as PDF and as JPG (low res), then save it in the ./assets/ folder --->
-
 _Infrastructure diagram for a OpenShift dual-region setup (click on the image to open the PDF version)_
 [![Infrastructure Diagram OpenShift Dual-Region](./assets/openshift-dual-region.jpg)](./assets/openshift-dual-region.pdf)
 


### PR DESCRIPTION
## Summary

- Removes author-facing Miro export instructions (comments telling authors how to export diagrams as images/PDFs) from 6 setup guide files — these were never intended to appear in the docs source visible to readers
- Removes a stale `TODO: before merge, replace => stable/8.7` comment from the ROSA single-region setup guide (the replacement was already done; the TODO was left behind)

## Files changed

- `setup/deploy/amazon/openshift/terraform-setup.md`
- `setup/deploy/amazon/openshift/terraform-setup-dual-region.md`
- `setup/deploy/amazon/amazon-eks/terraform-setup.md`
- `setup/deploy/amazon/amazon-eks/dual-region.md`
- `setup/deploy/openshift/dual-region.md`

## Notes

- No user-visible content is changed — only HTML comments are removed
- The intentionally deferred Route 53 TODO in `terraform-setup-dual-region.md` is left untouched