### PR TITLE
docs(8.8): document identity migration handler toggles and page-size config

### DIFF
--- a/versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md
@@ -348,18 +348,18 @@ Both values must be in the range `[1, 10000]`. Only the `/api/users` and `/api/g
 <Tabs>
   <TabItem value="env" label="Environment variables" default>
 
-| Environment variable                                              | Description                                                                  | Default value |
-| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
-| `CAMUNDA_MIGRATION_IDENTITY_MANAGEMENTIDENTITY_PAGESIZE_USERS`    | Page size used when fetching users from `/api/users` on Management Identity. | `100`         |
-| `CAMUNDA_MIGRATION_IDENTITY_MANAGEMENTIDENTITY_PAGESIZE_GROUPS`   | Page size used when fetching groups from `/api/groups` on Management Identity. | `100`       |
+| Environment variable                                            | Description                                                                    | Default value |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------- |
+| `CAMUNDA_MIGRATION_IDENTITY_MANAGEMENTIDENTITY_PAGESIZE_USERS`  | Page size used when fetching users from `/api/users` on Management Identity.   | `100`         |
+| `CAMUNDA_MIGRATION_IDENTITY_MANAGEMENTIDENTITY_PAGESIZE_GROUPS` | Page size used when fetching groups from `/api/groups` on Management Identity. | `100`         |
 
   </TabItem>
   <TabItem value="application.yaml" label="application.yaml">
 
-| Application.yaml property                                              | Description                                                                  | Default value |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
-| `camunda.migration.identity.management-identity.page-size.users`       | Page size used when fetching users from `/api/users` on Management Identity. | `100`         |
-| `camunda.migration.identity.management-identity.page-size.groups`      | Page size used when fetching groups from `/api/groups` on Management Identity. | `100`       |
+| Application.yaml property                                         | Description                                                                    | Default value |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------- |
+| `camunda.migration.identity.management-identity.page-size.users`  | Page size used when fetching users from `/api/users` on Management Identity.   | `100`         |
+| `camunda.migration.identity.management-identity.page-size.groups` | Page size used when fetching groups from `/api/groups` on Management Identity. | `100`         |
 
   </TabItem>
 </Tabs>
@@ -383,55 +383,55 @@ All toggles default to `true`. Setting a toggle to `false` removes only that han
 :::warning Inter-handler dependencies
 Some handlers consume entities created by predecessors. Disabling a predecessor while keeping a consumer enabled fails the migration with a `MigrationException` — recoverable, but worth knowing before flipping flags.
 
-| Mode       | Consumer                       | Requires                       |
-| ---------- | ------------------------------ | ------------------------------ |
-| `keycloak` | `user-role`                    | `role`                         |
-| `keycloak` | `authorization`                | `tenant`, `group`              |
-| `oidc`     | `mapping-rule`                 | `role`, `tenant`               |
-| `cloud`    | `console-role-authorization`   | `console-role`                 |
-| `cloud`    | `authorization`                | `group`                        |
+| Mode       | Consumer                     | Requires          |
+| ---------- | ---------------------------- | ----------------- |
+| `keycloak` | `user-role`                  | `role`            |
+| `keycloak` | `authorization`              | `tenant`, `group` |
+| `oidc`     | `mapping-rule`               | `role`, `tenant`  |
+| `cloud`    | `console-role-authorization` | `console-role`    |
+| `cloud`    | `authorization`              | `group`           |
 
 :::
 
 <Tabs>
   <TabItem value="env" label="Environment variables" default>
 
-| Environment variable                                                                  | Mode       | Default value |
-| ------------------------------------------------------------------------------------- | ---------- | ------------- |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_GROUP_ENABLED`                              | `cloud`    | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CONSOLEROLE_ENABLED`                        | `cloud`    | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CONSOLEROLEAUTHORIZATION_ENABLED`           | `cloud`    | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_AUTHORIZATION_ENABLED`                      | `cloud`    | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CLIENT_ENABLED`                             | `cloud`    | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_ROLE_ENABLED`                            | `keycloak` | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_GROUP_ENABLED`                           | `keycloak` | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_USERROLE_ENABLED`                        | `keycloak` | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_CLIENT_ENABLED`                          | `keycloak` | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_AUTHORIZATION_ENABLED`                   | `keycloak` | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_TENANT_ENABLED`                          | `keycloak` | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_ROLE_ENABLED`                                | `oidc`     | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_TENANT_ENABLED`                              | `oidc`     | `true`        |
-| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_MAPPINGRULE_ENABLED`                         | `oidc`     | `true`        |
+| Environment variable                                                        | Mode       | Default value |
+| --------------------------------------------------------------------------- | ---------- | ------------- |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_GROUP_ENABLED`                    | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CONSOLEROLE_ENABLED`              | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CONSOLEROLEAUTHORIZATION_ENABLED` | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_AUTHORIZATION_ENABLED`            | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CLIENT_ENABLED`                   | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_ROLE_ENABLED`                  | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_GROUP_ENABLED`                 | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_USERROLE_ENABLED`              | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_CLIENT_ENABLED`                | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_AUTHORIZATION_ENABLED`         | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_TENANT_ENABLED`                | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_ROLE_ENABLED`                      | `oidc`     | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_TENANT_ENABLED`                    | `oidc`     | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_MAPPINGRULE_ENABLED`               | `oidc`     | `true`        |
 
   </TabItem>
   <TabItem value="application.yaml" label="application.yaml">
 
-| Application.yaml property                                                             | Mode       | Default value |
-| ------------------------------------------------------------------------------------- | ---------- | ------------- |
-| `camunda.migration.identity.handler.cloud.group.enabled`                              | `cloud`    | `true`        |
-| `camunda.migration.identity.handler.cloud.console-role.enabled`                       | `cloud`    | `true`        |
-| `camunda.migration.identity.handler.cloud.console-role-authorization.enabled`         | `cloud`    | `true`        |
-| `camunda.migration.identity.handler.cloud.authorization.enabled`                      | `cloud`    | `true`        |
-| `camunda.migration.identity.handler.cloud.client.enabled`                             | `cloud`    | `true`        |
-| `camunda.migration.identity.handler.keycloak.role.enabled`                            | `keycloak` | `true`        |
-| `camunda.migration.identity.handler.keycloak.group.enabled`                           | `keycloak` | `true`        |
-| `camunda.migration.identity.handler.keycloak.user-role.enabled`                       | `keycloak` | `true`        |
-| `camunda.migration.identity.handler.keycloak.client.enabled`                          | `keycloak` | `true`        |
-| `camunda.migration.identity.handler.keycloak.authorization.enabled`                   | `keycloak` | `true`        |
-| `camunda.migration.identity.handler.keycloak.tenant.enabled`                          | `keycloak` | `true`        |
-| `camunda.migration.identity.handler.oidc.role.enabled`                                | `oidc`     | `true`        |
-| `camunda.migration.identity.handler.oidc.tenant.enabled`                              | `oidc`     | `true`        |
-| `camunda.migration.identity.handler.oidc.mapping-rule.enabled`                        | `oidc`     | `true`        |
+| Application.yaml property                                                     | Mode       | Default value |
+| ----------------------------------------------------------------------------- | ---------- | ------------- |
+| `camunda.migration.identity.handler.cloud.group.enabled`                      | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.console-role.enabled`               | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.console-role-authorization.enabled` | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.authorization.enabled`              | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.client.enabled`                     | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.keycloak.role.enabled`                    | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.group.enabled`                   | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.user-role.enabled`               | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.client.enabled`                  | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.authorization.enabled`           | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.tenant.enabled`                  | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.oidc.role.enabled`                        | `oidc`     | `true`        |
+| `camunda.migration.identity.handler.oidc.tenant.enabled`                      | `oidc`     | `true`        |
+| `camunda.migration.identity.handler.oidc.mapping-rule.enabled`                | `oidc`     | `true`        |
 
   </TabItem>
 </Tabs>

--- a/versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md
@@ -335,6 +335,107 @@ You can customize this behavior using the provided configuration options.
   </TabItem>
 </Tabs>
 
+### Tune the Management Identity API page size
+
+:::info Available since 8.8.24
+The page size properties below were added in **Camunda 8.8.24**. Earlier 8.8 patches always use a page size of `100` and cannot be tuned.
+:::
+
+The Identity Migration Application reads users and groups from the [Management Identity](/self-managed/components/management-identity/access-management/access-management-overview.md) API in pages. The page size used on the wire (`resultSize`) defaults to `100` and can be tuned per endpoint to balance migration throughput against memory and request duration on the Management Identity instance.
+
+Both values must be in the range `[1, 10000]`. Only the `/api/users` and `/api/groups` endpoints accept a configurable page size; other Management Identity endpoints return the full collection.
+
+<Tabs>
+  <TabItem value="env" label="Environment variables" default>
+
+| Environment variable                                              | Description                                                                  | Default value |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
+| `CAMUNDA_MIGRATION_IDENTITY_MANAGEMENTIDENTITY_PAGESIZE_USERS`    | Page size used when fetching users from `/api/users` on Management Identity. | `100`         |
+| `CAMUNDA_MIGRATION_IDENTITY_MANAGEMENTIDENTITY_PAGESIZE_GROUPS`   | Page size used when fetching groups from `/api/groups` on Management Identity. | `100`       |
+
+  </TabItem>
+  <TabItem value="application.yaml" label="application.yaml">
+
+| Application.yaml property                                              | Description                                                                  | Default value |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
+| `camunda.migration.identity.management-identity.page-size.users`       | Page size used when fetching users from `/api/users` on Management Identity. | `100`         |
+| `camunda.migration.identity.management-identity.page-size.groups`      | Page size used when fetching groups from `/api/groups` on Management Identity. | `100`       |
+
+  </TabItem>
+</Tabs>
+
+### Selectively enable or disable migration handlers
+
+:::info Available since 8.8.24
+The handler toggles below were added in **Camunda 8.8.24**. Earlier 8.8 patches always run every handler that applies to the active mode and cannot skip individual handlers.
+:::
+
+The Identity Migration Application is composed of independent handlers, each responsible for migrating a single resource type (for example: roles, groups, authorizations). By default every handler that applies to the active mode is enabled. Each handler can be disabled individually — for example to re-run only a subset of handlers after fixing a data issue, or to skip a resource type that has already been migrated by another tool.
+
+Each toggle is namespaced by the mode (profile) it applies to:
+
+- `cloud` — applies in [SaaS](/components/concepts/clusters.md) deployments
+- `keycloak` — applies in Self-Managed setups using the [default Keycloak](/self-managed/components/management-identity/configuration/connect-to-an-existing-keycloak.md) (`CAMUNDA_MIGRATION_IDENTITY_MODE=KEYCLOAK`)
+- `oidc` — applies in Self-Managed setups using a [custom OIDC provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md) (`CAMUNDA_MIGRATION_IDENTITY_MODE=OIDC`)
+
+All toggles default to `true`. Setting a toggle to `false` removes only that handler — the rest of the migration runs unchanged.
+
+:::warning Inter-handler dependencies
+Some handlers consume entities created by predecessors. Disabling a predecessor while keeping a consumer enabled fails the migration with a `MigrationException` — recoverable, but worth knowing before flipping flags.
+
+| Mode       | Consumer                       | Requires                       |
+| ---------- | ------------------------------ | ------------------------------ |
+| `keycloak` | `user-role`                    | `role`                         |
+| `keycloak` | `authorization`                | `tenant`, `group`              |
+| `oidc`     | `mapping-rule`                 | `role`, `tenant`               |
+| `cloud`    | `console-role-authorization`   | `console-role`                 |
+| `cloud`    | `authorization`                | `group`                        |
+
+:::
+
+<Tabs>
+  <TabItem value="env" label="Environment variables" default>
+
+| Environment variable                                                                  | Mode       | Default value |
+| ------------------------------------------------------------------------------------- | ---------- | ------------- |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_GROUP_ENABLED`                              | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CONSOLEROLE_ENABLED`                        | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CONSOLEROLEAUTHORIZATION_ENABLED`           | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_AUTHORIZATION_ENABLED`                      | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_CLOUD_CLIENT_ENABLED`                             | `cloud`    | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_ROLE_ENABLED`                            | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_GROUP_ENABLED`                           | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_USERROLE_ENABLED`                        | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_CLIENT_ENABLED`                          | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_AUTHORIZATION_ENABLED`                   | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_KEYCLOAK_TENANT_ENABLED`                          | `keycloak` | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_ROLE_ENABLED`                                | `oidc`     | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_TENANT_ENABLED`                              | `oidc`     | `true`        |
+| `CAMUNDA_MIGRATION_IDENTITY_HANDLER_OIDC_MAPPINGRULE_ENABLED`                         | `oidc`     | `true`        |
+
+  </TabItem>
+  <TabItem value="application.yaml" label="application.yaml">
+
+| Application.yaml property                                                             | Mode       | Default value |
+| ------------------------------------------------------------------------------------- | ---------- | ------------- |
+| `camunda.migration.identity.handler.cloud.group.enabled`                              | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.console-role.enabled`                       | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.console-role-authorization.enabled`         | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.authorization.enabled`                      | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.cloud.client.enabled`                             | `cloud`    | `true`        |
+| `camunda.migration.identity.handler.keycloak.role.enabled`                            | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.group.enabled`                           | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.user-role.enabled`                       | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.client.enabled`                          | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.authorization.enabled`                   | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.keycloak.tenant.enabled`                          | `keycloak` | `true`        |
+| `camunda.migration.identity.handler.oidc.role.enabled`                                | `oidc`     | `true`        |
+| `camunda.migration.identity.handler.oidc.tenant.enabled`                              | `oidc`     | `true`        |
+| `camunda.migration.identity.handler.oidc.mapping-rule.enabled`                        | `oidc`     | `true`        |
+
+  </TabItem>
+</Tabs>
+
 ## Identity authorization and permission changes
 
 Camunda 8.8 introduces a new authorization model for Orchestration Cluster Identity. As a result, existing permissions must be reviewed to ensure continued access to APIs and web applications.

--- a/versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md
@@ -370,7 +370,7 @@ Both values must be in the range `[1, 10000]`. Only the `/api/users` and `/api/g
 The handler toggles below were added in **Camunda 8.8.24**. Earlier 8.8 patches always run every handler that applies to the active mode and cannot skip individual handlers.
 :::
 
-The Identity Migration Application is composed of independent handlers, each responsible for migrating a single resource type (for example: roles, groups, authorizations). By default every handler that applies to the active mode is enabled. Each handler can be disabled individually — for example to re-run only a subset of handlers after fixing a data issue, or to skip a resource type that has already been migrated by another tool.
+The Identity Migration Application is composed of independent handlers. Each handler is responsible for migrating a single resource type, for example, roles, groups, or authorizations. By default, every handler that applies to the active mode is enabled. You can disable each handler individually, for example, to rerun only a subset of handlers after fixing a data issue or to skip a resource type that another tool has already migrated.
 
 Each toggle is namespaced by the mode (profile) it applies to:
 
@@ -381,7 +381,7 @@ Each toggle is namespaced by the mode (profile) it applies to:
 All toggles default to `true`. Setting a toggle to `false` removes only that handler — the rest of the migration runs unchanged.
 
 :::warning Inter-handler dependencies
-Some handlers consume entities created by predecessors. Disabling a predecessor while keeping a consumer enabled fails the migration with a `MigrationException` — recoverable, but worth knowing before flipping flags.
+Some handlers consume entities created by predecessor handlers. If you disable a predecessor while keeping a consumer enabled, the migration fails with a `MigrationException`. The failure is recoverable, but you should know about this behavior before changing these settings.
 
 | Mode       | Consumer                     | Requires          |
 | ---------- | ---------------------------- | ----------------- |


### PR DESCRIPTION
## Summary

Extends the versioned 8.8 upgrade docs for the new operator-tunable knobs added to the identity migration application in [camunda/camunda#52069](https://github.com/camunda/camunda/pull/52069), shipping in **8.8.24**.

Two new subsections under `## Camunda Orchestration Cluster Identity data migration` in `versioned_docs/version-8.8/self-managed/upgrade/components/870-to-880.md`:

- **Tune the Management Identity API page size** — documents `camunda.migration.identity.management-identity.page-size.users` and `.groups` (default `100`, range `[1, 10000]`), with both env-var and `application.yaml` tabs.
- **Selectively enable or disable migration handlers** — documents the 14 `camunda.migration.identity.handler.<mode>.<handler>.enabled` toggles, namespaced by mode (`cloud` / `keycloak` / `oidc`), and includes the inter-handler dependency table so operators know which consumers fail with a `MigrationException` if a predecessor is disabled.

Both sections carry an `Available since 8.8.24` admonition so the patch-level boundary is explicit.

Helm-level docs are unchanged: first-class helm values for these knobs are tracked as follow-up in `camunda-platform-helm` (per the source PR's follow-up note); until then operators set them through the existing `orchestration.migration.identity.env` escape hatch.

closes https://github.com/camunda/camunda/issues/52068

## Test plan

- [x] Render the updated 870-to-880 page locally and confirm the two new subsections appear in order between "Entity ID conversion rules" and "Identity authorization and permission changes".
- [x] Verify the `Available since 8.8.24` admonition renders as an info callout.
- [x] Confirm tabs (env / application.yaml) render correctly in both new sections.
- [x] Spot-check links: Management Identity overview, Keycloak setup, OIDC setup.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)