### PR TITLE
fix: fix document preview payload shape

### DIFF
--- a/docs/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
+++ b/docs/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
@@ -38,7 +38,7 @@ A form element to preview and download documents.
 When previewing documents that were uploaded via [Filepicker](./forms-element-library-filepicker.md) in Tasklist, document references are handled automatically:
 
 - Modifying the document’s metadata after upload may prevent the preview from working correctly.
-- To use Camunda's document service without Filepicker, you must include the `contentHash`, `endpoint`, and `documentId` values.
+- To use Camunda's document service without Filepicker, you must include the `contentHash` and `documentId` values.
   :::
 
 #### Condition

--- a/versioned_docs/version-8.7/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
+++ b/versioned_docs/version-8.7/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
@@ -38,7 +38,7 @@ A form element to preview and download documents.
 When previewing documents that were uploaded via [Filepicker](./forms-element-library-filepicker.md) in Tasklist, document references are handled automatically:
 
 - Modifying the document’s metadata after upload may prevent the preview from working correctly.
-- To use Camunda's document service without Filepicker, you must include the `contentHash`, `endpoint`, and `documentId` values.
+- To use Camunda's document service without Filepicker, you must include the `contentHash` and `documentId` values.
   :::
 
 #### Condition

--- a/versioned_docs/version-8.8/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
+++ b/versioned_docs/version-8.8/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
@@ -38,7 +38,7 @@ A form element to preview and download documents.
 When previewing documents that were uploaded via [Filepicker](./forms-element-library-filepicker.md) in Tasklist, document references are handled automatically:
 
 - Modifying the document’s metadata after upload may prevent the preview from working correctly.
-- To use Camunda's document service without Filepicker, you must include the `contentHash`, `endpoint`, and `documentId` values.
+- To use Camunda's document service without Filepicker, you must include the `contentHash` and `documentId` values.
   :::
 
 #### Condition

--- a/versioned_docs/version-8.9/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
+++ b/versioned_docs/version-8.9/components/modeler/forms/form-element-library/forms-element-library-document-preview.md
@@ -38,7 +38,7 @@ A form element to preview and download documents.
 When previewing documents that were uploaded via [Filepicker](./forms-element-library-filepicker.md) in Tasklist, document references are handled automatically:
 
 - Modifying the document’s metadata after upload may prevent the preview from working correctly.
-- To use Camunda's document service without Filepicker, you must include the `contentHash`, `endpoint`, and `documentId` values.
+- To use Camunda's document service without Filepicker, you must include the `contentHash` and `documentId` values.
   :::
 
 #### Condition


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

The docs has been wrong for a while. We only need the `documentId` and `contentHash` as you can see in the code: https://github.com/camunda/camunda/blob/main/tasklist/client/src/modules/form-js/formManager.tsx#L20-L22

This is also causing some confusing to customers as seen on [#inc-support-32383-download-image-from-rest-api-and-display-same-image-into](https://camunda.slack.com/archives/C0AT1P7UY6N)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
