### PR TITLE
fix: write MISSING_CHANGES to temp file to avoid ARG_MAX overflow

### DIFF
--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           OUTPUT=$(node .github/workflows/check-versions/build-messages.js "$RUNNER_TEMP/missing-changes.json")
           echo "MESSAGES<<EOF" >> $GITHUB_ENV
-          echo $OUTPUT >> $GITHUB_ENV
+          printf '%s\n' "$OUTPUT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Comment on PR if version updates are potentially missing

--- a/.github/workflows/check-versions/build-messages.js
+++ b/.github/workflows/check-versions/build-messages.js
@@ -9,8 +9,12 @@ const missingChangesRaw = missingChangesPath
   ? fs.readFileSync(missingChangesPath, "utf8")
   : process.env.MISSING_CHANGES || "";
 
+const missingChangesJson = missingChangesRaw.trim();
+
 /** @type {Array<import("./identify-missing-changes").SuggestedChanges>} */
-const missingChanges = JSON.parse(missingChangesRaw.trim());
+const missingChanges = JSON.parse(
+  missingChangesJson === "" ? "[]" : missingChangesJson
+);
 
 missingChanges.forEach((missingChange) => {
   console.log(`These files were changed only in *${

--- a/.github/workflows/check-versions/data-flow.spec.js
+++ b/.github/workflows/check-versions/data-flow.spec.js
@@ -189,8 +189,8 @@ describe("check-versions data flow (file-based)", () => {
       expect(messages).toContain("docs/");
       expect(messages).toContain("versioned_docs/version-8.8/");
 
-      // Verify the output JSON is large enough that it would have
-      // overflowed ARG_MAX (~2MB limit) if passed via env var.
+      // Verify the output JSON is large enough to exercise a realistic
+      // large-payload scenario if it were passed via an environment variable.
       const outputSize = Buffer.byteLength(identifyOutput, "utf8");
       expect(outputSize).toBeGreaterThan(100_000); // >100KB
     });


### PR DESCRIPTION
## Problem

PR #8458 fixed the input side (`CHANGED_FILES` → temp file), but the **output** side still overflows:

```yaml
echo "MISSING_CHANGES=$OUTPUT" >> $GITHUB_ENV
```

When a PR touches 1900+ files (e.g. [#8472](https://github.com/camunda/camunda-docs/pull/8472) — TypeScript SDK API reference), the `MISSING_CHANGES` JSON is also enormous. It inflates the process environment for subsequent steps, causing the same `Argument list too long` crash on the `build-messages` step.

Failing run: https://github.com/camunda/camunda-docs/actions/runs/23931927953/job/69800538807

## Fix

- Write `identify-missing-changes` output directly to `$RUNNER_TEMP/missing-changes.json` (no env var)
- Pass the file path as a CLI argument to `build-messages.js`
- `build-messages.js` reads from the file, falling back to `MISSING_CHANGES` env var for backwards compatibility

The final `MESSAGES` env var is a short human-readable HTML summary (not the raw file list), so it remains safe in `GITHUB_ENV`.