### PR TITLE
try mouseover

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -555,6 +555,9 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           editUrl: "https://github.com/camunda/camunda-docs/edit/main/",
+          remarkPlugins: [
+            require("./static/plugins/terminology/remark-glossary-terms"),
+          ],
           lastVersion: currentVersion,
           // 👋 When cutting a new version, remove the banner for maintained versions by adding an entry. Remove the entry to versions >18 months old.
           versions: {

--- a/src/components/GlossaryTerm/index.js
+++ b/src/components/GlossaryTerm/index.js
@@ -1,0 +1,24 @@
+import React, { useId } from "react";
+import Link from "@docusaurus/Link";
+
+export default function GlossaryTerm({ href, summary, title, children }) {
+  const tooltipId = useId();
+
+  return (
+    <span className="glossary-term">
+      <Link
+        className="glossary-term__link"
+        to={href}
+        aria-describedby={summary ? tooltipId : undefined}
+      >
+        {children}
+      </Link>
+      {summary ? (
+        <span id={tooltipId} className="glossary-term__tooltip" role="tooltip">
+          <span className="glossary-term__tooltip-title">{title}</span>
+          <span>{summary}</span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1794,15 +1794,16 @@ ul ul .table-of-contents__link--active {
 .glossary-term {
   display: inline;
   position: relative;
+  --glossary-term-accent: var(--ifm-color-primary);
 }
 
 .glossary-term__link {
-  color: inherit;
+  color: var(--glossary-term-accent);
   font: inherit;
   line-height: inherit;
   text-decoration-line: underline;
   text-decoration-style: dotted;
-  text-decoration-color: var(--ifm-color-warning-dark);
+  text-decoration-color: currentColor;
   text-decoration-thickness: 0.07em;
   text-underline-offset: 0.12em;
 }
@@ -1814,7 +1815,7 @@ ul ul .table-of-contents__link--active {
   z-index: 40;
   width: min(22rem, calc(100vw - 2rem));
   padding: 0.75rem 0.875rem;
-  border: 1px solid var(--ifm-color-warning-dark);
+  border: 1px solid var(--glossary-term-accent);
   border-radius: 0.5rem;
   background: var(--ifm-background-surface-color);
   box-shadow: 0 10px 28px rgba(17, 24, 39, 0.18);
@@ -1836,8 +1837,8 @@ ul ul .table-of-contents__link--active {
   left: 50%;
   width: 0.75rem;
   height: 0.75rem;
-  border-right: 1px solid var(--ifm-color-warning-dark);
-  border-bottom: 1px solid var(--ifm-color-warning-dark);
+  border-right: 1px solid var(--glossary-term-accent);
+  border-bottom: 1px solid var(--glossary-term-accent);
   background: var(--ifm-background-surface-color);
   transform: translateX(-50%) rotate(45deg);
 }
@@ -1845,8 +1846,18 @@ ul ul .table-of-contents__link--active {
 .glossary-term__tooltip-title {
   display: block;
   margin-bottom: 0.25rem;
-  color: var(--ifm-color-warning-darkest);
+  color: var(--glossary-term-accent);
   font-weight: 600;
+}
+
+[data-theme="dark"] .glossary-term {
+  --glossary-term-accent: #f3f3f3;
+}
+
+[data-theme="dark"] .glossary-term__link {
+  font-weight: 600;
+  text-decoration-thickness: auto;
+  text-underline-offset: auto;
 }
 
 .glossary-term:focus-within .glossary-term__tooltip {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1790,6 +1790,93 @@ ul ul .table-of-contents__link--active {
   opacity: 0.5;
   cursor: default;
 }
+
+.glossary-term {
+  display: inline-flex;
+  position: relative;
+}
+
+.glossary-term__link {
+  text-decoration-style: dotted;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.glossary-term__tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  z-index: 40;
+  width: min(20rem, 80vw);
+  padding: 0.75rem 0.875rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.5rem;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 10px 28px rgba(17, 24, 39, 0.18);
+  color: var(--ifm-font-color-base);
+  font-size: 0.875rem;
+  line-height: 1.45;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(0.25rem);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.glossary-term__tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.glossary-term__tooltip-title {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--ifm-heading-color);
+  font-weight: 600;
+}
+
+.glossary-term:focus-within .glossary-term__tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .glossary-term:hover .glossary-term__tooltip {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .glossary-term__tooltip {
+    left: 0;
+    transform: translateY(0.25rem);
+  }
+
+  .glossary-term__tooltip::after {
+    left: 1.5rem;
+    transform: rotate(45deg);
+  }
+
+  .glossary-term:focus-within .glossary-term__tooltip {
+    transform: translateY(0);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .glossary-term:hover .glossary-term__tooltip {
+      transform: translateY(0);
+    }
+  }
+}
 /* Style for custom Detail collapsbiles - for example used in /docs/reference/announcements-release-notes/860/860-release-notes.md */
 .changelog-dropdown {
   border: none !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1792,14 +1792,19 @@ ul ul .table-of-contents__link--active {
 }
 
 .glossary-term {
-  display: inline-flex;
+  display: inline;
   position: relative;
 }
 
 .glossary-term__link {
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  text-decoration-line: underline;
   text-decoration-style: dotted;
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.18em;
+  text-decoration-color: var(--ifm-color-warning-dark);
+  text-decoration-thickness: 0.07em;
+  text-underline-offset: 0.12em;
 }
 
 .glossary-term__tooltip {
@@ -1807,9 +1812,9 @@ ul ul .table-of-contents__link--active {
   left: 50%;
   bottom: calc(100% + 0.5rem);
   z-index: 40;
-  width: min(20rem, 80vw);
+  width: min(22rem, calc(100vw - 2rem));
   padding: 0.75rem 0.875rem;
-  border: 1px solid var(--ifm-color-emphasis-300);
+  border: 1px solid var(--ifm-color-warning-dark);
   border-radius: 0.5rem;
   background: var(--ifm-background-surface-color);
   box-shadow: 0 10px 28px rgba(17, 24, 39, 0.18);
@@ -1831,8 +1836,8 @@ ul ul .table-of-contents__link--active {
   left: 50%;
   width: 0.75rem;
   height: 0.75rem;
-  border-right: 1px solid var(--ifm-color-emphasis-300);
-  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  border-right: 1px solid var(--ifm-color-warning-dark);
+  border-bottom: 1px solid var(--ifm-color-warning-dark);
   background: var(--ifm-background-surface-color);
   transform: translateX(-50%) rotate(45deg);
 }
@@ -1840,7 +1845,7 @@ ul ul .table-of-contents__link--active {
 .glossary-term__tooltip-title {
   display: block;
   margin-bottom: 0.25rem;
-  color: var(--ifm-heading-color);
+  color: var(--ifm-color-warning-darkest);
   font-weight: 600;
 }
 
@@ -1856,14 +1861,14 @@ ul ul .table-of-contents__link--active {
   }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 768px) {
   .glossary-term__tooltip {
-    left: 0;
+    left: max(-0.5rem, calc(50% - 10rem));
     transform: translateY(0.25rem);
   }
 
   .glossary-term__tooltip::after {
-    left: 1.5rem;
+    left: clamp(1.5rem, 50%, 10rem);
     transform: rotate(45deg);
   }
 

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,7 @@
+import MDXComponents from "@theme-original/MDXComponents";
+import GlossaryTerm from "@site/src/components/GlossaryTerm";
+
+export default {
+  ...MDXComponents,
+  GlossaryTerm,
+};

--- a/static/plugins/terminology/remark-glossary-terms.js
+++ b/static/plugins/terminology/remark-glossary-terms.js
@@ -1,0 +1,201 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const glossaryCache = new Map();
+
+function walk(node, visitor) {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+
+  visitor(node);
+
+  if (Array.isArray(node.children)) {
+    node.children.forEach((child) => walk(child, visitor));
+  }
+}
+
+function slugifyHeading(value) {
+  return value
+    .toLowerCase()
+    .replace(/<[^>]+>/g, "")
+    .replace(/&[a-z0-9#]+;/gi, "")
+    .replace(/[']/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+function stripInlineMarkdown(value) {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractSummary(lines, startIndex) {
+  const summaryLines = [];
+
+  for (let index = startIndex; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      if (summaryLines.length > 0) {
+        break;
+      }
+
+      continue;
+    }
+
+    if (/^#{2,3}\s+/.test(trimmed)) {
+      break;
+    }
+
+    if (/^(:::|```|<details>|<div|\||- |\d+\. )/.test(trimmed)) {
+      if (summaryLines.length > 0) {
+        break;
+      }
+
+      continue;
+    }
+
+    summaryLines.push(trimmed);
+  }
+
+  return stripInlineMarkdown(summaryLines.join(" "));
+}
+
+function parseGlossaryFile(glossaryPath) {
+  if (glossaryCache.has(glossaryPath)) {
+    return glossaryCache.get(glossaryPath);
+  }
+
+  const terms = new Map();
+
+  if (!fs.existsSync(glossaryPath)) {
+    glossaryCache.set(glossaryPath, terms);
+    return terms;
+  }
+
+  const content = fs.readFileSync(glossaryPath, "utf8");
+  const lines = content.split(/\r?\n/);
+  let startIndex = 0;
+
+  if (lines[0] === "---") {
+    startIndex = 1;
+    while (startIndex < lines.length && lines[startIndex] !== "---") {
+      startIndex += 1;
+    }
+    startIndex += 1;
+  }
+
+  for (let index = startIndex; index < lines.length; index += 1) {
+    const line = lines[index];
+    const match = line.match(/^###\s+(.*)$/);
+
+    if (!match) {
+      continue;
+    }
+
+    const title = stripInlineMarkdown(match[1]);
+    const slug = slugifyHeading(title);
+    const summary = extractSummary(lines, index + 1);
+
+    if (slug && summary) {
+      terms.set(slug, { title, summary });
+    }
+  }
+
+  glossaryCache.set(glossaryPath, terms);
+  return terms;
+}
+
+function getDocsRoot(sourceFilePath) {
+  const normalizedPath = sourceFilePath.split(path.sep).join("/");
+  const versionMatch = normalizedPath.match(
+    /\/versioned_docs\/(version-[^/]+)\//
+  );
+
+  if (versionMatch) {
+    return path.join(process.cwd(), "versioned_docs", versionMatch[1]);
+  }
+
+  return path.join(process.cwd(), "docs");
+}
+
+function resolveGlossaryTarget(sourceFilePath, url) {
+  if (!url || url.startsWith("#") || /^(https?:)?\/\//.test(url)) {
+    return null;
+  }
+
+  const [targetPath, hash] = url.split("#");
+
+  if (!hash) {
+    return null;
+  }
+
+  const docsRoot = getDocsRoot(sourceFilePath);
+  let absolutePath;
+
+  if (targetPath.startsWith("/")) {
+    absolutePath = path.join(docsRoot, targetPath.replace(/^\//, ""));
+  } else {
+    absolutePath = path.resolve(path.dirname(sourceFilePath), targetPath);
+  }
+
+  if (!path.extname(absolutePath)) {
+    absolutePath = `${absolutePath}.md`;
+  }
+
+  if (path.basename(absolutePath) !== "glossary.md") {
+    return null;
+  }
+
+  return {
+    glossaryPath: absolutePath,
+    hash,
+  };
+}
+
+module.exports = function remarkGlossaryTerms() {
+  return (tree, file) => {
+    const sourceFilePath = file.history && file.history[0];
+
+    if (!sourceFilePath || path.basename(sourceFilePath) === "glossary.md") {
+      return;
+    }
+
+    walk(tree, (node) => {
+      if (node.type !== "link") {
+        return;
+      }
+
+      const target = resolveGlossaryTarget(sourceFilePath, node.url);
+
+      if (!target) {
+        return;
+      }
+
+      const glossaryTerms = parseGlossaryFile(target.glossaryPath);
+      const term = glossaryTerms.get(target.hash.toLowerCase());
+
+      if (!term) {
+        return;
+      }
+
+      node.type = "mdxJsxTextElement";
+      node.name = "GlossaryTerm";
+      node.attributes = [
+        { type: "mdxJsxAttribute", name: "href", value: node.url },
+        { type: "mdxJsxAttribute", name: "title", value: term.title },
+        { type: "mdxJsxAttribute", name: "summary", value: term.summary },
+      ];
+    });
+  };
+};

--- a/static/plugins/terminology/remark-glossary-terms.js
+++ b/static/plugins/terminology/remark-glossary-terms.js
@@ -129,6 +129,12 @@ function getDocsRoot(sourceFilePath) {
   return path.join(process.cwd(), "docs");
 }
 
+function normalizeGlossaryRoute(targetPath) {
+  return targetPath
+    .replace(/^\/docs\/(?:next|\d+\.\d+)\//, "/")
+    .replace(/\/$/, "");
+}
+
 function resolveGlossaryTarget(sourceFilePath, url) {
   if (!url || url.startsWith("#") || /^(https?:)?\/\//.test(url)) {
     return null;
@@ -141,19 +147,23 @@ function resolveGlossaryTarget(sourceFilePath, url) {
   }
 
   const docsRoot = getDocsRoot(sourceFilePath);
+  const normalizedTargetPath = normalizeGlossaryRoute(targetPath);
   let absolutePath;
 
-  if (targetPath.startsWith("/")) {
-    absolutePath = path.join(docsRoot, targetPath.replace(/^\//, ""));
+  if (normalizedTargetPath.startsWith("/")) {
+    absolutePath = path.join(docsRoot, normalizedTargetPath.replace(/^\//, ""));
   } else {
-    absolutePath = path.resolve(path.dirname(sourceFilePath), targetPath);
+    absolutePath = path.resolve(
+      path.dirname(sourceFilePath),
+      normalizedTargetPath
+    );
   }
 
   if (!path.extname(absolutePath)) {
-    absolutePath = `${absolutePath}.md`;
+    absolutePath = `${absolutePath.replace(/\/$/, "")}.md`;
   }
 
-  if (path.basename(absolutePath) !== "glossary.md") {
+  if (path.basename(absolutePath, path.extname(absolutePath)) !== "glossary") {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/camunda/camunda-docs/issues/1970. Add glossary term hover support to the docs site through a custom terminology pipeline integrated into the existing Docusaurus setup. _I think you will need to run this locally to see the deployment environment properly_

## What this project work includes

This work adds a glossary-driven term preview experience to the documentation site. The goal is to let documentation pages link to glossary entries in a normal Markdown-friendly way while rendering those links in the UI as hoverable glossary terms with short definitions.

Instead of relying on a third-party plugin directly, the implementation is built into the repo using a custom remark transform, a React component for rendering glossary terms, and supporting styles in the site theme.

## How it works

The implementation is based on glossary links in documentation content, for example:

- `/reference/glossary.md#elasticsearchopensearch`
- `/reference/glossary.md#user-task`

When a docs page contains one of those glossary links, the custom remark plugin parses the page during the docs build and transforms that Markdown link into a custom `GlossaryTerm` MDX component.

<img width="1017" height="699" alt="Screenshot 2026-05-04 at 3 19 43 PM" src="https://github.com/user-attachments/assets/a62dbbbf-6f97-439f-9ac9-53ab975a28bd" />

That component renders:

- A normal clickable documentation link
- A hover or focus tooltip
- A glossary title and short summary extracted from the glossary entry

The glossary content itself remains the source of truth. Term titles and summaries are read from `glossary.md`, so authors only need to maintain glossary definitions in one place.

## Main pieces of the implementation

### Remark plugin

A custom remark plugin in `static/plugins/terminology/remark-glossary-terms.js` scans Markdown AST link nodes and looks for glossary links. When it finds one, it resolves the glossary file, extracts the relevant term metadata, and rewrites the node into a `GlossaryTerm` component.

### MDX component registration

The custom component is registered in `src/theme/MDXComponents.js` so transformed glossary links can render as part of the normal Docusaurus MDX pipeline.

### React component

The `GlossaryTerm` component in `src/components/GlossaryTerm/index.js` renders the linked term and its tooltip content. It preserves standard navigation while adding accessible tooltip behavior.

### Styling

Tooltip and link styles are defined in `src/css/custom.css`, including hover and focus behavior for desktop and keyboard users.

### Docusaurus integration

The plugin is wired into the docs pipeline through `docusaurus.config.js` using the `remarkPlugins` configuration for the docs preset. This ensures glossary term rewriting happens automatically during docs processing.

## Authoring model

From a documentation author’s perspective, usage stays simple:

- Write or maintain glossary definitions in `glossary.md`
- Link to glossary anchors from doc pages using normal Markdown links
- Let the build pipeline convert those links into interactive glossary terms

This keeps authoring low-friction and avoids introducing custom syntax into content files.

## Why this approach

This implementation keeps the terminology behavior aligned with the repo’s existing Docusaurus and MDX architecture, while avoiding dependence on an archived external plugin. It also gives the project full control over:

- How glossary terms are detected
- How summaries are extracted
- How the tooltip UI is rendered
- How the behavior evolves alongside the docs site

## Validation

Validation for this work included checking that:

- Glossary links are transformed during the remark phase
- The custom component is available to rendered MDX pages
- Tooltip styles are applied in the site theme
- Docs builds complete successfully with the terminology pipeline enabled

## Notes

- Hover behavior only appears for links that point to glossary entries
- Regular internal documentation links are left unchanged
- The glossary page remains the canonical source for term definitions and summaries

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
