### PR TITLE
fix: add 8.9 version config for REST API doc generation

### DIFF
--- a/api/camunda/generation-strategy.js
+++ b/api/camunda/generation-strategy.js
@@ -11,7 +11,7 @@ function pick(apiConfig) {
     case "next":
       return next;
 
-    case parseFloat(version) > 8.8:
+    case "8.9":
       return next;
 
     case "8.8":

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -203,6 +203,13 @@ module.exports = {
             label: "Unused but required field",
             baseUrl: "Unused but required field",
             versions: {
+              8.9: {
+                specPath: "api/camunda/version-8.9/camunda-openapi.yaml",
+                outputDir:
+                  "versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/specifications",
+                label: "Unused but required field",
+                baseUrl: "Unused but required field",
+              },
               8.8: {
                 specPath: "api/camunda/version-8.8/camunda-openapi.yaml",
                 outputDir:


### PR DESCRIPTION
## What

Adds the missing 8.9 version configuration so the `sync-rest-api-docs` workflow can generate 8.9 versioned API docs with SDK autoImports.

## Changes

- **`docusaurus.config.js`**: Add `8.9` version entry to the `api-camunda-openapi` plugin config (specPath + outputDir)
- **`api/camunda/generation-strategy.js`**: Fix dispatcher bug — `case parseFloat(version) > 8.8:` in a `switch(version)` statement does strict equality comparison and never matches. Replaced with explicit `case "8.9":`.
- **`api/camunda/version-8.9/.gitkeep`**: Create the version directory. The workflow [skips versions whose directory doesn't exist](https://github.com/camunda/camunda-docs/blob/main/.github/workflows/sync-rest-api-docs.yaml#L77).

## What happens next

On the next `sync-rest-api-docs` workflow run (scheduled Thursdays or manual dispatch), the workflow will:
1. Sparse-checkout the 8.9 spec from `stable/8.9` in `camunda/camunda`
2. Copy the modular spec files into `api/camunda/version-8.9/`
3. Run `npm run api:generate -- camunda "8.9"` with the fixed strategy dispatcher
4. The generated MDX will include auto-detected SDK imports (via `autoImports: true` from #8576)

No spec files or generated MDX are included in this PR — the workflow handles those.