### PR TITLE
fix(docs/8.7): update WIP notice wording in reference-architecture to match 8.8

### DIFF
--- a/versioned_docs/version-8.7/self-managed/reference-architecture/reference-architecture.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/reference-architecture.md
@@ -96,8 +96,8 @@ If running a single instance is preferred, make sure to implement [regular backu
 
 ## Available reference architectures
 
-:::note Documentation Update in Progress
-This is a work in progress as the existing documentation is updated to provide better general guidance on the topic. The Docker and Manual documentation may point to older guides.
+:::note Documentation update in progress
+This documentation is being updated to provide clearer general guidance. Some Docker documentation may still point to older guides.
 :::
 
 Choosing the right reference architecture depends on various factors such as the organization's goals, existing infrastructure, and specific requirements. The following guides are available to help choose and guide deployments:


### PR DESCRIPTION
## Summary

- Lowercases the admonition title (`Documentation Update in Progress` → `Documentation update in progress`) to match Docusaurus/style-guide conventions
- Rewrites the notice body to match the cleaner wording already used in 8.8:
  - **Before:** `"This is a work in progress as the existing documentation is updated to provide better general guidance on the topic. The Docker and Manual documentation may point to older guides."`
  - **After:** `"This documentation is being updated to provide clearer general guidance. Some Docker documentation may still point to older guides."`

## Related

Part of a series of cleanup PRs for the 8.7 self-managed docs.