### PR TITLE
fix: fix typo and add missing Helm values for orchestration.security.initialization

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/core-settings/configuration/partials/_security.md
+++ b/docs/self-managed/components/orchestration-cluster/core-settings/configuration/partials/_security.md
@@ -600,9 +600,12 @@ script-src-attr 'none'.
 
 ### `orchestration.security.initialization`
 
-| Property                                      | Description                                                              | Default value |
-| --------------------------------------------- | ------------------------------------------------------------------------ | ------------- |
-| `orchestration.security.initialization.users` | List of users to initialize (each with username, password, name, email). |               |
+| Property                                               | Description                                                                                           | Default value |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------- |
+| `orchestration.security.initialization.users`          | List of users to initialize (each with username, password, name, email).                              |               |
+| `orchestration.security.initialization.defaultRoles`   | Dictionary of role names assigning initial users, clients, or mapping rules to default roles.         |               |
+| `orchestration.security.initialization.mappingRules`   | List of mapping rules to initialize when using OIDC (each with mappingRuleId, claimName, claimValue). |               |
+| `orchestration.security.initialization.authorizations` | List of authorizations to initialize.                                                                 |               |
 
 ### `orchestration.security.multiTenancy`
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md
@@ -1173,10 +1173,12 @@ script-src-attr 'none'.
 
 ### `orchestration.security.initialization`
 
-| Property                                         | Description                                                                          | Default value |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------- |
-| `orchestration.security.initiation.users`        | List of users to initialize (each with username, password, name, email).             |               |
-| `orchestration.security.initiation.mappingRules` | List of mapping rule to initialize (each with mappingRuleId, claimName, claimValue). |               |
+| Property                                               | Description                                                                                           | Default value |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------- |
+| `orchestration.security.initialization.users`          | List of users to initialize (each with username, password, name, email).                              |               |
+| `orchestration.security.initialization.defaultRoles`   | Dictionary of role names assigning initial users, clients, or mapping rules to default roles.         |               |
+| `orchestration.security.initialization.mappingRules`   | List of mapping rules to initialize when using OIDC (each with mappingRuleId, claimName, claimValue). |               |
+| `orchestration.security.initialization.authorizations` | List of authorizations to initialize.                                                                 |               |
 
 ### `orchestration.security.multiTenancy`
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/core-settings/configuration/partials/_security.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/core-settings/configuration/partials/_security.md
@@ -600,9 +600,12 @@ script-src-attr 'none'.
 
 ### `orchestration.security.initialization`
 
-| Property                                      | Description                                                              | Default value |
-| --------------------------------------------- | ------------------------------------------------------------------------ | ------------- |
-| `orchestration.security.initialization.users` | List of users to initialize (each with username, password, name, email). |               |
+| Property                                               | Description                                                                                           | Default value |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------- |
+| `orchestration.security.initialization.users`          | List of users to initialize (each with username, password, name, email).                              |               |
+| `orchestration.security.initialization.defaultRoles`   | Dictionary of role names assigning initial users, clients, or mapping rules to default roles.         |               |
+| `orchestration.security.initialization.mappingRules`   | List of mapping rules to initialize when using OIDC (each with mappingRuleId, claimName, claimValue). |               |
+| `orchestration.security.initialization.authorizations` | List of authorizations to initialize.                                                                 |               |
 
 ### `orchestration.security.multiTenancy`
 


### PR DESCRIPTION
## Summary

Fixes #8600.

- **Typo fix (8.8):** `orchestration.security.initiation.*` → `orchestration.security.initialization.*` in the 8.8 Helm values table
- **Missing rows (8.8, 8.9, 8.10):** Added `defaultRoles`, `mappingRules`, and `authorizations` to the `orchestration.security.initialization` Helm values table — all three are rendered by the Helm template but were undocumented

## Files changed

| File | Change |
|---|---|
| `versioned_docs/version-8.8/.../properties.md` | Fix typo + add 3 missing rows |
| `docs/.../partials/_security.md` | Add 3 missing rows (covers 8.9 and 8.10) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)