### PR TITLE
feat: enable autoImports for SDK code examples

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,6 +177,7 @@ module.exports = {
                 highlight: "typescript",
                 operationMapPath:
                   ".sdk-repos/orchestration-cluster-api-js/examples/operation-map.json",
+                autoImports: true,
                 defaultImports:
                   "import { createCamundaClient } from '@camunda8/orchestration-cluster-api';",
               },
@@ -185,6 +186,7 @@ module.exports = {
                 highlight: "python",
                 operationMapPath:
                   ".sdk-repos/orchestration-cluster-api-python/examples/operation-map.json",
+                autoImports: true,
                 defaultImports:
                   "from camunda_orchestration_sdk import CamundaClient",
               },
@@ -193,6 +195,7 @@ module.exports = {
                 highlight: "csharp",
                 operationMapPath:
                   ".sdk-repos/orchestration-cluster-api-csharp/examples/operation-map.json",
+                autoImports: true,
                 defaultImports: "using Camunda.Orchestration.Sdk;",
               },
             ],


### PR DESCRIPTION
## Summary

Enable `autoImports: true` for all three SDK code examples in the API reference pages.

### What this does

When `autoImports` is enabled, the plugin automatically detects the necessary import statements from each example file's header and prepends them to the displayed code snippet. This means each API operation's code sample shows only the imports it actually needs, rather than a single generic `defaultImports` line.

The `defaultImports` are kept as a fallback for any example file that doesn't have detectable imports at the top.

### Languages enabled

- TypeScript (`@camunda8/orchestration-cluster-api`)
- Python (`camunda_orchestration_sdk`)
- C# (`Camunda.Orchestration.Sdk`)