### PR TITLE
docs(helm): document CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME now emitted in 8.9

### DIFF
--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
@@ -172,6 +172,20 @@ Alternatively, if you do not need secondary storage, set `global.noSecondaryStor
 
 The Orchestration Cluster's default HTTP port changed from 8090 to 8080. If you have hardcoded port 8090 in network policies, Ingress rules, health check probes, or service mesh configuration, update these references to 8080 or explicitly set `orchestration.service.httpPort: 8090` in your `values.yaml`.
 
+#### Optimize Elasticsearch authentication username now explicitly set
+
+In 8.9, when `optimize.database.elasticsearch.auth.username` or `global.elasticsearch.auth.username` is configured, the chart automatically sets `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME` as an environment variable on the Optimize pod. This variable was not explicitly emitted in 8.8.
+
+If you previously set this variable manually via `optimize.env`, remove the duplicate entry to avoid conflicting values:
+
+```yaml
+# Remove this if present — it is now set automatically by the chart
+optimize:
+  env:
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME
+      value: "my-user"
+```
+
 #### TLS secret pattern deprecated
 
 The legacy TLS secret configuration using `*.tls.existingSecret` is deprecated. Migrate to `*.tls.secret.existingSecret`. The legacy keys still work in 8.9 but will be removed in a future version.


### PR DESCRIPTION
## Summary

- Documents that `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME` is now explicitly set by the 8.9 Helm chart when an Elasticsearch auth username is configured
- This variable was not emitted in 8.8 — users who set it manually via `optimize.env` need to remove the duplicate to avoid conflicting values
- Adds a `####` section to the 8.8 → 8.9 upgrade guide under Configuration changes

## Test plan

- [ ] Verify the description accurately reflects the 8.9 chart template behavior
- [ ] Confirm the yaml example renders correctly