### PR TITLE
fix: helm template command in gateway-api v8.6-8.8 doesnt work

### DIFF
--- a/versioned_docs/version-8.6/self-managed/setup/guides/gateway-api-setup.md
+++ b/versioned_docs/version-8.6/self-managed/setup/guides/gateway-api-setup.md
@@ -35,15 +35,17 @@ In testing, Camunda uses the [NGINX Gateway Fabric](https://github.com/nginx/ngi
 
 ## Implement
 
-Get started by running the `helm template` command against version 8.6 or later of the Helm chart to generate the resources, then modify them as needed. See the following command example:
+Get started by running the `helm template` command against version 8.9 or later of the Helm chart to generate the resources, then modify them as needed. See the following command example:
 
 ```bash
 helm template camunda camunda/camunda-platform \
-  --version $HELM_CHART_VERSION \
+  --devel \
+  --version 14.0.0-alpha5 \
   --set global.host=example.com \
   --set global.gateway.enabled=true \
   --set global.gateway.createGatewayResource=true \
   --set orchestration.data.secondaryStorage.type=elasticsearch \
+  --set orchestration.gateway.grpc.enabled=true \
   --show-only templates/orchestration/httproute.yaml \
   --show-only templates/orchestration/grpcroute.yaml \
   --show-only templates/common/referencegrant.yaml \

--- a/versioned_docs/version-8.7/self-managed/setup/guides/gateway-api-setup.md
+++ b/versioned_docs/version-8.7/self-managed/setup/guides/gateway-api-setup.md
@@ -39,11 +39,13 @@ Get started by running the `helm template` command against version 8.9 or later 
 
 ```bash
 helm template camunda camunda/camunda-platform \
-  --version 14.0.0 \
+  --devel \
+  --version 14.0.0-alpha5 \
   --set global.host=example.com \
   --set global.gateway.enabled=true \
   --set global.gateway.createGatewayResource=true \
   --set orchestration.data.secondaryStorage.type=elasticsearch \
+  --set orchestration.gateway.grpc.enabled=true \
   --show-only templates/orchestration/httproute.yaml \
   --show-only templates/orchestration/grpcroute.yaml \
   --show-only templates/common/referencegrant.yaml \

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
@@ -39,11 +39,13 @@ Get started by running the `helm template` command against version 8.9 or later 
 
 ```bash
 helm template camunda camunda/camunda-platform \
-  --version 14.0.0 \
+  --devel \
+  --version 14.0.0-alpha5 \
   --set global.host=example.com \
   --set global.gateway.enabled=true \
   --set global.gateway.createGatewayResource=true \
   --set orchestration.data.secondaryStorage.type=elasticsearch \
+  --set orchestration.gateway.grpc.enabled=true \
   --show-only templates/orchestration/httproute.yaml \
   --show-only templates/orchestration/grpcroute.yaml \
   --show-only templates/common/referencegrant.yaml \


### PR DESCRIPTION


## Description

closes #8428

@PetruGu  caught and fixed the following issue in the 8.6 to 8.8 docs. We wrongfully suggest people use the following helm template command to see what the 8.9 Gateway API resources would be rendered:

helm template camunda camunda/camunda-platform \
  --version 14.0.0 \
  --set global.host=example.com \
  --set global.gateway.enabled=true \
  --set global.gateway.createGatewayResource=true \
  --set orchestration.data.secondaryStorage.type=elasticsearch \
  --show-only templates/orchestration/httproute.yaml \
  --show-only templates/orchestration/grpcroute.yaml \
  --show-only templates/common/referencegrant.yaml \
  --show-only templates/common/gateway.yaml

  But this template has 2 errors:

  1. The version 14.0.0 has not yet been released
  2. The GRPC route is not rendered as orchestration.gateway.grpc.enabled is false by default.


<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
