### PR TITLE
add internal processing details

### DIFF
--- a/docs/components/zeebe/technical-concepts/internal-processing.md
+++ b/docs/components/zeebe/technical-concepts/internal-processing.md
@@ -87,6 +87,8 @@ The maximum rate of requests that can be processed by a broker depends on the pr
 
 The in-flight request count is incremented when a request is accepted, and decremented when a response is sent back to the client. The broker rejects requests when the in-flight request count reaches the limit.
 
+This is not a single static threshold for the whole broker. Zeebe calculates the in-flight count and the limit per partition, and the current limit changes over time based on the configured backpressure algorithm. To observe the current limit, monitor the `zeebe_backpressure_requests_limit` metric. For more details, see [backpressure](/self-managed/components/orchestration-cluster/zeebe/operations/backpressure.md) and [metrics](/self-managed/operational-guides/monitoring/metrics.md#performance-metrics).
+
 import BackpressureWarning from '../../../components/react-components/backpressure-warning.md'
 
 <BackpressureWarning/>

--- a/versioned_docs/version-8.9/components/zeebe/technical-concepts/internal-processing.md
+++ b/versioned_docs/version-8.9/components/zeebe/technical-concepts/internal-processing.md
@@ -87,6 +87,8 @@ The maximum rate of requests that can be processed by a broker depends on the pr
 
 The in-flight request count is incremented when a request is accepted, and decremented when a response is sent back to the client. The broker rejects requests when the in-flight request count reaches the limit.
 
+This is not a single static threshold for the whole broker. Zeebe calculates the in-flight count and the limit per partition, and the current limit changes over time based on the configured backpressure algorithm. To observe the current limit, monitor the `zeebe_backpressure_requests_limit` metric. For more details, see [backpressure](/self-managed/components/orchestration-cluster/zeebe/operations/backpressure.md) and [metrics](/self-managed/operational-guides/monitoring/metrics.md#performance-metrics).
+
 import BackpressureWarning from '../../../components/react-components/backpressure-warning.md'
 
 <BackpressureWarning/>


### PR DESCRIPTION
## Description

Clarify Zeebe backpressure limits in the internal processing docs. Closes https://github.com/camunda/documentation-team/issues/412.

## What changed

- clarify that the in-flight request limit is not a single static broker-wide threshold
- note that the in-flight count and limit are calculated per partition
- point readers to the `zeebe_backpressure_requests_limit` metric for observing the current limit
- add links to the backpressure and metrics docs for more detail
- apply the same clarification to the 8.9 docs

## Why

The existing docs already explained that Zeebe uses an adaptive limit, but they did not clearly answer the common question of where that limit is defined or how to observe it.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
