### PR TITLE
docs(zeebe): extend rebalancing documentation with caveats and guidance

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -55,4 +55,58 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-We recommend requesting rebalancing only under low load.
+### Caveats
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
+
+:::note
+
+If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+
+:::
+
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+
+This is typically observed externally as:
+
+- **Increased error rates** from clients, as requests are rejected while no leader is available
+- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
+- **Increased exporting latency**, for example, new data appears in Operate later than expected
+
+### When to rebalance
+
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+
+:::note
+
+If you are using Prometheus, you can query the replication lag for a given partition and desired leader with:
+
+```promql
+sum(atomix_non_replicated_entries{partition=~"$partition", follower=~"$follower"}) by (partition, follower)
+```
+
+Replace `$partition` and `$follower` by the desired combination.
+
+If you're using the Zeebe Grafana dashboard, you can already visualize this in the `Raft` section, in a graph named `Non replicated records`.
+
+:::
+
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+
+:::note
+
+If you are using Prometheus, you can query the total replication rate across all partitions with:
+
+```promql
+sum(rate(atomix_append_entries_data_rate_total[1m]))
+```
+
+This returns the replication rate in bytes per second of a cluster.
+
+You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
+
+:::
+
+What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -25,9 +25,9 @@ During the rebalancing, partitions might become unhealthy and can't make progres
 
 ### Limitations
 
-Manual rebalancing is done on a best-effort basis.
+Manual rebalancing is not guaranteed to succeed in all cases.
 
-Due to the nature of distributed systems, Zeebe can never guarantee a particular distribution and rebalancing cannot avoid that.
+Rebalancing is only supported under specific configurations, and even when supported, the resulting distribution cannot be guaranteed due to the nature of distributed systems.
 
 There are two configurations where manual rebalancing is supported:
 

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -57,9 +57,9 @@ This becomes more likely under high load or with increased network latency betwe
 
 ### Caveats
 
-Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
-
 :::note
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
 If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
@@ -93,7 +93,13 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+:::warn
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+
+:::
+
+For example, you could consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
 
 :::note
 
@@ -108,5 +114,3 @@ This returns the replication rate in bytes per second of a cluster.
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 
 :::
-
-What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -55,27 +55,27 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-### Caveats
+### Rebalancing impact
 
 :::note
 
 Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
-If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+If the desired leader for a partition (the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. If a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
 :::
 
-During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process, export, or accept new commands. In the worst case, when all partitions rebalance at the same time, the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
 
 This is typically observed externally as:
 
-- **Increased error rates** from clients, as requests are rejected while no leader is available
-- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
-- **Increased exporting latency**, for example, new data appears in Operate later than expected
+- Increased error rates from clients, as requests are rejected while no leader is available
+- Increased processing latency, as service tasks complete later and process instances progress more slowly
+- Increased exporting latency, as new data appears in Operate later than expected
 
 ### When to rebalance
 
-Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to determine how far a replica lags behind. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
 
 :::note
 
@@ -91,11 +91,11 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 :::
 
-Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. Decide whether the long-term benefit outweighs the short-term disruption.
 
 :::warn
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+Rebalance only when the cluster is under low load. To determine this, identify what low load means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
 
 :::
 
@@ -109,7 +109,7 @@ If you are using Prometheus, you can query the total replication rate across all
 sum(rate(atomix_append_entries_data_rate_total[1m]))
 ```
 
-This returns the replication rate in bytes per second of a cluster.
+This returns the cluster replication rate in bytes per second.
 
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -32,7 +32,6 @@ Due to the nature of distributed systems, Zeebe can never guarantee a particular
 There are two configurations where manual rebalancing is supported:
 
 - **Priority election** with **round-robin distribution**
-
   - Priority election and round-robin distribution are enabled by default.
   - As long as you have not manually disabled priority election or set a fixed distribution, rebalancing is supported.
   - Brokers are automatically assigned as primary partition leaders during startup, based on cluster size and replication factor.
@@ -56,4 +55,58 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-We recommend requesting rebalancing only under low load.
+### Caveats
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
+
+:::note
+
+If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+
+:::
+
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+
+This is typically observed externally as:
+
+- **Increased error rates** from clients, as requests are rejected while no leader is available
+- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
+- **Increased exporting latency**, for example, new data appears in Operate later than expected
+
+### When to rebalance
+
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+
+:::note
+
+If you are using Prometheus, you can query the replication lag for a given partition and desired leader with:
+
+```promql
+sum(atomix_non_replicated_entries{partition=~"$partition", follower=~"$follower"}) by (partition, follower)
+```
+
+Replace `$partition` and `$follower` by the desired combination.
+
+If you're using the Zeebe Grafana dashboard, you can already visualize this in the `Raft` section, in a graph named `Non replicated records`.
+
+:::
+
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+
+:::note
+
+If you are using Prometheus, you can query the total replication rate across all partitions with:
+
+```promql
+sum(rate(atomix_append_entries_data_rate_total[1m]))
+```
+
+This returns the replication rate in bytes per second of a cluster.
+
+You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
+
+:::
+
+What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -25,9 +25,9 @@ During the rebalancing, partitions might become unhealthy and can't make progres
 
 ### Limitations
 
-Manual rebalancing is done on a best-effort basis.
+Manual rebalancing is not guaranteed to succeed in all cases.
 
-Due to the nature of distributed systems, Zeebe can never guarantee a particular distribution and rebalancing cannot avoid that.
+Rebalancing is only supported under specific configurations, and even when supported, the resulting distribution cannot be guaranteed due to the nature of distributed systems.
 
 There are two configurations where manual rebalancing is supported:
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -57,9 +57,9 @@ This becomes more likely under high load or with increased network latency betwe
 
 ### Caveats
 
-Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
-
 :::note
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
 If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
@@ -93,7 +93,13 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+:::warn
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+
+:::
+
+For example, you could consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
 
 :::note
 
@@ -108,5 +114,3 @@ This returns the replication rate in bytes per second of a cluster.
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 
 :::
-
-What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/rebalancing.md
@@ -55,27 +55,27 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-### Caveats
+### Rebalancing impact
 
 :::note
 
 Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
-If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+If the desired leader for a partition (the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. If a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
 :::
 
-During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process, export, or accept new commands. In the worst case, when all partitions rebalance at the same time, the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
 
 This is typically observed externally as:
 
-- **Increased error rates** from clients, as requests are rejected while no leader is available
-- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
-- **Increased exporting latency**, for example, new data appears in Operate later than expected
+- Increased error rates from clients, as requests are rejected while no leader is available
+- Increased processing latency, as service tasks complete later and process instances progress more slowly
+- Increased exporting latency, as new data appears in Operate later than expected
 
 ### When to rebalance
 
-Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to determine how far a replica lags behind. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
 
 :::note
 
@@ -91,11 +91,11 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 :::
 
-Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. Decide whether the long-term benefit outweighs the short-term disruption.
 
 :::warn
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+Rebalance only when the cluster is under low load. To determine this, identify what low load means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
 
 :::
 
@@ -109,7 +109,7 @@ If you are using Prometheus, you can query the total replication rate across all
 sum(rate(atomix_append_entries_data_rate_total[1m]))
 ```
 
-This returns the replication rate in bytes per second of a cluster.
+This returns the cluster replication rate in bytes per second.
 
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -55,4 +55,58 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-We recommend requesting rebalancing only under low load.
+### Caveats
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
+
+:::note
+
+If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+
+:::
+
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+
+This is typically observed externally as:
+
+- **Increased error rates** from clients, as requests are rejected while no leader is available
+- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
+- **Increased exporting latency**, for example, new data appears in Operate later than expected
+
+### When to rebalance
+
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+
+:::note
+
+If you are using Prometheus, you can query the replication lag for a given partition and desired leader with:
+
+```promql
+sum(atomix_non_replicated_entries{partition=~"$partition", follower=~"$follower"}) by (partition, follower)
+```
+
+Replace `$partition` and `$follower` by the desired combination.
+
+If you're using the Zeebe Grafana dashboard, you can already visualize this in the `Raft` section, in a graph named `Non replicated records`.
+
+:::
+
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+
+:::note
+
+If you are using Prometheus, you can query the total replication rate across all partitions with:
+
+```promql
+sum(rate(atomix_append_entries_data_rate_total[1m]))
+```
+
+This returns the replication rate in bytes per second of a cluster.
+
+You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
+
+:::
+
+What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -25,9 +25,9 @@ During the rebalancing, partitions might become unhealthy and can't make progres
 
 ### Limitations
 
-Manual rebalancing is done on a best-effort basis.
+Manual rebalancing is not guaranteed to succeed in all cases.
 
-Due to the nature of distributed systems, Zeebe can never guarantee a particular distribution and rebalancing cannot avoid that.
+Rebalancing is only supported under specific configurations, and even when supported, the resulting distribution cannot be guaranteed due to the nature of distributed systems.
 
 There are two configurations where manual rebalancing is supported:
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -57,9 +57,9 @@ This becomes more likely under high load or with increased network latency betwe
 
 ### Caveats
 
-Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
-
 :::note
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
 If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
@@ -93,7 +93,13 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+:::warn
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+
+:::
+
+For example, you could consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
 
 :::note
 
@@ -108,5 +114,3 @@ This returns the replication rate in bytes per second of a cluster.
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 
 :::
-
-What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -55,27 +55,27 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-### Caveats
+### Rebalancing impact
 
 :::note
 
 Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
-If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+If the desired leader for a partition (the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. If a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
 :::
 
-During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process, export, or accept new commands. In the worst case, when all partitions rebalance at the same time, the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
 
 This is typically observed externally as:
 
-- **Increased error rates** from clients, as requests are rejected while no leader is available
-- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
-- **Increased exporting latency**, for example, new data appears in Operate later than expected
+- Increased error rates from clients, as requests are rejected while no leader is available
+- Increased processing latency, as service tasks complete later and process instances progress more slowly
+- Increased exporting latency, as new data appears in Operate later than expected
 
 ### When to rebalance
 
-Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to determine how far a replica lags behind. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
 
 :::note
 
@@ -91,11 +91,11 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 :::
 
-Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. Decide whether the long-term benefit outweighs the short-term disruption.
 
 :::warn
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+Rebalance only when the cluster is under low load. To determine this, identify what low load means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
 
 :::
 
@@ -109,7 +109,7 @@ If you are using Prometheus, you can query the total replication rate across all
 sum(rate(atomix_append_entries_data_rate_total[1m]))
 ```
 
-This returns the replication rate in bytes per second of a cluster.
+This returns the cluster replication rate in bytes per second.
 
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -55,4 +55,58 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-We recommend requesting rebalancing only under low load.
+### Caveats
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
+
+:::note
+
+If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+
+:::
+
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+
+This is typically observed externally as:
+
+- **Increased error rates** from clients, as requests are rejected while no leader is available
+- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
+- **Increased exporting latency**, for example, new data appears in Operate later than expected
+
+### When to rebalance
+
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+
+:::note
+
+If you are using Prometheus, you can query the replication lag for a given partition and desired leader with:
+
+```promql
+sum(atomix_non_replicated_entries{partition=~"$partition", follower=~"$follower"}) by (partition, follower)
+```
+
+Replace `$partition` and `$follower` by the desired combination.
+
+If you're using the Zeebe Grafana dashboard, you can already visualize this in the `Raft` section, in a graph named `Non replicated records`.
+
+:::
+
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+
+:::note
+
+If you are using Prometheus, you can query the total replication rate across all partitions with:
+
+```promql
+sum(rate(atomix_append_entries_data_rate_total[1m]))
+```
+
+This returns the replication rate in bytes per second of a cluster.
+
+You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
+
+:::
+
+What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -25,9 +25,9 @@ During the rebalancing, partitions might become unhealthy and can't make progres
 
 ### Limitations
 
-Manual rebalancing is done on a best-effort basis.
+Manual rebalancing is not guaranteed to succeed in all cases.
 
-Due to the nature of distributed systems, Zeebe can never guarantee a particular distribution and rebalancing cannot avoid that.
+Rebalancing is only supported under specific configurations, and even when supported, the resulting distribution cannot be guaranteed due to the nature of distributed systems.
 
 There are two configurations where manual rebalancing is supported:
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -57,9 +57,9 @@ This becomes more likely under high load or with increased network latency betwe
 
 ### Caveats
 
-Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
-
 :::note
+
+Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
 If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
@@ -93,7 +93,13 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. For example, you can consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
+:::warn
+
+We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+
+:::
+
+For example, you could consider the cluster idle if the total leader append rate across all partitions is low, such as below 64 KB/s. At this level of activity, the impact of a rebalance on your users and applications is minimal.
 
 :::note
 
@@ -108,5 +114,3 @@ This returns the replication rate in bytes per second of a cluster.
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 
 :::
-
-What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/rebalancing.md
@@ -55,27 +55,27 @@ Even when a rebalancing request is handled successfully by all leaders, the resu
 Followers that are not fully caught up with the leader cannot be elected as leader.
 This becomes more likely under high load or with increased network latency between leader and follower.
 
-### Caveats
+### Rebalancing impact
 
 :::note
 
 Rebalancing causes every partition leader to step down simultaneously, triggering a new leader election for each partition.
 
-If the desired leader for a partition (aka the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. This means that if a cluster is already perfectly balanced, a rebalancing call is a no-op.
+If the desired leader for a partition (the node with the highest priority) is _already_ the leader, rebalancing is a no-op for this partition. If a cluster is already perfectly balanced, a rebalancing call is a no-op.
 
 :::
 
-During the election period, the affected partition has no leader. While leaderless, a partition cannot process or export, and cannot accept new commands. In the worst case — when all partitions are rebalancing at the same time — this means the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
+During the election period, the affected partition has no leader. While leaderless, a partition cannot process, export, or accept new commands. In the worst case, when all partitions rebalance at the same time, the entire cluster is temporarily unavailable: no workflow engine processing occurs, no new data becomes visible in the web applications, and no client requests are accepted.
 
 This is typically observed externally as:
 
-- **Increased error rates** from clients, as requests are rejected while no leader is available
-- **Increased processing latency**, for example, service tasks complete later and process instances progress more slowly
-- **Increased exporting latency**, for example, new data appears in Operate later than expected
+- Increased error rates from clients, as requests are rejected while no leader is available
+- Increased processing latency, as service tasks complete later and process instances progress more slowly
+- Increased exporting latency, as new data appears in Operate later than expected
 
 ### When to rebalance
 
-Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to see how far behind a given replica is for a given partition. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
+Before triggering a rebalance, verify that it is likely to succeed. As described in [Limitations](#limitations), rebalancing only works if the desired leader for each partition is not lagging behind the current leader. You can verify this using the `atomix_non_replicated_entries` metric, filtering by the `partition` and `follower` labels to determine how far a replica lags behind. The closer this value is to `0`, the more likely rebalancing is to succeed. If the desired leader has a significant lag, triggering a rebalance will cause a temporary performance drop without achieving a better distribution.
 
 :::note
 
@@ -91,11 +91,11 @@ If you're using the Zeebe Grafana dashboard, you can already visualize this in t
 
 :::
 
-Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. You must decide whether the long-term benefit outweighs the short-term disruption for your situation.
+Once you have confirmed that rebalancing is likely to succeed, consider the trade-off: rebalancing can improve long-term cluster performance by achieving an optimal leader distribution, but it causes a temporary performance impact and potential unavailability window. Decide whether the long-term benefit outweighs the short-term disruption.
 
 :::warn
 
-We recommend rebalancing only when the cluster is under low load. To determine this, identify what "low load" means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
+Rebalance only when the cluster is under low load. To determine this, identify what low load means for your specific scenario. What constitutes low load, and whether rebalancing is appropriate at all in a given situation, is ultimately your decision.
 
 :::
 
@@ -109,7 +109,7 @@ If you are using Prometheus, you can query the total replication rate across all
 sum(rate(atomix_append_entries_data_rate_total[1m]))
 ```
 
-This returns the replication rate in bytes per second of a cluster.
+This returns the cluster replication rate in bytes per second.
 
 You can find this in the Zeebe Grafana dashboard under the `Raft` section, visualized as a graph named `Leader append data rate`.
 


### PR DESCRIPTION
## Summary

- Adds a **Caveats** section explaining the leader step-down mechanism, the leaderless window during election, and its external symptoms (error rates, processing latency, exporting latency)
- Adds a **When to rebalance** section with guidance on checking replication lag via `atomix_non_replicated_entries`, the stability vs. performance trade-off, and how to assess low load using `atomix_append_entries_data_rate_total`
- Applied to next-version docs and backported to 8.9, 8.8, and 8.7 (one commit per version)

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.