### PR TITLE
docs: document new variable skipping config and limitations

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -34,7 +34,7 @@ For example, set history rollover using:
 ### Options
 
 <Tabs groupId="configuration" defaultValue="index" queryString
-values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Other', value: 'other' }]} >
+values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Tasklist', value: 'tasklist' },{label: 'Other', value: 'other' }]} >
 
 <TabItem value="connect">
 
@@ -147,6 +147,23 @@ indices. The history can be configured as follows:
 
 </TabItem>
 
+<TabItem value="tasklist">
+
+Helm property path prefix for this option:
+`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
+
+Tasklist-specific export options:
+
+| Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| skipVariableWriteWithoutUserTasks | If `true`, the exporter skips writing task variable data to the `tasklist-task` index for process definitions that do not contain any user task flow node instances. This reduces index size and improves write and read performance by avoiding the persistence of task data that is never queried through Tasklist. The exporter uses the process cache to determine whether a deployed process definition contains at least one user task. | `false` |
+
+:::warning Process instance migration limitation
+When `skipVariableWriteWithoutUserTasks` is enabled, task variable data is not exported for process definitions without user tasks. If a process instance is later [migrated](/components/concepts/process-instance-migration.md) to a process definition version that **does** contain user tasks, variable data that was previously skipped will **not** be retroactively available for task-based variable search in Tasklist. Only variables exported **after** the migration (from new variable update events) will appear in task search results.
+:::
+
+</TabItem>
+
 <TabItem value="other">
 
 Helm property path prefix for these options:
@@ -208,6 +225,8 @@ exporters:
 
         batchOperation:
           exportItemsOnCreation: true
+
+      skipVariableWriteWithoutUserTasks: false
 
       createSchema: true
 ```


### PR DESCRIPTION
## Description

Added configuration (disabled by default), that will skip exporting of variables for process definitions without a user task (as they are not needed), this should lower load on ES and increase performance.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [] My changes are for an **already released minor** and are in a `/versioned_docs` directory.


- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.