### PR TITLE
resolve kafka pushfeedback

### DIFF
--- a/docs/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/docs/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -147,6 +147,8 @@ There is also documentation on [how to write a good job worker](../writing-good-
 
 Most projects want to connect to specific technologies. Currently, most people ask for REST, messaging, or Kafka.
 
+REST and messaging are common core integration patterns. Kafka is different: it is optional infrastructure that you would typically introduce for event streaming or broader event-driven architectures, not because Zeebe requires it to execute workflows.
+
 ### REST
 
 You could build a piece of code that provides a REST endpoint in the language of choice and then starts a process instance.
@@ -173,7 +175,16 @@ The [Ticket Booking Example](https://github.com/berndruecker/ticket-booking-camu
 
 ### Apache Kafka
 
-You can do the same trick with Kafka topics. The [Flowing Retail example](https://github.com/berndruecker/flowing-retail) shows this using Java, Spring Boot, and Spring Cloud Streams. There is [code to subscribe to a Kafka topic and start new process instances for new records](https://github.com/berndruecker/flowing-retail/blob/master/kafka/java/order-zeebe/src/main/java/io/flowing/retail/kafka/order/messages/MessageListener.java#L39), and there is some glue code to create new records when a process instance executes a service task. Of course, you could also use other frameworks to achieve the same result.
+Kafka is not required for Camunda 8 or Zeebe to work. Zeebe executes workflows itself, while Kafka can optionally be used as an event backbone around the workflow engine.
+
+Typical Kafka-based patterns are:
+
+- **Kafka to Zeebe**: Consume records from a Kafka topic and translate them into Zeebe API calls, such as starting a process instance or correlating a message.
+- **Zeebe to Kafka**: When a workflow reaches a service task or other integration point, write a record to Kafka so downstream systems can react asynchronously.
+
+You can implement these patterns with custom glue code. The [Flowing Retail example](https://github.com/berndruecker/flowing-retail) shows this using Java, Spring Boot, and Spring Cloud Streams. There is [code to subscribe to a Kafka topic and start new process instances for new records](https://github.com/berndruecker/flowing-retail/blob/master/kafka/java/order-zeebe/src/main/java/io/flowing/retail/kafka/order/messages/MessageListener.java#L39), and there is some glue code to create new records when a process instance executes a service task. Of course, you could also use other frameworks to achieve the same result.
+
+This means Kafka is a good fit if you already use Kafka, need loose coupling, or want to broadcast workflow-related events to multiple consumers. If you simply need to call a remote system from a workflow, a job worker or connector is often the more direct option.
 
 ![Kafka Example](connecting-the-workflow-engine-with-your-world-assets/kafka-example.png)
 
@@ -209,7 +220,7 @@ Another example is the [Kafka connector](https://github.com/camunda-community-hu
 
 ![Kafka connector](connecting-the-workflow-engine-with-your-world-assets/kafka-connector.png)
 
-This is a bidirectional connector which contains a Kafka listener for forwarding Kafka records to Zeebe and also a job worker which creates Kafka records every time a service task is executed. This is illustrated by the following example:
+This is a bidirectional connector which contains a Kafka listener for forwarding Kafka records to Zeebe and also a job worker which creates Kafka records every time a service task is executed. In other words, the connector helps Kafka exchange events with Zeebe; it does not replace Zeebe's own workflow execution or state handling. This is illustrated by the following example:
 
 ![Kafka connector Details](connecting-the-workflow-engine-with-your-world-assets/kafka-connector-details.png)
 

--- a/versioned_docs/version-8.9/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
+++ b/versioned_docs/version-8.9/components/best-practices/development/connecting-the-workflow-engine-with-your-world.md
@@ -147,6 +147,8 @@ There is also documentation on [how to write a good job worker](../writing-good-
 
 Most projects want to connect to specific technologies. Currently, most people ask for REST, messaging, or Kafka.
 
+REST and messaging are common core integration patterns. Kafka is different: it is optional infrastructure that you would typically introduce for event streaming or broader event-driven architectures, not because Zeebe requires it to execute workflows.
+
 ### REST
 
 You could build a piece of code that provides a REST endpoint in the language of choice and then starts a process instance.
@@ -173,7 +175,16 @@ The [Ticket Booking Example](https://github.com/berndruecker/ticket-booking-camu
 
 ### Apache Kafka
 
-You can do the same trick with Kafka topics. The [Flowing Retail example](https://github.com/berndruecker/flowing-retail) shows this using Java, Spring Boot, and Spring Cloud Streams. There is [code to subscribe to a Kafka topic and start new process instances for new records](https://github.com/berndruecker/flowing-retail/blob/master/kafka/java/order-zeebe/src/main/java/io/flowing/retail/kafka/order/messages/MessageListener.java#L39), and there is some glue code to create new records when a process instance executes a service task. Of course, you could also use other frameworks to achieve the same result.
+Kafka is not required for Camunda 8 or Zeebe to work. Zeebe executes workflows itself, while Kafka can optionally be used as an event backbone around the workflow engine.
+
+Typical Kafka-based patterns are:
+
+- **Kafka to Zeebe**: Consume records from a Kafka topic and translate them into Zeebe API calls, such as starting a process instance or correlating a message.
+- **Zeebe to Kafka**: When a workflow reaches a service task or other integration point, write a record to Kafka so downstream systems can react asynchronously.
+
+You can implement these patterns with custom glue code. The [Flowing Retail example](https://github.com/berndruecker/flowing-retail) shows this using Java, Spring Boot, and Spring Cloud Streams. There is [code to subscribe to a Kafka topic and start new process instances for new records](https://github.com/berndruecker/flowing-retail/blob/master/kafka/java/order-zeebe/src/main/java/io/flowing/retail/kafka/order/messages/MessageListener.java#L39), and there is some glue code to create new records when a process instance executes a service task. Of course, you could also use other frameworks to achieve the same result.
+
+This means Kafka is a good fit if you already use Kafka, need loose coupling, or want to broadcast workflow-related events to multiple consumers. If you simply need to call a remote system from a workflow, a job worker or connector is often the more direct option.
 
 ![Kafka Example](connecting-the-workflow-engine-with-your-world-assets/kafka-example.png)
 
@@ -209,7 +220,7 @@ Another example is the [Kafka connector](https://github.com/camunda-community-hu
 
 ![Kafka connector](connecting-the-workflow-engine-with-your-world-assets/kafka-connector.png)
 
-This is a bidirectional connector which contains a Kafka listener for forwarding Kafka records to Zeebe and also a job worker which creates Kafka records every time a service task is executed. This is illustrated by the following example:
+This is a bidirectional connector which contains a Kafka listener for forwarding Kafka records to Zeebe and also a job worker which creates Kafka records every time a service task is executed. In other words, the connector helps Kafka exchange events with Zeebe; it does not replace Zeebe's own workflow execution or state handling. This is illustrated by the following example:
 
 ![Kafka connector Details](connecting-the-workflow-engine-with-your-world-assets/kafka-connector-details.png)
 


### PR DESCRIPTION
## Description

User feedback summary:
- The page made Kafka feel like a standard or required part of Camunda integration without clearly explaining why it appears at all.
- It did not explicitly distinguish Kafka from core Camunda interaction patterns like clients, job workers, and connectors.
- A reader could reasonably come away unsure whether Kafka is required for workflow execution, or what Kafka is actually responsible for.

What we changed:
- Clarified that Kafka is optional infrastructure and is not required for Camunda 8 / Zeebe to execute workflows.
- Added a short explanation that Kafka is typically used for event-driven integration patterns, not as part of Zeebe's core execution path.
- Made the two main Kafka directions explicit:
  - Kafka → Zeebe: consume Kafka records and translate them into Zeebe API calls.
  - Zeebe → Kafka: publish records to Kafka when workflows reach integration points.
- Clarified that for straightforward remote system calls, job workers or connectors are usually the more direct option.
- Clarified that the Kafka connector exchanges events with Zeebe, but does not replace Zeebe's workflow execution or state handling.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
