### PR TITLE
dx(build): fix preview env

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -2,10 +2,24 @@ name: build-docs
 
 on: pull_request
 
+# If the workflow is triggered while an instance is already running,
+# cancel the in-progress instance.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-docs:
+    # Use self-hosted runner with more resources
     runs-on: gcp-core-16-default
+
+    # The execution of a job shares the same container and resources as the runner agent
+    # that communicates with GitHub. Excessive and intensive consumption of resources
+    # by a job steps may starve the runner agent to the point where communication is lost,
+    # forcing GitHub to consider it offline. To prevent this, we can use a separate container
+    # with its own resources for the job execution.
     container: node:24
+
     steps:
       - uses: actions/checkout@v6
       - name: Install Dependencies
@@ -16,13 +30,14 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NODE_OPTIONS: --max_old_space_size=8192
+          NODE_OPTIONS: --max-old-space-size=30720
       - name: Upload build
         uses: actions/upload-artifact@v7
         with:
           name: docs-build
           path: build
           include-hidden-files: true
+
   validate-links:
     runs-on: gcp-core-16-default
     needs: build-docs
@@ -93,3 +108,25 @@ jobs:
         uses: ./.github/actions/muffet
         with:
           url_to_validate: http://localhost:8081/connectors-element-template-links.html
+
+  retry-shutdowns:
+    # Because we run these jobs on preemptible runners, they can be shut down
+    # automatically at any time. Instead of requiring a manual rerun every time
+    # this happens, use the reusable action developed by the infra team to retry.
+    runs-on: ubuntu-latest
+    needs:
+      - build-docs
+      - validate-links
+    if: failure() && fromJSON(github.run_attempt) < 3
+    steps:
+      - name: Retry job
+        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        with:
+          error-messages: |
+            The runner has received a shutdown signal.
+            The operation was canceled.
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -8,16 +8,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  deploy-preview:
-    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy') || contains( github.event.pull_request.labels.*.name, 'deploy'))
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    name: deploy-preview-env
+  build-docs:
+    if: >
+      github.event.pull_request.state != 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'deploy')
+
+    # Use self-hosted runner with more resources
+    runs-on: gcp-core-16-default
+
+    # The execution of a job shares the same container and resources as the runner agent
+    # that communicates with GitHub. Excessive and intensive consumption of resources
+    # by a job steps may starve the runner agent to the point where communication is lost,
+    # forcing GitHub to consider it offline. To prevent this, we can use a separate container
+    # with its own resources for the job execution.
+    container: node:24
+
+    name: build-docs
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
 
       - name: Import secrets from Vault
         id: secrets
@@ -46,10 +54,41 @@ jobs:
 
       - name: Build Docs
         env:
-          NODE_OPTIONS: --max_old_space_size=8192
+          NODE_OPTIONS: --max-old-space-size=30720
           DOCS_SITE_URL: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
           DOCS_SITE_BASE_URL: /pr-${{ github.event.number }}/
         run: npm run build
+
+      - name: Upload build
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-build
+          path: build
+          include-hidden-files: true
+
+  deploy-preview:
+    name: deploy-preview-env
+    runs-on: ubuntu-24.04
+    needs: build-docs
+    timeout-minutes: 30
+    steps:
+      - name: Import secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_BUCKET_NAME;
+            secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
+
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-build
+          path: build
 
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v3
@@ -98,3 +137,25 @@ jobs:
           refresh-message-position: true
           message: |
             The preview environment relating to the commit ${{ github.sha }} has successfully been deployed. You can access it at [https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/](https://${{ env.BUCKET_NAME }}/pr-${{ github.event.number }}/)
+
+  retry-shutdowns:
+    # Because we run these jobs on preemptible runners, they can be shut down
+    # automatically at any time. Instead of requiring a manual rerun every time
+    # this happens, use the reusable action developed by the infra team to retry.
+    runs-on: ubuntu-latest
+    needs:
+      - build-docs
+      - deploy-preview
+    if: failure() && fromJSON(github.run_attempt) < 3
+    steps:
+      - name: Retry job
+        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        with:
+          error-messages: |
+            The runner has received a shutdown signal.
+            The operation was canceled.
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

Fix preview builds. Introduces the following major changes:

- Add automatic retry behavior to build and preview env pipelines (avoid some manual retry effort)
- Use self-hosted runner for building preview env (github runner struggles with large builds)
- Split build + deploy preview env into two jobs (used to be one). This acts as a check point (if a job fails during the env deploy after build for some intermittent reason, we don't need to rerun the build again, we can just rerun the deploy job)
- For build pipeline, cancel running jobs if a newer version starts (reduce overhead)
- Increase node memory limit for build steps

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
