### PR TITLE
fix(docs/8.7): fix typos and double-slash link in self-managed docs

### DIFF
--- a/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
@@ -295,7 +295,7 @@ zeebe:
     policyName: zeebe-record-retention-policy
 ```
 
-For more information on configuring ILM policy, refer to the configuration guide on the [OpenSearch exporter](/self-managed/zeebe-deployment/exporters//opensearch-exporter.md#configuration).
+For more information on configuring ILM policy, refer to the configuration guide on the [OpenSearch exporter](/self-managed/zeebe-deployment/exporters/opensearch-exporter.md#configuration).
 
 ### Configure backups
 

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/user-task-access-restrictions.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/user-task-access-restrictions.md
@@ -15,4 +15,4 @@ user or a [group](/self-managed/identity/application-user-group-role-management/
 
 For example, if a task has a candidate group named `Team A` and a candidate user named `example`, only the users that belong to `Team A` and the user `example` will have access to the task.
 
-See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailled description.
+See [Tasklist authentication documentation on **user task access restrictions**](self-managed/tasklist-deployment/tasklist-authentication.md#user-task-access-restrictions) for a more detailed description.

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/cluster-scaling.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/cluster-scaling.md
@@ -647,7 +647,7 @@ The response is a JSON object. See detailed specs [here](https://github.com/camu
 - `changeId`: The ID of the changes initiated to scale the cluster. This can be used to monitor the progress of the scaling operation. The ID typically increases so new requests get a higher ID than the previous one.
 - `currentTopology`: A list of current brokers and the partition distribution.
 - `plannedChanges`: A sequence of operations that has to be executed to achieve scaling.
-- `expectedToplogy`: The expected list of brokers and the partition distribution once the scaling is completed.
+- `expectedTopology`: The expected list of brokers and the partition distribution once the scaling is completed.
 
 <details>
   <summary>Example response</summary>


### PR DESCRIPTION
## Summary

Three small correctness fixes in 8.7 self-managed docs:

- **`cluster-scaling.md`**: `expectedToplogy` → `expectedTopology` (the surrounding code blocks already used the correct spelling)
- **`user-task-access-restrictions.md`**: `detailled` → `detailed`
- **`helm-chart-production-guide.md`**: Remove double slash in the OpenSearch exporter link (`exporters//opensearch-exporter.md` → `exporters/opensearch-exporter.md`)