### PR TITLE
docs: add Web Modeler PVC name fix upgrade warning for 8.9

### DIFF
--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
@@ -33,6 +33,22 @@ helm search repo camunda/camunda-platform --versions
 
 ## Upgrade notes
 
+### Web Modeler PVC name fix (chart 14.0.2+)
+
+:::warning Web Modeler persistence workaround migration
+Helm chart versions 14.0.0 and 14.0.1 contain a bug where the Web Modeler restapi deployment references a PersistentVolumeClaim named `<release>-webModeler-data` (capital M), while the PVC template creates it as `<release>-webmodeler-data` (lowercase). This mismatch causes the restapi pod to remain `Pending` when `webModeler.persistence.enabled=true`.
+
+**Chart 14.0.2+ fixes this issue.** No action is required in most cases because:
+
+- If you never enabled `webModeler.persistence`, you are not affected.
+- If you enabled it and the pod was stuck `Pending`, upgrading to chart 14.0.2+ resolves the issue automatically — the existing PVC (created with the correct lowercase name) will be mounted.
+
+**Action required only if** you manually created a PVC named `<release>-webModeler-data` (capital M) as a workaround for the bug. In this case, after upgrading to chart 14.0.2+, the deployment will look for the lowercase name and will not find your manually-created PVC. To resolve this:
+
+- Set `webModeler.persistence.existingClaim` to the name of your manually-created PVC, **or**
+- Migrate your data from the manually-created PVC to the correctly-named PVC (`<release>-webmodeler-data`).
+:::
+
 ### Bitnami Docker repository migration
 
 On August 28, 2025, Bitnami migrated its container images from [bitnami](https://hub.docker.com/u/bitnami) to [bitnamilegacy](https://hub.docker.com/u/bitnamilegacy). The Camunda Helm charts have been updated to use the new repository.

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
@@ -33,20 +33,21 @@ helm search repo camunda/camunda-platform --versions
 
 ## Upgrade notes
 
-### Web Modeler PVC name fix (chart 14.0.2+)
+### Web Modeler PVC name fix (chart 14.6.0+)
 
 :::warning Web Modeler persistence workaround migration
-Helm chart versions 14.0.0 and 14.0.1 contain a bug where the Web Modeler restapi deployment references a PersistentVolumeClaim named `<release>-webModeler-data` (capital M), while the PVC template creates it as `<release>-webmodeler-data` (lowercase). This mismatch causes the restapi pod to remain `Pending` when `webModeler.persistence.enabled=true`.
+Helm chart versions 14.0.0 through 14.5.0 contain a bug where the Web Modeler restapi deployment references a PersistentVolumeClaim named `<release>-webModeler-data` (capital M), while the PVC template creates it as `<release>-webmodeler-data` (lowercase). This mismatch causes the restapi pod to remain `Pending` when `webModeler.persistence.enabled=true`.
 
-**Chart 14.0.2+ fixes this issue.** No action is required in most cases because:
+**Chart 14.6.0+ fixes this issue.** No action is required in most cases because:
 
 - If you never enabled `webModeler.persistence`, you are not affected.
-- If you enabled it and the pod was stuck `Pending`, upgrading to chart 14.0.2+ resolves the issue automatically — the existing PVC (created with the correct lowercase name) will be mounted.
+- If you enabled it and the pod was stuck `Pending`, upgrading to chart 14.6.0+ resolves the issue automatically — the existing PVC (created with the correct lowercase name) will be mounted.
 
-**Action required only if** you manually created a PVC named `<release>-webModeler-data` (capital M) as a workaround for the bug. In this case, after upgrading to chart 14.0.2+, the deployment will look for the lowercase name and will not find your manually-created PVC. To resolve this:
+**Action required only if** you manually created a PVC named `<release>-webModeler-data` (capital M) as a workaround for the bug. In this case, after upgrading to chart 14.6.0+, the deployment will look for the lowercase name and will not find your manually-created PVC. To resolve this:
 
 - Set `webModeler.persistence.existingClaim` to the name of your manually-created PVC, **or**
 - Migrate your data from the manually-created PVC to the correctly-named PVC (`<release>-webmodeler-data`).
+
 :::
 
 ### Bitnami Docker repository migration


### PR DESCRIPTION
## Summary

- Adds a warning banner to the 8.9 Helm upgrade notes explaining the Web Modeler PVC casing bug fix in chart 14.6.0+

## Context

Helm chart versions 14.0.0 through 14.5.0 have a bug where `webModeler.persistence.enabled=true` causes the restapi pod to remain Pending due to a PVC name mismatch (capital M in the deployment vs lowercase in the PVC template). Chart 14.6.0+ fixes this.

Verified against the published chart tags: `camunda-platform-8.9-14.0.0` and `-14.5.0` reference `webModeler-data`, while `-14.6.0` and `-14.8.2` reference `webmodeler-data`.

The warning covers the edge case where a user manually created a PVC with the incorrect casing as a workaround and now needs to either use `existingClaim` or migrate data.

## Related

- Helm chart fix PR: camunda/camunda-platform-helm#5887 (first released in chart 14.6.0)
- SUPPORT-30069

## Note for reviewers

camunda/camunda-platform-helm#6027 (merged, not yet in a release) replaces the standalone Web Modeler PVC with a per-pod ephemeral volume. This note documents the behaviour of currently released charts; it will need a follow-up once #6027 ships.

Fixes https://github.com/camunda/camunda-platform-helm/issues/4698
