### PR TITLE
docs(pim): add note for user task migration failure

### DIFF
--- a/docs/components/concepts/process-instance-migration.md
+++ b/docs/components/concepts/process-instance-migration.md
@@ -180,6 +180,10 @@ When you migrate a job worker user task to a Camunda user task:
 - The current `assignee` is not preserved. The task is assigned to the initial assignee defined in the target user task definition.
   :::
 
+:::note
+Incidents on the job worker user task need to be resolved before migrating to a Camunda user task, otherwise the migration will fail.
+:::
+
 ## Deal with catch events
 
 An exception to changing the process instance state is specific to catch events.

--- a/versioned_docs/version-8.8/components/concepts/process-instance-migration.md
+++ b/versioned_docs/version-8.8/components/concepts/process-instance-migration.md
@@ -166,6 +166,10 @@ When you migrate a job worker user task to a Camunda user task:
 - The current `assignee` is not preserved. The task is assigned to the initial assignee defined in the target user task definition.
   :::
 
+:::note
+Incidents on the job worker user task need to be resolved before migrating to a Camunda user task, otherwise the migration will fail.
+:::
+
 ## Dealing with catch events
 
 An exception to changing the process instance state is specific to catch events.

--- a/versioned_docs/version-8.9/components/concepts/process-instance-migration.md
+++ b/versioned_docs/version-8.9/components/concepts/process-instance-migration.md
@@ -180,6 +180,10 @@ When you migrate a job worker user task to a Camunda user task:
 - The current `assignee` is not preserved. The task is assigned to the initial assignee defined in the target user task definition.
   :::
 
+:::note
+Incidents on the job worker user task need to be resolved before migrating to a Camunda user task, otherwise the migration will fail.
+:::
+
 ## Deal with catch events
 
 An exception to changing the process instance state is specific to catch events.


### PR DESCRIPTION
## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->
Add note for behavior of user task migration when an incident is present on the jobworker.

relates to https://github.com/camunda/camunda/issues/49714

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
