### PR TITLE
docs(desktop-modeler): add tenant ID field and warning

### DIFF
--- a/docs/components/modeler/desktop-modeler/connect-to-camunda-8.md
+++ b/docs/components/modeler/desktop-modeler/connect-to-camunda-8.md
@@ -20,9 +20,13 @@ To deploy diagrams, start process instances, or test tasks, you must first conne
 
    ![Connection manager showing add button](./img/connection-manager-add.png)
 
-4. Enter a name, the cluster URL, and the credentials (client ID and client secret) for your [API client](../../hub/organization/manage-clusters/manage-api-clients.md).
+4. Enter a name, the cluster URL, and the credentials (client ID and client secret) for your [API client](../../hub/organization/manage-clusters/manage-api-clients.md). Optionally enter the tenant ID.
 
    ![Connection manager with new connection information filled in](./img/connection-manager-new-connection-loading.png)
+
+   :::caution
+   When connecting to a tenant, the API client must be assigned to it through [Orchestration Cluster Admin](../../admin/admin-introduction.md).
+   :::
 
    Desktop Modeler automatically validates the connection.
    If you have issues connecting to the cluster, see the [troubleshooting page](./troubleshooting.md#debug-zeebe-connection-issues).

--- a/versioned_docs/version-8.8/components/modeler/desktop-modeler/connect-to-camunda-8.md
+++ b/versioned_docs/version-8.8/components/modeler/desktop-modeler/connect-to-camunda-8.md
@@ -20,9 +20,13 @@ To deploy diagrams, start process instances, or test tasks, you must first conne
 
    ![Connection manager showing add button](./img/connection-manager-add.png)
 
-4. Enter a name, the cluster URL, and the credentials (client ID and client secret) for your [API client](../../console/manage-clusters/manage-api-clients.md).
+4. Enter a name, the cluster URL, and the credentials (client ID and client secret) for your [API client](../../console/manage-clusters/manage-api-clients.md). Optionally enter the tenant ID.
 
    ![Connection manager with new connection information filled in](./img/connection-manager-new-connection-loading.png)
+
+   :::caution
+   When connecting to a tenant, the API client must be assigned to it through [Orchestration Cluster Identity](../../identity/identity-introduction.md).
+   :::
 
    Desktop Modeler automatically validates the connection.
    If you have issues connecting to the cluster, see the [troubleshooting page](./troubleshooting.md#debug-zeebe-connection-issues).

--- a/versioned_docs/version-8.9/components/modeler/desktop-modeler/connect-to-camunda-8.md
+++ b/versioned_docs/version-8.9/components/modeler/desktop-modeler/connect-to-camunda-8.md
@@ -20,9 +20,13 @@ To deploy diagrams, start process instances, or test tasks, you must first conne
 
    ![Connection manager showing add button](./img/connection-manager-add.png)
 
-4. Enter a name, the cluster URL, and the credentials (client ID and client secret) for your [API client](../../console/manage-clusters/manage-api-clients.md).
+4. Enter a name, the cluster URL, and the credentials (client ID and client secret) for your [API client](../../console/manage-clusters/manage-api-clients.md). Optionally enter the tenant ID.
 
    ![Connection manager with new connection information filled in](./img/connection-manager-new-connection-loading.png)
+
+   :::caution
+   When connecting to a tenant, the API client must be assigned to it through [Orchestration Cluster Admin](../../admin/admin-introduction.md).
+   :::
 
    Desktop Modeler automatically validates the connection.
    If you have issues connecting to the cluster, see the [troubleshooting page](./troubleshooting.md#debug-zeebe-connection-issues).


### PR DESCRIPTION
## Description

related https://github.com/camunda/camunda-modeler/issues/5818

The documented functionality is not released yet. It will be available as part of the Desktop Modeler released during the `8.10.0-alpha3` cycle.

This change is now also added to the `8.9` and `8.8` versioned docs, as the feature will be available on 8.8+ SaaS clusters. The tenant warning links to "Orchestration Cluster Admin" in `/docs` and 8.9, but to "Orchestration Cluster Identity" in 8.8 (the page was renamed in 8.9).

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- <a href="https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting">x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)</a>

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - <a href="https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process"> ] [Engineering team review</a>
  - <a href="https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process">x] [Technical writer review</a> via `@camunda/tech-writers` unless working with an embedded writer.