### PR TITLE
ci: automerge minor and patch updates of Maven/Java dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,5 +60,11 @@
       groupName: "node",
       automerge: true,
     },
+    {
+      // Automerge minor and patch updates of Maven/Java dependencies
+      matchManagers: ["maven"],
+      matchUpdateTypes: ["patch", "minor"],
+      automerge: true,
+    },
   ],
 }


### PR DESCRIPTION
Enable Renovate automerge for minor and patch updates of Maven/Java dependencies (e.g. `io.camunda:camunda-spring-boot-starter`).