### PR TITLE
pushfeedback admin overview

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/admin/overview.md
+++ b/docs/self-managed/components/orchestration-cluster/admin/overview.md
@@ -46,6 +46,19 @@ If users are managed within the Orchestration Cluster (that is, without an exter
 - Using the [Setup endpoint of the Orchestration Cluster REST API](#option-2-setup-rest-api)
 - Using the [configuration](#option-3-configuration)
 
+:::info Production and no-clickops setups
+For production environments, prefer **Option 3: configuration** so your admin bootstrap, role assignments, and authentication settings are defined declaratively in `application.yaml`, environment variables, or Helm-managed application configuration.
+
+The UI and Setup API options are useful for manual bootstrap, but they are not the best fit for repeatable, Git-managed deployments.
+
+Typical production next steps are:
+
+- Define initial users and role assignments with the configuration examples on this page.
+- Enable API authentication and authorizations in configuration.
+- If you deploy with Helm, provide these settings through [application configs](/self-managed/deployment/helm/configure/application-configs.md) and the [Helm authentication and authorization guides](/self-managed/deployment/helm/configure/authentication-and-authorization/index.md).
+- If you use an external Identity Provider, continue with [connect Admin to an identity provider](./connect-external-identity-provider.md).
+  :::
+
 :::warning
 After completing the initial setup, ensure at least one user remains assigned to the `admin` role.  
 If no admin user exists, a third party could create a new admin account and gain full access.
@@ -77,6 +90,8 @@ with the following JSON request body:
 ```
 
 This endpoint is only available if **no user is assigned to the `admin` role**.
+
+This option is convenient for scripted bootstrap, but for long-lived production environments we recommend keeping the desired state in configuration.
 
 ### Option 3: Define initial users via the configuration{#option-3-configuration}
 

--- a/docs/self-managed/components/orchestration-cluster/admin/overview.md
+++ b/docs/self-managed/components/orchestration-cluster/admin/overview.md
@@ -42,6 +42,8 @@ To modify the [initial configuration](/self-managed/components/orchestration-clu
 
 If users are managed within the Orchestration Cluster (that is, without an external Identity Provider), you can create an initial user in three ways:
 
+If you use an external Identity Provider instead, continue with [connect Admin to an identity provider](./connect-external-identity-provider.md).
+
 - Using the [Orchestration Cluster UI](#option-1-orchestration-cluster-ui)
 - Using the [Setup endpoint of the Orchestration Cluster REST API](#option-2-setup-rest-api)
 - Using the [configuration](#option-3-configuration)
@@ -53,10 +55,8 @@ The UI and Setup API options are useful for manual bootstrap, but they are not t
 
 Typical production next steps are:
 
-- Define initial users and role assignments with the configuration examples on this page.
-- Enable API authentication and authorizations in configuration.
+- Define initial users with the [configuration examples](#option-3-configuration) and assign them to roles with the [role assignment examples](#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
 - If you deploy with Helm, provide these settings through [application configs](/self-managed/deployment/helm/configure/application-configs.md) and the [Helm authentication and authorization guides](/self-managed/deployment/helm/configure/authentication-and-authorization/index.md).
-- If you use an external Identity Provider, continue with [connect Admin to an identity provider](./connect-external-identity-provider.md).
   :::
 
 :::warning

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/overview.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/overview.md
@@ -46,6 +46,19 @@ If users are managed within the Orchestration Cluster (that is, without an exter
 - Using the [Setup endpoint of the Orchestration Cluster REST API](#option-2-setup-rest-api)
 - Using the [configuration](#option-3-configuration)
 
+:::info Production and no-clickops setups
+For production environments, prefer **Option 3: configuration** so your admin bootstrap, role assignments, and authentication settings are defined declaratively in `application.yaml`, environment variables, or Helm-managed application configuration.
+
+The UI and Setup API options are useful for manual bootstrap, but they are not the best fit for repeatable, Git-managed deployments.
+
+Typical production next steps are:
+
+- Define initial users and role assignments with the configuration examples on this page.
+- Enable API authentication and authorizations in configuration.
+- If you deploy with Helm, provide these settings through [application configs](/self-managed/deployment/helm/configure/application-configs.md) and the [Helm authentication and authorization guides](/self-managed/deployment/helm/configure/authentication-and-authorization/index.md).
+- If you use an external Identity Provider, continue with [connect Admin to an identity provider](./connect-external-identity-provider.md).
+  :::
+
 :::warning
 After completing the initial setup, ensure at least one user remains assigned to the `admin` role.  
 If no admin user exists, a third party could create a new admin account and gain full access.
@@ -77,6 +90,8 @@ with the following JSON request body:
 ```
 
 This endpoint is only available if **no user is assigned to the `admin` role**.
+
+This option is convenient for scripted bootstrap, but for long-lived production environments we recommend keeping the desired state in configuration.
 
 ### Option 3: Define initial users via the configuration{#option-3-configuration}
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/overview.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/admin/overview.md
@@ -42,6 +42,8 @@ To modify the [initial configuration](/self-managed/components/orchestration-clu
 
 If users are managed within the Orchestration Cluster (that is, without an external Identity Provider), you can create an initial user in three ways:
 
+If you use an external Identity Provider instead, continue with [connect Admin to an identity provider](./connect-external-identity-provider.md).
+
 - Using the [Orchestration Cluster UI](#option-1-orchestration-cluster-ui)
 - Using the [Setup endpoint of the Orchestration Cluster REST API](#option-2-setup-rest-api)
 - Using the [configuration](#option-3-configuration)
@@ -53,10 +55,8 @@ The UI and Setup API options are useful for manual bootstrap, but they are not t
 
 Typical production next steps are:
 
-- Define initial users and role assignments with the configuration examples on this page.
-- Enable API authentication and authorizations in configuration.
+- Define initial users with the [configuration examples](#option-3-configuration) and assign them to roles with the [role assignment examples](#assign-users-clients-groups-or-mapping-rules-to-roles-via-configuration).
 - If you deploy with Helm, provide these settings through [application configs](/self-managed/deployment/helm/configure/application-configs.md) and the [Helm authentication and authorization guides](/self-managed/deployment/helm/configure/authentication-and-authorization/index.md).
-- If you use an external Identity Provider, continue with [connect Admin to an identity provider](./connect-external-identity-provider.md).
   :::
 
 :::warning


### PR DESCRIPTION
## Description

User complaint:
- The page felt too introductory and did not give readers a realistic path from "Admin overview" to a production-ready, configuration-driven setup.
- In particular, the feedback called out the gap between the overview and a "no clickops" deployment model, where teams want to manage admin bootstrap and security setup declaratively rather than through the UI.

What I changed:
- Added explicit guidance that production and no-clickops setups should prefer **Option 3: configuration**.
- Clarified that the UI and Setup API options are useful for manual bootstrap, but are not the recommended path for repeatable, Git-managed deployments.
- Added a short "what to do next" path for production readers:
  - define initial users and role assignments in configuration
  - enable API authentication and authorizations in configuration
  - use Helm application configs and the Helm authentication/authorization guides when deploying with Helm
  - continue to the external IdP guide when using an external identity provider
- The page now works better as an overview because it still introduces the options, but it also tells production users which path to follow and where to go next for a configuration-first setup.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
