### PR TITLE
docs(helm): document Optimize PVC consolidation breaking change in 8.9 upgrade

### DIFF
--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
@@ -225,6 +225,47 @@ The legacy Keycloak auth secret configuration using `global.identity.keycloak.au
 
 The legacy keys still work in 8.9 via normalizers. See [Secret management](/self-managed/deployment/helm/configure/secret-management.md).
 
+### Optimize PVC consolidation
+
+:::warning Breaking change if `optimize.persistence.enabled=true`
+This change causes silent data loss on upgrade if you do not take action first. Optimize will start with an empty data directory — there is no crash or obvious error pointing to this cause.
+:::
+
+In 8.8, Optimize used two separate PersistentVolumeClaims:
+
+- `<release>-optimize-data-camunda` (mounted at `/camunda`)
+- `<release>-optimize-data-tmp` (mounted at `/tmp`)
+
+In 8.9, these are consolidated into a single PVC:
+
+- `<release>-optimize-data` (mounted at both paths)
+
+On upgrade, Helm creates the new `optimize-data` PVC empty. Data stored in the old PVCs is not migrated automatically and will be inaccessible to Optimize.
+
+**If you need to preserve Optimize data**, complete the following steps before running `helm upgrade`:
+
+1. Scale down Optimize:
+
+   ```bash
+   kubectl scale deploy <release>-optimize --replicas=0 -n <namespace>
+   ```
+
+1. Create the new PVC manually with adequate capacity.
+
+1. Copy data from `<release>-optimize-data-camunda` into the new PVC. The `/camunda` path is the primary data directory.
+
+1. Set `optimize.persistence.existingClaim` in your `values-8.9.yaml` to prevent Helm from creating a new empty PVC:
+
+   ```yaml
+   optimize:
+     persistence:
+       existingClaim: <release>-optimize-data
+   ```
+
+1. Run `helm upgrade`.
+
+If Optimize data loss is acceptable (for example, in non-production environments or when data can be re-indexed), no action is needed — Optimize will start with an empty data directory.
+
 ## Example: upgrade `values.yaml` from 8.8 to 8.9
 
 This section shows a before-and-after example of a Helm `values.yaml` migrated from Camunda 8.8 to 8.9, covering the most common upgrade scenarios.


### PR DESCRIPTION
## Summary

- Documents the breaking Optimize PVC consolidation in the 8.8 → 8.9 Helm upgrade guide
- In 8.9, `optimize-data-camunda` and `optimize-data-tmp` were merged into a single `optimize-data` PVC (introduced in camunda/camunda-platform-helm#4463, first commit of the 8.9 chart)
- Without migration steps, an in-place upgrade silently loses Optimize data — there is no crash or obvious error pointing to the cause
- Provides actionable migration steps for users with `optimize.persistence.enabled=true`

## Test plan

- [ ] Verify the warning admonition renders correctly
- [ ] Confirm the migration steps are accurate against the 8.9 chart values
- [ ] Check that `optimize.persistence.existingClaim` is a valid key in the 8.9 chart