### PR TITLE
docs: document message-subscriptions/search behavior change for 8.10

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-to-810.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-810.md
@@ -44,7 +44,7 @@ Review the actions required for the following 8.10 changes:
 | Type                                                         | Change                                                                                                               |
 | :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
 | <span className="label-highlight red">Breaking change</span> | [Search filters: `UserTaskFilter` process filters converted into advanced search filters] (#usertask-process-filter) |
-| <span className="label-highlight red">Breaking change</span> | [`POST /v2/message-subscriptions/search` returns start event subscriptions](#message-subscription-type) |
+| <span className="label-highlight red">Breaking change</span> | [`POST /v2/message-subscriptions/search` returns start event subscriptions](#message-subscription-type)              |
 
 ## Breaking changes
 
@@ -103,9 +103,9 @@ This change provides complete visibility into all active message subscriptions f
 
 Each result includes a new `messageSubscriptionType` enum field:
 
-| Value | Description |
-| :---- | :---------- |
-| `START_EVENT` | A start event message subscription. |
+| Value           | Description                                       |
+| :-------------- | :------------------------------------------------ |
+| `START_EVENT`   | A start event message subscription.               |
 | `PROCESS_EVENT` | An intermediate catch event message subscription. |
 
 In existing legacy data, this field is `NULL`.

--- a/docs/apis-tools/migration-manuals/migrate-to-810.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-810.md
@@ -101,14 +101,14 @@ This change provides complete visibility into all active message subscriptions f
 
 #### New field
 
-A new `messageSubscriptionType` enum field is included in each result:
+Each result includes a new `messageSubscriptionType` enum field:
 
 | Value | Description |
 | :---- | :---------- |
 | `START_EVENT` | A start event message subscription. |
 | `PROCESS_EVENT` | An intermediate catch event message subscription. |
 
-Existing (legacy) data has `NULL` for this field.
+In existing legacy data, this field is `NULL`.
 
 #### Impact
 
@@ -129,7 +129,7 @@ Update to the latest SDK version. If your code relies on the endpoint returning 
 </TabItem>
 <TabItem value='generated'>
 
-Regenerate your client from the 8.10 OpenAPI specification to include the new `messageSubscriptionType` field. If your code expects only intermediate event subscriptions, add the filter shown in the custom integrations tab to your request payload.
+Regenerate your client from the 8.10 OpenAPI specification to include the new `messageSubscriptionType` field. If your code expects only intermediate event subscriptions, add the filter shown in the **Custom integrations** tab to your request payload.
 
 </TabItem>
 <TabItem value='custom'>

--- a/docs/apis-tools/migration-manuals/migrate-to-810.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-810.md
@@ -44,6 +44,7 @@ Review the actions required for the following 8.10 changes:
 | Type                                                         | Change                                                                                                               |
 | :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
 | <span className="label-highlight red">Breaking change</span> | [Search filters: `UserTaskFilter` process filters converted into advanced search filters] (#usertask-process-filter) |
+| <span className="label-highlight red">Breaking change</span> | [`POST /v2/message-subscriptions/search` returns start event subscriptions](#message-subscription-type) |
 
 ## Breaking changes
 
@@ -84,6 +85,72 @@ Regenerate your client.
 <TabItem value='custom'>
 
 No change is needed if your code already uses the exact-match filters for `processDefinitionKey`, `processInstanceKey`, and `bpmnProcessId` in `UserTaskFilter`.
+
+</TabItem>
+</Tabs>
+
+### `POST /v2/message-subscriptions/search` returns start event subscriptions {#message-subscription-type}
+
+#### Change
+
+The `POST /v2/message-subscriptions/search` endpoint now returns both start event and intermediate event message subscriptions. Previously, only intermediate event subscriptions were returned.
+
+#### Why
+
+This change provides complete visibility into all active message subscriptions for a process, including start event subscriptions that were previously excluded.
+
+#### New field
+
+A new `messageSubscriptionType` enum field is included in each result:
+
+| Value | Description |
+| :---- | :---------- |
+| `START_EVENT` | A start event message subscription. |
+| `PROCESS_EVENT` | An intermediate catch event message subscription. |
+
+Existing (legacy) data has `NULL` for this field.
+
+#### Impact
+
+Integrations that consume results from `POST /v2/message-subscriptions/search` will now receive start event subscriptions in addition to intermediate event subscriptions. Code that assumes only intermediate events may produce unexpected behavior.
+
+#### Action
+
+<Tabs groupId="audience" defaultValue="sdk" queryString values={[
+{label: 'Official SDK users', value: 'sdk'},
+{label: 'Generated-client users', value: 'generated'},
+{label: 'Custom integrations', value: 'custom'},
+]}>
+
+<TabItem value='sdk'>
+
+Update to the latest SDK version. If your code relies on the endpoint returning only intermediate event subscriptions, add a filter to exclude start events when constructing your search query.
+
+</TabItem>
+<TabItem value='generated'>
+
+Regenerate your client from the 8.10 OpenAPI specification to include the new `messageSubscriptionType` field. If your code expects only intermediate event subscriptions, add the filter shown in the custom integrations tab to your request payload.
+
+</TabItem>
+<TabItem value='custom'>
+
+If your code relies on the endpoint returning only intermediate event subscriptions, add the following filter to restore the previous behavior:
+
+```json title="Before (no filter needed — endpoint returned only intermediate events)"
+{
+  "filter": {}
+}
+```
+
+```json title="After (filter required to exclude start events)"
+{
+  "filter": {
+    "messageSubscriptionType": { "$neq": "START_EVENT" }
+  }
+}
+```
+
+This filter works correctly for both new data and legacy data (which has `NULL` in the `messageSubscriptionType` field).
 
 </TabItem>
 </Tabs>

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -86,11 +86,23 @@ Camunda clients (Java client, Spring SDK, Node.js SDK) and Camunda Process Test 
 </div>
 <div className="release-announcement-content">
 
-#### APIs & tools change 1
+#### `POST /v2/message-subscriptions/search` now returns start event subscriptions
 
-APIs & tools change 1 description.
+Starting with 8.10, the `POST /v2/message-subscriptions/search` endpoint returns both **start event** and **intermediate event** message subscriptions. Previously, only intermediate event subscriptions were returned.
 
-**Action:** Description.
+A new `messageSubscriptionType` enum field is included in each result. Existing (legacy) data has `NULL` for this field.
+
+**Action:** If your integration expects the endpoint to return only intermediate event subscriptions, add the following filter to restore the previous behavior:
+
+```json
+{
+  "filter": {
+    "messageSubscriptionType": { "$neq": "START_EVENT" }
+  }
+}
+```
+
+<p className="link-arrow">[8.10 APIs & Tools migration guide](/apis-tools/migration-manuals/migrate-to-810.md#message-subscription-type)</p>
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -88,7 +88,7 @@ Camunda clients (Java client, Spring SDK, Node.js SDK) and Camunda Process Test 
 
 #### `POST /v2/message-subscriptions/search` now returns start event subscriptions
 
-Starting with 8.10, the `POST /v2/message-subscriptions/search` endpoint returns both **start event** and **intermediate event** message subscriptions. Previously, only intermediate event subscriptions were returned.
+Starting with 8.10, the `POST /v2/message-subscriptions/search` endpoint returns both start event and intermediate event message subscriptions. Previously, only intermediate event subscriptions were returned.
 
 A new `messageSubscriptionType` enum field is included in each result. Existing (legacy) data has `NULL` for this field.
 


### PR DESCRIPTION
## Description

The POST /v2/message-subscriptions/search endpoint now returns both start event and intermediate event subscriptions (previously only intermediate). Documents the new messageSubscriptionType enum field and how to restore old behavior using a $neq filter.

Closes camunda/camunda#51047

https://claude.ai/code/session_01JhAmmZiY4Q4LCb4QUm3KEF

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [X] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
