### PR TITLE
fix(ux): Dark mode nav link color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -173,6 +173,7 @@ See: https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
   --ifm-color-info-contrast-background: rgb(244, 249, 254);
   --ifm-color-warning-dark: rgb(252 93 13);
   --ifm-color-warning-contrast-background: rgb(252, 243, 238);
+  --ifm-navbar-link-color: #1c1e21;
 }
 
 /* Match Algolia colours to Camunda brand colours */
@@ -300,10 +301,6 @@ we make it less bold compared to the search keyword */
   padding-left: 10px;
   font-size: 16px;
   display: none;
-}
-
-.navbar__link {
-  color: #1c1e21;
 }
 
 a {


### PR DESCRIPTION
## Description

Fix dark mode navbar link colors.

## Current dark mode (bug)

<img width="877" height="327" alt="image" src="https://github.com/user-attachments/assets/6392489e-0c66-4915-b3e2-8bc624e16761" />


## Fixed dark mode

<img width="877" height="322" alt="image" src="https://github.com/user-attachments/assets/387dbad3-7f93-49c7-9d5d-07a2b1885c78" />

## Fixed light mode (to confirm color)

<img width="881" height="330" alt="image" src="https://github.com/user-attachments/assets/d9d7811c-7f89-4872-9f4c-3cc6e59e211e" />

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
