### PR TITLE
ci: add prettier formatting to SDK docs sync workflows

### DIFF
--- a/.github/workflows/sync-csharp-sdk-docs.yaml
+++ b/.github/workflows/sync-csharp-sdk-docs.yaml
@@ -98,6 +98,17 @@ jobs:
 
           echo "Copied $(find "$TARGET" -name '*.md' | wc -l) markdown files → ${{ steps.resolve.outputs.docs_root }}"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Format generated docs with Prettier
+        working-directory: docs
+        run: |
+          npm ci
+          npx prettier --write "${{ steps.resolve.outputs.docs_root }}/apis-tools/csharp-sdk/api-reference/"
+
       - name: Check for changes
         id: check_changes
         working-directory: docs

--- a/.github/workflows/sync-python-sdk-docs.yaml
+++ b/.github/workflows/sync-python-sdk-docs.yaml
@@ -94,6 +94,18 @@ jobs:
           API_COUNT=$(find "$TARGET/api-reference" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Format generated docs with Prettier
+        working-directory: docs
+        run: |
+          npm ci
+          DOCS_ROOT="${{ steps.resolve.outputs.docs_root }}"
+          npx prettier --write "$DOCS_ROOT/apis-tools/python-sdk.md" "$DOCS_ROOT/apis-tools/python-sdk/"
+
       - name: Check for changes
         id: check_changes
         working-directory: docs

--- a/.github/workflows/sync-ts-sdk-docs.yaml
+++ b/.github/workflows/sync-ts-sdk-docs.yaml
@@ -80,6 +80,12 @@ jobs:
 
           echo "Copied $(find "$TARGET" -name '*.md' | wc -l) markdown files → ${{ steps.resolve.outputs.docs_root }}"
 
+      - name: Format generated docs with Prettier
+        working-directory: docs
+        run: |
+          npm ci
+          npx prettier --write "${{ steps.resolve.outputs.docs_root }}/apis-tools/typescript/api-reference/"
+
       - name: Check for changes
         id: check_changes
         working-directory: docs


### PR DESCRIPTION
## Description

The `check-format` CI gate runs prettier on all PRs, but the SDK docs sync workflows (Python, TypeScript, C#) were not formatting the generated markdown before committing. This caused the auto-generated PRs to fail the prettier check.

This PR adds `prettier --write` steps to all three SDK sync workflows so the committed files are already formatted to the repo's standard before the PR is created.

### Changes

- **`sync-python-sdk-docs.yaml`** — added Node.js 24 setup + prettier formatting on `python-sdk.md` and `python-sdk/`
- **`sync-csharp-sdk-docs.yaml`** — added Node.js 24 setup + prettier formatting on `csharp-sdk/api-reference/`
- **`sync-ts-sdk-docs.yaml`** — added prettier formatting on `typescript/api-reference/` (Node.js was already set up for the SDK build)

All three run `npm ci` in the `docs/` checkout to install prettier from the project's own dependencies, then `npx prettier --write` on the relevant paths.

## When should this change go live?

- There is **no urgency** with this change and can be released at any time.

## PR Checklist

- My changes are in `/.github/workflows/`.