### PR TITLE
feat: removed c8run bundled ES

### DIFF
--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -33,7 +33,7 @@ Supported environment changes and breaking changes or deprecations for the Camun
 The minimum supported Elasticsearch version for the Orchestration cluster and Optimize is now 8.19 (previously 8.16+).
 
 - This aligns with the Elasticsearch 8 versions maintained by Elastic as of April 2025.
-- The default Elasticsearch version used by Camunda 8 Run, Docker Compose, and Helm templates has been updated to `8.19.9+` accordingly.
+- The default Elasticsearch version used by Docker Compose examples and Helm templates has been updated to `8.19.9+` accordingly.
 - Upgrade your Elasticsearch clusters before moving to Camunda 8.9 to avoid compatibility issues.
 - For best results, Camunda recommends upgrading to the latest supported Elasticsearch 9.2+ to take advantage of new features and improvements.
 
@@ -537,11 +537,11 @@ For more information on optimizing connector performance with virtual threads, s
 
 #### Camunda 8 Run with H2 as the default secondary data storage
 
-Camunda 8 Run now uses H2 as the default secondary data storage, instead of Elasticsearch.
+Camunda 8 Run now uses H2 as the default secondary data storage, instead of Elasticsearch. Elasticsearch is no longer bundled with Camunda 8 Run.
 
 When running with H2 (or any other RDBMS) as secondary storage, Camunda is only compatible with the V2 API. As a result, some features are not available in Operate and Tasklist. See [Migrate to the V2 Orchestration Cluster API](/apis-tools/migration-manuals/migrate-to-camunda-api.md) for more details.
 
-To continue using features exclusive to the V1 API, you must run Camunda with Elasticsearch and switch back to V1 mode.
+To continue using features exclusive to the V1 API, configure Camunda 8 Run with an external Elasticsearch instance and switch back to V1 mode.
 
 <p className="link-arrow">[Camunda 8 Run default secondary storage](/self-managed/quickstart/developer-quickstart/c8run.md#default-h2-camunda-8-run)</p>
 

--- a/docs/self-managed/quickstart/developer-quickstart/c8run-troubleshooting.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run-troubleshooting.md
@@ -9,7 +9,8 @@ Camunda 8 Run provides log files in the `c8run/logs` directory that can help dia
 
 - `c8run.log` – main log for Camunda 8 Run
 - `connectors.log` – Connectors component
-- `elasticsearch.log` – embedded Elasticsearch instance (if enabled). Camunda 8 Run bundles Elasticsearch for evaluations. If you point Camunda 8 Run to an external OpenSearch instead, the embedded instance (and this log) is not used.
+
+If you configured external Elasticsearch, inspect that deployment's logs separately.
 
 ## Startup failures
 
@@ -24,8 +25,6 @@ Camunda 8 Run provides log files in the `c8run/logs` directory that can help dia
    - `8086` – Connectors API
    - `26500` – Zeebe gRPC gateway
    - `9600` – Prometheus metrics
-   - `9200` – Elasticsearch (embedded)
-   - `9300` – Elasticsearch cluster communication
 
 2. Stop processes using these ports or change the Camunda core port:
 
@@ -118,27 +117,11 @@ Replace `21` in the examples with the version you installed (21–25), and open 
 
 ### Out of memory errors
 
-**Problem:** Camunda 8 Run becomes unresponsive, often due to Elasticsearch memory usage.
+**Problem:** Camunda 8 Run becomes unresponsive.
 
 **Solution:**
 
-1. Increase Elasticsearch heap size:
-
-   ```bash
-   # macOS/Linux
-   export ES_JAVA_OPTS="-Xms2g -Xmx2g"
-   ./start.sh
-
-   # Windows (Command Prompt)
-   set ES_JAVA_OPTS=-Xms2g -Xmx2g
-   c8run.exe start
-
-   # Windows (PowerShell)
-   $env:ES_JAVA_OPTS="-Xms2g -Xmx2g"
-   c8run.exe start
-   ```
-
-2. Increase JVM heap for Camunda:
+1. Increase JVM heap for Camunda:
 
    ```bash
    # macOS/Linux
@@ -151,7 +134,7 @@ Replace `21` in the examples with the version you installed (21–25), and open 
    $env:JAVA_OPTS="-Xmx4g"
    ```
 
-3. For resource-constrained environments, consider using H2 instead of Elasticsearch for testing.
+2. For resource-constrained environments, consider using H2 instead of Elasticsearch for testing.
 
 ### Slow performance
 
@@ -161,7 +144,7 @@ Replace `21` in the examples with the version you installed (21–25), and open 
 
 1. Ensure the system meets the minimum requirements (8 GB RAM recommended).
 2. Close unnecessary applications to free system resources.
-3. Check Elasticsearch health:
+3. If you use external Elasticsearch, check cluster health:
 
    ```bash
    curl http://localhost:9200/_cluster/health
@@ -169,57 +152,51 @@ Replace `21` in the examples with the version you installed (21–25), and open 
 
 On Windows, open this page directly: [http://localhost:9200/\_cluster/health](http://localhost:9200/_cluster/health)
 
-## Elasticsearch issues
+## External Elasticsearch issues
 
-### Elasticsearch fails to start
+### Cannot connect to Elasticsearch
 
-**Problem:** The embedded Elasticsearch instance fails to start, preventing Orchestration Cluster web applications (Operate and Tasklist) from functioning.
+**Problem:** Camunda 8 Run starts with Elasticsearch configured as secondary storage, but search-backed features do not work or startup fails.
 
 **Solution:**
 
-1. Check Elasticsearch logs in the `c8run/logs` directory.
-2. Ensure sufficient disk space is available.
-3. Verify Elasticsearch ports (9200, 9300) are not in use.
-4. If Elasticsearch continues to fail, consider using an external Elasticsearch instance:
+1. Verify the Elasticsearch cluster is reachable:
+
+   ```bash
+   curl http://localhost:9200
+   ```
+
+2. Confirm `application.yaml` points Camunda 8 Run to that cluster:
+
+   ```yaml
+   camunda:
+     data:
+       secondary-storage:
+         type: elasticsearch
+         elasticsearch:
+           url: http://localhost:9200/
+   ```
+
+3. If the cluster requires authentication or TLS, add the corresponding credentials and security settings to the same configuration block.
+4. Start Camunda 8 Run with the configuration file:
 
    ```bash
    # macOS/Linux
-   ./c8run start --disable-elasticsearch --config custom-application.yaml
+   ./c8run start --config custom-application.yaml
 
    # Windows
-   c8run.exe start --disable-elasticsearch --config custom-application.yaml
+   c8run.exe start --config custom-application.yaml
    ```
 
-### Index creation errors
+### Elasticsearch index or permission errors
 
 **Problem:** Operate or Tasklist show errors related to Elasticsearch indices.
 
 **Solution:**
 
-1. Stop Camunda:
-
-   ```bash
-   # macOS/Linux
-   ./shutdown.sh
-
-   # Windows
-   c8run.exe stop
-   ```
-
-2. Clear Elasticsearch data (warning: this deletes all data):
-
-   ```bash
-   # macOS/Linux
-   rm -rf data/elasticsearch
-
-   # Windows (Command Prompt)
-   rmdir /s /q data\elasticsearch
-
-   # Windows (PowerShell)
-   # Remove-Item -Path data\elasticsearch -Recurse -Force
-   ```
-
-3. Restart Camunda 8 Run.
+1. Ensure the Elasticsearch user has permission to create, read, and write the required Camunda indices. For restricted setups, see [Configure Elasticsearch without cluster privileges](/self-managed/concepts/databases/elasticsearch/elasticsearch-without-cluster-privileges.md).
+2. Verify the Elasticsearch cluster is healthy and has sufficient free disk space.
+3. For local development, if you need to recreate the secondary store, stop Camunda 8 Run, delete the Camunda indices from your external Elasticsearch instance using your Elasticsearch tooling, and start Camunda 8 Run again. This rebuilds the secondary store from scratch.
 
 ## Authentication and access issues
 

--- a/docs/self-managed/quickstart/developer-quickstart/c8run.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run.md
@@ -18,14 +18,13 @@ For detailed steps, see the [manual installation](../../../deployment/manual/ins
 
 Camunda 8 Run is a local distribution of Camunda 8 that bundles the Camunda 8 runtime, core services, startup scripts, and a launcher application for Windows, macOS, and Linux.
 
-Camunda 8 Run enables you to run the [Orchestration Cluster](../../../../reference/glossary#orchestration-cluster), including Zeebe, Operate, Tasklist, Identity, and Elasticsearch, with minimal configuration. It is intended for developers who want to model BPMN diagrams, deploy them, and interact with running process instances in a simple environment. This guide explains how to get started on your local or virtual machine.
+Camunda 8 Run enables you to run the [Orchestration Cluster](../../../../reference/glossary#orchestration-cluster), including Zeebe, Operate, Tasklist, and Identity, with minimal configuration. It is intended for developers who want to model BPMN diagrams, deploy them, and interact with running process instances in a simple environment. This guide explains how to get started on your local or virtual machine.
 
 Camunda 8 Run includes the following:
 
 - Orchestration Cluster
 - Connectors
 - H2 (default secondary storage for Camunda 8 Run in 8.9-alpha3)
-- Elasticsearch (bundled, optional, enable when you need full-text indexing or advanced analytics)
 
 Camunda 8 Run also supports document storage and management with [document handling](/self-managed/concepts/document-handling/overview.md).
 
@@ -247,12 +246,11 @@ For more advanced or permanent configuration, modify the default `configuration/
 | `--port <arg>`             | Sets the Camunda core port (default: `8080`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `--log-level <arg>`        | Sets the log level for the Camunda core.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `--docker`                 | Downloads and runs the Camunda Docker Compose distribution. This option provides an easy shortcut to run Camunda in Docker Compose. Most other Camunda 8 Run flags are ignored, but you can combine `--docker` with `--config` to supply an alternative RDBMS configuration (for example, PostgreSQL). For more information on running Camunda with Docker Compose see the [documentation](./docker-compose.md). See the [shutdown script](#shut-down-camunda-8-run) for information on stopping the Docker application. |
-| `--disable-elasticsearch`  | Prevents the built-in Elasticsearch from starting. Ensure another Elasticsearch instance is provided via `--config`. See the [external Elasticsearch](#start-external-elasticsearch) section for details.                                                                                                                                                                                                                                                                                                                |
 | `--startup-url`            | The URL to open after startup (e.g., `'http://localhost:8080/operate'`). By default, Operate is opened.                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### Configure or switch secondary storage (H2 or Elasticsearch)
 
-Camunda 8 Run supports multiple secondary-storage options. Starting in 8.9-alpha3, **H2 is the default secondary storage** for Camunda 8 Run lightweight setups and quickstarts and its data persists across restarts. Elasticsearch remains bundled and supported as an optional alternative that you can enable when you need full-text indexing, search, or advanced analytics.
+Camunda 8 Run supports multiple secondary-storage options. Starting in 8.9-alpha3, **H2 is the default secondary storage** for Camunda 8 Run lightweight setups and quickstarts and its data persists across restarts. If you need full-text indexing, search, or advanced analytics, use an external Elasticsearch instance.
 
 #### Default: H2 (Camunda 8 Run)
 
@@ -489,7 +487,7 @@ docker run -d --name camunda-mssql \
 
 #### Optional: Elasticsearch
 
-If you need indexing, search, or full Operate/Tasklist functionality, enable Elasticsearch. Elasticsearch is still bundled with Camunda 8 Run in 8.9 and can be managed by Camunda 8 Run or provided as an external service.
+If you need indexing, search, or full Operate/Tasklist functionality, use an external Elasticsearch instance.
 
 To use Elasticsearch:
 
@@ -498,16 +496,16 @@ data:
   secondary-storage:
     type: elasticsearch
     elasticsearch:
-      url: http://elasticsearch:9200/
+      url: http://localhost:9200/
 ```
 
-Start Camunda 8 Run without `--disable-elasticsearch` to let Camunda 8 Run manage Elasticsearch, or use `--disable-elasticsearch --config <file>` and point to an external cluster.
+Start Camunda 8 Run with `--config <file>` and point the configuration to your external cluster.
 
 ### Switching between storage types and migration notes
 
 - Switching the secondary storage type (for example, H2 ⇄ Elasticsearch) in 8.9-alpha3 does **not** preserve existing secondary-store data. The system starts with a fresh secondary store.
 - If you upgrade from alpha1/alpha2 and keep the same secondary storage backend, no migration steps are required. Only users who change the storage backend need to update configuration and accept a fresh secondary store.
-- To switch storage, update `data.secondary-storage` in `application.yaml` (or Helm `values.yaml`) and restart Camunda 8 Run. Use `--disable-elasticsearch` to prevent Camunda 8 Run from starting the embedded Elasticsearch when you want to rely on H2 or an external ES instance.
+- To switch storage, update `data.secondary-storage` in `application.yaml` (or Helm `values.yaml`) and restart Camunda 8 Run. If you want to use Elasticsearch, configure an external Elasticsearch instance in the same file.
 
 Choose **H2** for quick local development and **Elasticsearch** for production-like scenarios where advanced search/analytics are required.
 
@@ -517,7 +515,7 @@ Operate can run against the default H2 store in 8.9-alpha3, but some user-facing
 
 - Operate may not provide complete analytics, advanced search, or long-running query features when backed by H2.
 - Performance and scaling behavior when using H2 will differ from Elasticsearch in production scenarios.
-- Users who require full Operate feature parity should enable Elasticsearch (embedded or external) until full H2 parity is confirmed in a later alpha.
+- Users who require full Operate feature parity should use an external Elasticsearch instance until full H2 parity is confirmed in a later alpha.
 
 <!--- Maybe add something like "For engineering details and progress on Operate feature parity, see issue #7315 and the Operate migration tracking in the project board. If we want a precise feature list for alpha3, I can add a checklist here after stakeholder confirmation." ---!>
     authentication:
@@ -641,7 +639,7 @@ For more information, see the [metrics](/self-managed/operational-guides/monitor
 
 ### Configure or switch secondary storage (H2 or Elasticsearch)
 
-Camunda 8 Run supports multiple secondary-storage options. Starting in 8.9-alpha3, **H2 is the default secondary storage** for Camunda 8 Run lightweight setups and quickstarts. Elasticsearch remains bundled and supported as an optional alternative that you can enable when you need full-text indexing, search, or advanced analytics.
+Camunda 8 Run supports multiple secondary-storage options. Starting in 8.9-alpha3, **H2 is the default secondary storage** for Camunda 8 Run lightweight setups and quickstarts. If you need full-text indexing, search, or advanced analytics, use an external Elasticsearch instance.
 
 #### Default: H2 (Camunda 8 Run)
 
@@ -710,7 +708,7 @@ Operate v2 has limited functionality in 8.9-alpha3 when running against H2; full
 
 #### Optional: Elasticsearch
 
-If you need indexing, search, or full Operate/Tasklist functionality, enable Elasticsearch. Elasticsearch is still bundled with Camunda 8 Run in 8.9-alpha3 and can be managed by Camunda 8 Run or provided as an external service.
+If you need indexing, search, or full Operate/Tasklist functionality, use an external Elasticsearch instance.
 
 To use Elasticsearch:
 
@@ -719,16 +717,16 @@ data:
   secondary-storage:
     type: elasticsearch
     elasticsearch:
-      url: http://elasticsearch:9200/
+      url: http://localhost:9200/
 ```
 
-Start Camunda 8 Run without `--disable-elasticsearch` to let Camunda 8 Run manage Elasticsearch, or use `--disable-elasticsearch --config <file>` and point to an external cluster.
+Start Camunda 8 Run with `--config <file>` and point the configuration to your external cluster.
 
 ### Switching between storage types and migration notes
 
 - Switching the secondary storage type (for example, H2 ⇄ Elasticsearch) in 8.9-alpha3 does **not** preserve existing secondary-store data. The system starts with a fresh secondary store.
 - If you upgrade from alpha1/alpha2 and keep the same secondary storage backend, no migration steps are required. Only users who change the storage backend need to update configuration and accept a fresh secondary store.
-- To switch storage, update `data.secondary-storage` in `application.yaml` (or Helm `values.yaml`) and restart Camunda 8 Run. Use `--disable-elasticsearch` to prevent Run from starting the embedded Elasticsearch when you want to rely on H2 or an external ES instance.
+- To switch storage, update `data.secondary-storage` in `application.yaml` (or Helm `values.yaml`) and restart Camunda 8 Run. If you want to use Elasticsearch, configure an external Elasticsearch instance in the same file.
 
 Choose **H2** for quick local development and **Elasticsearch** for production-like scenarios where advanced search/analytics are required.
 
@@ -753,10 +751,9 @@ Camunda 8 Run uses v2 APIs by default, so no additional configuration is require
 
 The following advanced configuration options can be provided via environment variables:
 
-| Variable       | Description                                                                                                                                       |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ES_JAVA_OPTS` | Allows you to override Java command line parameters for Elasticsearch. This can allow you to increase memory limits. **Default:** `-Xms1g -Xmx1g` |
-| `JAVA_OPTS`    | Allows you to override Java command line parameters for Camunda.                                                                                  |
+| Variable    | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
+| `JAVA_OPTS` | Allows you to override Java command line parameters for Camunda. |
 
 ## Next steps
 


### PR DESCRIPTION
 This PR updates the C8Run docs to match the removal of bundled Elasticsearch from the distribution package.

  It removes references to bundled or embedded Elasticsearch and the `--disable-elasticsearch` flag, keeps H2 documented as the default secondary storage, and retains only the guidance needed for connecting Camunda 8 Run to an external
  Elasticsearch instance.

  Related to the C8Run packaging change for versions 8.9 and 8.10. #48957
https://github.com/camunda/camunda/issues/48957

  ## When should this change go live?

  - [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
  - [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
  - [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
  - [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
  - [ ] There is **no urgency** with this change (add `low prio` label)

  ## PR Checklist

  - [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
  - [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
  - [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
  - [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
    - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
    - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
