### PR TITLE
fix(8.6): replace absolute versioned_docs paths with root-relative links

### DIFF
--- a/versioned_docs/version-8.6/self-managed/identity/identity-first-steps.md
+++ b/versioned_docs/version-8.6/self-managed/identity/identity-first-steps.md
@@ -10,7 +10,7 @@ import IdentityLoginImg from './img/identity-login-page.png';
 Get started with Identity in Self-Managed by learning how to open and log in to the Identity interface.
 
 :::note
-Identity is included in the [Docker-Compose](/versioned_docs/version-8.7/self-managed/setup/deploy/local/docker-compose.md) and [Helm](/versioned_docs/version-8.7/self-managed/setup/install.md) based deployment of Camunda 8 Self-Managed. With the default configuration, Identity uses an included Keycloak container/pod.
+Identity is included in the [Docker-Compose](/self-managed/setup/deploy/local/docker-compose.md) and [Helm](/self-managed/setup/install.md) based deployment of Camunda 8 Self-Managed. With the default configuration, Identity uses an included Keycloak container/pod.
 :::
 
 ## Log in to Identity
@@ -21,8 +21,8 @@ Once Identity has successfully started, you can open the **Log in** page and log
 
 If you are running the default configuration, you can access the Identity interface via the following URLs:
 
-- [Docker-Compose](/versioned_docs/version-8.7/self-managed/setup/deploy/local/docker-compose.md): `http://localhost:8084/`
-- [Helm](/versioned_docs/version-8.7/self-managed/setup/install.md): Follow your [`port-forward` or Ingress configuration](/self-managed/setup/guides/accessing-components-without-ingress.md)
+- [Docker-Compose](/self-managed/setup/deploy/local/docker-compose.md): `http://localhost:8084/`
+- [Helm](/self-managed/setup/install.md): Follow your [`port-forward` or Ingress configuration](/self-managed/setup/guides/accessing-components-without-ingress.md)
 
 ## Default user
 

--- a/versioned_docs/version-8.6/self-managed/operate-deployment/operate-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/operate-deployment/operate-configuration.md
@@ -511,7 +511,7 @@ You must configure the following on your chosen database:
 Operate is configured with the snapshot repository name to trigger database snapshots. This is important for coherent backups.
 
 :::info
-Learn more about the procedure and the need to trigger it through Camunda components in the [backup guide](/versioned_docs/version-8.6/self-managed/operational-guides/backup-restore/backup-and-restore.md).
+Learn more about the procedure and the need to trigger it through Camunda components in the [backup guide](/self-managed/operational-guides/backup-restore/backup-and-restore.md).
 :::
 
 Operate must be configured with the repository name:

--- a/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
+++ b/versioned_docs/version-8.6/self-managed/tasklist-deployment/tasklist-configuration.md
@@ -452,7 +452,7 @@ You must configure the following on your chosen database:
 Tasklist is configured with the snapshot repository name to trigger database snapshots. This is important for coherent backups.
 
 :::info
-Learn more about the procedure and the need to trigger it through Camunda components in the [backup guide](/versioned_docs/version-8.6/self-managed/operational-guides/backup-restore/backup-and-restore.md).
+Learn more about the procedure and the need to trigger it through Camunda components in the [backup guide](/self-managed/operational-guides/backup-restore/backup-and-restore.md).
 :::
 
 Tasklist must be configured with the repository name:


### PR DESCRIPTION
## Summary

Replaces absolute `/versioned_docs/version-X.Y/` internal links with root-relative `/self-managed/` paths in three files.

Using hardcoded `versioned_docs` paths is an anti-pattern in Docusaurus — it bypasses the version-switching mechanism and can silently point to the wrong version of a page.

### Files changed

- **`identity/identity-first-steps.md`** — 3 links were pointing to `version-8.7` pages (Docker-Compose and Helm install guides). Corrected to version-agnostic root-relative paths.
- **`operate-deployment/operate-configuration.md`** — 1 link to the backup guide used a hardcoded `version-8.6` absolute path.
- **`tasklist-deployment/tasklist-configuration.md`** — same issue as operate-configuration.md.