### PR TITLE
docs: announce removal of Web Modeler API milestone endpoints

### DIFF
--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -444,6 +444,22 @@ Camunda 8.9 introduces a new built-in Identity role, `task-worker`. Use this rol
 </div>
 </div>
 
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Removed</span>
+</div>
+<div className="release-announcement-content">
+
+#### Removed: Web Modeler API milestone endpoints
+
+The Web Modeler API endpoints under `/api/v1/milestones` that were deprecated in Camunda 8.8 are now removed in 8.9.
+You can use the corresponding endpoints under `/api/v1/versions` instead.
+
+<p className="link-arrow">[Web Modeler API](/apis-tools/web-modeler-api/index.md)</p>
+
+</div>
+</div>
+
 ## Connectors
 
 <div className="release-announcement-row">


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

Add a note on the removal of the Web Modeler API milestone endpoints (which were deprecated with 8.8) to the release announcements page for 8.9.

Relates to https://github.com/camunda/camunda-hub/issues/18945.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.