### PR TITLE
Consolidate RDBMS prod architecture into ref architecture

### DIFF
--- a/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -204,6 +204,7 @@ For hands-on instructions to deploy Camunda with RDBMS, start with:
 
 Then choose your deployment pattern:
 
-- [Production architecture with RDBMS](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) - Reference topology and design considerations.
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) - Canonical backend trade-offs and production architecture guidance.
+- [Production architecture with RDBMS](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) - Manual deployment topology guidance for RDBMS.
 - [Manual installation with RDBMS](/self-managed/deployment/manual/rdbms/index.md) - Entry point for manual installation, configuration, and operations.
 - [RDBMS example deployment for Helm](/self-managed/deployment/helm/install/helm-with-rdbms.md) - Kubernetes/Helm-based example walkthrough.

--- a/docs/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/kind.md
@@ -48,6 +48,8 @@ mkcert requires [NSS](https://github.com/FiloSottile/mkcert#supported-root-store
 
 In addition to the deployment mode, you must choose a [secondary storage](/self-managed/concepts/secondary-storage/index.md) backend. The `SECONDARY_STORAGE` environment variable controls which backend the deployment scripts use. You must set it explicitly before running any deployment command — there is no default.
 
+For production backend trade-offs between Elasticsearch/OpenSearch and RDBMS, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture). This kind guide is for local development and testing only.
+
 | Value           | Operators deployed                    | Components                                                  |
 | --------------- | ------------------------------------- | ----------------------------------------------------------- |
 | `elasticsearch` | ECK, CloudNativePG, Keycloak Operator | Full platform including Optimize                            |

--- a/docs/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms.md
@@ -15,6 +15,7 @@ This page provides:
 
 Related guides:
 
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [Secondary storage overview](/self-managed/concepts/secondary-storage/index.md)
 - [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md)
 - [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md)

--- a/docs/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/docs/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -14,21 +14,16 @@ If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-manage
 Related guides:
 
 - [Production install](/self-managed/deployment/helm/install/production/index.md)
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [Secondary storage overview](/self-managed/concepts/secondary-storage/index.md)
 - [Configure RDBMS in Helm charts](/self-managed/deployment/helm/configure/database/rdbms.md)
 - [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md)
 
 ## What changes when using RDBMS?
 
-In Camunda 8, secondary storage stores historical data and process state. You can use either a document-store backend (Elasticsearch/OpenSearch) or an RDBMS, depending on your requirements. This guide focuses on the RDBMS option:
+In Camunda 8, secondary storage stores historical data and process state. You can use either a document-store backend (Elasticsearch/OpenSearch) or an RDBMS, depending on your requirements. For the canonical production trade-off guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
 
-| Aspect               | Document-store backend (Elasticsearch/OpenSearch)   | RDBMS                                                       |
-| -------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
-| **Storage choice**   | Helm-managed subchart                               | You manage (PostgreSQL, etc.)                               |
-| **Scaling**          | Scale the search cluster independently from Camunda | Scale via your database service (vertical or read replicas) |
-| **Backup strategy**  | ES/OS snapshot/restore tooling                      | Database-native backups (e.g., pg_dump, vendor tools)       |
-| **Monitoring**       | ES/OS metrics and dashboards                        | Database-native monitoring and alerts                       |
-| **Operator support** | No embedded document-store operator bundled         | Database operators (optional)                               |
+This guide focuses on the Helm-specific RDBMS path. In practice, that means you provide and operate an external supported relational database, and the Orchestration Cluster reads operational data through that backend.
 
 When using RDBMS, **Optimize still requires Elasticsearch or OpenSearch**. Only the Orchestration Cluster uses RDBMS.
 
@@ -166,7 +161,7 @@ If you're using Oracle, MySQL, or a database version not covered by bundled driv
 For detailed information about JDBC driver strategies, security configurations, and validation, see [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md).
 :::
 
-**Option A: Init container (recommended for production)**
+#### Option A: Init container (recommended for production)
 
 Update your `values-rdbms.yaml`:
 
@@ -197,7 +192,7 @@ orchestration:
 
 For other driver sources (e.g., private repositories), adjust the `wget` command or use a private container registry for pre-built images.
 
-**Option B: ConfigMap (GitOps-friendly)**
+#### Option B: ConfigMap (GitOps-friendly)
 
 Store the driver JAR in a ConfigMap and mount it:
 
@@ -313,7 +308,7 @@ orchestration:
 
 In production, separate the Orchestration Cluster from management components (WebModeler, Console, Identity, Optimize):
 
-**Namespace 1: Orchestration + Connectors**
+#### Namespace 1: Orchestration + Connectors
 
 ```yaml
 orchestration:
@@ -339,7 +334,7 @@ identity:
   enabled: false
 ```
 
-**Namespace 2: Management components (with document-store secondary storage)**
+#### Namespace 2: Management components (with document-store secondary storage)
 
 ```yaml
 orchestration:

--- a/docs/self-managed/deployment/manual/install.md
+++ b/docs/self-managed/deployment/manual/install.md
@@ -21,7 +21,7 @@ This page guides you through the manual installation of Camunda 8 on a local mac
   - Choose a supported secondary storage backend for your installation path.
   - **Document-store backend (Elasticsearch or OpenSearch)**: See [supported environments](/reference/supported-environments.md).
     - For deployment options, see the [Elasticsearch documentation](https://www.elastic.co/docs/deploy-manage/deploy).
-  - **RDBMS**: See [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) and [manual installation with RDBMS](/self-managed/deployment/manual/rdbms/index.md) for supported databases and setup details.
+  - **RDBMS**: See [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs, and [manual installation with RDBMS](/self-managed/deployment/manual/rdbms/index.md) for supported databases and setup details.
 
 For suggested minimum hardware requirements and networking, see the [manual reference architecture requirements](/self-managed/reference-architecture/manual.md#requirements).
 

--- a/docs/self-managed/deployment/manual/rdbms/configuration.md
+++ b/docs/self-managed/deployment/manual/rdbms/configuration.md
@@ -135,6 +135,7 @@ Download scripts: [Access SQL and Liquibase scripts](/self-managed/deployment/he
 ## Next steps
 
 - [Operations and maintenance](/self-managed/deployment/manual/rdbms/operations.md)
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
 - [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)

--- a/docs/self-managed/deployment/manual/rdbms/index.md
+++ b/docs/self-managed/deployment/manual/rdbms/index.md
@@ -11,9 +11,11 @@ Install Camunda 8 Self-Managed manually on a VM, bare-metal server, or standalon
 Manual installation is **not** supported for Kubernetes. If you run on Kubernetes, use the [Helm charts](/self-managed/deployment/helm/index.md).
 :::
 
-## Secondary storage architecture
+## Manual deployment data flow
 
-The Orchestration Cluster reads from a single configured secondary storage type (RDBMS in this deployment). However, the Zeebe broker can export to multiple targets simultaneously. If you deploy Optimize, configure both the RDBMS exporter (for Orchestration Cluster operations) and an Elasticsearch/OpenSearch exporter for Optimize.
+For backend trade-offs and production architecture decisions, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
+
+In this manual deployment path, the Orchestration Cluster reads from a single configured secondary storage type: RDBMS. However, the Zeebe broker can export to multiple targets simultaneously. If you deploy Optimize, configure both the RDBMS exporter (for Orchestration Cluster operations) and an Elasticsearch/OpenSearch exporter for Optimize.
 
 ```mermaid
 graph LR
@@ -83,7 +85,7 @@ The Orchestration Cluster is fully supported with RDBMS secondary storage for wo
 
 1. [Configure drivers and connections](/self-managed/deployment/manual/rdbms/configuration.md).
 2. Review [operations and maintenance](/self-managed/deployment/manual/rdbms/operations.md) for backup, upgrades, troubleshooting, and tuning.
-3. Review the [production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for sizing and topology guidance.
+3. Review [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs and [manual production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for manual deployment topology guidance.
 
 ## Related documentation
 

--- a/docs/self-managed/deployment/manual/rdbms/operations.md
+++ b/docs/self-managed/deployment/manual/rdbms/operations.md
@@ -158,11 +158,12 @@ Avoid DROP, TRUNCATE, SUPERUSER, or other unnecessary privileges.
 
 ## Production deployment
 
-Before deploying to production, review the [production architecture guidance](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for recommended topologies, and refer to the verification steps in the [troubleshooting section](#verification-and-troubleshooting) above to validate your RDBMS setup is healthy.
+Before deploying to production, review [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs and the [manual production architecture guide](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for recommended topology. Then use the verification steps in the [troubleshooting section](#verification-and-troubleshooting) above to validate your RDBMS setup is healthy.
 
 ## Next steps
 
 - [RDBMS configuration](/self-managed/deployment/manual/rdbms/configuration.md)
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
 - [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)

--- a/docs/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md
+++ b/docs/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md
@@ -5,9 +5,20 @@ title: Production architecture for Camunda 8 with RDBMS
 description: "Reference architecture for deploying Camunda 8 Self-Managed in production using an external RDBMS as secondary storage."
 ---
 
-Understand reference architectures for running Camunda 8 Self-Managed in production with a relational database (RDBMS) as secondary storage, including supported topologies, Orchestration Cluster interactions, and critical constraints.
+Apply RDBMS secondary storage to a **manual deployment**. For the canonical production architecture and trade-off guidance across manual, containerized, and Kubernetes deployments, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
 
-## Recommended topology
+## Manual deployment baseline
+
+For manual production deployments with RDBMS, use these baseline decisions:
+
+- Run at least three brokers across three availability zones for high availability.
+- Use an external supported RDBMS for the Orchestration Cluster's secondary storage.
+- Keep the database in the same region as the Orchestration Cluster.
+- Use managed database services or vendor-supported high-availability mechanisms when possible.
+
+For backend selection trade-offs, Optimize requirements, and Elasticsearch/OpenSearch versus RDBMS comparison guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
+
+## Example topology
 
 For production deployments with RDBMS, Camunda recommends a **HA Zeebe cluster backed by an external managed RDBMS**:
 
@@ -48,19 +59,19 @@ graph TB
 
 ### Key characteristics
 
-**Clustering**
+#### Clustering
 
 - Minimum three brokers for production HA
 - Each broker in separate availability zone
 - Default replication factor 3 (spans AZs)
 
-**Secondary storage**
+#### Secondary storage
 
 - Single external managed RDBMS instance
 - Database handles replication and failover
 - Camunda does not manage database HA
 
-**Data flow**
+#### Data flow
 
 - Processes are executed
 - State is flushed to RDBMS
@@ -78,7 +89,7 @@ Without Optimize: RDBMS-only stack is fully supported.
 
 ## Production constraints
 
-❌ **ES/OS ↔ RDBMS migration not supported**: Choose your secondary storage backend before production. No automated migration tools available.
+❌ **ES/OS ↔ RDBMS migration not supported**: Choose your secondary storage backend before production. No automated migration tools are available.
 
 ❌ **Uniform broker configuration required**: All brokers in the Orchestration Cluster must export to the same secondary storage backend for its Orchestration Cluster indices. In addition, you may run Elasticsearch/OpenSearch to support Optimize, but the Orchestration Cluster still uses a single backend for its own secondary storage.
 
@@ -99,6 +110,7 @@ Without Optimize: RDBMS-only stack is fully supported.
 
 ## Next steps
 
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS configuration](/self-managed/deployment/manual/rdbms/configuration.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
 - [RDBMS Helm configuration](/self-managed/deployment/helm/configure/database/rdbms.md)

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -257,7 +257,7 @@ The following databases are required:
 Camunda 8 supports both [Amazon OpenSearch](https://aws.amazon.com/opensearch-service) and the open-source [OpenSearch](https://opensearch.org/) distribution.
 :::
 
-For more information, see the [reference architecture overview](/self-managed/reference-architecture/reference-architecture.md#architecture).
+For backend trade-offs and production guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture). For more general context, see the [reference architecture overview](/self-managed/reference-architecture/reference-architecture.md#architecture).
 
 Sizing is use case dependent. It is crucial to conduct thorough load testing and benchmarking to determine the appropriate sizing for your specific environment and workload.
 

--- a/docs/self-managed/reference-architecture/manual.md
+++ b/docs/self-managed/reference-architecture/manual.md
@@ -66,7 +66,7 @@ Connectors expose additional HTTP(s) endpoints for handling incoming webhooks, w
 The Orchestration Cluster relies on a configured [secondary storage](/reference/glossary.md#secondary-storage) backend for indexing and search. Depending on your deployment and configuration, this backend can use a document-store backend ([Elasticsearch/OpenSearch](/reference/glossary.md#elasticsearchopensearch)) or an [RDBMS](/reference/glossary.md#rdbms) for supported scenarios.
 
 :::note
-Secondary storage is configurable. For RDBMS-based secondary storage, see [RDBMS configuration](/self-managed/concepts/databases/relational-db/configuration.md) and the glossary entry [RDBMS](/reference/glossary.md#rdbms).
+Secondary storage is configurable. For backend trade-offs and production guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture). For RDBMS configuration details, see [RDBMS configuration](/self-managed/concepts/databases/relational-db/configuration.md) and the glossary entry [RDBMS](/reference/glossary.md#rdbms).
 :::
 
 Components within the Orchestration Cluster communicate seamlessly, particularly:

--- a/docs/self-managed/reference-architecture/reference-architecture.md
+++ b/docs/self-managed/reference-architecture/reference-architecture.md
@@ -103,6 +103,59 @@ Databases can be deployed as part of the Camunda clusters, but using external da
 
 While some guides explain how to deploy databases with Camunda, the recommendation is to manage databases externally for greater control and flexibility.
 
+### Secondary storage architecture
+
+Choose the secondary storage architecture before you finalize a production deployment pattern. This decision applies across manual, containerized, and Kubernetes deployments.
+
+For production, use an external managed service or an externally operated database cluster whenever possible. Camunda does not manage database high availability, failover, backups, or lifecycle operations for you.
+
+#### Production topology baseline
+
+For a production Orchestration Cluster, use these baseline assumptions regardless of deployment method:
+
+- Run at least three brokers across three availability zones for high availability.
+- Use one secondary storage backend family for the Orchestration Cluster's web applications and APIs.
+- Keep the secondary storage backend in the same region as the Orchestration Cluster to reduce latency and failure domains.
+- Treat secondary storage as part of your production data layer, with its own backup, monitoring, and scaling plan.
+
+#### Compare Elasticsearch/OpenSearch and RDBMS
+
+Both backend families are supported for production in the right scenarios. Choose based on query patterns, operational preferences, and component requirements.
+
+| Topic                              | Elasticsearch/OpenSearch                                                              | RDBMS                                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Best fit                           | Search-heavy, filter-heavy, analytics-heavy workloads                                 | Teams that prefer relational database operations and moderate query workloads                                                |
+| Write throughput profile           | Higher write throughput in published comparison tests                                 | Lower write throughput than Elasticsearch/OpenSearch in current published tests                                              |
+| Read/query profile                 | Better suited for broad filtering, sorting, aggregations, and dashboard-style queries | Better suited for key-based access and moderate query workloads; broad filters and statistics queries need closer validation |
+| Optimize support                   | Required for Optimize                                                                 | Optimize still requires Elasticsearch or OpenSearch                                                                          |
+| Operational model                  | Adds a document-store technology to your stack                                        | Reuses standard relational database tooling and operational practices                                                        |
+| Migration between backend families | Not supported as an in-place production migration                                     | Not supported as an in-place production migration                                                                            |
+
+Use benchmarking and workload validation before choosing a backend for production. For current published PostgreSQL results and caveats, see [RDBMS benchmark results](/self-managed/concepts/secondary-storage/rdbms-benchmark-results.md). For general capacity planning, see [sizing your environment](/components/best-practices/architecture/sizing-your-environment.md).
+
+#### Backend-specific guidance
+
+Choose Elasticsearch/OpenSearch when:
+
+- You expect heavy search, filtering, sorting, or dashboard-style query workloads.
+- You need Optimize and want to avoid running two secondary storage technologies.
+- You want the strongest current fit for large query-heavy environments.
+
+Choose RDBMS when:
+
+- You already operate relational databases at scale and want to align with existing tooling.
+- Your workloads are moderate and you can validate query performance with production-like data.
+- You prefer a relational secondary storage model for Orchestration Cluster APIs and web applications.
+
+If you deploy Optimize with RDBMS-based secondary storage, plan for both backends: RDBMS for the Orchestration Cluster and Elasticsearch or OpenSearch for Optimize.
+
+For supported versions and configuration details, see:
+
+- [Secondary storage overview](/self-managed/concepts/secondary-storage/index.md)
+- [Configure secondary storage](/self-managed/concepts/secondary-storage/configuring-secondary-storage.md)
+- [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
+- [Supported environments](/reference/supported-environments.md)
+
 ### High availability (HA)
 
 High availability (HA) ensures that a system remains operational even when components fail. All components can run in HA mode, but Optimize requires special consideration: the importer/archiver must run on only one replica at a time. See the [Optimize configuration](/self-managed/components/optimize/configuration/system-configuration-platform-8.md#general-settings) for details.

--- a/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -204,6 +204,7 @@ For hands-on instructions to deploy Camunda with RDBMS, start with:
 
 Then choose your deployment pattern:
 
-- [Production architecture with RDBMS](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) - Reference topology and design considerations.
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) - Canonical backend trade-offs and production architecture guidance.
+- [Production architecture with RDBMS](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) - Manual deployment topology guidance for RDBMS.
 - [Manual installation with RDBMS](/self-managed/deployment/manual/rdbms/index.md) - Entry point for manual installation, configuration, and operations.
 - [RDBMS example deployment for Helm](/self-managed/deployment/helm/install/helm-with-rdbms.md) - Kubernetes/Helm-based example walkthrough.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
@@ -48,6 +48,8 @@ mkcert requires [NSS](https://github.com/FiloSottile/mkcert#supported-root-store
 
 In addition to the deployment mode, you must choose a [secondary storage](/self-managed/concepts/secondary-storage/index.md) backend. The `SECONDARY_STORAGE` environment variable controls which backend the deployment scripts use. You must set it explicitly before running any deployment command — there is no default.
 
+For production backend trade-offs between Elasticsearch/OpenSearch and RDBMS, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture). This kind guide is for local development and testing only.
+
 | Value           | Operators deployed                    | Components                                                  |
 | --------------- | ------------------------------------- | ----------------------------------------------------------- |
 | `elasticsearch` | ECK, CloudNativePG, Keycloak Operator | Full platform including Optimize                            |

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms.md
@@ -15,6 +15,7 @@ This page provides:
 
 Related guides:
 
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [Secondary storage overview](/self-managed/concepts/secondary-storage/index.md)
 - [RDBMS example deployment](/self-managed/deployment/helm/install/helm-with-rdbms.md)
 - [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md)

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -14,21 +14,16 @@ If you deploy on AWS EKS, use [Install Camunda 8 on an EKS cluster](/self-manage
 Related guides:
 
 - [Production install](/self-managed/deployment/helm/install/production/index.md)
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [Secondary storage overview](/self-managed/concepts/secondary-storage/index.md)
 - [Configure RDBMS in Helm charts](/self-managed/deployment/helm/configure/database/rdbms.md)
 - [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md)
 
 ## What changes when using RDBMS?
 
-In Camunda 8, secondary storage stores historical data and process state. You can use either a document-store backend (Elasticsearch/OpenSearch) or an RDBMS, depending on your requirements. This guide focuses on the RDBMS option:
+In Camunda 8, secondary storage stores historical data and process state. You can use either a document-store backend (Elasticsearch/OpenSearch) or an RDBMS, depending on your requirements. For the canonical production trade-off guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
 
-| Aspect               | Document-store backend (Elasticsearch/OpenSearch)   | RDBMS                                                       |
-| -------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
-| **Storage choice**   | Helm-managed subchart                               | You manage (PostgreSQL, etc.)                               |
-| **Scaling**          | Scale the search cluster independently from Camunda | Scale via your database service (vertical or read replicas) |
-| **Backup strategy**  | ES/OS snapshot/restore tooling                      | Database-native backups (e.g., pg_dump, vendor tools)       |
-| **Monitoring**       | ES/OS metrics and dashboards                        | Database-native monitoring and alerts                       |
-| **Operator support** | No embedded document-store operator bundled         | Database operators (optional)                               |
+This guide focuses on the Helm-specific RDBMS path. In practice, that means you provide and operate an external supported relational database, and the Orchestration Cluster reads operational data through that backend.
 
 When using RDBMS, **Optimize still requires Elasticsearch or OpenSearch**. Only the Orchestration Cluster uses RDBMS.
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/install/helm-with-rdbms.md
@@ -161,7 +161,7 @@ If you're using Oracle, MySQL, or a database version not covered by bundled driv
 For detailed information about JDBC driver strategies, security configurations, and validation, see [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md).
 :::
 
-**Option A: Init container (recommended for production)**
+#### Option A: Init container (recommended for production)
 
 Update your `values-rdbms.yaml`:
 
@@ -192,7 +192,7 @@ orchestration:
 
 For other driver sources (e.g., private repositories), adjust the `wget` command or use a private container registry for pre-built images.
 
-**Option B: ConfigMap (GitOps-friendly)**
+#### Option B: ConfigMap (GitOps-friendly)
 
 Store the driver JAR in a ConfigMap and mount it:
 
@@ -308,7 +308,7 @@ orchestration:
 
 In production, separate the Orchestration Cluster from management components (WebModeler, Console, Identity, Optimize):
 
-**Namespace 1: Orchestration + Connectors**
+#### Namespace 1: Orchestration + Connectors
 
 ```yaml
 orchestration:
@@ -334,7 +334,7 @@ identity:
   enabled: false
 ```
 
-**Namespace 2: Management components (with document-store secondary storage)**
+#### Namespace 2: Management components (with document-store secondary storage)
 
 ```yaml
 orchestration:

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/install.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/install.md
@@ -21,7 +21,7 @@ This page guides you through the manual installation of Camunda 8 on a local mac
   - Choose a supported secondary storage backend for your installation path.
   - **Document-store backend (Elasticsearch or OpenSearch)**: See [supported environments](/reference/supported-environments.md).
     - For deployment options, see the [Elasticsearch documentation](https://www.elastic.co/docs/deploy-manage/deploy).
-  - **RDBMS**: See [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) and [manual installation with RDBMS](/self-managed/deployment/manual/rdbms/index.md) for supported databases and setup details.
+  - **RDBMS**: See [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs, and [manual installation with RDBMS](/self-managed/deployment/manual/rdbms/index.md) for supported databases and setup details.
 
 For suggested minimum hardware requirements and networking, see the [manual reference architecture requirements](/self-managed/reference-architecture/manual.md#requirements).
 

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/configuration.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/configuration.md
@@ -135,6 +135,7 @@ Download scripts: [Access SQL and Liquibase scripts](/self-managed/deployment/he
 ## Next steps
 
 - [Operations and maintenance](/self-managed/deployment/manual/rdbms/operations.md)
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
 - [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/index.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/index.md
@@ -11,9 +11,11 @@ Install Camunda 8 Self-Managed manually on a VM, bare-metal server, or standalon
 Manual installation is **not** supported for Kubernetes. If you run on Kubernetes, use the [Helm charts](/self-managed/deployment/helm/index.md).
 :::
 
-## Secondary storage architecture
+## Manual deployment data flow
 
-The Orchestration Cluster reads from a single configured secondary storage type (RDBMS in this deployment). However, the Zeebe broker can export to multiple targets simultaneously. If you deploy Optimize, configure both the RDBMS exporter (for Orchestration Cluster operations) and an Elasticsearch/OpenSearch exporter for Optimize.
+For backend trade-offs and production architecture decisions, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
+
+In this manual deployment path, the Orchestration Cluster reads from a single configured secondary storage type: RDBMS. However, the Zeebe broker can export to multiple targets simultaneously. If you deploy Optimize, configure both the RDBMS exporter (for Orchestration Cluster operations) and an Elasticsearch/OpenSearch exporter for Optimize.
 
 ```mermaid
 graph LR
@@ -83,7 +85,7 @@ The Orchestration Cluster is fully supported with RDBMS secondary storage for wo
 
 1. [Configure drivers and connections](/self-managed/deployment/manual/rdbms/configuration.md).
 2. Review [operations and maintenance](/self-managed/deployment/manual/rdbms/operations.md) for backup, upgrades, troubleshooting, and tuning.
-3. Review the [production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for sizing and topology guidance.
+3. Review [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs and [manual production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for manual deployment topology guidance.
 
 ## Related documentation
 

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/operations.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/operations.md
@@ -158,11 +158,12 @@ Avoid DROP, TRUNCATE, SUPERUSER, or other unnecessary privileges.
 
 ## Production deployment
 
-Before deploying to production, review the [production architecture guidance](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for recommended topologies, and refer to the verification steps in the [troubleshooting section](#verification-and-troubleshooting) above to validate your RDBMS setup is healthy.
+Before deploying to production, review [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs and the [manual production architecture guide](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for recommended topology. Then use the verification steps in the [troubleshooting section](#verification-and-troubleshooting) above to validate your RDBMS setup is healthy.
 
 ## Next steps
 
 - [RDBMS configuration](/self-managed/deployment/manual/rdbms/configuration.md)
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
 - [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md
@@ -5,9 +5,20 @@ title: Production architecture for Camunda 8 with RDBMS
 description: "Reference architecture for deploying Camunda 8 Self-Managed in production using an external RDBMS as secondary storage."
 ---
 
-Understand reference architectures for running Camunda 8 Self-Managed in production with a relational database (RDBMS) as secondary storage, including supported topologies, Orchestration Cluster interactions, and critical constraints.
+Apply RDBMS secondary storage to a **manual deployment**. For the canonical production architecture and trade-off guidance across manual, containerized, and Kubernetes deployments, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
 
-## Recommended topology
+## Manual deployment baseline
+
+For manual production deployments with RDBMS, use these baseline decisions:
+
+- Run at least three brokers across three availability zones for high availability.
+- Use an external supported RDBMS for the Orchestration Cluster's secondary storage.
+- Keep the database in the same region as the Orchestration Cluster.
+- Use managed database services or vendor-supported high-availability mechanisms when possible.
+
+For backend selection trade-offs, Optimize requirements, and Elasticsearch/OpenSearch versus RDBMS comparison guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture).
+
+## Example topology
 
 For production deployments with RDBMS, Camunda recommends a **HA Zeebe cluster backed by an external managed RDBMS**:
 
@@ -48,19 +59,19 @@ graph TB
 
 ### Key characteristics
 
-**Clustering**
+#### Clustering
 
 - Minimum three brokers for production HA
 - Each broker in separate availability zone
 - Default replication factor 3 (spans AZs)
 
-**Secondary storage**
+#### Secondary storage
 
 - Single external managed RDBMS instance
 - Database handles replication and failover
 - Camunda does not manage database HA
 
-**Data flow**
+#### Data flow
 
 - Processes are executed
 - State is flushed to RDBMS
@@ -78,7 +89,7 @@ Without Optimize: RDBMS-only stack is fully supported.
 
 ## Production constraints
 
-❌ **ES/OS ↔ RDBMS migration not supported**: Choose your secondary storage backend before production. No automated migration tools available.
+❌ **ES/OS ↔ RDBMS migration not supported**: Choose your secondary storage backend before production. No automated migration tools are available.
 
 ❌ **Uniform broker configuration required**: All brokers in the Orchestration Cluster must export to the same secondary storage backend for its Orchestration Cluster indices. In addition, you may run Elasticsearch/OpenSearch to support Optimize, but the Orchestration Cluster still uses a single backend for its own secondary storage.
 
@@ -99,6 +110,7 @@ Without Optimize: RDBMS-only stack is fully supported.
 
 ## Next steps
 
+- [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS configuration](/self-managed/deployment/manual/rdbms/configuration.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
 - [RDBMS Helm configuration](/self-managed/deployment/helm/configure/database/rdbms.md)

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -257,7 +257,7 @@ The following databases are required:
 Camunda 8 supports both [Amazon OpenSearch](https://aws.amazon.com/opensearch-service) and the open-source [OpenSearch](https://opensearch.org/) distribution.
 :::
 
-For more information, see the [reference architecture overview](/self-managed/reference-architecture/reference-architecture.md#architecture).
+For backend trade-offs and production guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture). For more general context, see the [reference architecture overview](/self-managed/reference-architecture/reference-architecture.md#architecture).
 
 Sizing is use case dependent. It is crucial to conduct thorough load testing and benchmarking to determine the appropriate sizing for your specific environment and workload.
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/manual.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/manual.md
@@ -66,7 +66,7 @@ Connectors expose additional HTTP(s) endpoints for handling incoming webhooks, w
 The Orchestration Cluster relies on a configured [secondary storage](/reference/glossary.md#secondary-storage) backend for indexing and search. Depending on your deployment and configuration, this backend can use a document-store backend ([Elasticsearch/OpenSearch](/reference/glossary.md#elasticsearchopensearch)) or an [RDBMS](/reference/glossary.md#rdbms) for supported scenarios.
 
 :::note
-Secondary storage is configurable. For RDBMS-based secondary storage, see [RDBMS configuration](/self-managed/concepts/databases/relational-db/configuration.md) and the glossary entry [RDBMS](/reference/glossary.md#rdbms).
+Secondary storage is configurable. For backend trade-offs and production guidance, see [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture). For RDBMS configuration details, see [RDBMS configuration](/self-managed/concepts/databases/relational-db/configuration.md) and the glossary entry [RDBMS](/reference/glossary.md#rdbms).
 :::
 
 Components within the Orchestration Cluster communicate seamlessly, particularly:

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/reference-architecture.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/reference-architecture.md
@@ -103,6 +103,59 @@ Databases can be deployed as part of the Camunda clusters, but using external da
 
 While some guides explain how to deploy databases with Camunda, the recommendation is to manage databases externally for greater control and flexibility.
 
+### Secondary storage architecture
+
+Choose the secondary storage architecture before you finalize a production deployment pattern. This decision applies across manual, containerized, and Kubernetes deployments.
+
+For production, use an external managed service or an externally operated database cluster whenever possible. Camunda does not manage database high availability, failover, backups, or lifecycle operations for you.
+
+#### Production topology baseline
+
+For a production Orchestration Cluster, use these baseline assumptions regardless of deployment method:
+
+- Run at least three brokers across three availability zones for high availability.
+- Use one secondary storage backend family for the Orchestration Cluster's web applications and APIs.
+- Keep the secondary storage backend in the same region as the Orchestration Cluster to reduce latency and failure domains.
+- Treat secondary storage as part of your production data layer, with its own backup, monitoring, and scaling plan.
+
+#### Compare Elasticsearch/OpenSearch and RDBMS
+
+Both backend families are supported for production in the right scenarios. Choose based on query patterns, operational preferences, and component requirements.
+
+| Topic                              | Elasticsearch/OpenSearch                                                              | RDBMS                                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Best fit                           | Search-heavy, filter-heavy, analytics-heavy workloads                                 | Teams that prefer relational database operations and moderate query workloads                                                |
+| Write throughput profile           | Higher write throughput in published comparison tests                                 | Lower write throughput than Elasticsearch/OpenSearch in current published tests                                              |
+| Read/query profile                 | Better suited for broad filtering, sorting, aggregations, and dashboard-style queries | Better suited for key-based access and moderate query workloads; broad filters and statistics queries need closer validation |
+| Optimize support                   | Required for Optimize                                                                 | Optimize still requires Elasticsearch or OpenSearch                                                                          |
+| Operational model                  | Adds a document-store technology to your stack                                        | Reuses standard relational database tooling and operational practices                                                        |
+| Migration between backend families | Not supported as an in-place production migration                                     | Not supported as an in-place production migration                                                                            |
+
+Use benchmarking and workload validation before choosing a backend for production. For current published PostgreSQL results and caveats, see [RDBMS benchmark results](/self-managed/concepts/secondary-storage/rdbms-benchmark-results.md). For general capacity planning, see [sizing your environment](/components/best-practices/architecture/sizing-your-environment.md).
+
+#### Backend-specific guidance
+
+Choose Elasticsearch/OpenSearch when:
+
+- You expect heavy search, filtering, sorting, or dashboard-style query workloads.
+- You need Optimize and want to avoid running two secondary storage technologies.
+- You want the strongest current fit for large query-heavy environments.
+
+Choose RDBMS when:
+
+- You already operate relational databases at scale and want to align with existing tooling.
+- Your workloads are moderate and you can validate query performance with production-like data.
+- You prefer a relational secondary storage model for Orchestration Cluster APIs and web applications.
+
+If you deploy Optimize with RDBMS-based secondary storage, plan for both backends: RDBMS for the Orchestration Cluster and Elasticsearch or OpenSearch for Optimize.
+
+For supported versions and configuration details, see:
+
+- [Secondary storage overview](/self-managed/concepts/secondary-storage/index.md)
+- [Configure secondary storage](/self-managed/concepts/secondary-storage/configuring-secondary-storage.md)
+- [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
+- [Supported environments](/reference/supported-environments.md)
+
 ### High availability (HA)
 
 High availability (HA) ensures that a system remains operational even when components fail. All components can run in HA mode, but Optimize requires special consideration: the importer/archiver must run on only one replica at a time. See the [Optimize configuration](/self-managed/components/optimize/configuration/system-configuration-platform-8.md#general-settings) for details.


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/camunda-docs/issues/8382. Consolidates secondary storage architecture guidance into the reference architecture docs and reduces duplicated ES/OS vs RDBMS guidance across install paths.

## What changed

- Added a canonical secondary storage architecture section to the reference architecture overview.
- Added a clear Elasticsearch/OpenSearch vs RDBMS comparison, including production fit, Optimize requirements, and migration constraints.
- Linked the canonical section to published RDBMS benchmark results and general sizing guidance.
- Refocused manual and Helm RDBMS pages to stay implementation-focused and defer architecture/trade-off decisions to the canonical reference architecture page.
- Updated related manual, Helm, kind, and support-policy docs to point to the canonical guidance.

## Why

Secondary storage architecture guidance was fragmented across deployment-specific pages, especially around RDBMS production architecture. This change makes the reference architecture section the single source of truth for backend trade-offs while keeping install guides focused on setup and operations.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
