### PR TITLE
docs(apis): add client and API compatibility section

### DIFF
--- a/docs/apis-tools/working-with-apis-tools.md
+++ b/docs/apis-tools/working-with-apis-tools.md
@@ -54,7 +54,7 @@ In addition to the core Camunda-maintained clients, there are a number of [commu
 
 ## Client and API compatibility
 
-Camunda clients and SDKs are **forward-compatible** and **backward-compatible** with the Orchestration Cluster, meaning you can upgrade the cluster and clients independently. The Orchestration Cluster REST API is backward-compatible, ensuring no breaking changes to existing endpoints across versions.
+Camunda clients and SDKs are **forward-compatible** with the Orchestration Cluster, meaning you can upgrade the cluster first and clients after. The Orchestration Cluster REST API is backward-compatible, ensuring no breaking changes to existing endpoints across versions.
 
 <p class="link-arrow">[Client and API compatibility guarantees](/reference/public-api.md#client-and-api-compatibility)</p>
 

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -150,7 +150,7 @@ Migrate your API integrations, SDKs, and generated clients to Camunda 8.9 using 
 :::
 
 :::tip Client and API compatibility
-Camunda clients (Java client, Spring SDK, Node.js SDK) and Camunda Process Test are **forward-compatible** and **backward-compatible** with the Orchestration Cluster, meaning you can upgrade the cluster and clients independently. For example, you can run a client on 8.8 against a cluster on 8.9, or upgrade the client to 8.9 without code changes. See [Client and API compatibility](/reference/public-api.md#client-and-api-compatibility).
+Camunda clients (Java client, Spring SDK, Node.js SDK) and Camunda Process Test are **forward-compatible** with the Orchestration Cluster, meaning you can upgrade the cluster and clients independently. For example, you can run a client on 8.8 against a cluster on 8.9, see [Client and API compatibility](/reference/public-api.md#client-and-api-compatibility).
 :::
 <br/>
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -87,7 +87,7 @@ Public API components follow strict compatibility guarantees so you can upgrade 
 
 ### Clients and SDKs
 
-The Camunda Java client, Spring SDK, Node.js SDK, and Camunda Process Test (CPT) are both **forward-compatible** and **backward-compatible** with the Orchestration Cluster.
+The Camunda Java client, Spring SDK, Node.js SDK, and Camunda Process Test (CPT) are both **forward-compatible** with new releases of the Orchestration Cluster while being **backward-compatible** regarding application integration.
 
 - **Forward compatibility**: Your application can use an older client version and still work correctly against a newer cluster. For example, an application using Camunda Java client **8.8.3** works against an Orchestration Cluster running **8.9.1**. This allows you to upgrade the Orchestration Cluster first without immediately updating your client libraries.
 
@@ -95,7 +95,7 @@ The Camunda Java client, Spring SDK, Node.js SDK, and Camunda Process Test (CPT)
 
 ### Camunda Process Test (CPT)
 
-CPT is both forward-compatible and backward-compatible with the Orchestration Cluster and Connectors runtime:
+CPT is both forward-compatible with the Orchestration Cluster and Connectors runtime and backward-compatible regarding application integration:
 
 - **Forward-compatible**: You can change the version of the Orchestration Cluster/Connectors bundle in your tests to a newer version without any changes.
 - **Backward-compatible**: Upgrading the CPT dependency version does not require changes to your existing tests.


### PR DESCRIPTION
## Description

Adds documentation explaining the forward and backward compatibility guarantees between Camunda clients/SDKs and the Orchestration Cluster. Based on review feedback, the compatibility descriptions have been refined to clarify that clients/SDKs are **forward-compatible** with the Orchestration Cluster (upgrade cluster first, then clients), while the Orchestration Cluster REST API is **backward-compatible**. Client backward-compatibility refers specifically to application integration (no code changes required when upgrading client versions).

## When should this change go live?



- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.