### PR TITLE
fix: avoid ARG_MAX overflow in check-versions workflow

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -15,13 +15,13 @@ jobs:
       - name: Capture version configuration as environment variable
         run: echo "VERSION_CONFIG=$(jq -c . < .github/workflows/check-versions/version-config.json)" >> $GITHUB_ENV
 
-      - name: Capture changed files as environment variable
-        run: echo "CHANGED_FILES=$(git diff --name-only HEAD^ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
+      - name: Capture changed files to temp file
+        run: git diff --name-only HEAD^ | jq -R -s -c 'split("\n")[:-1]' > "$RUNNER_TEMP/changed-files.json"
 
       - name: Identify missing changes
         id: identify-missing-changes
         run: |
-          OUTPUT=$(node .github/workflows/check-versions/identify-missing-changes.action.js)
+          OUTPUT=$(node .github/workflows/check-versions/identify-missing-changes.action.js "$RUNNER_TEMP/changed-files.json")
           echo "MISSING_CHANGES=$OUTPUT" >> $GITHUB_ENV
 
       - name: Build messages

--- a/.github/workflows/check-versions/identify-missing-changes.action.js
+++ b/.github/workflows/check-versions/identify-missing-changes.action.js
@@ -1,7 +1,14 @@
+const fs = require("fs");
 const { identifyMissingChanges } = require("./identify-missing-changes");
 
 const versionConfigRaw = process.env.VERSION_CONFIG || "";
-const changedFilesRaw = process.env.CHANGED_FILES || "";
+
+// Read changed files from a file path (passed as CLI arg) to avoid
+// exceeding ARG_MAX when the PR touches many files.
+const changedFilesPath = process.argv[2];
+const changedFilesRaw = changedFilesPath
+  ? fs.readFileSync(changedFilesPath, "utf8")
+  : process.env.CHANGED_FILES || "[]";
 
 const versionConfig = JSON.parse(versionConfigRaw.trim());
 const changedFiles = JSON.parse(changedFilesRaw.trim());


### PR DESCRIPTION
## Problem

The `list-pr-changes` job in the `check-versions` workflow fails with:

```
An error occurred trying to start process '/usr/bin/bash' with working directory '...'. Argument list too long
```

This happens when a PR touches hundreds of files (e.g. generated TypeScript SDK API reference docs). The workflow stores the entire changed file list as a `GITHUB_ENV` variable (`CHANGED_FILES`), which inflates the process environment beyond the OS `ARG_MAX` limit, preventing subsequent steps from launching.

Example failure: https://github.com/camunda/camunda-docs/actions/runs/23882354142/job/69638029725

Closes #8459

## Fix

- Write the changed file list to `$RUNNER_TEMP/changed-files.json` (a temp file) instead of a `GITHUB_ENV` variable
- Pass the file path as a CLI argument to `identify-missing-changes.action.js`
- The JS script reads from the file, falling back to the env var for backwards compatibility