### PR TITLE
docs: bring your own groups (OIDC)

### DIFF
--- a/docs/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/docs/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -327,7 +327,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
-- For OIDC-based Self-Managed deployments, you can reuse groups from your Identity Provider for authorization, role, and tenant assignment. See [Bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
+- For OIDC-based Self-Managed deployments, you can reuse groups from your identity provider for authorization, role, and tenant assignment. See [bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/docs/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/docs/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -327,6 +327,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
+- For OIDC-based Self-Managed deployments, you can reuse groups from your Identity Provider for authorization, role, and tenant assignment. See [Bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/docs/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
+++ b/docs/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your identity provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
 
-:::note 
+:::note
 This feature is Self-Managed only. Bring your own groups (external IdP groups) is not available in Camunda 8 SaaS.
 :::
 

--- a/docs/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
+++ b/docs/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
@@ -7,21 +7,21 @@ description: Use groups from your external OIDC Identity Provider for authorizat
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your Identity Provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
+When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your identity provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
 
-:::note This feature is Self-Managed only.
-Bring your own groups is not available in Camunda 8 SaaS.
+:::note 
+This feature is Self-Managed only. Bring your own groups (external IdP groups) is not available in Camunda 8 SaaS.
 :::
 
-## When to use this
+## When to use external IdP groups
 
-Use bring your own groups when:
+Use external IdP groups if:
 
 - Your IdP is already the source of truth for user-to-group membership.
 - You want a single place to manage group membership for both sign-in and Camunda authorization.
 - You need group-based authorization in Camunda but do not want to duplicate group data between your IdP and Camunda.
 
-Do not use it when:
+Do not use external IdP groups if:
 
 - You need to manage groups through the Orchestration Cluster REST API or Identity UI.
 - You need Camunda to list or browse IdP-managed groups.
@@ -30,7 +30,7 @@ Do not use it when:
 ## Prerequisites
 
 - A Self-Managed Camunda 8 deployment running 8.8 or later.
-- OIDC authentication configured for the Orchestration Cluster. See [Connect to an external Identity Provider](./connect-external-identity-provider.md).
+- OIDC authentication configured for the Orchestration Cluster. See [connect to an external identity provider](./connect-external-identity-provider.md).
 - An IdP that can include a groups claim in the issued ID or access token. The claim value must be a JSON array of strings, where each string is a group ID.
 
 ## Configure the groups claim
@@ -39,7 +39,7 @@ Set `camunda.security.authentication.oidc.groups-claim` to the name of the claim
 
 For nested claims, use a [JSONPath expression](https://www.rfc-editor.org/rfc/rfc9535.html) — the same mechanism used by `username-claim`. For example, `$['camundaorg']['groups']` resolves to the `groups` array inside a nested `camundaorg` object.
 
-<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
 <TabItem value="yaml">
 
 ```yaml
@@ -56,7 +56,7 @@ CAMUNDA_SECURITY_AUTHENTICATION_OIDC_GROUPSCLAIM=<YOUR_GROUPS_CLAIM>
 </TabItem>
 </Tabs>
 
-See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [Connect multiple Identity Providers](./connect-multiple-identity-providers.md).
+See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [connect multiple identity providers](./connect-multiple-identity-providers.md).
 
 ## Use IdP groups in Camunda
 
@@ -64,31 +64,31 @@ Once `groups-claim` is set, the group IDs extracted from each token can be used 
 
 ### Role assignment
 
-Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [Assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
+Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
 
 ### Authorizations
 
-Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [Authorizations](../../../../components/concepts/access-control/authorizations.md).
+Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [authorizations](../../../../components/concepts/access-control/authorizations.md).
 
 ### Tenant assignment
 
-Add IdP groups to tenants so that every member of that group gains access to the tenant. See [Tenants](../../../../components/admin/tenant.md).
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [tenants](../../../../components/admin/tenant.md).
 
 ## Limitations and behavior
 
-- **Self-Managed only.** The feature is not available in Camunda 8 SaaS.
-- **No group sync or listing.** Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
-- **REST group management is disabled while the claim is set.** When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
-- **Per-token evaluation.** Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
-- **Array shape required.** The claim value must always be a JSON array, even for users who belong to a single group.
-- **Clients use the same claim.** Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
+- Self-Managed only. The feature is not available in Camunda 8 SaaS.
+- No group sync or listing. Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
+- REST group management is disabled while the claim is set. When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
+- Per-token evaluation. Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
+- Array shape required. The claim value must always be a JSON array, even for users who belong to a single group.
+- Clients use the same claim. Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
 
 ## Troubleshooting
 
 If groups from your IdP are not being applied in Camunda, check the following:
 
-- **The claim is present in the issued token.** Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
-- **JSONPath matches the actual structure.** If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
-- **Group IDs match exactly.** Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
+- The claim is present in the issued token. Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
+- JSONPath matches the actual structure. If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
+- Group IDs match exactly. Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
 
-For deeper investigation, see [Debugging authentication](./debugging-authentication.md).
+For deeper investigation, see [debugging authentication](./debugging-authentication.md).

--- a/docs/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
+++ b/docs/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
@@ -1,8 +1,94 @@
 ---
 id: bring-your-groups
 title: Bring your own groups
-description: TBD
-unlisted: true
+description: Use groups from your external OIDC Identity Provider for authorization, role, and tenant assignment in Camunda 8 Self-Managed.
 ---
 
-TODO: Bring groups from your external Identity Provider.
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your Identity Provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
+
+:::note This feature is Self-Managed only.
+Bring your own groups is not available in Camunda 8 SaaS.
+:::
+
+## When to use this
+
+Use bring your own groups when:
+
+- Your IdP is already the source of truth for user-to-group membership.
+- You want a single place to manage group membership for both sign-in and Camunda authorization.
+- You need group-based authorization in Camunda but do not want to duplicate group data between your IdP and Camunda.
+
+Do not use it when:
+
+- You need to manage groups through the Orchestration Cluster REST API or Identity UI.
+- You need Camunda to list or browse IdP-managed groups.
+- You are running Camunda 8 SaaS.
+
+## Prerequisites
+
+- A Self-Managed Camunda 8 deployment running 8.8 or later.
+- OIDC authentication configured for the Orchestration Cluster. See [Connect to an external Identity Provider](./connect-external-identity-provider.md).
+- An IdP that can include a groups claim in the issued ID or access token. The claim value must be a JSON array of strings, where each string is a group ID.
+
+## Configure the groups claim
+
+Set `camunda.security.authentication.oidc.groups-claim` to the name of the claim that contains the user's groups. The claim value must be a JSON array of strings, where each entry is a group ID.
+
+For nested claims, use a [JSONPath expression](https://www.rfc-editor.org/rfc/rfc9535.html) — the same mechanism used by `username-claim`. For example, `$['camundaorg']['groups']` resolves to the `groups` array inside a nested `camundaorg` object.
+
+<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<TabItem value="yaml">
+
+```yaml
+camunda.security.authentication.oidc.groups-claim: <YOUR_GROUPS_CLAIM>
+```
+
+</TabItem>
+<TabItem value="env">
+
+```
+CAMUNDA_SECURITY_AUTHENTICATION_OIDC_GROUPSCLAIM=<YOUR_GROUPS_CLAIM>
+```
+
+</TabItem>
+</Tabs>
+
+See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [Connect multiple Identity Providers](./connect-multiple-identity-providers.md).
+
+## Use IdP groups in Camunda
+
+Once `groups-claim` is set, the group IDs extracted from each token can be used anywhere a Camunda group ID can be used. The group ID in the token and the Camunda-side group ID must match **exactly**: comparisons are case-sensitive and treat group IDs as opaque strings.
+
+### Role assignment
+
+Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [Assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
+
+### Authorizations
+
+Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [Authorizations](../../../../components/concepts/access-control/authorizations.md).
+
+### Tenant assignment
+
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [Tenants](../../../../components/admin/tenant.md).
+
+## Limitations and behavior
+
+- **Self-Managed only.** The feature is not available in Camunda 8 SaaS.
+- **No group sync or listing.** Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
+- **REST group management is disabled while the claim is set.** When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
+- **Per-token evaluation.** Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
+- **Array shape required.** The claim value must always be a JSON array, even for users who belong to a single group.
+- **Clients use the same claim.** Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
+
+## Troubleshooting
+
+If groups from your IdP are not being applied in Camunda, check the following:
+
+- **The claim is present in the issued token.** Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
+- **JSONPath matches the actual structure.** If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
+- **Group IDs match exactly.** Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
+
+For deeper investigation, see [Debugging authentication](./debugging-authentication.md).

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -329,7 +329,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
-- For OIDC-based Self-Managed deployments, you can reuse groups from your identity provider for authorization, role, and tenant assignment. See [bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
+- For OIDC-based Self-Managed deployments, you can reuse groups from your identity provider for authorization, role, and tenant assignment. See [bring your own groups](../../../self-managed/components/orchestration-cluster/identity/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -329,7 +329,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
-- For OIDC-based Self-Managed deployments, you can reuse groups from your Identity Provider for authorization, role, and tenant assignment. See [Bring your own groups](../../../self-managed/components/orchestration-cluster/identity/bring-your-groups.md).
+- For OIDC-based Self-Managed deployments, you can reuse groups from your identity provider for authorization, role, and tenant assignment. See [bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -329,6 +329,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
+- For OIDC-based Self-Managed deployments, you can reuse groups from your Identity Provider for authorization, role, and tenant assignment. See [Bring your own groups](../../../self-managed/components/orchestration-cluster/identity/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/identity/bring-your-groups.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/identity/bring-your-groups.md
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your identity provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
 
-:::note 
+:::note
 This feature is Self-Managed only. Bring your own groups (external IdP groups) is not available in Camunda 8 SaaS.
 :::
 
@@ -72,7 +72,7 @@ Grant authorizations directly to IdP groups to control access to Camunda resourc
 
 ### Tenant assignment
 
-Add IdP groups to tenants so that every member of that group gains access to the tenant. See [tenants](../../../../components/admin/tenant.md).
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [tenants](../../../../components/identity/tenant.md).
 
 ## Limitations and behavior
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/identity/bring-your-groups.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/identity/bring-your-groups.md
@@ -1,8 +1,94 @@
 ---
 id: bring-your-groups
 title: Bring your own groups
-description: TBD
-unlisted: true
+description: Use groups from your external OIDC Identity Provider for authorization, role, and tenant assignment in Camunda 8 Self-Managed.
 ---
 
-TODO: Bring groups from your external Identity Provider.
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your Identity Provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
+
+:::note This feature is Self-Managed only.
+Bring your own groups is not available in Camunda 8 SaaS.
+:::
+
+## When to use this
+
+Use bring your own groups when:
+
+- Your IdP is already the source of truth for user-to-group membership.
+- You want a single place to manage group membership for both sign-in and Camunda authorization.
+- You need group-based authorization in Camunda but do not want to duplicate group data between your IdP and Camunda.
+
+Do not use it when:
+
+- You need to manage groups through the Orchestration Cluster REST API or Identity UI.
+- You need Camunda to list or browse IdP-managed groups.
+- You are running Camunda 8 SaaS.
+
+## Prerequisites
+
+- A Self-Managed Camunda 8 deployment running 8.8 or later.
+- OIDC authentication configured for the Orchestration Cluster. See [Connect to an external Identity Provider](./connect-external-identity-provider.md).
+- An IdP that can include a groups claim in the issued ID or access token. The claim value must be a JSON array of strings, where each string is a group ID.
+
+## Configure the groups claim
+
+Set `camunda.security.authentication.oidc.groups-claim` to the name of the claim that contains the user's groups. The claim value must be a JSON array of strings, where each entry is a group ID.
+
+For nested claims, use a [JSONPath expression](https://www.rfc-editor.org/rfc/rfc9535.html) — the same mechanism used by `username-claim`. For example, `$['camundaorg']['groups']` resolves to the `groups` array inside a nested `camundaorg` object.
+
+<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<TabItem value="yaml">
+
+```yaml
+camunda.security.authentication.oidc.groups-claim: <YOUR_GROUPS_CLAIM>
+```
+
+</TabItem>
+<TabItem value="env">
+
+```
+CAMUNDA_SECURITY_AUTHENTICATION_OIDC_GROUPSCLAIM=<YOUR_GROUPS_CLAIM>
+```
+
+</TabItem>
+</Tabs>
+
+See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [Connect multiple Identity Providers](./connect-multiple-identity-providers.md).
+
+## Use IdP groups in Camunda
+
+Once `groups-claim` is set, the group IDs extracted from each token can be used anywhere a Camunda group ID can be used. The group ID in the token and the Camunda-side group ID must match **exactly**: comparisons are case-sensitive and treat group IDs as opaque strings.
+
+### Role assignment
+
+Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [Assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
+
+### Authorizations
+
+Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [Authorizations](../../../../components/concepts/access-control/authorizations.md).
+
+### Tenant assignment
+
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [Tenants](../../../../components/identity/tenant.md).
+
+## Limitations and behavior
+
+- **Self-Managed only.** The feature is not available in Camunda 8 SaaS.
+- **No group sync or listing.** Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
+- **REST group management is disabled while the claim is set.** When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
+- **Per-token evaluation.** Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
+- **Array shape required.** The claim value must always be a JSON array, even for users who belong to a single group.
+- **Clients use the same claim.** Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
+
+## Troubleshooting
+
+If groups from your IdP are not being applied in Camunda, check the following:
+
+- **The claim is present in the issued token.** Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
+- **JSONPath matches the actual structure.** If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
+- **Group IDs match exactly.** Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
+
+For deeper investigation, see [Debugging authentication](./debugging-authentication.md).

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/identity/bring-your-groups.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/identity/bring-your-groups.md
@@ -7,21 +7,21 @@ description: Use groups from your external OIDC Identity Provider for authorizat
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your Identity Provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
+When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your identity provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
 
-:::note This feature is Self-Managed only.
-Bring your own groups is not available in Camunda 8 SaaS.
+:::note 
+This feature is Self-Managed only. Bring your own groups (external IdP groups) is not available in Camunda 8 SaaS.
 :::
 
-## When to use this
+## When to use external IdP groups
 
-Use bring your own groups when:
+Use external IdP groups if:
 
 - Your IdP is already the source of truth for user-to-group membership.
 - You want a single place to manage group membership for both sign-in and Camunda authorization.
 - You need group-based authorization in Camunda but do not want to duplicate group data between your IdP and Camunda.
 
-Do not use it when:
+Do not use external IdP groups if:
 
 - You need to manage groups through the Orchestration Cluster REST API or Identity UI.
 - You need Camunda to list or browse IdP-managed groups.
@@ -30,7 +30,7 @@ Do not use it when:
 ## Prerequisites
 
 - A Self-Managed Camunda 8 deployment running 8.8 or later.
-- OIDC authentication configured for the Orchestration Cluster. See [Connect to an external Identity Provider](./connect-external-identity-provider.md).
+- OIDC authentication configured for the Orchestration Cluster. See [connect to an external identity provider](./connect-external-identity-provider.md).
 - An IdP that can include a groups claim in the issued ID or access token. The claim value must be a JSON array of strings, where each string is a group ID.
 
 ## Configure the groups claim
@@ -39,7 +39,7 @@ Set `camunda.security.authentication.oidc.groups-claim` to the name of the claim
 
 For nested claims, use a [JSONPath expression](https://www.rfc-editor.org/rfc/rfc9535.html) — the same mechanism used by `username-claim`. For example, `$['camundaorg']['groups']` resolves to the `groups` array inside a nested `camundaorg` object.
 
-<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
 <TabItem value="yaml">
 
 ```yaml
@@ -56,7 +56,7 @@ CAMUNDA_SECURITY_AUTHENTICATION_OIDC_GROUPSCLAIM=<YOUR_GROUPS_CLAIM>
 </TabItem>
 </Tabs>
 
-See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [Connect multiple Identity Providers](./connect-multiple-identity-providers.md).
+See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [connect multiple identity providers](./connect-multiple-identity-providers.md).
 
 ## Use IdP groups in Camunda
 
@@ -64,31 +64,31 @@ Once `groups-claim` is set, the group IDs extracted from each token can be used 
 
 ### Role assignment
 
-Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [Assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
+Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
 
 ### Authorizations
 
-Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [Authorizations](../../../../components/concepts/access-control/authorizations.md).
+Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [authorizations](../../../../components/concepts/access-control/authorizations.md).
 
 ### Tenant assignment
 
-Add IdP groups to tenants so that every member of that group gains access to the tenant. See [Tenants](../../../../components/identity/tenant.md).
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [tenants](../../../../components/admin/tenant.md).
 
 ## Limitations and behavior
 
-- **Self-Managed only.** The feature is not available in Camunda 8 SaaS.
-- **No group sync or listing.** Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
-- **REST group management is disabled while the claim is set.** When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
-- **Per-token evaluation.** Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
-- **Array shape required.** The claim value must always be a JSON array, even for users who belong to a single group.
-- **Clients use the same claim.** Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
+- Self-Managed only. The feature is not available in Camunda 8 SaaS.
+- No group sync or listing. Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
+- REST group management is disabled while the claim is set. When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
+- Per-token evaluation. Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
+- Array shape required. The claim value must always be a JSON array, even for users who belong to a single group.
+- Clients use the same claim. Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
 
 ## Troubleshooting
 
 If groups from your IdP are not being applied in Camunda, check the following:
 
-- **The claim is present in the issued token.** Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
-- **JSONPath matches the actual structure.** If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
-- **Group IDs match exactly.** Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
+- The claim is present in the issued token. Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
+- JSONPath matches the actual structure. If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
+- Group IDs match exactly. Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
 
-For deeper investigation, see [Debugging authentication](./debugging-authentication.md).
+For deeper investigation, see [debugging authentication](./debugging-authentication.md).

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -327,7 +327,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
-- For OIDC-based Self-Managed deployments, you can reuse groups from your Identity Provider for authorization, role, and tenant assignment. See [Bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
+- For OIDC-based Self-Managed deployments, you can reuse groups from your identity provider for authorization, role, and tenant assignment. See [bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/whats-new-in-88.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/whats-new-in-88.md
@@ -327,6 +327,7 @@ After you deploy all Camunda 8 components in a Self-Managed environment, you wil
 - Management Identity, Keycloak and Postgres are no longer needed for an Orchestration Cluster. They are only needed when using Web Modeler, Console or Optimize.
   - For the Orchestration Cluster, you can bring your own Identity Provider (for example, Keycloak, Microsoft EntraID, Okta) or use the built-in Basic authentication method.
   - A special setup is no longer required for Keycloak as it is now integrated like any other Identity Provider via OpenID Connect (OIDC). Management Identity relies by default on Keycloak, but you can also configure it to use any OIDC-compatible Identity Provider.
+- For OIDC-based Self-Managed deployments, you can reuse groups from your Identity Provider for authorization, role, and tenant assignment. See [Bring your own groups](../../../self-managed/components/orchestration-cluster/admin/bring-your-groups.md).
 
 The following table summarizes where Orchestration Cluster Identity entities are managed in Camunda 8.8 Self-Managed:
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your identity provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
 
-:::note 
+:::note
 This feature is Self-Managed only. Bring your own groups (external IdP groups) is not available in Camunda 8 SaaS.
 :::
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
@@ -7,21 +7,21 @@ description: Use groups from your external OIDC Identity Provider for authorizat
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your Identity Provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
+When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your identity provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
 
-:::note This feature is Self-Managed only.
-Bring your own groups is not available in Camunda 8 SaaS.
+:::note 
+This feature is Self-Managed only. Bring your own groups (external IdP groups) is not available in Camunda 8 SaaS.
 :::
 
-## When to use this
+## When to use external IdP groups
 
-Use bring your own groups when:
+Use external IdP groups if:
 
 - Your IdP is already the source of truth for user-to-group membership.
 - You want a single place to manage group membership for both sign-in and Camunda authorization.
 - You need group-based authorization in Camunda but do not want to duplicate group data between your IdP and Camunda.
 
-Do not use it when:
+Do not use external IdP groups if:
 
 - You need to manage groups through the Orchestration Cluster REST API or Identity UI.
 - You need Camunda to list or browse IdP-managed groups.
@@ -30,7 +30,7 @@ Do not use it when:
 ## Prerequisites
 
 - A Self-Managed Camunda 8 deployment running 8.8 or later.
-- OIDC authentication configured for the Orchestration Cluster. See [Connect to an external Identity Provider](./connect-external-identity-provider.md).
+- OIDC authentication configured for the Orchestration Cluster. See [connect to an external identity provider](./connect-external-identity-provider.md).
 - An IdP that can include a groups claim in the issued ID or access token. The claim value must be a JSON array of strings, where each string is a group ID.
 
 ## Configure the groups claim
@@ -39,7 +39,7 @@ Set `camunda.security.authentication.oidc.groups-claim` to the name of the claim
 
 For nested claims, use a [JSONPath expression](https://www.rfc-editor.org/rfc/rfc9535.html) — the same mechanism used by `username-claim`. For example, `$['camundaorg']['groups']` resolves to the `groups` array inside a nested `camundaorg` object.
 
-<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
 <TabItem value="yaml">
 
 ```yaml
@@ -56,7 +56,7 @@ CAMUNDA_SECURITY_AUTHENTICATION_OIDC_GROUPSCLAIM=<YOUR_GROUPS_CLAIM>
 </TabItem>
 </Tabs>
 
-See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [Connect multiple Identity Providers](./connect-multiple-identity-providers.md).
+See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [connect multiple identity providers](./connect-multiple-identity-providers.md).
 
 ## Use IdP groups in Camunda
 
@@ -64,31 +64,31 @@ Once `groups-claim` is set, the group IDs extracted from each token can be used 
 
 ### Role assignment
 
-Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [Assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
+Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
 
 ### Authorizations
 
-Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [Authorizations](../../../../components/concepts/access-control/authorizations.md).
+Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [authorizations](../../../../components/concepts/access-control/authorizations.md).
 
 ### Tenant assignment
 
-Add IdP groups to tenants so that every member of that group gains access to the tenant. See [Tenants](../../../../components/admin/tenant.md).
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [tenants](../../../../components/admin/tenant.md).
 
 ## Limitations and behavior
 
-- **Self-Managed only.** The feature is not available in Camunda 8 SaaS.
-- **No group sync or listing.** Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
-- **REST group management is disabled while the claim is set.** When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
-- **Per-token evaluation.** Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
-- **Array shape required.** The claim value must always be a JSON array, even for users who belong to a single group.
-- **Clients use the same claim.** Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
+- Self-Managed only. The feature is not available in Camunda 8 SaaS.
+- No group sync or listing. Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
+- REST group management is disabled while the claim is set. When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
+- Per-token evaluation. Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
+- Array shape required. The claim value must always be a JSON array, even for users who belong to a single group.
+- Clients use the same claim. Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
 
 ## Troubleshooting
 
 If groups from your IdP are not being applied in Camunda, check the following:
 
-- **The claim is present in the issued token.** Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
-- **JSONPath matches the actual structure.** If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
-- **Group IDs match exactly.** Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
+- The claim is present in the issued token. Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
+- JSONPath matches the actual structure. If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
+- Group IDs match exactly. Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
 
-For deeper investigation, see [Debugging authentication](./debugging-authentication.md).
+For deeper investigation, see [debugging authentication](./debugging-authentication.md).

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/bring-your-groups.md
@@ -1,8 +1,94 @@
 ---
 id: bring-your-groups
 title: Bring your own groups
-description: TBD
-unlisted: true
+description: Use groups from your external OIDC Identity Provider for authorization, role, and tenant assignment in Camunda 8 Self-Managed.
 ---
 
-TODO: Bring groups from your external Identity Provider.
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+When Camunda 8 Self-Managed is configured with OpenID Connect (OIDC), the Orchestration Cluster can read a configurable claim from each token and treat its values as Camunda group IDs. This lets you use groups that already exist in your Identity Provider (IdP) as the basis for Camunda's authorization, role, and tenant assignment.
+
+:::note This feature is Self-Managed only.
+Bring your own groups is not available in Camunda 8 SaaS.
+:::
+
+## When to use this
+
+Use bring your own groups when:
+
+- Your IdP is already the source of truth for user-to-group membership.
+- You want a single place to manage group membership for both sign-in and Camunda authorization.
+- You need group-based authorization in Camunda but do not want to duplicate group data between your IdP and Camunda.
+
+Do not use it when:
+
+- You need to manage groups through the Orchestration Cluster REST API or Identity UI.
+- You need Camunda to list or browse IdP-managed groups.
+- You are running Camunda 8 SaaS.
+
+## Prerequisites
+
+- A Self-Managed Camunda 8 deployment running 8.8 or later.
+- OIDC authentication configured for the Orchestration Cluster. See [Connect to an external Identity Provider](./connect-external-identity-provider.md).
+- An IdP that can include a groups claim in the issued ID or access token. The claim value must be a JSON array of strings, where each string is a group ID.
+
+## Configure the groups claim
+
+Set `camunda.security.authentication.oidc.groups-claim` to the name of the claim that contains the user's groups. The claim value must be a JSON array of strings, where each entry is a group ID.
+
+For nested claims, use a [JSONPath expression](https://www.rfc-editor.org/rfc/rfc9535.html) — the same mechanism used by `username-claim`. For example, `$['camundaorg']['groups']` resolves to the `groups` array inside a nested `camundaorg` object.
+
+<Tabs groupId="optionsType" defaultValue="yaml" queryString values={[{label: 'Application.yaml', value: 'yaml' }, {label: 'Environment variables', value: 'env' }]}>
+<TabItem value="yaml">
+
+```yaml
+camunda.security.authentication.oidc.groups-claim: <YOUR_GROUPS_CLAIM>
+```
+
+</TabItem>
+<TabItem value="env">
+
+```
+CAMUNDA_SECURITY_AUTHENTICATION_OIDC_GROUPSCLAIM=<YOUR_GROUPS_CLAIM>
+```
+
+</TabItem>
+</Tabs>
+
+See the [`groupsClaim` configuration reference](../core-settings/configuration/properties.md) for the full property definition. For multi-IdP setups where each provider may use a different claim name, see [Connect multiple Identity Providers](./connect-multiple-identity-providers.md).
+
+## Use IdP groups in Camunda
+
+Once `groups-claim` is set, the group IDs extracted from each token can be used anywhere a Camunda group ID can be used. The group ID in the token and the Camunda-side group ID must match **exactly**: comparisons are case-sensitive and treat group IDs as opaque strings.
+
+### Role assignment
+
+Assign IdP groups to Camunda roles to grant every member of that group the role's permissions on sign-in. See [Assign users, clients, groups, or mapping rules to roles via configuration](./overview.md#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
+
+### Authorizations
+
+Grant authorizations directly to IdP groups to control access to Camunda resources such as process definitions, decisions, or tenants. See [Authorizations](../../../../components/concepts/access-control/authorizations.md).
+
+### Tenant assignment
+
+Add IdP groups to tenants so that every member of that group gains access to the tenant. See [Tenants](../../../../components/admin/tenant.md).
+
+## Limitations and behavior
+
+- **Self-Managed only.** The feature is not available in Camunda 8 SaaS.
+- **No group sync or listing.** Groups exist only at the moment a token is evaluated. They are not persisted in Camunda and are not browsable in the Identity UI or the REST API.
+- **REST group management is disabled while the claim is set.** When `groups-claim` is set, the `/v2/groups/**` endpoints return HTTP 404. This is a hard switch, not a merge — you cannot manage some groups via REST and others via the claim at the same time.
+- **Per-token evaluation.** Group membership is re-read from every token. Changes in your IdP take effect on the next sign-in or token refresh; they do not propagate to already-active sessions.
+- **Array shape required.** The claim value must always be a JSON array, even for users who belong to a single group.
+- **Clients use the same claim.** Machine-to-machine tokens resolve their groups through the same `groups-claim` configuration as user tokens.
+
+## Troubleshooting
+
+If groups from your IdP are not being applied in Camunda, check the following:
+
+- **The claim is present in the issued token.** Decode an ID or access token for a user who should have the groups and verify the claim appears with the expected array value. Your IdP may require explicit scope or claim-mapping configuration to include it.
+- **JSONPath matches the actual structure.** If your groups claim is nested, make sure the JSONPath expression in `groups-claim` resolves to the array itself, not its parent object.
+- **Group IDs match exactly.** Camunda matches group IDs as literal strings. A trailing space, different case, or stray prefix will cause Camunda-side assignments to silently miss.
+
+For deeper investigation, see [Debugging authentication](./debugging-authentication.md).


### PR DESCRIPTION
## Summary

- Replaces the `bring-your-groups.md` placeholder pages in next / 8.9 / 8.8 with a published, provider-agnostic Self-Managed guide for the `groups-claim` OIDC feature.
- Cross-links the new page from the 8.8 "What's new" page (next / 8.9 / 8.8 copies).

Closes #6327. Implements the docs side of camunda/camunda#31451 (PRD: camunda/product-hub#2094).

## What's in the page

- Intro and Self-Managed-only admonition.
- When to use / when not to use.
- Prerequisites.
- \`groups-claim\` configuration (YAML / env tabs, JSONPath for nested claims).
- Using IdP groups for role assignment, authorizations, and tenant assignment.
- Limitations including the HTTP 404 behavior on \`/v2/groups/**\` when the claim is set (enforced by \`@ConditionalOnCamundaGroupsEnabled\`).
- Troubleshooting pointers.

The existing "Step 8" section in \`connect-external-identity-provider.md\` is left untouched as supplementary surface.

## Test plan

- [x] All three page versions spec-reviewed; next and 8.9 are byte-identical, 8.8 differs only by the tenant link (\`components/identity/tenant.md\` instead of \`components/admin/tenant.md\`).
- [x] All 21 relative link targets verified to exist on disk in each version (7 targets × 3 versions).
- [x] Role-assignment anchor (\`#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration\`) confirmed present in \`overview.md\` in each version.
- [x] Pages render locally in \`npm run start\` (next / 8.9 / 8.8).
- [ ] CI \`preview-env-deploy\` and \`links\` workflows pass on the branch.