### PR TITLE
docs(helm): document webModeler restapi default resource increase in 8.9

### DIFF
--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
@@ -216,6 +216,31 @@ Depending on your setup, you might need to migrate custom configuration settings
 See the [component upgrade guide](/self-managed/upgrade/components/880-to-890.md#migrate-webapp-configuration) for details.
 :::
 
+#### Web Modeler `restapi` default resource limits increased
+
+Because `restapi` now handles the workload previously split across two components (`restapi` and `webapp`), its default resource requests and limits have increased in 8.9:
+
+| Resource | 8.8 requests / limits | 8.9 requests / limits |
+| :------- | :-------------------- | :-------------------- |
+| CPU      | `500m` / `1000m`      | `900m` / `1800m`      |
+| Memory   | `1Gi` / `2Gi`         | `1280Mi` / `2560Mi`   |
+
+If you have not explicitly set `webModeler.restapi.resources` in your `values.yaml`, the pod will use these higher defaults after upgrade. In resource-constrained clusters this can cause the pod to remain in `Pending` state with no scheduling capacity.
+
+If your cluster cannot accommodate the new defaults, override them explicitly before upgrading:
+
+```yaml
+webModeler:
+  restapi:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+```
+
 #### Keycloak auth secret pattern deprecated
 
 The legacy Keycloak auth secret configuration using `global.identity.keycloak.auth.existingSecret` and `global.identity.keycloak.auth.existingSecretKey` is deprecated. Migrate to the new standard secret pattern:


### PR DESCRIPTION
## Summary

- Documents the ~80% increase in `webModeler.restapi` default CPU and ~25% memory increase in 8.9
- The increase is a direct consequence of `webapp` being removed and its workload absorbed by `restapi` (already documented in the same guide)
- Without this note, constrained clusters will silently get a pod stuck in `Pending` after upgrade with no obvious cause
- Adds the section directly after the existing `webapp` removal note and includes a fallback override example

## Test plan

- [ ] Verify the table and values match the actual 8.8 and 8.9 `values.yaml` defaults
- [ ] Confirm the yaml override example renders correctly