### PR TITLE
Improve RDBMS and AWS EKS deployment guidance

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -22,6 +22,8 @@ This guide provides a comprehensive walkthrough for installing the Camunda 8 Hel
 
 Lastly you'll verify that the connection to your Self-Managed Camunda 8 environment is working.
 
+If you use Amazon Aurora PostgreSQL or another relational database (RDBMS) as the Orchestration Cluster secondary storage, use this page for the AWS EKS infrastructure and Helm deployment flow, then complete the RDBMS-specific Helm steps in [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md). If you use Amazon OpenSearch Service for secondary storage, continue with the default path in this guide.
+
 ## Requirements
 
 - A Kubernetes cluster; see the [eksctl](./eksctl.md) or [Terraform](./terraform-setup.md) guide.
@@ -326,7 +328,9 @@ To enable these enterprise components in an OIDC-enabled full cluster, first dep
 This guide includes a managed Amazon OpenSearch example path for secondary storage. Choose the backend that fits your requirements:
 
 - **Managed OpenSearch**: Use the managed Amazon OpenSearch domain provisioned in the [eksctl](./eksctl.md) or [Terraform](./terraform-setup.md) setup.
-- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster — see [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md).
+- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster. Follow this EKS guide for the cluster, networking, ingress, and optional AWS services, then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) for the Helm workflow and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md) for the values reference.
+
+If you choose RDBMS for the Orchestration Cluster, do not follow the managed OpenSearch configuration path in this guide unless you also deploy Optimize. Optimize still requires Elasticsearch or OpenSearch.
 
 #### Advanced: Use Helm-chart Elasticsearch instead of managed OpenSearch
 

--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -22,7 +22,15 @@ This guide provides a comprehensive walkthrough for installing the Camunda 8 Hel
 
 Lastly you'll verify that the connection to your Self-Managed Camunda 8 environment is working.
 
-If you use Amazon Aurora PostgreSQL or another relational database (RDBMS) as the Orchestration Cluster secondary storage, use this page for the AWS EKS infrastructure and Helm deployment flow, then complete the RDBMS-specific Helm steps in [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md). If you use Amazon OpenSearch Service for secondary storage, continue with the default path in this guide.
+<!-- TODO(camunda/team-infrastructure-experience#1063): Reword this Aurora PostgreSQL routing guidance when the broader InfraEx guidance is finalized. -->
+
+:::note Using Amazon Aurora PostgreSQL as secondary storage
+Use this page for the EKS cluster, networking, Ingress, and AWS-managed services.
+
+Then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md).
+
+If you use Amazon OpenSearch Service for secondary storage, continue with the default path in this guide.
+:::
 
 ## Requirements
 
@@ -328,9 +336,9 @@ To enable these enterprise components in an OIDC-enabled full cluster, first dep
 This guide includes a managed Amazon OpenSearch example path for secondary storage. Choose the backend that fits your requirements:
 
 - **Managed OpenSearch**: Use the managed Amazon OpenSearch domain provisioned in the [eksctl](./eksctl.md) or [Terraform](./terraform-setup.md) setup.
-- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster. Follow this EKS guide for the cluster, networking, ingress, and optional AWS services, then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) for the Helm workflow and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md) for the values reference.
+- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster. Follow this EKS guide for the cluster, networking, Ingress, and optional AWS services, then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) for the Helm workflow and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md) for the values reference.
 
-If you choose RDBMS for the Orchestration Cluster, do not follow the managed OpenSearch configuration path in this guide unless you also deploy Optimize. Optimize still requires Elasticsearch or OpenSearch.
+RDBMS as secondary storage disables Optimize unless you also deploy Elasticsearch or OpenSearch alongside it.
 
 #### Advanced: Use Helm-chart Elasticsearch instead of managed OpenSearch
 

--- a/docs/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/docs/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -9,6 +9,8 @@ This guide is a focused walkthrough for teams using an external relational datab
 
 Use [production install](/self-managed/deployment/helm/install/production/index.md) as the primary installation guide. Use this page when you want additional RDBMS-specific examples for that flow.
 
+If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) for the cluster, ingress, and AWS-managed service setup, then return to this page for the RDBMS-specific Helm configuration and installation steps.
+
 Related guides:
 
 - [Production install](/self-managed/deployment/helm/install/production/index.md)
@@ -95,6 +97,12 @@ The user needs DDL permissions only if you enable auto-schema creation (`autoDDL
 ```bash
 helm repo add camunda https://camunda.github.io/camunda-platform-helm
 helm repo update
+```
+
+If you install a prerelease chart version, such as an alpha or release candidate, include `--devel` when you search, install, or upgrade the chart. For example:
+
+```bash
+helm search repo camunda/camunda-platform --devel
 ```
 
 ### Step 4: Create a values file
@@ -223,6 +231,8 @@ helm install camunda camunda/camunda-platform \
   --namespace camunda \
   -f values-rdbms.yaml
 ```
+
+For a prerelease chart version, include `--devel` in the install command.
 
 Monitor the installation:
 

--- a/docs/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/docs/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -9,7 +9,7 @@ This guide is a focused walkthrough for teams using an external relational datab
 
 Use [production install](/self-managed/deployment/helm/install/production/index.md) as the primary installation guide. Use this page when you want additional RDBMS-specific examples for that flow.
 
-If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) for the cluster, ingress, and AWS-managed service setup, then return to this page for the RDBMS-specific Helm configuration and installation steps.
+If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) for the cluster, Ingress, and AWS-managed service setup, then return to this page for the RDBMS-specific Helm configuration and installation steps.
 
 Related guides:
 
@@ -72,6 +72,10 @@ Before you begin:
 
 ### Step 2: Prepare your database
 
+:::note On Amazon Aurora PostgreSQL
+Skip the local `createdb` and `createuser` commands. Connect to your Aurora writer endpoint with `psql`, and prefer IAM database authentication over a static password. See [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) and the [Aurora Terraform module](https://github.com/camunda/camunda-deployment-references/tree/stable/8.9/aws/modules/aurora).
+:::
+
 Create a database and user. For example, in PostgreSQL:
 
 ```bash
@@ -97,12 +101,6 @@ The user needs DDL permissions only if you enable auto-schema creation (`autoDDL
 ```bash
 helm repo add camunda https://camunda.github.io/camunda-platform-helm
 helm repo update
-```
-
-If you install a prerelease chart version, such as an alpha or release candidate, include `--devel` when you search, install, or upgrade the chart. For example:
-
-```bash
-helm search repo camunda/camunda-platform --devel
 ```
 
 ### Step 4: Create a values file
@@ -231,8 +229,6 @@ helm install camunda camunda/camunda-platform \
   --namespace camunda \
   -f values-rdbms.yaml
 ```
-
-For a prerelease chart version, include `--devel` in the install command.
 
 Monitor the installation:
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -22,6 +22,8 @@ This guide provides a comprehensive walkthrough for installing the Camunda 8 Hel
 
 Lastly you'll verify that the connection to your Self-Managed Camunda 8 environment is working.
 
+If you use Amazon Aurora PostgreSQL or another relational database (RDBMS) as the Orchestration Cluster secondary storage, use this page for the AWS EKS infrastructure and Helm deployment flow, then complete the RDBMS-specific Helm steps in [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md). If you use Amazon OpenSearch Service for secondary storage, continue with the default path in this guide.
+
 ## Requirements
 
 - A Kubernetes cluster; see the [eksctl](./eksctl.md) or [Terraform](./terraform-setup.md) guide.
@@ -326,7 +328,9 @@ To enable these enterprise components in an OIDC-enabled full cluster, first dep
 This guide includes a managed Amazon OpenSearch example path for secondary storage. Choose the backend that fits your requirements:
 
 - **Managed OpenSearch**: Use the managed Amazon OpenSearch domain provisioned in the [eksctl](./eksctl.md) or [Terraform](./terraform-setup.md) setup.
-- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster — see [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md).
+- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster. Follow this EKS guide for the cluster, networking, ingress, and optional AWS services, then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) for the Helm workflow and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md) for the values reference.
+
+If you choose RDBMS for the Orchestration Cluster, do not follow the managed OpenSearch configuration path in this guide unless you also deploy Optimize. Optimize still requires Elasticsearch or OpenSearch.
 
 #### Advanced: Use Helm-chart Elasticsearch instead of managed OpenSearch
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -22,7 +22,15 @@ This guide provides a comprehensive walkthrough for installing the Camunda 8 Hel
 
 Lastly you'll verify that the connection to your Self-Managed Camunda 8 environment is working.
 
-If you use Amazon Aurora PostgreSQL or another relational database (RDBMS) as the Orchestration Cluster secondary storage, use this page for the AWS EKS infrastructure and Helm deployment flow, then complete the RDBMS-specific Helm steps in [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md). If you use Amazon OpenSearch Service for secondary storage, continue with the default path in this guide.
+<!-- TODO(camunda/team-infrastructure-experience#1063): Reword this Aurora PostgreSQL routing guidance when the broader InfraEx guidance is finalized. -->
+
+:::note Using Amazon Aurora PostgreSQL as secondary storage
+Use this page for the EKS cluster, networking, Ingress, and AWS-managed services.
+
+Then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md).
+
+If you use Amazon OpenSearch Service for secondary storage, continue with the default path in this guide.
+:::
 
 ## Requirements
 
@@ -328,9 +336,9 @@ To enable these enterprise components in an OIDC-enabled full cluster, first dep
 This guide includes a managed Amazon OpenSearch example path for secondary storage. Choose the backend that fits your requirements:
 
 - **Managed OpenSearch**: Use the managed Amazon OpenSearch domain provisioned in the [eksctl](./eksctl.md) or [Terraform](./terraform-setup.md) setup.
-- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster. Follow this EKS guide for the cluster, networking, ingress, and optional AWS services, then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) for the Helm workflow and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md) for the values reference.
+- **Amazon Aurora PostgreSQL**: Use Aurora PostgreSQL as secondary storage for the Orchestration Cluster. Follow this EKS guide for the cluster, networking, Ingress, and optional AWS services, then continue with [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md) for the Helm workflow and [configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md) for the values reference.
 
-If you choose RDBMS for the Orchestration Cluster, do not follow the managed OpenSearch configuration path in this guide unless you also deploy Optimize. Optimize still requires Elasticsearch or OpenSearch.
+RDBMS as secondary storage disables Optimize unless you also deploy Elasticsearch or OpenSearch alongside it.
 
 #### Advanced: Use Helm-chart Elasticsearch instead of managed OpenSearch
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -9,6 +9,8 @@ This guide is a focused walkthrough for teams using an external relational datab
 
 Use [production install](/self-managed/deployment/helm/install/production/index.md) as the primary installation guide. Use this page when you want additional RDBMS-specific examples for that flow.
 
+If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) for the cluster, ingress, and AWS-managed service setup, then return to this page for the RDBMS-specific Helm configuration and installation steps.
+
 Related guides:
 
 - [Production install](/self-managed/deployment/helm/install/production/index.md)
@@ -95,6 +97,12 @@ The user needs DDL permissions only if you enable auto-schema creation (`autoDDL
 ```bash
 helm repo add camunda https://camunda.github.io/camunda-platform-helm
 helm repo update
+```
+
+If you install a prerelease chart version, such as an alpha or release candidate, include `--devel` when you search, install, or upgrade the chart. For example:
+
+```bash
+helm search repo camunda/camunda-platform --devel
 ```
 
 ### Step 4: Create a values file
@@ -223,6 +231,8 @@ helm install camunda camunda/camunda-platform \
   --namespace camunda \
   -f values-rdbms.yaml
 ```
+
+For a prerelease chart version, include `--devel` in the install command.
 
 Monitor the installation:
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -9,7 +9,7 @@ This guide is a focused walkthrough for teams using an external relational datab
 
 Use [production install](/self-managed/deployment/helm/install/production/index.md) as the primary installation guide. Use this page when you want additional RDBMS-specific examples for that flow.
 
-If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) for the cluster, ingress, and AWS-managed service setup, then return to this page for the RDBMS-specific Helm configuration and installation steps.
+If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) for the cluster, Ingress, and AWS-managed service setup, then return to this page for the RDBMS-specific Helm configuration and installation steps.
 
 Related guides:
 
@@ -72,6 +72,10 @@ Before you begin:
 
 ### Step 2: Prepare your database
 
+:::note On Amazon Aurora PostgreSQL
+Skip the local `createdb` and `createuser` commands. Connect to your Aurora writer endpoint with `psql`, and prefer IAM database authentication over a static password. See [Install Camunda 8 on an EKS cluster](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md) and the [Aurora Terraform module](https://github.com/camunda/camunda-deployment-references/tree/stable/8.9/aws/modules/aurora).
+:::
+
 Create a database and user. For example, in PostgreSQL:
 
 ```bash
@@ -97,12 +101,6 @@ The user needs DDL permissions only if you enable auto-schema creation (`autoDDL
 ```bash
 helm repo add camunda https://camunda.github.io/camunda-platform-helm
 helm repo update
-```
-
-If you install a prerelease chart version, such as an alpha or release candidate, include `--devel` when you search, install, or upgrade the chart. For example:
-
-```bash
-helm search repo camunda/camunda-platform --devel
 ```
 
 ### Step 4: Create a values file
@@ -231,8 +229,6 @@ helm install camunda camunda/camunda-platform \
   --namespace camunda \
   -f values-rdbms.yaml
 ```
-
-For a prerelease chart version, include `--devel` in the install command.
 
 Monitor the installation:
 


### PR DESCRIPTION
## Description

Closes docs portion of https://github.com/camunda/camunda-docs/issues/8416.

This issue addressed a documentation gap for users deploying Camunda 8 on AWS EKS with RDBMS secondary storage, especially Aurora PostgreSQL. The current docs required users to combine multiple pages manually across the EKS Helm guide, RDBMS configuration docs, and related Helm installation content. That made it unclear when to follow the default OpenSearch path versus the RDBMS path, and increased the chance of misconfiguration.

## What I changed in docs

Improved navigation and decision-making within the existing Helm documentation by:

- Clarifying in the AWS EKS Helm guide that users choosing Aurora PostgreSQL or another RDBMS for Orchestration secondary storage should use the EKS guide for cluster and AWS setup, then continue with the RDBMS Helm docs.
- Making the secondary storage choice more explicit, so users can distinguish between the default OpenSearch path and the RDBMS path.
- Adding reciprocal links from the Helm RDBMS example deployment back to the EKS guide for AWS-specific setup.
- Adding a note that prerelease Helm chart versions require `--devel` when searching or installing alpha or release candidate charts.

These changes improve flow and discoverability without introducing a new reference architecture.

## Potential engineering follow-up outside docs

A few issues surfaced during the deployment exercise that are better addressed outside documentation:

- Helm chart schema usability: `clusterSize`, `partitionCount`, and `replicationFactor` currently expect strings in schema validation, which can surprise users who provide integers.
- Prerelease Helm behavior: engineering could consider whether prerelease chart discoverability can be made clearer or less error-prone.
- Reference architecture improvements: AWS SSO examples and a simplified RDBMS-only database setup job would be better handled in the infrastructure/reference architecture materials.
- Broader end-to-end deployment patterns for RDBMS on EKS remain a reference architecture concern rather than a docs-only change.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
