### PR TITLE
docs(api): address breaking changes in error response

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-to-89.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-89.md
@@ -66,6 +66,7 @@ Review the actions required for the following 8.9 changes:
 | <span className="label-highlight red">Breaking change</span> | [OpenAPI enum extensions](#enum-extensions)                                                                         |
 | <span className="label-highlight red">Breaking change</span> | [OpenAPI type-safety enhancements](#type-safety-enhancements)                                                       |
 | <span className="label-highlight red">Breaking change</span> | [Resource deletion endpoint now returns a response body](#resource-deletion)                                        |
+| <span className="label-highlight red">Breaking change</span> | [Search filter validation errors now return structured error collections](#search-filter-validation-errors)         |
 | <span className="label-highlight red">Breaking change</span> | [Spring Boot 4.0 default for Camunda Spring Boot Starter](#spring-boot)                                             |
 | <span className="label-highlight red">Breaking change</span> | [`versionTag` returns `null` instead of empty string when absent](#version-tag-null)                                |
 | <span className="label-highlight red">Breaking change</span> | [Web Modeler changes](#web-modeler)                                                                                 |
@@ -392,6 +393,43 @@ if (versionTag != null) {
 
 </TabItem>
 </Tabs>
+
+### Search filter validation errors now return structured error collections {#search-filter-validation-errors}
+
+#### Change
+
+REST API search endpoints now collect all filter validation errors and return them together in a single `400 Bad Request` response. Previously, only the first conversion error was returned.
+
+#### Why
+
+This is a bug fix that improves error handling consistency across the REST API. Collecting all validation errors in a single response makes debugging easier.
+
+#### Impact
+
+Search filter validation error responses now contain a list of all validation issues instead of stopping at the first error. The error detail format has changed:
+
+| Aspect                 | Before                                   | After                                                                                                    | Breaking?                              |
+| :--------------------- | :--------------------------------------- | :------------------------------------------------------------------------------------------------------- | :------------------------------------- |
+| HTTP status code       | `400`                                    | `400`                                                                                                    | No                                     |
+| ProblemDetail `title`  | `"Bad Request"`                          | `"INVALID_ARGUMENT"`                                                                                     | Yes                                    |
+| ProblemDetail `detail` | `"Failed to parse date-time: [invalid]"` | `"The provided evaluationDate 'invalid' cannot be parsed as a date according to RFC 3339, section 5.6."` | Yes                                    |
+| Error collection       | Fails on first error                     | Collects all validation errors                                                                           | Yes (response may contain more errors) |
+
+Affected search endpoints include all endpoints that accept advanced search filters with key fields (such as `processInstanceKey`, `processDefinitionKey`, `scopeKey`) or date fields (such as `startDate`, `endDate`, `creationDate`).
+
+**Who is affected?**
+
+- Customers parsing error response bodies (specifically `title` or `detail` fields) for validation errors → **affected**.
+- Customers only checking HTTP status codes → **not affected**.
+- Customers sending valid requests → **not affected** (happy path is unchanged).
+
+#### Action
+
+If your code parses error response bodies from search endpoints for specific validation error messages, update it to handle:
+
+- The `title` field value changed from `"Bad Request"` to `"INVALID_ARGUMENT"`.
+- The `detail` field now contains more descriptive, structured messages.
+- A collection of validation errors in the response body (instead of a single error message).
 
 ## Deprecations
 

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -336,6 +336,40 @@ What to do:
 
 <div className="release-announcement-row">
 <div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Search filter validation errors now return structured error collections
+
+REST API search endpoints now collect all filter validation errors and return them together in a single `400 Bad Request` response.
+
+Previously, only the first conversion error was returned. This fix improves consistency by collecting all validation issues in a single response.
+
+What changed:
+
+- All search filter validation errors are now collected and returned together, instead of stopping at the first error.
+- The ProblemDetail `title` changed from `"Bad Request"` to `"INVALID_ARGUMENT"`.
+- The ProblemDetail `detail` now contains more descriptive, structured messages (for example, `"The provided evaluationDate 'invalid' cannot be parsed as a date according to RFC 3339, section 5.6."` instead of `"Failed to parse date-time: [invalid]"`).
+
+Who is affected:
+
+- Customers parsing error response bodies (specifically `title` or `detail` fields) for validation errors → affected.
+- Customers only checking HTTP status codes → not affected.
+- Customers sending valid requests → not affected (happy path is unchanged).
+
+What to do:
+
+- If your code parses error response bodies from search endpoints, update it to handle a collection of validation errors instead of a single error message.
+- If your code checks for `"Bad Request"` in the `title` field, update it to check for `"INVALID_ARGUMENT"`.
+
+<p className="link-arrow">[8.9 API migration guide](../../../apis-tools/migration-manuals/migrate-to-89.md#search-filter-validation-errors)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Documents the behavioral change introduced in [camunda/camunda#48744](https://github.com/camunda/camunda/pull/48744) (backported to 8.9 via [#48820](https://github.com/camunda/camunda/pull/48820)).

REST API search endpoints now collect all filter validation errors and return them together in a single `400 Bad Request` response instead of failing on the first conversion error. The ProblemDetail `title` changed from `"Bad Request"` to `"INVALID_ARGUMENT"`, and error messages are now more descriptive.

While the HTTP status code remains `400`, customers parsing the `title` or `detail` fields of error responses will need to update their code.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
