### PR TITLE
docs(security): add Notice 46 for CVE-2026-42264 (axios prototype pollution) to 8.7 and 8.8

### DIFF
--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -21,6 +21,32 @@ Report security vulnerabilities to Camunda immediately, following the instructio
 To learn more about security at Camunda, including our security policy, security issue management, and more, see [Camunda.com/security](https://camunda.com/security).
 :::
 
+## Notice 46
+
+### Publication date
+
+May 7, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The version of `axios` used by Camunda Web Modeler was affected by [CVE-2026-42264](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj), a prototype pollution vulnerability in the HTTP adapter that could allow credential injection and request hijacking when `Object.prototype` is polluted by another dependency in the same process.
+
+### How to determine if the installation is affected
+
+You are using:
+
+- Web Modeler Self-Managed ≤ 8.8.13, or ≤ 8.7.20
+
+### Solution
+
+Camunda has provided the following releases that contain the fix:
+
+- Web Modeler Self-Managed 8.8.14, 8.7.21
+
 ## Notice 45
 
 ### Publication date

--- a/versioned_docs/version-8.7/reference/notices.md
+++ b/versioned_docs/version-8.7/reference/notices.md
@@ -19,6 +19,32 @@ Report security vulnerabilities to Camunda immediately, following the instructio
 To learn more about security at Camunda, including our security policy, security issue management, and more, see [Camunda.com/security](https://camunda.com/security).
 :::
 
+## Notice 46
+
+### Publication date
+
+May 7, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The version of `axios` used by Camunda Web Modeler was affected by [CVE-2026-42264](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj), a prototype pollution vulnerability in the HTTP adapter that could allow credential injection and request hijacking when `Object.prototype` is polluted by another dependency in the same process.
+
+### How to determine if the installation is affected
+
+You are using:
+
+- Web Modeler Self-Managed ≤ 8.8.13, or ≤ 8.7.20
+
+### Solution
+
+Camunda has provided the following releases that contain the fix:
+
+- Web Modeler Self-Managed 8.8.14, 8.7.21
+
 ## Notice 45
 
 ### Publication date

--- a/versioned_docs/version-8.8/reference/notices.md
+++ b/versioned_docs/version-8.8/reference/notices.md
@@ -19,6 +19,32 @@ Report security vulnerabilities to Camunda immediately, following the instructio
 To learn more about security at Camunda, including our security policy, security issue management, and more, see [Camunda.com/security](https://camunda.com/security).
 :::
 
+## Notice 46
+
+### Publication date
+
+May 7, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The version of `axios` used by Camunda Web Modeler was affected by [CVE-2026-42264](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj), a prototype pollution vulnerability in the HTTP adapter that could allow credential injection and request hijacking when `Object.prototype` is polluted by another dependency in the same process.
+
+### How to determine if the installation is affected
+
+You are using:
+
+- Web Modeler Self-Managed ≤ 8.8.13, or ≤ 8.7.20
+
+### Solution
+
+Camunda has provided the following releases that contain the fix:
+
+- Web Modeler Self-Managed 8.8.14, 8.7.21
+
 ## Notice 45
 
 ### Publication date

--- a/versioned_docs/version-8.9/reference/notices.md
+++ b/versioned_docs/version-8.9/reference/notices.md
@@ -21,6 +21,32 @@ Report security vulnerabilities to Camunda immediately, following the instructio
 To learn more about security at Camunda, including our security policy, security issue management, and more, see [Camunda.com/security](https://camunda.com/security).
 :::
 
+## Notice 46
+
+### Publication date
+
+May 7, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The version of `axios` used by Camunda Web Modeler was affected by [CVE-2026-42264](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj), a prototype pollution vulnerability in the HTTP adapter that could allow credential injection and request hijacking when `Object.prototype` is polluted by another dependency in the same process.
+
+### How to determine if the installation is affected
+
+You are using:
+
+- Web Modeler Self-Managed ≤ 8.8.13, or ≤ 8.7.20
+
+### Solution
+
+Camunda has provided the following releases that contain the fix:
+
+- Web Modeler Self-Managed 8.8.14, 8.7.21
+
 ## Notice 45
 
 ### Publication date


### PR DESCRIPTION
## Description

Adds security Notice 46 to the 8.7 and 8.8 versioned notices pages for [CVE-2026-42264](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj) (GHSA-q8qp-cvcw-x6jj), a high-severity prototype pollution vulnerability in the `axios` npm package (CVSS 7.4) affecting Camunda Web Modeler.

Fixed in Web Modeler Self-Managed 8.8.14 and 8.7.21.

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.