### PR TITLE
pushfeedback add details on saving diagram

### DIFF
--- a/docs/components/modeler/desktop-modeler/model-your-first-diagram.md
+++ b/docs/components/modeler/desktop-modeler/model-your-first-diagram.md
@@ -14,9 +14,9 @@ The BPMN diagram opens with a start event. [Events](/components/modeler/bpmn/eve
 
 ![new diagram](./img/new-diagram.png)
 
-2. The basic elements of BPMN processes are [tasks](/components/modeler/bpmn/tasks.md), or atomic units of work composed to create a meaningful result. Click on the start event and select the rectangular task element. This creates a task directly following the start event, connected by an arrow. Next, double-click the task and type in a name for the element. For example, `My Service Task`.
+1. The basic elements of BPMN processes are [tasks](/components/modeler/bpmn/tasks.md), or atomic units of work composed to create a meaningful result. Click on the start event and select the rectangular task element. This creates a task directly following the start event, connected by an arrow. Next, double-click the task and type in a name for the element. For example, `My Service Task`.
 
-3. Click on the task and select the dark circle in the top left. This attaches an end event directly to the task. On the left side of the screen you will find the element palette, where you can also drag and drop elements onto the canvas.
+1. Click on the task and select the dark circle in the top left. This attaches an end event directly to the task. On the left side of the screen you will find the element palette, where you can also drag and drop elements onto the canvas.
 
 ![elements](./img/elements.png)
 
@@ -26,10 +26,12 @@ Above, you can see that elements that support different types can be reconfigure
 
 You can also [orchestrate human tasks](/guides/getting-started-orchestrate-human-tasks.md). Review the [complete list of supported BPMN elements](/components/modeler/bpmn/bpmn-coverage.md)
 
-4. Open the properties panel by selecting the light gray arrow on the right side of the page halfway down the canvas. Here, you can edit the properties of the currently selected element:
+1. Open the properties panel by selecting the light gray arrow on the right side of the page halfway down the canvas. Here, you can edit the properties of the currently selected element:
 
 ![properties panel](img/properties-panel.png)
 
 For example, you might name your element and give it an ID under the **General** section.
 
-5. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda 8 cluster](./connect-to-camunda-8.md).
+1. Save the diagram using **File > Save**, **File > Save As**, or the `Cmd/Ctrl + S` shortcut. Desktop Modeler saves the file to the location you choose on your local file system; it does not store diagrams in a separate internal workspace. To find the file again, reopen it from that folder or from the recent files list on the Desktop Modeler start screen.
+
+1. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda 8 cluster](./connect-to-camunda-8.md).

--- a/docs/components/modeler/desktop-modeler/model-your-first-diagram.md
+++ b/docs/components/modeler/desktop-modeler/model-your-first-diagram.md
@@ -32,6 +32,6 @@ You can also [orchestrate human tasks](/guides/getting-started-orchestrate-human
 
 For example, you might name your element and give it an ID under the **General** section.
 
-1. Save the diagram using **File > Save**, **File > Save As**, or the `Cmd/Ctrl + S` shortcut. Desktop Modeler saves the file to the location you choose on your local file system; it does not store diagrams in a separate internal workspace. To find the file again, reopen it from that folder or from the recent files list on the Desktop Modeler start screen.
+1. Save the diagram using **File > Save**, **File > Save As**, or the keyboard shortcut (`Cmd + S` on macOS or `Ctrl + S` on Windows and Linux). Desktop Modeler saves the file to the location you choose on your local file system; it does not store diagrams in a separate internal workspace. To find the file again, reopen it from that folder or from the recent files list on the Desktop Modeler start screen.
 
 1. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda 8 cluster](./connect-to-camunda-8.md).

--- a/versioned_docs/version-8.9/components/modeler/desktop-modeler/model-your-first-diagram.md
+++ b/versioned_docs/version-8.9/components/modeler/desktop-modeler/model-your-first-diagram.md
@@ -14,9 +14,9 @@ The BPMN diagram opens with a start event. [Events](/components/modeler/bpmn/eve
 
 ![new diagram](./img/new-diagram.png)
 
-2. The basic elements of BPMN processes are [tasks](/components/modeler/bpmn/tasks.md), or atomic units of work composed to create a meaningful result. Click on the start event and select the rectangular task element. This creates a task directly following the start event, connected by an arrow. Next, double-click the task and type in a name for the element. For example, `My Service Task`.
+1. The basic elements of BPMN processes are [tasks](/components/modeler/bpmn/tasks.md), or atomic units of work composed to create a meaningful result. Click on the start event and select the rectangular task element. This creates a task directly following the start event, connected by an arrow. Next, double-click the task and type in a name for the element. For example, `My Service Task`.
 
-3. Click on the task and select the dark circle in the top left. This attaches an end event directly to the task. On the left side of the screen you will find the element palette, where you can also drag and drop elements onto the canvas.
+1. Click on the task and select the dark circle in the top left. This attaches an end event directly to the task. On the left side of the screen you will find the element palette, where you can also drag and drop elements onto the canvas.
 
 ![elements](./img/elements.png)
 
@@ -26,10 +26,12 @@ Above, you can see that elements that support different types can be reconfigure
 
 You can also [orchestrate human tasks](/guides/getting-started-orchestrate-human-tasks.md). Review the [complete list of supported BPMN elements](/components/modeler/bpmn/bpmn-coverage.md)
 
-4. Open the properties panel by selecting the light gray arrow on the right side of the page halfway down the canvas. Here, you can edit the properties of the currently selected element:
+1. Open the properties panel by selecting the light gray arrow on the right side of the page halfway down the canvas. Here, you can edit the properties of the currently selected element:
 
 ![properties panel](img/properties-panel.png)
 
 For example, you might name your element and give it an ID under the **General** section.
 
-5. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda 8 cluster](./connect-to-camunda-8.md).
+1. Save the diagram using **File > Save**, **File > Save As**, or the `Cmd/Ctrl + S` shortcut. Desktop Modeler saves the file to the location you choose on your local file system; it does not store diagrams in a separate internal workspace. To find the file again, reopen it from that folder or from the recent files list on the Desktop Modeler start screen.
+
+1. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda 8 cluster](./connect-to-camunda-8.md).

--- a/versioned_docs/version-8.9/components/modeler/desktop-modeler/model-your-first-diagram.md
+++ b/versioned_docs/version-8.9/components/modeler/desktop-modeler/model-your-first-diagram.md
@@ -32,6 +32,6 @@ You can also [orchestrate human tasks](/guides/getting-started-orchestrate-human
 
 For example, you might name your element and give it an ID under the **General** section.
 
-1. Save the diagram using **File > Save**, **File > Save As**, or the `Cmd/Ctrl + S` shortcut. Desktop Modeler saves the file to the location you choose on your local file system; it does not store diagrams in a separate internal workspace. To find the file again, reopen it from that folder or from the recent files list on the Desktop Modeler start screen.
+1. Save the diagram using **File > Save**, **File > Save As**, or the keyboard shortcut (`Cmd + S` on macOS or `Ctrl + S` on Windows and Linux). Desktop Modeler saves the file to the location you choose on your local file system; it does not store diagrams in a separate internal workspace. To find the file again, reopen it from that folder or from the recent files list on the Desktop Modeler start screen.
 
 1. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda 8 cluster](./connect-to-camunda-8.md).


### PR DESCRIPTION
## Description

### user complaint

The tutorial is simple and easy to follow, but after saving the diagram it does not tell the user where the file was saved or how to find it again.

### what I changed

Updated the Desktop Modeler "Model your first diagram" page to add an explicit save step. It now explains that Desktop Modeler saves the diagram to the location the user chooses on their local file system, not to a separate internal workspace, and that the file can be reopened either from that folder or from the recent files list on the Desktop Modeler start screen.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory (version 8.9).
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
