### PR TITLE
docs(metrics): replace deprecated ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED env var

### DIFF
--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -240,7 +240,7 @@ The health of partitions in a broker can be monitored using the metric `zeebe_he
 
 Brokers can export optional execution latency metrics.
 
-To enable export of execution metrics, set the `ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED` environment variable to `true` in your Zeebe [configuration file](/self-managed/components/orchestration-cluster/zeebe/configuration/configuration.md).
+To enable export of execution metrics, set the `CAMUNDA_MONITORING_METRICS_ENABLEEXPORTEREXECUTIONMETRICS` environment variable to `true` in your Zeebe [configuration file](/self-managed/components/orchestration-cluster/zeebe/configuration/configuration.md).
 
 ## Optimize error metrics
 

--- a/versioned_docs/version-8.9/self-managed/operational-guides/monitoring/metrics.md
+++ b/versioned_docs/version-8.9/self-managed/operational-guides/monitoring/metrics.md
@@ -240,7 +240,7 @@ The health of partitions in a broker can be monitored using the metric `zeebe_he
 
 Brokers can export optional execution latency metrics.
 
-To enable export of execution metrics, set the `ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED` environment variable to `true` in your Zeebe [configuration file](/self-managed/components/orchestration-cluster/zeebe/configuration/configuration.md).
+To enable export of execution metrics, set the `CAMUNDA_MONITORING_METRICS_ENABLEEXPORTEREXECUTIONMETRICS` environment variable to `true` in your Zeebe [configuration file](/self-managed/components/orchestration-cluster/zeebe/configuration/configuration.md).
 
 ## Grafana
 


### PR DESCRIPTION
## Summary

- Replaces all references to the deprecated `ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED` environment variable with `CAMUNDA_MONITORING_METRICS_ENABLEEXPORTEREXECUTIONMETRICS`
- Affects `docs/` and versioned docs for v8.7, v8.8, and v8.9

## Test plan

- [ ] Verify the new env var name appears correctly in rendered docs
- [ ] Confirm no remaining references to the deprecated env var name

🤖 Generated with [Claude Code](https://claude.com/claude-code)