### PR TITLE
fix(docs/8.7): remove internal draft/author comments from helm-chart-production-guide

### DIFF
--- a/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
@@ -412,9 +412,6 @@ The following resources and configuration options are important to keep in mind 
           mountPath: /mount
   ```
 
-<!-- This seems very specific to the application. I might remove this: -->
-<!-- - Mount Secrets as volumes, not environment variables -->
-
 - It is recommended to set a memory and resource quota for your namespace. Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/) to do so. Namespace-Level Quotas apply limits to all workloads within a namespace. It ensures aggregate resource consumption by all pods in the namespace do not exceed your desired resource limits.
 
 ### Security
@@ -449,7 +446,6 @@ The following resources and configuration options are important to keep in mind 
   :::
 
 - [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) can be enabled with Camunda Helm charts if needed by your infrastructure requirements.
-<!--Maybe link this to customer: https://github.com/ahmetb/kubernetes-network-policy-recipes-->
 - It is possible to have a pod security standard that is suited to your security constraints. This is enabled by modifying the Pod Security Admission. See the [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) guide in the official Kubernetes documentation for more information.
 - By default, the Camunda Helm chart is configured to use a read-only root file system for the pod. It is advisable to retain this default setting, and no modifications are required in your Helm values files.
 - Disable privileged containers. This can be achieved by implementing a pod security policy. For more information, see the official [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/pod-security-admission/).


### PR DESCRIPTION
## Summary

- Removes two stale internal author comments from `helm-chart-production-guide.md` that were left over from the drafting process:
  - `<!-- This seems very specific to the application. I might remove this: -->` + `<!-- - Mount Secrets as volumes, not environment variables -->`
  - `<!--Maybe link this to customer: https://github.com/ahmetb/kubernetes-network-policy-recipes-->`

These comments were never intended to be published and have no value for readers.

## Related

Part of a series of cleanup PRs for the 8.7 self-managed docs.