### PR TITLE
docs(operate): only processes with active instance

### DIFF
--- a/docs/components/operate/userguide/basic-operate-navigation.md
+++ b/docs/components/operate/userguide/basic-operate-navigation.md
@@ -14,7 +14,7 @@ This section and the next section, [Resolve incidents and update variables](./re
 
 To view a deployed process, take the following steps:
 
-1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances. The dashboard only displays processes that have active instances, so processes with no running or incident instances are not shown.
+1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances. The dashboard only displays processes with active instances, so processes without running or incident instances are not shown.
 2. When you click on the name of a deployed process in the **Process Instances by Name** panel, you’ll navigate to a view of that process model and all running instances.
 3. From this **Processes** page, you can cancel a single running process instance by clicking the cancel icon under the **Operations** column of the **Process Instances** table.
 

--- a/docs/components/operate/userguide/basic-operate-navigation.md
+++ b/docs/components/operate/userguide/basic-operate-navigation.md
@@ -14,7 +14,7 @@ This section and the next section, [Resolve incidents and update variables](./re
 
 To view a deployed process, take the following steps:
 
-1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances.
+1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances. The dashboard only displays processes that have active instances, so processes with no running or incident instances are not shown.
 2. When you click on the name of a deployed process in the **Process Instances by Name** panel, you’ll navigate to a view of that process model and all running instances.
 3. From this **Processes** page, you can cancel a single running process instance by clicking the cancel icon under the **Operations** column of the **Process Instances** table.
 

--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -823,7 +823,6 @@ Camunda 8 now supports Elasticsearch 9 as a secondary data store, allowing you t
 Granular task-level authorization is now integrated into the Tasklist UI and the Orchestration Cluster REST API.
 
 - Property-based task permissions:
-
   - Grant users permission to view or work on a task, based on task properties.
   - Permissions apply when the assignee matches the current user, or when the user belongs to a candidate group (or is listed as a candidate user). This ensures all relevant users have appropriate access, whether directly assigned or eligible to claim the task.
   - Permissions apply consistently across both the Tasklist UI and the orchestration cluster REST API.

--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -367,6 +367,10 @@ Camunda 8.9 adds support for BPMN conditional events in the platform itself, com
 
 <div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--long" title="This feature affects SaaS">SaaS</span><span class="badge badge--medium" title="This feature affects Operate">Operate</span></div>
 
+### Dashboard focuses on active processes
+
+The Operate dashboard now only displays processes that have active instances. Processes with no running or incident instances are no longer shown, providing a clean view of what is currently running in your cluster.
+
 ### Unified, context-aware process instance view
 
 <!-- https://github.com/camunda/product-hub/issues/3255 -->
@@ -819,6 +823,7 @@ Camunda 8 now supports Elasticsearch 9 as a secondary data store, allowing you t
 Granular task-level authorization is now integrated into the Tasklist UI and the Orchestration Cluster REST API.
 
 - Property-based task permissions:
+
   - Grant users permission to view or work on a task, based on task properties.
   - Permissions apply when the assignee matches the current user, or when the user belongs to a candidate group (or is listed as a candidate user). This ensures all relevant users have appropriate access, whether directly assigned or eligible to claim the task.
   - Permissions apply consistently across both the Tasklist UI and the orchestration cluster REST API.

--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -369,7 +369,7 @@ Camunda 8.9 adds support for BPMN conditional events in the platform itself, com
 
 ### Dashboard focuses on active processes
 
-The Operate dashboard now only displays processes that have active instances. Processes with no running or incident instances are no longer shown, providing a clean view of what is currently running in your cluster.
+The Operate dashboard now only displays processes with active instances. Processes without running or incident instances are no longer shown, providing a clean view of what is currently running in your cluster.
 
 ### Unified, context-aware process instance view
 

--- a/versioned_docs/version-8.9/components/operate/userguide/basic-operate-navigation.md
+++ b/versioned_docs/version-8.9/components/operate/userguide/basic-operate-navigation.md
@@ -14,7 +14,7 @@ This section and the next section, [Resolve incidents and update variables](./re
 
 To view a deployed process, take the following steps:
 
-1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances. The dashboard only displays processes that have active instances, so processes with no running or incident instances are not shown.
+1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances. The dashboard only displays processes with active instances, so processes without running or incident instances are not shown.
 2. When you click on the name of a deployed process in the **Process Instances by Name** panel, you’ll navigate to a view of that process model and all running instances.
 3. From this **Processes** page, you can cancel a single running process instance by clicking the cancel icon under the **Operations** column of the **Process Instances** table.
 

--- a/versioned_docs/version-8.9/components/operate/userguide/basic-operate-navigation.md
+++ b/versioned_docs/version-8.9/components/operate/userguide/basic-operate-navigation.md
@@ -14,7 +14,7 @@ This section and the next section, [Resolve incidents and update variables](./re
 
 To view a deployed process, take the following steps:
 
-1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances.
+1. On the **Dashboard** page, in the **Process Instances by Name** panel, note the list of your deployed processes and running instances. The dashboard only displays processes that have active instances, so processes with no running or incident instances are not shown.
 2. When you click on the name of a deployed process in the **Process Instances by Name** panel, you’ll navigate to a view of that process model and all running instances.
 3. From this **Processes** page, you can cancel a single running process instance by clicking the cancel icon under the **Operations** column of the **Process Instances** table.
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -365,6 +365,10 @@ Camunda 8.9 adds support for BPMN conditional events in the platform itself, com
 
 <div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--long" title="This feature affects SaaS">SaaS</span><span class="badge badge--medium" title="This feature affects Operate">Operate</span></div>
 
+### Dashboard focuses on active processes
+
+The Operate dashboard now only displays processes that have active instances. Processes with no running or incident instances are no longer shown, providing a clean view of what is currently running in your cluster.
+
 ### Unified, context-aware process instance view
 
 <!-- https://github.com/camunda/product-hub/issues/3255 -->
@@ -817,6 +821,7 @@ Camunda 8 now supports Elasticsearch 9 as a secondary data store, allowing you t
 Granular task-level authorization is now integrated into the Tasklist UI and the Orchestration Cluster REST API.
 
 - Property-based task permissions:
+
   - Grant users permission to view or work on a task, based on task properties.
   - Permissions apply when the assignee matches the current user, or when the user belongs to a candidate group (or is listed as a candidate user). This ensures all relevant users have appropriate access, whether directly assigned or eligible to claim the task.
   - Permissions apply consistently across both the Tasklist UI and the orchestration cluster REST API.

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -367,7 +367,7 @@ Camunda 8.9 adds support for BPMN conditional events in the platform itself, com
 
 ### Dashboard focuses on active processes
 
-The Operate dashboard now only displays processes that have active instances. Processes with no running or incident instances are no longer shown, providing a clean view of what is currently running in your cluster.
+The Operate dashboard now only displays processes with active instances. Processes without running or incident instances are no longer shown, providing a clean view of what is currently running in your cluster.
 
 ### Unified, context-aware process instance view
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -821,7 +821,6 @@ Camunda 8 now supports Elasticsearch 9 as a secondary data store, allowing you t
 Granular task-level authorization is now integrated into the Tasklist UI and the Orchestration Cluster REST API.
 
 - Property-based task permissions:
-
   - Grant users permission to view or work on a task, based on task properties.
   - Permissions apply when the assignee matches the current user, or when the user belongs to a candidate group (or is listed as a candidate user). This ensures all relevant users have appropriate access, whether directly assigned or eligible to claim the task.
   - Permissions apply consistently across both the Tasklist UI and the orchestration cluster REST API.


### PR DESCRIPTION
## Description

Documents that only active processes are shown in the Operate dashboard, and that this is a change from 8.8.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.