### PR TITLE
fix(8.6): correct wrong version references in self-managed docs

### DIFF
--- a/versioned_docs/version-8.6/self-managed/setup/guides/gateway-api-setup.md
+++ b/versioned_docs/version-8.6/self-managed/setup/guides/gateway-api-setup.md
@@ -35,11 +35,11 @@ In testing, Camunda uses the [NGINX Gateway Fabric](https://github.com/nginx/ngi
 
 ## Implement
 
-Get started by running the `helm template` command against version 8.9 or later of the Helm chart to generate the resources, then modify them as needed. See the following command example:
+Get started by running the `helm template` command against version 8.6 or later of the Helm chart to generate the resources, then modify them as needed. See the following command example:
 
 ```bash
 helm template camunda camunda/camunda-platform \
-  --version 14.0.0 \
+  --version $HELM_CHART_VERSION \
   --set global.host=example.com \
   --set global.gateway.enabled=true \
   --set global.gateway.createGatewayResource=true \

--- a/versioned_docs/version-8.6/self-managed/setup/install.md
+++ b/versioned_docs/version-8.6/self-managed/setup/install.md
@@ -442,7 +442,7 @@ For upgrading the Camunda Helm chart from one release to another, perform a [Hel
 
 ## Production installation
 
-For production installation, see the [Camunda production installation guide with Kubernetes and Helm](/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md), available starting with version 8.7.
+For production installation, see the Camunda production installation guide with Kubernetes and Helm, available starting with version 8.7.
 
 ## General notes
 

--- a/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
+++ b/versioned_docs/version-8.6/self-managed/zeebe-deployment/configuration/logging.md
@@ -8,7 +8,7 @@ in `config/log4j2.xml`.
 
 ## Default logging configuration
 
-You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/stable/8.7/dist/src/main/config/log4j2.xml).
+You can find the default log4j2.xml used by the application in the [GitHub repository](https://github.com/camunda/camunda/blob/stable/8.6/dist/src/main/config/log4j2.xml).
 
 It configures the [log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) to `WARN` by default, and sets the following exceptions to `INFO`:
 


### PR DESCRIPTION
## Summary

Fixes three incorrect version references in the Camunda 8.6 self-managed documentation.

- **`zeebe-deployment/configuration/logging.md`**: GitHub link pointed to `stable/8.7` branch instead of `stable/8.6`
- **`setup/install.md`**: "Production installation" section contained a hyperlink to a page in `versioned_docs/version-8.7/` (which doesn't exist in 8.6). Removed the broken link while keeping the explanatory text intact.
- **`setup/guides/gateway-api-setup.md`**: Referred to "version 8.9 or later" and hardcoded Helm chart version `14.0.0` (which maps to Camunda ~8.9). Corrected to "version 8.6 or later" and replaced the hardcoded version with `$HELM_CHART_VERSION` to be consistent with every other Helm install command in the 8.6 docs.