### PR TITLE
docs: add AGENTS.md and SKILLS.md for AI agent contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Cursor, GitHub Copilot, Codex, Aider, and similar) working in the `camunda-docs` repository. This file follows the [agents.md](https://agents.md) convention and complements `.github/copilot-instructions.md` and `CONTRIBUTING.MD`.
+
+Human contributors should start with `README.md` and `CONTRIBUTING.MD`.
+
+## Project overview
+
+This repository contains the public Camunda 8 documentation published at <https://docs.camunda.io>. It is a [Docusaurus 3](https://docusaurus.io/) site. Content is authored in Markdown and MDX by Camunda engineers and the wider community.
+
+- **Build system**: Docusaurus 3 + React 19, Node-based toolchain, Prettier for formatting, Jest for unit tests, Playwright for regression tests.
+- **Primary language**: Markdown / MDX. JavaScript and TypeScript are used for site infrastructure under `src/`, `hacks/`, `api/`, and `config-reference/`.
+- **Versioning model**: "Next" (unreleased) docs live in `/docs/`. Released versions live in `/versioned_docs/version-*/` with matching sidebars in `/versioned_sidebars/`. See `howtos/versioning.md`.
+
+## Repository layout
+
+| Path                        | Purpose                                                                                                   |
+| --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `docs/`                     | Next (unreleased) documentation.                                                                          |
+| `versioned_docs/version-*/` | Frozen documentation for released versions.                                                               |
+| `versioned_sidebars/`       | Sidebar JSON for each released version.                                                                   |
+| `sidebars.js`               | Sidebar configuration for Next.                                                                           |
+| `docusaurus.config.js`      | Site configuration.                                                                                       |
+| `src/`                      | React components, theme overrides, and version metadata.                                                  |
+| `static/`                   | Static assets. `static/img/` for images, `static/bpmn/` for BPMN files, `static/.htaccess` for redirects. |
+| `api/`                      | OpenAPI ingestion and generation scripts.                                                                 |
+| `config-reference/`         | Auto-generated configuration reference pages.                                                             |
+| `howtos/`                   | Internal contributor guides — read these before non-trivial changes.                                      |
+| `.github/instructions/`     | Condensed instructions for AI tooling. Always read before editing.                                        |
+| `spec/`                     | Playwright regression specs.                                                                              |
+
+## Required reading before changes
+
+Read these in order before editing — they are authoritative:
+
+1. `.github/copilot-instructions.md` — entry point for AI tooling.
+2. `.github/instructions/repo.instructions.md` — file structure, PR workflow, commit conventions.
+3. `.github/instructions/content.instructions.md` — language, formatting, links, terminology. Required for any Markdown change.
+4. `howtos/technical-writing-styleguide.md` — full style guide. Consult for questions not covered above.
+5. `howtos/documentation-guidelines.md` — broader contributor guidance.
+
+## Setup and common commands
+
+```bash
+npm install                # install dependencies
+npm run start              # local dev server with hot reload
+npm run build              # full static build (resource intensive)
+npm run build:docker       # containerized build, easier on local resources
+npm run format             # Prettier write — run before committing
+npm run format:check       # Prettier check
+npm test                   # Jest unit tests
+npm run test:regression    # Playwright regression tests
+npm run docusaurus -- clear  # clear Docusaurus cache when hot reload misbehaves
+```
+
+If `npm run start` produces core dumps, raise the Node heap:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=10248
+```
+
+For large API or config regenerations, stop and restart the dev server rather than relying on hot reload.
+
+## Style and content rules (summary)
+
+The full rules live in `.github/instructions/content.instructions.md`. Highlights agents must follow:
+
+- **American English**, second person, active voice, common contractions.
+- **Sentence case** for all titles and headers. No trailing colons in headers.
+- Use `>` to separate sequential UI navigation: `**File > New > BPMN Diagram**`.
+- **Bold** UI elements and button labels. Never use quotation marks for them. Never use bold for emphasis.
+- Internal links include the `.md` extension. Use **relative paths** within a subtree, **absolute paths** across subtrees. Do not prefix with `/docs/`.
+- Use descriptive link text. Never "click here" or bare URLs.
+- Use **process**, not "workflow" (with the documented exceptions). **Upgrade** for version changes; **update** for in-place changes.
+- Admonitions: only `:::warning`, `:::note`, `:::tip`. Never stack. Never put required steps inside.
+- Bulleted lists use `-`, not `*`.
+- Write "Elasticsearch", "GitHub" — capitalization matters.
+
+## Adding, moving, or removing pages
+
+- **Add**: create the file in kebab-case, then add its document ID to the sidebar(s).
+- **Move**: update sidebar(s) and add a redirect to the **top** of `static/.htaccess`.
+- **Remove**: remove from sidebar(s) and add a redirect to `static/.htaccess`.
+- When a change applies to the current released version and beyond, edit both the most recent `versioned_docs/version-*/` folder **and** `/docs/`.
+
+## Pull request workflow
+
+- Branch from `main`.
+- Keep the PR in **draft** while working. Removing draft signals ready for review.
+- Apply **labels** for component, version, and priority. Unlabeled PRs are triaged slowly.
+- Add the **`deploy`** label to trigger a preview deployment (recommended for large or complex changes).
+- Run `npm run format` before pushing. CI runs Prettier and will fail otherwise.
+- Use the PR template at `.github/pull_request_template.md`.
+
+## Commit message convention
+
+Format: `{type}(scope): {description}`
+
+- Valid types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `chore`.
+- Header length: 72–120 characters.
+- Description in present tense, imperative mood. Example: `docs(8.9): clarify update vs upgrade for license rotation`.
+
+## Things agents should not do
+
+- Do not invent or guess external URLs in content. Link to verified sources.
+- Do not edit auto-generated content directly. Files under `docs/apis-tools/` API references and `config-reference/` outputs are regenerated — change the upstream source or the generator instead.
+- Do not introduce GIFs or uncropped screenshots containing personal information.
+- Do not change `versions.json` or release-related files unless following `howtos/release-procedure.md`.
+- Do not skip Prettier or commit-hook checks with `--no-verify` flags.
+- Do not bypass the broken-link check (`onBrokenLinks: "throw"`). Fix the link.
+- Do not modify `LICENSE.txt`, `code-of-conduct.md`, or CLA-related materials.
+
+## Verification checklist before opening a PR
+
+- [ ] `npm run format` is clean.
+- [ ] `npm test` passes if JS/TS was touched.
+- [ ] Local `npm run start` renders the changed page without console errors.
+- [ ] All internal links resolve (the build will throw on broken links).
+- [ ] If pages were moved or removed, redirects exist in `static/.htaccess`.
+- [ ] If a Next-and-versioned change, both folders are updated.
+- [ ] PR has a meaningful title following the commit convention and appropriate labels.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,91 @@ This repository contains the public Camunda 8 documentation published at <https:
 | `.github/instructions/`     | Condensed instructions for AI tooling. Always read before editing.                                        |
 | `spec/`                     | Playwright regression specs.                                                                              |
 
+## Where each Camunda component is documented
+
+Camunda 8 is a suite of components. Use this map to find the right folder before editing. Paths are shown for the Next docs (`/docs/`); the same structure exists under each `versioned_docs/version-*/`.
+
+### Top-level documentation areas
+
+| Area                | Path                 | What lives here                                                                                                                    |
+| ------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Components          | `docs/components/`   | User-facing docs for each Camunda component (Operate, Tasklist, Modeler, Connectors, etc.) and shared concepts.                    |
+| Self-Managed        | `docs/self-managed/` | Installation, deployment, and operations for customers running Camunda 8 themselves (Helm, Docker, manual, upgrade, architecture). |
+| APIs and tools      | `docs/apis-tools/`   | REST APIs, gRPC, SDKs, clients, CLIs, and developer tooling.                                                                       |
+| Guides              | `docs/guides/`       | End-to-end getting-started and migration tutorials.                                                                                |
+| Reference           | `docs/reference/`    | Release notes, supported environments, glossary, legal, announcements.                                                             |
+| Versioned snapshots | `versioned_docs/`    | Frozen copies of all of the above per released minor version.                                                                      |
+
+### Components area (`docs/components/`)
+
+| Camunda component               | Path                                                       | Notes                                                                                                            |
+| ------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Orchestration cluster (Zeebe)   | `components/zeebe/`, `components/orchestration-cluster.md` | Workflow engine internals, deployment concepts, exporters. Zeebe is the engine inside the orchestration cluster. |
+| Operate                         | `components/operate/`                                      | Monitoring and troubleshooting running process instances.                                                        |
+| Tasklist                        | `components/tasklist/`                                     | Human task list UI for end users.                                                                                |
+| Optimize                        | `components/optimize/`                                     | Process analytics, dashboards, KPIs.                                                                             |
+| Web Modeler and Desktop Modeler | `components/modeler/`                                      | BPMN, DMN, and Forms authoring. Includes element templates and Play.                                             |
+| Connectors                      | `components/connectors/`                                   | Out-of-the-box connectors and custom connector authoring.                                                        |
+| Console                         | `components/console/`                                      | SaaS and Self-Managed administration UI.                                                                         |
+| Identity / Admin                | `components/admin/`                                        | User management, authorizations, tenants, identity federation.                                                   |
+| Agentic orchestration           | `components/agentic-orchestration/`                        | AI agent orchestration features.                                                                                 |
+| RPA                             | `components/rpa/`                                          | Robotic process automation.                                                                                      |
+| Document handling               | `components/document-handling/`                            | Document store and document references in processes.                                                             |
+| Audit log                       | `components/audit-log/`                                    | Audit trail features.                                                                                            |
+| Hub                             | `components/hub/`                                          | Camunda Hub (shared assets, marketplace).                                                                        |
+| Camunda integrations            | `components/camunda-integrations/`                         | First-party integrations (Slack, Microsoft 365, Salesforce, etc.).                                               |
+| Concepts                        | `components/concepts/`                                     | Cross-component concepts: BPMN/DMN/FEEL, expressions, incidents, batch operations, access control.               |
+| Best practices                  | `components/best-practices/`                               | Modeling and operational best practices.                                                                         |
+| Early access                    | `components/early-access/`                                 | Alpha/beta features not yet GA.                                                                                  |
+| SaaS specifics                  | `components/saas/`                                         | SaaS-only topics: regions, BYOK, IP addresses, auto-updates, monitoring, secure connectivity.                    |
+
+### Self-Managed area (`docs/self-managed/`)
+
+| Topic                        | Path                                                                                                                                                         | Notes                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| Setup overview               | `self-managed/setup/`                                                                                                                                        | Pre-install planning and the deploy entry point.                                                       |
+| Deployment                   | `self-managed/deployment/helm/`, `.../docker/`, `.../containers/`, `.../manual/`                                                                             | How to install Camunda 8 with each method.                                                             |
+| Reference architecture       | `self-managed/reference-architecture/`                                                                                                                       | Sizing, topology, networking, storage recommendations.                                                 |
+| Component-specific SM topics | `self-managed/components/orchestration-cluster/`, `.../management-identity/`, `.../console/`, `.../modeler/`, `.../connectors/`, `.../optimize/`, `.../hub/` | Self-Managed-only configuration, secrets, networking, exporters, and upgrade notes for each component. |
+| Components upgrade           | `self-managed/components/components-upgrade/`                                                                                                                | Per-component upgrade guides (do not confuse with the top-level `upgrade/` area).                      |
+| Operational guides           | `self-managed/operational-guides/`                                                                                                                           | Backups, monitoring, troubleshooting, license rotation.                                                |
+| Upgrade                      | `self-managed/upgrade/`                                                                                                                                      | Cross-cutting upgrade procedures across versions.                                                      |
+| Quickstart                   | `self-managed/quickstart/`                                                                                                                                   | Fastest local install path.                                                                            |
+
+### APIs and tools area (`docs/apis-tools/`)
+
+| API or tool                     | Path                                                                         | Notes                                                                    |
+| ------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Orchestration Cluster REST API  | `apis-tools/orchestration-cluster-api-rest/`                                 | Primary unified REST API for the cluster. Largely OpenAPI-generated.     |
+| Orchestration Cluster API (MCP) | `apis-tools/orchestration-cluster-api-mcp/`                                  | Model Context Protocol server for the cluster API.                       |
+| Zeebe API (gRPC and REST)       | `apis-tools/zeebe-api/`, `apis-tools/zeebe-api-rest/`                        | Engine-level APIs (legacy gRPC and the REST surface).                    |
+| Operate API                     | `apis-tools/operate-api/`                                                    | Operate REST API.                                                        |
+| Tasklist API                    | `apis-tools/tasklist-api-rest/`                                              | Tasklist REST API.                                                       |
+| Optimize API                    | `apis-tools/optimize-api/`                                                   | Optimize public API.                                                     |
+| Administration APIs (SaaS / SM) | `apis-tools/administration-api/`, `apis-tools/administration-sm-api/`        | SaaS console API and Self-Managed administration API.                    |
+| Web Modeler API                 | `apis-tools/web-modeler-api/`                                                | Web Modeler programmatic API.                                            |
+| Java client                     | `apis-tools/java-client/`                                                    | Official Java client.                                                    |
+| Spring Boot starter             | `apis-tools/camunda-spring-boot-starter/`                                    | Java/Spring integration. Reference is generated via `config-reference/`. |
+| C# / Python / TypeScript SDKs   | `apis-tools/csharp-sdk/`, `apis-tools/python-sdk/`, `apis-tools/typescript/` | Official SDKs.                                                           |
+| `c8ctl` CLI                     | `apis-tools/c8ctl/`                                                          | Camunda 8 CLI.                                                           |
+| Community clients               | `apis-tools/community-clients/`                                              | Community-maintained clients.                                            |
+| Migration manuals               | `apis-tools/migration-manuals/`                                              | API and SDK migration between versions.                                  |
+| Frontend development            | `apis-tools/frontend-development/`                                           | Embedding and extending Camunda UIs.                                     |
+| Testing                         | `apis-tools/testing/`                                                        | Process testing tooling.                                                 |
+
+### Guides and reference
+
+| Path              | Audience and content                                                                                                                   |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs/guides/`    | Hello-world, getting-started flows (APIs, human tasks, agentic orchestration), Camunda 7 migration.                                    |
+| `docs/reference/` | Release notes (`announcements-release-notes/`), `glossary.md`, `supported-environments.md`, legal, MCP docs index, public API summary. |
+
+### Generated content (do not hand-edit)
+
+- `api/` — OpenAPI specs and generation scripts. Edit specs here, not the generated pages.
+- `config-reference/` — Spring Boot starter configuration metadata. Regenerate via the `config-reference:*` npm scripts.
+- API reference pages under `docs/apis-tools/*-api*/` for the REST APIs are largely produced by the `api:generate:*` scripts.
+
 ## Required reading before changes
 
 Read these in order before editing — they are authoritative:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,233 @@
+# SKILLS.md
+
+Catalog of reusable skills — task-shaped operating procedures — that AI agents and contributors can invoke when working in `camunda-docs`. Each skill is a named, self-contained recipe with triggers, inputs, steps, and verification. Skills compose with the rules in `AGENTS.md` and `.github/instructions/`.
+
+This file is intentionally bleeding-edge: it follows the emerging convention of pairing `AGENTS.md` (what the project is) with `SKILLS.md` (what an agent should know how to do).
+
+## Index
+
+- [author-new-page](#skill-author-new-page) — Add a new documentation page to Next and the right sidebar.
+- [edit-versioned-page](#skill-edit-versioned-page) — Apply a change to Next and one or more released versions consistently.
+- [move-or-rename-page](#skill-move-or-rename-page) — Move or rename a page with redirects.
+- [retire-page](#skill-retire-page) — Remove a page and redirect readers to the right replacement.
+- [regenerate-api-reference](#skill-regenerate-api-reference) — Refresh OpenAPI-driven reference pages.
+- [regenerate-config-reference](#skill-regenerate-config-reference) — Refresh the Camunda Spring Boot starter config reference.
+- [add-redirect](#skill-add-redirect) — Add an `.htaccess` redirect at the top of the file.
+- [run-link-check](#skill-run-link-check) — Validate internal and external links.
+- [verify-build-locally](#skill-verify-build-locally) — Reproduce the production build locally.
+- [open-versioned-release-cut](#skill-open-versioned-release-cut) — Steps for cutting a new versioned snapshot.
+- [style-pass](#skill-style-pass) — Apply the style guide to a draft.
+- [terminology-sweep](#skill-terminology-sweep) — Normalize Camunda product terminology across files.
+
+---
+
+## Skill: author-new-page
+
+**Trigger**: User asks to "add a page", "document a new feature", or "create a new section".
+
+**Inputs**: target section, page title, intended version (Next-only or Next + a release).
+
+**Steps**:
+
+1. Pick the directory under `docs/` (Next) that matches the section. Use kebab-case for the filename and match the page title.
+2. Add front matter with `id`, `title`, and `description`. Title in sentence case.
+3. Write content following `.github/instructions/content.instructions.md`. Lead with the user goal; place required steps in a numbered list; place optional or reference material in `<details>`.
+4. Add the document `id` to `sidebars.js` in the correct position.
+5. If the change applies to a released version, repeat in `versioned_docs/version-*/` and `versioned_sidebars/version-*-sidebars.json`.
+6. Run `npm run format`.
+7. Start `npm run start`, navigate to the new page, confirm it renders and all links resolve.
+
+**Done when**: page renders locally, sidebars include it, Prettier is clean, build does not throw on broken links.
+
+---
+
+## Skill: edit-versioned-page
+
+**Trigger**: A correction, clarification, or feature note that applies to "current and beyond".
+
+**Steps**:
+
+1. Identify the most recent versioned folder from `versions.json` (the first entry).
+2. Apply the edit in `/docs/<path>` (Next).
+3. Apply the same edit in `versioned_docs/version-<latest>/<path>`.
+4. If the issue exists in older supported versions, propagate to those `version-*` folders too. Check `src/versions.js` (`unmaintainedVersions`) to skip versions that are out of support.
+5. Run `npm run format` and verify each version of the page renders.
+
+**Done when**: the edit is identical (or version-appropriate) across all maintained versions and Next.
+
+---
+
+## Skill: move-or-rename-page
+
+**Trigger**: Information architecture change, clearer URL, or section restructure.
+
+**Steps**:
+
+1. Move the file to its new location. Update its `id` if the rename should change it.
+2. Update the sidebar reference(s) in `sidebars.js` and any `versioned_sidebars/version-*-sidebars.json`.
+3. Update inbound links across the repo:
+   ```bash
+   git grep -nF "<old-path>" -- '*.md' '*.mdx' '*.js' '*.json'
+   ```
+4. Add a redirect to the **top** of `static/.htaccess` from the old path to the new path. See [add-redirect](#skill-add-redirect).
+5. Clear the Docusaurus cache: `npm run docusaurus -- clear`.
+6. Run the build and confirm `onBrokenLinks: "throw"` does not fire.
+
+**Done when**: old URL redirects, all in-repo links updated, build is green.
+
+---
+
+## Skill: retire-page
+
+**Trigger**: Page is obsolete, superseded, or describes removed functionality.
+
+**Steps**:
+
+1. Remove the file from `/docs/` and from each `versioned_docs/version-*/` where it applies.
+2. Remove its `id` from each affected sidebar file.
+3. Add a redirect at the top of `static/.htaccess` pointing to the most relevant replacement page.
+4. Update inbound links to point to the replacement directly, rather than relying solely on the redirect.
+5. If the topic appears in search synonyms or curated lists (`product-links.txt`, `connectors-element-template-links.txt`), update them.
+
+**Done when**: no broken links, redirect verified, replacement is reachable from prior entry points.
+
+---
+
+## Skill: regenerate-api-reference
+
+**Trigger**: Upstream OpenAPI spec changed, or a new API needs to be added.
+
+**Steps**:
+
+1. Update or add the spec under `api/`.
+2. Run the targeted generator:
+   - `npm run api:generate:camunda`
+   - `npm run api:generate:operate`
+   - `npm run api:generate:tasklist`
+   - `npm run api:generate:zeebe`
+   - `npm run api:generate:adminsm`
+3. Inspect the diff. Generated files should not be hand-edited; if output is wrong, fix the spec or the generator under `api/`.
+4. Run `npm run format`.
+
+**Done when**: the spec change is the only authored change; generated output is consistent and reviewed.
+
+---
+
+## Skill: regenerate-config-reference
+
+**Trigger**: Camunda Spring Boot starter config changed for a maintained minor version.
+
+**Steps**:
+
+1. Download the latest config metadata: `npm run config-reference:download:camunda-spring-boot-starter:<version>` (for example `8.9`).
+2. Generate the markdown: `npm run config-reference:generate:camunda-spring-boot-starter:<version>`.
+3. Review the diff for unintended removals.
+4. Run `npm run format`.
+
+**Done when**: regenerated pages match upstream config and render in the dev server.
+
+---
+
+## Skill: add-redirect
+
+**Trigger**: Any move, rename, or removal that changes a published URL.
+
+**Steps**:
+
+1. Open `static/.htaccess`.
+2. Add a `RedirectMatch` (or equivalent) rule at the **top** of the file. Order matters: top-most rules win.
+3. Use a 301 redirect for permanent moves.
+4. Test by building the site and visiting the old URL in the preview deployment, or by reading the rule carefully — local dev does not exercise `.htaccess`.
+
+**Done when**: the rule is in place, ordered correctly, and the new URL is the canonical replacement.
+
+---
+
+## Skill: run-link-check
+
+**Trigger**: Before merging changes that touch many links, or after a large move.
+
+**Steps**:
+
+1. Local internal link check: `npm run build` — Docusaurus throws on broken internal links.
+2. External link check uses Lychee. Configuration is in `lychee-external-links.toml`. CI runs this on a schedule; reproduce locally with the Lychee CLI if needed.
+
+**Done when**: build passes and any new external link in your change is reachable.
+
+---
+
+## Skill: verify-build-locally
+
+**Trigger**: Before opening a PR with non-trivial structural changes.
+
+**Steps**:
+
+1. `npm run format:check`.
+2. `npm test` if JS/TS changed.
+3. `npm run build` (or `npm run build:docker` to keep memory usage low).
+4. Optional: `npm run serve` to inspect the static output.
+
+**Done when**: build completes without warnings about broken links or MDX errors.
+
+---
+
+## Skill: open-versioned-release-cut
+
+**Trigger**: A new Camunda minor version is being released. Follow `howtos/release-procedure.md` as the source of truth — this skill is a high-level checklist.
+
+**Steps**:
+
+1. Confirm the cut date and version with the release manager.
+2. Run the documented Docusaurus version snapshot command per `howtos/release-procedure.md`.
+3. Update `versions.json` and `src/versions.js`.
+4. Update sidebars and verify the new versioned folder builds cleanly.
+5. Open the PR with the `release` label and the appropriate version label.
+
+**Done when**: site builds, version selector shows the new version, prior `Next` content is preserved.
+
+---
+
+## Skill: style-pass
+
+**Trigger**: Editing a draft from a non-native English contributor, or polishing a community PR.
+
+**Steps**:
+
+1. Skim `.github/instructions/content.instructions.md`.
+2. Convert headers to sentence case. Remove trailing colons in headers.
+3. Replace passive voice with active voice; convert third person or "I/me" to second person.
+4. Ensure UI elements are in `**bold**`, not quoted; filenames and identifiers are in `inline code`.
+5. Replace "click here", bare URLs, and "please" in instructional steps.
+6. Verify Oxford commas, em-dash usage, and that admonitions are limited to `:::warning`, `:::note`, `:::tip`.
+7. Run `npm run format`.
+
+**Done when**: the draft conforms to the style guide and renders cleanly.
+
+---
+
+## Skill: terminology-sweep
+
+**Trigger**: A doc set still uses legacy terms ("workflow" instead of "process", "Github" instead of "GitHub", inconsistent casing of product names).
+
+**Steps**:
+
+1. Search:
+   ```bash
+   git grep -nE "workflow (instance|automation)" -- 'docs' 'versioned_docs'
+   git grep -n "Github" -- 'docs' 'versioned_docs'
+   git grep -n "ElasticSearch\|Elastic search" -- 'docs' 'versioned_docs'
+   ```
+2. Replace each hit with the correct term, respecting documented exceptions ("workflow engine", "sequence flow", "process flow").
+3. For "upgrade" vs "update", check semantic meaning before replacing — see the rule in `content.instructions.md`.
+4. Re-run the searches to confirm zero remaining occurrences (modulo the legitimate exceptions).
+
+**Done when**: terminology is consistent and only legitimate exceptions remain.
+
+---
+
+## Adding a new skill
+
+1. Pick a short, verb-led name (`do-the-thing`).
+2. Add an entry to the index above and a section below with **Trigger**, **Inputs** (optional), **Steps**, and **Done when**.
+3. Keep skills focused: one task, fewer than ~12 steps. Split larger procedures into composable skills.
+4. Cite the source-of-truth doc in `howtos/` rather than duplicating its content.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` at the repo root following the [agents.md](https://agents.md) convention. It gives AI coding agents (Claude Code, Cursor, Copilot, Codex, Aider, etc.) a single entry point: project overview, repo layout, required reading, setup commands, a condensed style summary, the page add/move/remove workflow, the PR and commit conventions, and an explicit list of things agents should not do.
- Add a companion `SKILLS.md` cataloguing reusable, task-shaped procedures (authoring pages, versioned edits, moves with redirects, page retirement, API and config-reference regeneration, redirects, link checks, local builds, release cuts, style passes, terminology sweeps). Each skill has Trigger / Steps / Done-when so agents can pick the right one and finish it cleanly.
- Both files defer to `.github/instructions/`, `howtos/`, and `CONTRIBUTING.MD` as the source of truth — they index and operationalize what already exists rather than duplicating it.

## Why now

`.github/copilot-instructions.md` already exists for Copilot, but other agents (Claude Code, Cursor, Codex, Aider) look for a root-level `AGENTS.md` by convention. Centralizing the agent-facing guidance here means fewer divergent rules across tools and a clearer single source of project context for any agent that wanders in.

## Test plan

- [ ] `npm run format:check` is clean for both files (Prettier was run before commit).
- [ ] Both files render correctly on GitHub.
- [ ] Reviewer sanity-check: paths and commands referenced in each file (npm scripts, sidebar files, `.htaccess`, `versions.json`, instructions paths) match the current repo layout.
- [ ] No links to the new files are required from sidebars (they are repo-root meta files, not site content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)