### PR TITLE
feat(kind): Add PG variant for secondary storage

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/kind.md
@@ -259,7 +259,7 @@ Before deploying Camunda, you need to deploy the external services it depends on
 - PostgreSQL via [CloudNativePG](https://cloudnative-pg.io/)
 - Keycloak via the [Keycloak Operator](https://www.keycloak.org/operator/installation)
 
-Run the operator deployment script, specifying the domain deployment mode and your chosen [secondary storage](#secondary-storage-options) backend:
+Run the operator deployment script, specifying the domain deployment mode:
 
 ```bash
 CAMUNDA_MODE=domain ./procedure/operators-deploy.sh
@@ -335,7 +335,7 @@ Before deploying Camunda, you need to deploy the external services it depends on
 - PostgreSQL via [CloudNativePG](https://cloudnative-pg.io/)
 - Keycloak via the [Keycloak Operator](https://www.keycloak.org/operator/installation)
 
-Run the operator deployment script, specifying the no-domain deployment mode and your chosen [secondary storage](#secondary-storage-options) backend:
+Run the operator deployment script, specifying the no-domain deployment mode:
 
 ```bash
 CAMUNDA_MODE=no-domain ./procedure/operators-deploy.sh


### PR DESCRIPTION


## Description

### Summary

  - Adds a new "Secondary storage options" section documenting the SECONDARY_STORAGE environment variable
  (elasticsearch or postgres), treating both backends as equal first-class options with no implicit default
  - Updates all deployment commands (Makefile quick setup, operator deploy, Camunda deploy) in both domain
  and no-domain modes to require SECONDARY_STORAGE
  - Adds availability annotations to component tables marking Optimize as Elasticsearch-only

###  Context

  Companion docs PR for camunda/camunda-deployment-references#2044, which adds PostgreSQL RDBMS as an
  alternative secondary storage backend for the local Kind deployment.

  Addresses camunda/team-infrastructure-experience#1019 (documentation update item 5).

  Key design decision: neither Elasticsearch nor PostgreSQL is treated as the default — both are presented
  symmetrically as explicit choices the user must make via SECONDARY_STORAGE. This aligns with the review
  feedback on the deployment references PR.
## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
