### PR TITLE
docs(connectors): remove writeTimeout documentation from REST and GraphQL connectors

### DIFF
--- a/docs/components/connectors/protocol/graphql.md
+++ b/docs/components/connectors/protocol/graphql.md
@@ -185,8 +185,6 @@ Variables:
 
 - **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
-- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
-
 ## Response mapping
 
 The HTTP response will be available in a temporary local `response` variable. This variable can be mapped to the process by specifying the **Result Variable**.

--- a/docs/components/connectors/protocol/rest.md
+++ b/docs/components/connectors/protocol/rest.md
@@ -8,7 +8,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST connector, ensure you do not have any process variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`
 
 :::
 

--- a/versioned_docs/version-8.6/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.6/components/connectors/protocol/graphql.md
@@ -185,8 +185,6 @@ Variables:
 
 - **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
-- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
-
 ## Response mapping
 
 The HTTP response will be available in a temporary local `response` variable. This variable can be mapped to the process by specifying the **Result Variable**.

--- a/versioned_docs/version-8.6/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.6/components/connectors/protocol/rest.md
@@ -7,7 +7,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST Connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`
 
 :::
 

--- a/versioned_docs/version-8.7/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.7/components/connectors/protocol/graphql.md
@@ -185,8 +185,6 @@ Variables:
 
 - **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
-- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
-
 ## Response mapping
 
 The HTTP response will be available in a temporary local `response` variable. This variable can be mapped to the process by specifying the **Result Variable**.

--- a/versioned_docs/version-8.7/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.7/components/connectors/protocol/rest.md
@@ -8,7 +8,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST connector, ensure you do not have any instance variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`
 
 :::
 

--- a/versioned_docs/version-8.8/components/connectors/protocol/graphql.md
+++ b/versioned_docs/version-8.8/components/connectors/protocol/graphql.md
@@ -185,8 +185,6 @@ Variables:
 
 - **Read timeout in seconds** is the amount of time the client will wait to read data from the server after the connection has been made. The default is also set to 20 seconds. To allow an unlimited wait time for slow responses, set this to 0.
 
-- **Write timeout in seconds** controls how long the client will wait to successfully send data to the server. The default setting for this is 0, indicating that there is no limit and the client will wait indefinitely for the operation to complete.
-
 ## Response mapping
 
 The HTTP response will be available in a temporary local `response` variable. This variable can be mapped to the process by specifying the **Result Variable**.

--- a/versioned_docs/version-8.8/components/connectors/protocol/rest.md
+++ b/versioned_docs/version-8.8/components/connectors/protocol/rest.md
@@ -8,7 +8,7 @@ description: Make a request to a REST API and use the response in the next steps
 :::caution
 If you use the REST connector, ensure you do not have any process variable named in the list below:
 
-- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`, `writeTimeoutInSeconds`
+- `body`, `url`, `method`, `headers`, `authentication`, `queryParameters`, `connectionTimeoutInSeconds`, `readTimeoutInSeconds`
 
 :::
 


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Removes `writeTimeoutInSeconds` from the reserved variable names warning in the REST connector docs, and removes the **Write timeout in seconds** description from the GraphQL connector docs.

Affects current docs and versioned docs for 8.6, 8.7, and 8.8.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->