### PR TITLE
Document auto-correction of Global User Task Listeners configuration

### DIFF
--- a/docs/components/concepts/global-user-task-listeners.md
+++ b/docs/components/concepts/global-user-task-listeners.md
@@ -78,7 +78,7 @@ The two ways of configuring global listeners can be used at the same time, howev
 
 You can configure the global user task listeners through the [Unified Configuration](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camundaclusterglobal-listeners) by setting the appropriate properties under the configuration path `camunda.cluster.global-listeners.user-task`.
 
-Each listener entry can be configured with the properties described in the [Global listener definition](#global-listener-definition) section above, except for the `source` property which is automatically set to `CONFIGURATION` by the system.
+Each listener entry can be configured with the properties described in the [Global listener definition](#global-listener-definition) section above, except for the `source` property, which is automatically set to `CONFIGURATION` by the system. Any provided `source` value will be ignored.
 
 #### How the configuration is validated
 
@@ -86,14 +86,18 @@ If you provide an invalid configuration, the system attempts to automatically re
 
 The following validation rules are applied automatically on startup:
 
-- If a listener is missing the required `id`, `type`, or `event-types` properties, it is removed and ignored.
-- If a listener defines invalid event types, those event types are removed. If all event types of a listener are invalid, the listener is removed and ignored.
-  - Note that event types in the configuration are treated case-insensitively, so for example `Creating` and `creating` are both valid, but `create` is not.
+- If a listener is missing the required `id`, `type`, or `event-types` properties, it is removed.
+- If a listener defines invalid event types, those event types are removed. If all event types are invalid, the listener is removed.
+  - Valid event types are: `creating`, `assigning`, `updating`, `completing`, `canceling`, or the special value `all`. Event type matching is case-insensitive, so `Creating` and `creating` are both valid, but `create` is not.
 - If a listener defines duplicate event types, the duplicates are removed and only one instance of each event type is kept.
-- If a listener defines both the special `all` value and a normal event type for `event-types`, the configuration is corrected to include only `all`.
-- If a listener defines invalid retry values, i.e., non-numeric or negative, the listener is removed and ignored.
+- If a listener defines both the special `all` value and a normal event type for `event-types`, the configuration is corrected to include only `all`. This ensures the listener catches all events as intended.
+- If a listener defines invalid retry values (non-numeric, negative, or zero), it is removed. Valid retry values are positive integers.
 
-In all the above cases, a warning is written to the Orchestration Cluster startup log, identifying the problem and its location in the configuration.
+In all the above cases, a warning is written to the Orchestration Cluster startup log identifying the problem location. Invalid listeners are removed while valid ones remain active.
+
+:::note
+Listeners defined through the API are not subject to this validation.
+:::
 
 #### Example configuration
 


### PR DESCRIPTION

## Description

When invalid data is provided for the configuration of Global User Task Listeners, the system attempts to auto-correct it by removing the invalid of outright failing (see camunda/camunda#39931).

This behaviour is now documented in the section regarding the configuration of Global User Task Listeners through the configuration file.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->

## Related issues
#closes camunda/camunda#48384
