### PR TITLE
docs(connectors): clarify AWS Lambda status codes

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/docs/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -37,9 +37,11 @@ To make the **AWS Lambda connector** executable, fill out the mandatory fields h
 The **AWS Lambda connector** returns the HTTP status code, executed version, and payload (the response from the function, or an error object).
 The following fields are available in the response variable:
 
-- `statusCode` - HTTP status code.
+- `statusCode` - HTTP status code returned by the AWS Lambda Invoke API. This shows whether AWS Lambda accepted and handled the invocation request. It does not indicate whether the Lambda function itself returned a successful result.
 - `executedVersion` - Executed version of the Lambda function.
-- `payload` - The response from the function, or an error object.
+- `payload` - The response returned by the Lambda function, or an error object. If your function returns its own `statusCode` in the payload, that value describes the function result and is separate from the top-level connector `statusCode`.
+
+If your Lambda function includes a `statusCode` in its response body, access it with `response.payload.statusCode` rather than `response.statusCode`.
 
 You can use an output mapping to map the response:
 

--- a/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/versioned_docs/version-8.6/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -36,9 +36,11 @@ To make the **AWS Lambda Connector** executable, fill out the mandatory fields h
 The **AWS Lambda Connector** returns the HTTP status code, executed version, and payload (the response from the function, or an error object).
 The following fields are available in the response variable:
 
-- `statusCode` - HTTP status code.
+- `statusCode` - HTTP status code returned by the AWS Lambda Invoke API. This shows whether AWS Lambda accepted and handled the invocation request. It does not indicate whether the Lambda function itself returned a successful result.
 - `executedVersion` - Executed version of the Lambda function.
-- `payload` - The response from the function, or an error object.
+- `payload` - The response returned by the Lambda function, or an error object. If your function returns its own `statusCode` in the payload, that value describes the function result and is separate from the top-level connector `statusCode`.
+
+If your Lambda function includes a `statusCode` in its response body, access it with `response.payload.statusCode` rather than `response.statusCode`.
 
 You can use an output mapping to map the response:
 

--- a/versioned_docs/version-8.7/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/versioned_docs/version-8.7/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -37,9 +37,11 @@ To make the **AWS Lambda connector** executable, fill out the mandatory fields h
 The **AWS Lambda connector** returns the HTTP status code, executed version, and payload (the response from the function, or an error object).
 The following fields are available in the response variable:
 
-- `statusCode` - HTTP status code.
+- `statusCode` - HTTP status code returned by the AWS Lambda Invoke API. This shows whether AWS Lambda accepted and handled the invocation request. It does not indicate whether the Lambda function itself returned a successful result.
 - `executedVersion` - Executed version of the Lambda function.
-- `payload` - The response from the function, or an error object.
+- `payload` - The response returned by the Lambda function, or an error object. If your function returns its own `statusCode` in the payload, that value describes the function result and is separate from the top-level connector `statusCode`.
+
+If your Lambda function includes a `statusCode` in its response body, access it with `response.payload.statusCode` rather than `response.statusCode`.
 
 You can use an output mapping to map the response:
 

--- a/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/aws-lambda.md
+++ b/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/aws-lambda.md
@@ -37,9 +37,11 @@ To make the **AWS Lambda connector** executable, fill out the mandatory fields h
 The **AWS Lambda connector** returns the HTTP status code, executed version, and payload (the response from the function, or an error object).
 The following fields are available in the response variable:
 
-- `statusCode` - HTTP status code.
+- `statusCode` - HTTP status code returned by the AWS Lambda Invoke API. This shows whether AWS Lambda accepted and handled the invocation request. It does not indicate whether the Lambda function itself returned a successful result.
 - `executedVersion` - Executed version of the Lambda function.
-- `payload` - The response from the function, or an error object.
+- `payload` - The response returned by the Lambda function, or an error object. If your function returns its own `statusCode` in the payload, that value describes the function result and is separate from the top-level connector `statusCode`.
+
+If your Lambda function includes a `statusCode` in its response body, access it with `response.payload.statusCode` rather than `response.statusCode`.
 
 You can use an output mapping to map the response:
 


### PR DESCRIPTION
Clarify that the top-level connector statusCode reflects the AWS Lambda Invoke API response, while any status code in the payload comes from the Lambda function itself.

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Improving documentation as requested in the Support ticket: https://jira.camunda.com/browse/SUPPORT-31981

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
