### PR TITLE
Update archival process

### DIFF
--- a/hacks/archiveVersion/1-ignore-version-prod.py
+++ b/hacks/archiveVersion/1-ignore-version-prod.py
@@ -10,7 +10,7 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 import os
 import re
 
-def load_prod_deploy_workflow(archive_version):
+def load_prod_deploy_workflow(archived_version):
     yaml = YAML()
     yaml.default_flow_style = False
     yaml.indent(mapping=2, sequence=4, offset=2)
@@ -21,23 +21,23 @@ def load_prod_deploy_workflow(archive_version):
     with open(publish_prod_path) as f:
         data = yaml.load(f)
 
-    # Ignore archive_version
-    data["on"]["push"]["tags"].append(DoubleQuotedScalarString(f"!{archive_version}.[0-9]+"))
+    # Ignore archived_version
+    data["on"]["push"]["tags"].append(DoubleQuotedScalarString(f"!{archived_version}.[0-9]+"))
 
     with open(publish_prod_path, "w") as f:
         yaml.dump(data, f)
 
-def get_archive_version():
-    """Get the archive version from environment variables.
+def get_archived_version():
+    """Get the archived version from environment variables.
 
     Assert the version is in the correct format.
     """
 
-    archive_version = os.environ["ARCHIVED_VERSION"]
-    assert re.match("^8.[0-9]+$", archive_version), "Set the archive version: `export ARCHIVED_VERSION=8.x`"
+    archived_version = os.environ["ARCHIVED_VERSION"]
+    assert re.match("^8.[0-9]+$", archived_version), "Set the archive version: `export ARCHIVED_VERSION=8.x`"
 
-    return archive_version
+    return archived_version
 
 if __name__ == "__main__":
-    archive_version = get_archive_version()
-    load_prod_deploy_workflow(archive_version)
+    archived_version = get_archived_version()
+    load_prod_deploy_workflow(archived_version)

--- a/hacks/archiveVersion/1-ignore-version-prod.py
+++ b/hacks/archiveVersion/1-ignore-version-prod.py
@@ -23,7 +23,6 @@ def load_prod_deploy_workflow(archive_version):
 
     # Ignore archive_version
     data["on"]["push"]["tags"].append(DoubleQuotedScalarString(f"!{archive_version}.[0-9]+"))
-    data["on"]["push"]["tags"].append(DoubleQuotedScalarString(f"!{archive_version}.123.[0-9]+"))
 
     with open(publish_prod_path, "w") as f:
         yaml.dump(data, f)

--- a/hacks/archiveVersion/1-ignore-version-prod.py
+++ b/hacks/archiveVersion/1-ignore-version-prod.py
@@ -4,6 +4,7 @@
 2. Add the to-be-archived version to the list of ignored tags.
 """
 
+
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 import os

--- a/hacks/archiveVersion/1-ignore-version-prod.py
+++ b/hacks/archiveVersion/1-ignore-version-prod.py
@@ -1,0 +1,43 @@
+"""Automate step one of the version archival process.
+
+1. Load the prod deploy workflow.
+2. Add the to-be-archived version to the list of ignored tags.
+"""
+
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+import os
+import re
+
+def load_prod_deploy_workflow(archive_version):
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.preserve_quotes = True
+    yaml.width = 200
+
+    publish_prod_path = "../../.github/workflows/publish-prod.yaml"
+    with open(publish_prod_path) as f:
+        data = yaml.load(f)
+
+    # Ignore archive_version
+    data["on"]["push"]["tags"].append(DoubleQuotedScalarString(f"!{archive_version}.[0-9]+"))
+    data["on"]["push"]["tags"].append(DoubleQuotedScalarString(f"!{archive_version}.123.[0-9]+"))
+
+    with open(publish_prod_path, "w") as f:
+        yaml.dump(data, f)
+
+def get_archive_version():
+    """Get the archive version from environment variables.
+
+    Assert the version is in the correct format.
+    """
+
+    archive_version = os.environ["ARCHIVED_VERSION"]
+    assert re.match("^8.[0-9]+$", archive_version), "Set the archive version: `export ARCHIVED_VERSION=8.x`"
+
+    return archive_version
+
+if __name__ == "__main__":
+    archive_version = get_archive_version()
+    load_prod_deploy_workflow(archive_version)

--- a/hacks/archiveVersion/2-postprocess.py
+++ b/hacks/archiveVersion/2-postprocess.py
@@ -1,0 +1,35 @@
+"""Postprocess the docs.
+
+After isolating the documentation, we need to do some more processing.
+This includes:
+
+1. remove_root_references: Remove links to /docs, as that directory no longer exists.
+2. update_version_banner: Update the unmaintained version banner text.
+"""
+
+
+import os
+import re
+
+def update_version_banner():
+    with open("../../src/theme/DocVersionBanner/index.tsx") as f:
+        content = f.read()
+        content = re.sub(r"to=\{latestVersionSuggestedDoc\.path\}", "to='https://docs.camunda.io/'", content)
+        content = re.sub(r"see \{latestVersionLink\} \(\{versionLabel\}\)", r"see \{latestVersionLink\}", content)
+
+    with open("../../src/theme/DocVersionBanner/index.tsx", "w") as f:
+        f.write(content) 
+
+def remove_root_references():
+    for dir_, _, files in os.walk("../../versioned_docs"):
+        for file_ in files:
+            if file_.endswith(".md"):
+                with open(f"{dir_}/{file_}") as f:
+                    content = f.read()
+                    content = re.sub(r"\[(.+?)\]\(/docs.+?\)", r"\1", content)
+
+                with open(f"{dir_}/{file_}", "w") as f:
+                    f.write(content)
+
+if __name__ == "__main__":
+    remove_root_references()

--- a/hacks/archiveVersion/2-postprocess.py
+++ b/hacks/archiveVersion/2-postprocess.py
@@ -5,6 +5,7 @@ This includes:
 
 1. remove_root_references: Remove links to /docs, as that directory no longer exists.
 2. update_version_banner: Update the unmaintained version banner text.
+3. remove_build_with_camunda: Remove build with Camunda page.
 """
 
 
@@ -15,10 +16,15 @@ def update_version_banner():
     with open("../../src/theme/DocVersionBanner/index.tsx") as f:
         content = f.read()
         content = re.sub(r"to=\{latestVersionSuggestedDoc\.path\}", "to='https://docs.camunda.io/'", content)
-        content = re.sub(r"see \{latestVersionLink\} \(\{versionLabel\}\)", r"see \{latestVersionLink\}", content)
+        content = re.sub(r"see \{latestVersionLink\} \(\{versionLabel\}\)", "see {latestVersionLink}", content)
 
     with open("../../src/theme/DocVersionBanner/index.tsx", "w") as f:
         f.write(content) 
+
+def _replace_if_root_reference(match):
+    if match.group(2).startswith("/docs"):
+        return match.group(1)
+    return match.group(0)
 
 def remove_root_references():
     for dir_, _, files in os.walk("../../versioned_docs"):
@@ -26,10 +32,20 @@ def remove_root_references():
             if file_.endswith(".md"):
                 with open(f"{dir_}/{file_}") as f:
                     content = f.read()
-                    content = re.sub(r"\[(.+?)\]\(/docs.+?\)", r"\1", content)
+                    content = re.sub(r"\[(.+?)\]\((.+?)\)", _replace_if_root_reference, content)
 
                 with open(f"{dir_}/{file_}", "w") as f:
                     f.write(content)
 
+def remove_build_with_camunda():
+    """Remove build-with-camunda files.
+
+    They aren't rendered or needed in this context, and they link to root docs, causing build errors.
+    """
+    os.remove("../../src/pages/build-with-camunda.js")
+    os.remove("../../src/pages/build-with-camunda.module.css")
+
 if __name__ == "__main__":
     remove_root_references()
+    update_version_banner()
+    remove_build_with_camunda()

--- a/hacks/archiveVersion/2-preprocess.py
+++ b/hacks/archiveVersion/2-preprocess.py
@@ -15,6 +15,8 @@ import os
 import re
 import shutil
 
+ARCHIVED_VERSION = os.environ["ARCHIVED_VERSION"]
+
 def update_version_banner():
     with open("../../src/theme/DocVersionBanner/index.tsx") as f:
         content = f.read()
@@ -29,14 +31,24 @@ def _replace_if_root_reference(match):
         return match.group(1)
     return match.group(0)
 
+def _replace_if_another_version(match):
+    m = re.search(r"/version-(8\.\d+)/", match.group(2))
+    if m and m.group(1) != ARCHIVED_VERSION:
+        return match.group(1)
+    return match.group(0)
+
 def remove_root_references():
+    markdown_link_pattern = r"\[(.+?)\]\((.+?)\)"
+
     for dir_, _, files in os.walk("../../versioned_docs"):
         for file_ in files:
             if file_.endswith(".md"):
                 with open(f"{dir_}/{file_}") as f:
                     content = f.read()
-                    content = re.sub(r"\[(.+?)\]\((.+?)\)", _replace_if_root_reference, content)
+                    content = re.sub(markdown_link_pattern, _replace_if_root_reference, content)
+                    content = re.sub(markdown_link_pattern, _replace_if_another_version, content)
                     content = re.sub(r"href:\s*\"\/docs\/8.6\/(.+?)\"", "href:\"/docs/\\1\"", content)
+                    content = re.sub(r"href:\s*\"\/docs\/next\/(.+?)\"", "href:\"/docs/\\1\"", content)
 
                 with open(f"{dir_}/{file_}", "w") as f:
                     f.write(content)
@@ -44,8 +56,8 @@ def remove_root_references():
 def fix_image_references():
     with open("../../docusaurus.config.js") as f:
         content = f.read()
-        content = re.sub(r'img src="/8\.6/img/twitter\.svg"', 'img src="/img/twitter.svg"', content)
-        content = re.sub(r'img src="/8\.6/img/github-mark-white\.svg"', 'img src="/img/github-mark-white.svg"', content)
+        content = re.sub(r'img src="/8\.\d+/img/twitter\.svg"', 'img src="/img/twitter.svg"', content)
+        content = re.sub(r'img src="/8\.\d+/img/github-mark-white\.svg"', 'img src="/img/github-mark-white.svg"', content)
 
     with open("../../docusaurus.config.js", "w") as f:
         f.write(content)

--- a/hacks/archiveVersion/2-preprocess.py
+++ b/hacks/archiveVersion/2-preprocess.py
@@ -1,16 +1,19 @@
-"""Postprocess the docs.
+"""Preprocess the docs.
 
 After isolating the documentation, we need to do some more processing.
 This includes:
 
-1. remove_root_references: Remove links to /docs, as that directory no longer exists.
+1. remove_root_references: Remove links to /docs.
 2. update_version_banner: Update the unmaintained version banner text.
 3. remove_build_with_camunda: Remove build with Camunda page.
+4. replace_homepage: Replace the homepage with a simplified version, removing problematic components and links.
+5. fix_image_references: Fix invalid image references.
 """
 
 
 import os
 import re
+import shutil
 
 def update_version_banner():
     with open("../../src/theme/DocVersionBanner/index.tsx") as f:
@@ -33,9 +36,19 @@ def remove_root_references():
                 with open(f"{dir_}/{file_}") as f:
                     content = f.read()
                     content = re.sub(r"\[(.+?)\]\((.+?)\)", _replace_if_root_reference, content)
+                    content = re.sub(r"href:\s*\"\/docs\/8.6\/(.+?)\"", "href:\"/docs/\\1\"", content)
 
                 with open(f"{dir_}/{file_}", "w") as f:
                     f.write(content)
+
+def fix_image_references():
+    with open("../../docusaurus.config.js") as f:
+        content = f.read()
+        content = re.sub(r'img src="/8\.6/img/twitter\.svg"', 'img src="/img/twitter.svg"', content)
+        content = re.sub(r'img src="/8\.6/img/github-mark-white\.svg"', 'img src="/img/github-mark-white.svg"', content)
+
+    with open("../../docusaurus.config.js", "w") as f:
+        f.write(content)
 
 def remove_build_with_camunda():
     """Remove build-with-camunda files.
@@ -45,7 +58,12 @@ def remove_build_with_camunda():
     os.remove("../../src/pages/build-with-camunda.js")
     os.remove("../../src/pages/build-with-camunda.module.css")
 
+def replace_homepage():
+    shutil.copyfile("./templates/homepage.js", "../../src/pages/index.js")
+
 if __name__ == "__main__":
     remove_root_references()
     update_version_banner()
     remove_build_with_camunda()
+    replace_homepage()
+    fix_image_references()

--- a/hacks/archiveVersion/Makefile
+++ b/hacks/archiveVersion/Makefile
@@ -1,0 +1,18 @@
+ignore-version-prod: venv/bin/activate check-env
+	./venv/bin/python3 1-ignore-version-prod.py	
+
+postprocess: venv/bin/activate check-env
+	./venv/bin/python3 2-postprocess.py	
+
+venv/bin/activate: requirements.txt
+	python3 -m venv venv
+	./venv/bin/pip install -r requirements.txt
+
+clean:
+	rm -rf __pycache__
+	rm -rf venv
+
+check-env:
+ifndef ARCHIVED_VERSION
+	$(error You must run `export ARCHIVED_VERSION=8.x` with the version you're archiving.))
+endif

--- a/hacks/archiveVersion/Makefile
+++ b/hacks/archiveVersion/Makefile
@@ -1,10 +1,15 @@
 ignore-version-prod: venv/bin/activate check-env
 	./venv/bin/python3 1-ignore-version-prod.py	
 
-postprocess: venv/bin/activate check-env
-	./venv/bin/python3 2-postprocess.py	
+preprocess: venv/bin/activate check-env
+	./venv/bin/python3 2-preprocess.py	
+
+isolate-version: check-env
+	cd ../..; ./hacks/isolateVersion/allSteps.sh
 
 venv/bin/activate: requirements.txt
+	rm -rf __pycache__
+	rm -rf venv
 	python3 -m venv venv
 	./venv/bin/pip install -r requirements.txt
 

--- a/hacks/archiveVersion/requirements.txt
+++ b/hacks/archiveVersion/requirements.txt
@@ -1,0 +1,1 @@
+ruamel.yaml==0.19.1

--- a/hacks/archiveVersion/templates/homepage.js
+++ b/hacks/archiveVersion/templates/homepage.js
@@ -1,0 +1,142 @@
+import clsx from "clsx";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import styles from "./styles.module.css";
+
+const features = [
+  {
+    title: "Get started",
+    imageUrl: "img/home-get-started.png",
+    url: "/docs/guides",
+    description:
+      "New to Camunda 8? Create an account and start modeling your first process.",
+  },
+  {
+    title: "Using Camunda",
+    imageUrl: "img/home-components.png",
+    url: "/docs/components/",
+    description:
+      "Learn how to use Camunda 8 components, features, and integrations.",
+  },
+  {
+    title: "Self-Managed",
+    imageUrl: "img/home-self-managed.png",
+    url: "/docs/self-managed/about-self-managed/",
+    description:
+      "Set up and host Camunda 8 yourself instead of using Camunda 8 SaaS.",
+  },
+  {
+    title: "APIs & tools",
+    imageUrl: "img/home-apis.png",
+    url: "/docs/apis-tools/working-with-apis-tools/",
+    description:
+      "Explore Zeebe client libraries, Camunda component APIs, and SDKs.",
+  },
+  {
+    title: "Best Practices",
+    imageUrl: "img/home-bp.png",
+    url: "/docs/components/best-practices/best-practices-overview/",
+    description:
+      "Level up your BPMN and DMN skills, including insights from consulting and the community.",
+  },
+  {
+    title: "Reference",
+    imageUrl: "img/home-reference.png",
+    url: "/docs/reference/",
+    description:
+      "Release notes, announcements, supported environments, licenses, and more.",
+  },
+];
+
+function Feature({ imageUrl, url, title, description }) {
+  const imgUrl = useBaseUrl(imageUrl);
+  return (
+    <div
+      className={clsx(
+        "col component-block",
+        styles.features,
+        styles.featuresSection
+      )}
+    >
+      <Link
+        to={useBaseUrl(url)}
+        title={title}
+        className={clsx(styles.featuresLink)}
+      >
+        {imgUrl && (
+          <div className="text--center">
+            <img className={styles.featuresImage} src={imgUrl} alt={title} />
+          </div>
+        )}
+        <h3 className={clsx("text--center", styles.featuresTitle)}>{title}</h3>
+        <p className={clsx("text--center", styles.featuresDescription)}>
+          {description}
+        </p>
+      </Link>
+    </div>
+  );
+}
+
+function Home() {
+  const context = useDocusaurusContext();
+  const { siteConfig = {} } = context;
+
+  return (
+    <Layout
+      title={`${siteConfig.title}`}
+      description="Start orchestrating your processes with Camunda 8 SaaS or Self-Managed."
+    >
+      <header className={clsx("hero hero--primary", styles.heroBanner)}>
+        <div className="container">
+          <h1 className="hero__title">{siteConfig.title}</h1>
+          <p className="hero__subtitle">{siteConfig.tagline}</p>
+          <div className={clsx("row", styles.buttonsWrapper)}>
+            <div className={clsx("", styles.buttons)}>
+              <Link
+                className={clsx(
+                  "button button--outline button--secondary button--lg button--hero get-started",
+                  styles.getStarted
+                )}
+                to={useBaseUrl("docs/guides/")}
+                title="Get started with Camunda 8"
+              >
+                Get started
+              </Link>
+            </div>
+            <div className={clsx("", styles.buttons)}>
+              <Link
+                className={clsx(
+                  "button button--outline button--secondary button--lg sign-up",
+                  styles.getStarted
+                )}
+                to={useBaseUrl(
+                  "https://signup.camunda.com/accounts?utm_source=docs.camunda.io&utm_medium=referral"
+                )}
+                title="Sign up for Camunda 8 SaaS"
+              >
+                Sign up
+              </Link>
+            </div>
+          </div>
+        </div>
+      </header>
+      <main>
+        {features && features.length > 0 && (
+          <section className={(styles.features, styles.featuresBlock)}>
+            <div className="container">
+              <div className={styles.featuresGrid}>
+                {features.map((props, idx) => (
+                  <Feature key={idx} {...props} />
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+      </main>
+    </Layout>
+  );
+}
+
+export default Home;

--- a/hacks/isolateVersion/4-fixDockerfile.sh
+++ b/hacks/isolateVersion/4-fixDockerfile.sh
@@ -1,7 +1,12 @@
 notify "Fixing Dockerfile for local debugging..."
 
-sed -i '' -e "s/\(COPY \/build \/usr\/local\/apache2\/htdocs\/\)/\1$ARCHIVED_VERSION\//" Dockerfile
-sed -i '' -e "s/\(\/usr\/local\/apache2\/htdocs\/\)\(.htaccess\)/\1$ARCHIVED_VERSION\/\2/" Dockerfile
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' -e "s/\(COPY \/build \/usr\/local\/apache2\/htdocs\/\)/\1$ARCHIVED_VERSION\//" Dockerfile
+  sed -i '' -e "s/\(\/usr\/local\/apache2\/htdocs\/\)\(.htaccess\)/\1$ARCHIVED_VERSION\/\2/" Dockerfile
+else
+  sed -i -e "s/\(COPY \/build \/usr\/local\/apache2\/htdocs\/\)/\1$ARCHIVED_VERSION\//" Dockerfile
+  sed -i -e "s/\(\/usr\/local\/apache2\/htdocs\/\)\(.htaccess\)/\1$ARCHIVED_VERSION\/\2/" Dockerfile
+fi
 
 git add Dockerfile
 git commit -m "archiving($ARCHIVED_VERSION): fix Dockerfile for local debugging"

--- a/hacks/isolateVersion/5-updateThemeComponents.sh
+++ b/hacks/isolateVersion/5-updateThemeComponents.sh
@@ -1,8 +1,6 @@
 notify "Updating theme components..."
 
 rm -rf src/theme/AnnouncementBar
-mkdir -p src/theme/DocVersionBanner
-cp hacks/isolateVersion/assets/theme/DocVersionBanner/index.js src/theme/DocVersionBanner/index.js
 
 git add src/theme
 git commit -m "archiving($ARCHIVED_VERSION): update theme components"

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -1,43 +1,89 @@
 notify "Updating CI workflows..."
 
 # 1. build-docs: remove everything after the line containing `NODE_OPTIONS: --max_old_space_size=`.
-sed -i '' '/NODE_OPTIONS: --max_old_space_size=/q' .github/workflows/build-docs.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/NODE_OPTIONS: --max_old_space_size=/q' .github/workflows/build-docs.yaml
+else
+  sed -i '/NODE_OPTIONS: --max_old_space_size=/q' .github/workflows/build-docs.yaml
+fi
 
 # 2. publish-prod: 
 
 #   a. remove every line after `tags:` until the first blank line.
-sed -i '' '/tags:/,/^$/ { /tags:/! { /^$/!d; }; }' .github/workflows/publish-prod.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/tags:/,/^$/ { /tags:/! { /^$/!d; }; }' .github/workflows/publish-prod.yaml
+else
+  sed -i '/tags:/,/^$/ { /tags:/! { /^$/!d; }; }' .github/workflows/publish-prod.yaml
+fi
 
 #   b. add a line after `tags:` that says `{ARCHIVED_VERSION}.[0-9]+`, so that only this archived version's tags trigger a production build.
-sed -i '' "/tags:/a\\
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "/tags:/a\\
       - \"$ARCHIVED_VERSION.[0-9]+\"
 " .github/workflows/publish-prod.yaml
+else
+  sed -i "/tags:/a\\
+      - \"$ARCHIVED_VERSION.[0-9]+\"
+" .github/workflows/publish-prod.yaml
+fi
 
 #   c. build-docs: remove the trigger-crawl job.
-sed -i '' '/trigger-crawl:/,$d' .github/workflows/publish-prod.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/trigger-crawl:/,$d' .github/workflows/publish-prod.yaml
+else
+  sed -i '/trigger-crawl:/,$d' .github/workflows/publish-prod.yaml
+fi
 
 #   d. add `unsupported.` to docs URLs
-sed -i '' 's/https:\/\/docs.camunda.io/https:\/\/unsupported.docs.camunda.io/' .github/workflows/publish-prod.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/https:\/\/docs.camunda.io/https:\/\/unsupported.docs.camunda.io/' .github/workflows/publish-prod.yaml
+else
+  sed -i 's/https:\/\/docs.camunda.io/https:\/\/unsupported.docs.camunda.io/' .github/workflows/publish-prod.yaml
+fi
 
 #   e. replace the main docs remote_path with this isolated version's remote_path.
-sed -i '' "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
+else
+  sed -i "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
+fi
 
 #   f. update `DOCS_SITE_BASE_URL` to specify isolated version
-sed -i '' "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-prod.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-prod.yaml
+else
+  sed -i "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-prod.yaml
+fi
 
 # 3. publish-stage:
 
 #   a. replace `branches: - main` with `branches: - unsupported/{version}`
-sed -i '' "s/- \"main\"/- \"unsupported\/$ARCHIVED_VERSION\"/" .github/workflows/publish-stage.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/- \"main\"/- \"unsupported\/$ARCHIVED_VERSION\"/" .github/workflows/publish-stage.yaml
+else
+  sed -i "s/- \"main\"/- \"unsupported\/$ARCHIVED_VERSION\"/" .github/workflows/publish-stage.yaml
+fi
 
 #   b. add `unsupported.` to docs URLs
-sed -i '' 's/https:\/\/stage.docs.camunda.io/https:\/\/stage.unsupported.docs.camunda.io/' .github/workflows/publish-stage.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/https:\/\/stage.docs.camunda.io/https:\/\/stage.unsupported.docs.camunda.io/' .github/workflows/publish-stage.yaml
+else
+  sed -i 's/https:\/\/stage.docs.camunda.io/https:\/\/stage.unsupported.docs.camunda.io/' .github/workflows/publish-stage.yaml
+fi
 
 #   c. replace `${{ secrets.AWS_STAGE_PUBLISH_PATH }}` with `${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}/{version}`
-sed -i '' "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
+else
+  sed -i "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
+fi
 
 #   d. update `DOCS_SITE_BASE_URL` to specify isolated version
-sed -i '' "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-stage.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-stage.yaml
+else
+  sed -i "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-stage.yaml
+fi
 
 git add .github/workflows
 git commit -m "archiving($ARCHIVED_VERSION): update CI workflows"

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -85,5 +85,8 @@ else
   sed -i "s/DOCS_SITE_BASE_URL: \//DOCS_SITE_BASE_URL: \/$ARCHIVED_VERSION\//" .github/workflows/publish-stage.yaml
 fi
 
+# 3. remove check-format
+rm .github/workflows/check-format.yaml
+
 git add .github/workflows
 git commit -m "archiving($ARCHIVED_VERSION): update CI workflows"

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -2,36 +2,70 @@ notify "Updating docusaurus.config.js..."
 
 # Update `url` to include `unsupported`
 #  Note that this introduces one line that reads "unsupported.unsupported.docs.camunda.io" but that line gets removed in a later step.
-sed -i '' "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
+else
+  sed -i "s/docs.camunda.io/unsupported.docs.camunda.io/" docusaurus.config.js
+fi
 
 # Update footer social icons based on the new baseUrl
-sed -i '' "s/src= \"\/img\//src=\"\/$ARCHIVED_VERSION\/img\//g" docusaurus.config.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/src= \"\/img\//src=\"\/$ARCHIVED_VERSION\/img\//g" docusaurus.config.js
+else
+  sed -i "s/src= \"\/img\//src=\"\/$ARCHIVED_VERSION\/img\//g" docusaurus.config.js
+fi
 
 # Update announcement bar to show a version warning.
 #   Find the announcementBar block and replace it with a new one.
-sed -i '' "/announcementBar: {/,/    },/c\\
-    announcementBar: {\\
-      id: \"camunda8\",\\
-      content:\\
-        '🚨 This version of Camunda 8 is no longer actively maintained. For up-to-date documentation, see <b><a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://docs.camunda.io\">the latest version</a></b>.',\\
-      backgroundColor: \"#FFC600\",\\
-      textColor: \"#434343\",\\
-      isCloseable: false,\\
-    },\\
-" docusaurus.config.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "/announcementBar: {/,/    },/c\\
+      announcementBar: {\\
+        id: \"camunda8\",\\
+        content:\\
+          '🚨 This version of Camunda 8 is no longer actively maintained. For up-to-date documentation, see <b><a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://docs.camunda.io\">the latest version</a></b>.',\\
+        backgroundColor: \"#FFC600\",\\
+        textColor: \"#434343\",\\
+        isCloseable: false,\\
+      },\\
+  " docusaurus.config.js
+else
+  sed -i "/announcementBar: {/,/    },/c\\
+      announcementBar: {\\
+        id: \"camunda8\",\\
+        content:\\
+          '🚨 This version of Camunda 8 is no longer actively maintained. For up-to-date documentation, see <b><a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://docs.camunda.io\">the latest version</a></b>.',\\
+        backgroundColor: \"#FFC600\",\\
+        textColor: \"#434343\",\\
+        isCloseable: false,\\
+      },\\
+  " docusaurus.config.js
+fi
 
 # Convert version dropdown in top nav to static version number
-sed -i '' "s/docsVersionDropdown/docsVersion/" docusaurus.config.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/docsVersionDropdown/docsVersion/" docusaurus.config.js
+else
+  sed -i "s/docsVersionDropdown/docsVersion/" docusaurus.config.js
+fi
 
 # Remove unused version dropdown configuration
 #   Find the block starting with dropdownItemsAfter, and ending with the correctly-indented closing bracket, and delete the block.
-sed -i '' '/dropdownItemsAfter/,/          ],/d' docusaurus.config.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/dropdownItemsAfter/,/          ],/d' docusaurus.config.js
+else
+  sed -i '/dropdownItemsAfter/,/          ],/d' docusaurus.config.js
+fi
 
 # Remove the Search experience, by removing Algolia configuration
-sed -i '' '/algolia: {/,/    },/d' docusaurus.config.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/algolia: {/,/    },/d' docusaurus.config.js
+else
+  sed -i '/algolia: {/,/    },/d' docusaurus.config.js
+fi
 
 # Replace the `docs` block with one that limits to only the isolated version
-sed -i '' "/^        docs: {/,/^        },/c\\
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "/^        docs: {/,/^        },/c\\
         docs: {\\
           lastVersion: currentVersion,\\
           includeCurrentVersion: false,\\
@@ -45,14 +79,39 @@ sed -i '' "/^        docs: {/,/^        },/c\\
           },\\
         },\\
 " docusaurus.config.js
+else
+  sed -i "/^        docs: {/,/^        },/c\\
+        docs: {\\
+          lastVersion: currentVersion,\\
+          includeCurrentVersion: false,\\
+          versions: {\\
+            \"$ARCHIVED_VERSION\": {\\
+              label: \"$ARCHIVED_VERSION\",\\
+              path: \"/\",\\
+              noIndex: true,\\
+              banner: \"unmaintained\",\\
+            },\\
+          },\\
+        },\\
+  " docusaurus.config.js
+fi
 
 # Replace the `sitemap`` block with one that only specifies a blanket ignorePattern.
-sed -i '' '/^        sitemap: {/,/^        },/c\
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/^        sitemap: {/,/^        },/c\
         sitemap: {\
           \/\/ exclude everything from sitemap\
           ignorePatterns: [\"**\"],\
         },\
 ' docusaurus.config.js
+else
+  sed -i '/^        sitemap: {/,/^        },/c\
+        sitemap: {\
+          \/\/ exclude everything from sitemap\
+          ignorePatterns: [\"**\"],\
+        },\
+' docusaurus.config.js
+fi
 
 git add docusaurus.config.js
 git commit -m "archiving($ARCHIVED_VERSION): update docusaurus config"

--- a/hacks/isolateVersion/7-updateDocusaurusConfig.sh
+++ b/hacks/isolateVersion/7-updateDocusaurusConfig.sh
@@ -69,6 +69,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         docs: {\\
           lastVersion: currentVersion,\\
           includeCurrentVersion: false,\\
+          docItemComponent: \"@theme/ApiItem\",\\
           versions: {\\
             \"$ARCHIVED_VERSION\": {\\
               label: \"$ARCHIVED_VERSION\",\\
@@ -84,6 +85,7 @@ else
         docs: {\\
           lastVersion: currentVersion,\\
           includeCurrentVersion: false,\\
+          docItemComponent: \"@theme/ApiItem\",\\
           versions: {\\
             \"$ARCHIVED_VERSION\": {\\
               label: \"$ARCHIVED_VERSION\",\\

--- a/hacks/isolateVersion/8-updateCurrentVersion.sh
+++ b/hacks/isolateVersion/8-updateCurrentVersion.sh
@@ -1,6 +1,10 @@
 notify "Updating current version configuration..."
 
-sed -i '' "s/const currentVersion = \"[0-9]\.[0-9]\";/const currentVersion = \"$ARCHIVED_VERSION\";/" src/versions.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/const currentVersion = \"[0-9]\.[0-9]\";/const currentVersion = \"$ARCHIVED_VERSION\";/" src/versions.js
+else
+  sed -i "s/const currentVersion = \"[0-9]\.[0-9]\";/const currentVersion = \"$ARCHIVED_VERSION\";/" src/versions.js
+fi
 
 git add src/versions.js
 git commit -m "archiving($ARCHIVED_VERSION): configure current version"

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -67,8 +67,4 @@ if [[ "$script_index" == 8 || -z "$script_index" ]]; then
   source $script_directory/8-updateCurrentVersion.sh
 fi
 
-notify "Automated steps are complete! For ease of review, consider PR'ing the deletion commits separate from the rest of the changes."
-notify "Manual steps that remain:
-9. Fix htaccess rules
-10. Fix links
-"
+notify "Automated steps are complete!"

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash   
+#!/bin/bash
 set -e # exit at first error
 
 # Before running this script make sure the version is set
@@ -68,7 +68,7 @@ if [[ "$script_index" == 8 || -z "$script_index" ]]; then
 fi
 
 notify "Automated steps are complete! For ease of review, consider PR'ing the deletion commits separate from the rest of the changes."
-notify "Manual steps that remain: 
+notify "Manual steps that remain:
 9. Fix htaccess rules
 10. Fix links
 "

--- a/hacks/isolateVersion/allSteps.sh
+++ b/hacks/isolateVersion/allSteps.sh
@@ -1,8 +1,12 @@
 #!/bin/bash   
 set -e # exit at first error
 
-# Before running this script make sure this version is correct!
-ARCHIVED_VERSION="8.3"
+# Before running this script make sure the version is set
+if [[ -z "${ARCHIVED_VERSION}" ]]
+then
+    echo 'Set the archive version: `export ARCHIVED_VERSION=8.x`'
+    exit 1
+fi
 
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -94,10 +94,10 @@ You now have a branch named `unsupported/8.x` (using your actual minor version).
 
 ### Create and publish the unmaintained branch
 
-On the `unsupported/8.x` branch, in `/hacks/isolateVersion`, run `allSteps.sh`:
+On the `unsupported/8.x` branch, isolate the archived version:
 
 ```sh
-./hacks/isolateVersion/allSteps.sh
+make -C hacks/archiveVersion isolate-version
 ```
 
 This automates a handful of basic steps to remove all other versions of the documentation and prepare the site for being published as unsupported. See the script for more details.
@@ -119,25 +119,29 @@ You can review the changes at https://github.com/camunda/camunda-docs/commits/un
 
 ### Fix links and redirects
 
-Make the manual changes described by the output of the `allSteps.sh` script in a new PR. See [this PR](https://github.com/camunda/camunda-docs/pull/6586) as an example. You may need to remove generated API reference docs, and tidy up any broken links in this step, to get the build green and successful.
-
-Postprocess the docs to help automate some of the changes you need to make in this step:
+Preprocess the docs to automate some common changes that need to be made against the isolated version:
 
 ```sh
-make -C hacks/archiveVersion postprocess
+make -C hacks/archiveVersion preprocess
 ```
 
-Read the docstring in the postprocess file for details.
+Read the docstring in the preprocess file for details.
+
+#### Manually fix links
 
 Unfortunately, there will likely be other broken links you'll need to fix manually:
 
 1. Run `npm run build` to discover and resolve remaining build errors.
 2. Submit a PR targeting `unsupported/8.6` (not `main`). The build pipeline will show the remaining broken links.
 
+#### Manually remove redirects
+
 Next, you'll need to remove 8.6 redirects from `.htaccess`. This helps keep the redirects file clean and maintainable for future authors.
 
 1. Add a catch-all redirect at the top of the file, pointing all 8.6 documentation at the unsupported site:
 2. Remove everything except redirects from `/8.6/` files to other `/8.6/` files.
+
+Make the manual changes described by the output of the `allSteps.sh` script in a new PR. See [this PR](https://github.com/camunda/camunda-docs/pull/6586) as an example. You may need to remove generated API reference docs, and tidy up any broken links in this step, to get the build green and successful.
 
 ### Merge all PRs
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -73,11 +73,7 @@ git checkout -b archive-step-1
 Navigate to `hacks/archiveVersion`, and run `1-ignore-version-prod.py`:
 
 ```sh
-cd hacks/archiveVersion
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-python 1-ignore-version-prod.py
+make -C hacks/archiveVersion ignore-version-prod
 ```
 
 This automatically updates `publish-prod.yaml` to ignore tags for the archived minor version and any future patches during future production releases.
@@ -110,22 +106,12 @@ This creates a large set of commits. Push them to remote, but don't open a PR.
 
 > **Warning:** Do not merge this branch into `main`! This branch will persist indefinitely alongside `main` and will never be merged. Instead, it will be used to deploy to unsupported.docs.camunda.io.
 
-You can review the changes at:
-
-https://github.com/camunda/camunda-docs/commits/unsupported/8.6/
-
-Change the version to your archived version.
+You can review the changes at https://github.com/camunda/camunda-docs/commits/unsupported/8.6/ (Change the version to your archived version.)
 
 <details>
-    <summary>Reference video: archiving 8.5</summary>
+    <summary>Reference materials</summary>
 
-You can view a video of the archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
-
-</details>
-
-<details>
-    <summary>Reference pull requests</summary>
-
+- 8.5 archival video (old): You can view a video of the 8.5 archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
 - [Very large PR](https://github.com/camunda/camunda-docs/pull/5586)
 - [Much smaller PR](https://github.com/camunda/camunda-docs/pull/5587)
 
@@ -138,14 +124,20 @@ Make the manual changes described by the output of the `allSteps.sh` script in a
 Postprocess the docs to help automate some of the changes you need to make in this step:
 
 ```sh
-cd hacks/archiveVersion
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-python 2-postprocess.py
+make -C hacks/archiveVersion postprocess
 ```
 
 Read the docstring in the postprocess file for details.
+
+Unfortunately, there will likely be other broken links you'll need to fix manually:
+
+1. Run `npm run build` to discover and resolve remaining build errors.
+2. Submit a PR targeting `unsupported/8.6` (not `main`). The build pipeline will show the remaining broken links.
+
+Next, you'll need to remove 8.6 redirects from `.htaccess`. This helps keep the redirects file clean and maintainable for future authors.
+
+1. Add a catch-all redirect at the top of the file, pointing all 8.6 documentation at the unsupported site:
+2. Remove everything except redirects from `/8.6/` files to other `/8.6/` files.
 
 ### Merge all PRs
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -23,45 +23,139 @@ Our current policy is to support versions for 18 months. Any version older than 
 
 When a version is archived, it is removed from the main docs, isolated on a branch named `unsupported/x.xx` where `x.xx` is the version, and deployed to the URLs `https://unsupported.docs.camunda.io/x.xx/` and `https://stage.unsupported.docs.camunda.io/x.xx/`.
 
-### Archival steps
+### Create a GitHub issue
 
-Examples:
+Create a new GitHub issue to track your progress:
 
-See the following previous issues for examples of all the steps required/completed.
+```
+## Overview
 
-- [8.5 archival](https://github.com/camunda/camunda-docs/issues/7077)
-- [8.4 archival](https://github.com/camunda/camunda-docs/issues/6628)
-- [8.3 archival](https://github.com/camunda/camunda-docs/issues/5564)
+With the latest release, <VERSION> has reached end of maintenance.
+We will archive <VERSION> docs to an unsupported, standalone instance.
 
-You should first create a new issue for the archival, using these previous issues as a template.
+This issue tracks related activities.
 
-Video: You can also view a video of the archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
+## Activities
 
-#### Step 1: Make sure the new archive version is not published in main
+- [ ] Ignore <VERSION> when deploying prod (reference link)
+- [ ] Create new `unsupported/<VERSION>` branch (reference link)
+- [ ] Ran automated scripts to isolate the <VERSION> docs (reference link)
+- [ ] Manually fix links (reference link)
+- [ ] Deploy isolated version (reference link)
+- [ ] Logically remove <VERSION> from main (reference link)
+- [ ] Physically remove <VERSION> from main (reference link)
+```
 
-On the `main` docs branch, configure the `publish-prod` workflow to ignore tags for the archived version. See [this PR](https://github.com/camunda/camunda-docs/pull/5567) as an example.
+### Set your archive version environment variable
 
-**Warning**: You must do this before publishing a production release for the archived version, to avoid accidentally publishing the archived version as the main docs.
+Set an environment variable to be used in future automations:
 
-#### Step 2: Create the new archived version branch
+```sh
+export ARCHIVED_VERSION=8.x  # use the real minor version number
+```
 
-Create a new branch named `unsupported/x.xx` where `x.xx` is the version to be archived. The branch should be created from the latest commit on the `main` branch.
+All future steps should be run from the same shell, or you need to export this environment variable again. You can always verify it's set with `echo`:
 
-For example, for the 8.6 docs archival, you would create a new branch named `unsupported/8.6`.
+```sh
+echo $ARCHIVED_VERSION
+```
 
-#### Step 3: Create and publish the unmaintained branch
+### Make sure the new archive version is not published in main
 
-1. On the `unsupported/x.xx` branch:
-   1. Confirm the version number to be archived at the top of the `./hacks/isolateVersion/allSteps.sh` script.
-   2. Run the `./hacks/isolateVersion/allSteps.sh` script. This automates a handful of basic steps; see the script for more details.
-      - This creates a large set of commits, with a subset of large deletion commits, and smaller commits. You can review this using the GitHub Commits interface (see video). See [this very large PR](https://github.com/camunda/camunda-docs/pull/5586) and [this much smaller PR](https://github.com/camunda/camunda-docs/pull/5587) as examples of the types of commits involved.
-   3. Make the manual changes described by the output of the `allSteps.sh` script in a new PR. See [this PR](https://github.com/camunda/camunda-docs/pull/6586) as an example. You may need to remove generated API reference docs, and tidy up any broken links in this step, to get the build green and successful.
-   4. Merge all these PRs.
-   5. After they're all merged, confirm that these changes publish to the associated staging location: `https://stage.unsupported.docs.camunda.io/x.xx/`.
-   6. Publish the production release for the archived version, by adding a tag to the HEAD of the `unsupported/x.xx` branch.
-      1. Create a new tag after the last one for that version. Name the tag `x.xx.0` where `x.xx` is the version number. For example, for the 8.4 archival, as `8.4.30` was the last tag used, we created a new `8.4.31` to use for the archival.
-      2. **Important** Choose the `unsupported/x.xx` branch as the target.
-      3. **Important** Deselect the `Set as the latest release` option.
+From `main`, create a branch for step one:
+
+```sh
+git checkout main
+git pull
+git checkout -b archive-step-1
+```
+
+Navigate to `hacks/archiveVersion`, and run `1-ignore-version-prod.py`:
+
+```sh
+cd hacks/archiveVersion
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python 1-ignore-version-prod.py
+```
+
+This automatically updates `publish-prod.yaml` to ignore tags for the archived minor version and any future patches during future production releases.
+
+Commit and submit a PR.
+
+### Create the new archived version branch
+
+From the latest commit on `main`, create a new `unsupported/8.x` branch for the archived version:
+
+```sh
+git checkout main
+git pull
+git checkout -b unsupported/$ARCHIVED_VERSION
+```
+
+You now have a branch named `unsupported/8.x` (using your actual minor version).
+
+### Create and publish the unmaintained branch
+
+On the `unsupported/8.x` branch, in `/hacks/isolateVersion`, run `allSteps.sh`:
+
+```sh
+./hacks/isolateVersion/allSteps.sh
+```
+
+This automates a handful of basic steps to remove all other versions of the documentation and prepare the site for being published as unsupported. See the script for more details.
+
+This creates a large set of commits. Push them to remote, but don't open a PR.
+
+> **Warning:** Do not merge this branch into `main`! This branch will persist indefinitely alongside `main` and will never be merged. Instead, it will be used to deploy to unsupported.docs.camunda.io.
+
+You can review the changes at:
+
+https://github.com/camunda/camunda-docs/commits/unsupported/8.6/
+
+Change the version to your archived version.
+
+<details>
+    <summary>Reference video: archiving 8.5 with Mark and Maxim</summary>
+
+You can view a video of the archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
+
+</details>
+
+<details>
+    <summary>Reference pull requests</summary>
+
+- [Very large PR](https://github.com/camunda/camunda-docs/pull/5586)
+- [Much smaller PR](https://github.com/camunda/camunda-docs/pull/5587)
+
+</details>
+
+### Fix links and redirects
+
+Make the manual changes described by the output of the `allSteps.sh` script in a new PR. See [this PR](https://github.com/camunda/camunda-docs/pull/6586) as an example. You may need to remove generated API reference docs, and tidy up any broken links in this step, to get the build green and successful.
+
+### Merge all PRs
+
+Merge all the pull requests submitted so far. Then, confirm these changes are successfully published to the associated staging location: `https://stage.unsupported.docs.camunda.io/8.x/`.
+
+### Publish the production release for the archived version
+
+Look up the last tag for the archived version:
+
+```sh
+git ls-remote --tags origin "$ARCHIVED_VERSION.*" | awk '{print $2}' | sed 's#refs/tags/##' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1
+```
+
+1. Go to https://github.com/camunda/camunda-docs/releases.
+2. Click **Draft a new release**.
+3. Click **Select tag**.
+4. Click **Create new tag**.
+5. Enter the next tag for the archived version. (If the last tag was `8.7.100`, use `8.7.101`.)
+6. **(IMPORTANT)** Choose `unsupported/8.x` as the target branch.
+7. Use the new tag for the title.
+8. Click **Generate release notes**.
+9. **(IMPORTANT)** Deselect **Set as the latest release**.
 
 #### Step 4: Remove the archived version from the main docs
 
@@ -75,7 +169,19 @@ On the `main` branch:
 
 Congratulations! You should now have removed the archived version from the docs, and published the archived version to `https://unsupported.docs.camunda.io/x.xx`.
 
-### Archived for posterity: 8.3 archival steps
+### Reference
+
+<details>
+    <summary>Previous archival issues</summary>
+
+- [8.6 archival](https://github.com/camunda/camunda-docs/issues/8659)
+- [8.5 archival](https://github.com/camunda/camunda-docs/issues/7077)
+- [8.4 archival](https://github.com/camunda/camunda-docs/issues/6628)
+- [8.3 archival](https://github.com/camunda/camunda-docs/issues/5564)
+
+</details>
+<details>
+    <summary>8.3 archival steps (for posterity)</summary>
 
 Note that there was a difference in the process between 8.3 and 8.4 archival, so these 8.3 steps remain here for reference/posterity.
 
@@ -98,6 +204,8 @@ Note that there was a difference in the process between 8.3 and 8.4 archival, so
       1. Open a smaller, reviewable PR that logically removes the version, and links to the external unmaintained version in the top navigation bar. [Example](https://github.com/camunda/camunda-docs/pull/5597).
       2. Open a second larger PR that physically removes the source files. [Example](https://github.com/camunda/camunda-docs/pull/5601).
    2. [Publish a new patch release of the main docs](./release-procedure.md#perform-a-patch-release).
+
+</details>
 
 ## Further information
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -23,6 +23,16 @@ Our current policy is to support versions for 18 months. Any version older than 
 
 When a version is archived, it is removed from the main docs, isolated on a branch named `unsupported/x.xx` where `x.xx` is the version, and deployed to the URLs `https://unsupported.docs.camunda.io/x.xx/` and `https://stage.unsupported.docs.camunda.io/x.xx/`.
 
+### Prerequisites
+
+This process relies on automations to take care of the bulk of the archiving work on your behalf. To run those automations, you'll need the following dependencies:
+
+- Bash
+- Make
+- Python 3.12+
+
+Additionally, you'll also need to configure your Git email and name in your development environment with `git config`.
+
 ### Create a GitHub issue
 
 Create a new GitHub issue to track your progress:
@@ -48,13 +58,13 @@ This issue tracks related activities.
 
 ### Set your archive version environment variable
 
-Set an environment variable to be used in future automations:
+Set the archived version in an environment variable:
 
 ```sh
 export ARCHIVED_VERSION=8.x  # use the real minor version number
 ```
 
-All future steps should be run from the same shell, or you need to export this environment variable again. You can always verify it's set with `echo`:
+All future steps will use this environment variable and should, therefore, be run from the same shell. Otherwise, you need to export this environment variable again. You can always verify it's set with `echo`:
 
 ```sh
 echo $ARCHIVED_VERSION
@@ -70,13 +80,13 @@ git pull
 git checkout -b archive-step-1
 ```
 
-Navigate to `hacks/archiveVersion`, and run `1-ignore-version-prod.py`:
+Run the `ignore-version-prod` automation:
 
 ```sh
 make -C hacks/archiveVersion ignore-version-prod
 ```
 
-This automatically updates `publish-prod.yaml` to ignore tags for the archived minor version and any patches during future production releases.
+This updates `publish-prod.yaml` to ignore tags for the archived minor version and any patches during future production releases.
 
 Commit and submit a PR.
 
@@ -108,13 +118,15 @@ This creates a large set of commits. Push them to remote, but **don't open a PR*
 
 ### Fix links and redirects
 
-Preprocess the docs to automate some common changes that need to be made against the isolated version:
+Preprocess the docs to automate common changes that need to be made against the isolated version:
 
 ```sh
 make -C hacks/archiveVersion preprocess
 ```
 
 Read the docstring in `hacks/archiveVersion/2-preprocess.py` for details.
+
+Review and commit the changes.
 
 #### Manually fix links
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -117,7 +117,7 @@ https://github.com/camunda/camunda-docs/commits/unsupported/8.6/
 Change the version to your archived version.
 
 <details>
-    <summary>Reference video: archiving 8.5 with Mark and Maxim</summary>
+    <summary>Reference video: archiving 8.5</summary>
 
 You can view a video of the archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -76,7 +76,7 @@ Navigate to `hacks/archiveVersion`, and run `1-ignore-version-prod.py`:
 make -C hacks/archiveVersion ignore-version-prod
 ```
 
-This automatically updates `publish-prod.yaml` to ignore tags for the archived minor version and any future patches during future production releases.
+This automatically updates `publish-prod.yaml` to ignore tags for the archived minor version and any patches during future production releases.
 
 Commit and submit a PR.
 
@@ -100,22 +100,11 @@ On the `unsupported/8.x` branch, isolate the archived version:
 make -C hacks/archiveVersion isolate-version
 ```
 
-This automates a handful of basic steps to remove all other versions of the documentation and prepare the site for being published as unsupported. See the script for more details.
+This automates a handful of basic steps to remove all other versions of the documentation and prepare the site for being published as unsupported. See the scripts in `hacks/isolateVersion` for more details.
 
-This creates a large set of commits. Push them to remote, but don't open a PR.
+This creates a large set of commits. Push them to remote, but **don't open a PR**. You can review the changes at https://github.com/camunda/camunda-docs/commits/unsupported/8.6/ (Change the version to your archived version.)
 
 > **Warning:** Do not merge this branch into `main`! This branch will persist indefinitely alongside `main` and will never be merged. Instead, it will be used to deploy to unsupported.docs.camunda.io.
-
-You can review the changes at https://github.com/camunda/camunda-docs/commits/unsupported/8.6/ (Change the version to your archived version.)
-
-<details>
-    <summary>Reference materials</summary>
-
-- 8.5 archival video (old): You can view a video of the 8.5 archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
-- [Very large PR](https://github.com/camunda/camunda-docs/pull/5586)
-- [Much smaller PR](https://github.com/camunda/camunda-docs/pull/5587)
-
-</details>
 
 ### Fix links and redirects
 
@@ -125,23 +114,30 @@ Preprocess the docs to automate some common changes that need to be made against
 make -C hacks/archiveVersion preprocess
 ```
 
-Read the docstring in the preprocess file for details.
+Read the docstring in `hacks/archiveVersion/2-preprocess.py` for details.
 
 #### Manually fix links
 
 Unfortunately, there will likely be other broken links you'll need to fix manually:
 
 1. Run `npm run build` to discover and resolve remaining build errors.
-2. Submit a PR targeting `unsupported/8.6` (not `main`). The build pipeline will show the remaining broken links.
+2. Submit a PR targeting `unsupported/8.x` (not `main`). The build pipeline will show the remaining broken links.
 
 #### Manually remove redirects
 
-Next, you'll need to remove 8.6 redirects from `.htaccess`. This helps keep the redirects file clean and maintainable for future authors.
+Next, you'll need to remove irrelevant redirects from `.htaccess`. The unsupported site for the archived version is only concerned with that version's redirects.
 
-1. Add a catch-all redirect at the top of the file, pointing all 8.6 documentation at the unsupported site:
-2. Remove everything except redirects from `/8.6/` files to other `/8.6/` files.
+As a rule of thumb, remove everything except redirects belonging to the archived version. For example, if you're archiving version 8.6:
 
-Make the manual changes described by the output of the `allSteps.sh` script in a new PR. See [this PR](https://github.com/camunda/camunda-docs/pull/6586) as an example. You may need to remove generated API reference docs, and tidy up any broken links in this step, to get the build green and successful.
+```txt
+RewriteRule ^docs/8.6/components/console/manage-plan/upgrade-to-starter-plan/?$ /docs/8.6/components/console/manage-plan/upgrade-to-enterprise-plan/ [R=301,L]
+```
+
+Should be kept and rewritten as:
+
+```txt
+RewriteRule ^docs/components/console/manage-plan/upgrade-to-starter-plan/?$ /8.6/docs/components/console/manage-plan/upgrade-to-enterprise-plan/ [R=301,L]
+```
 
 ### Merge all PRs
 
@@ -212,6 +208,14 @@ Note that there was a difference in the process between 8.3 and 8.4 archival, so
       1. Open a smaller, reviewable PR that logically removes the version, and links to the external unmaintained version in the top navigation bar. [Example](https://github.com/camunda/camunda-docs/pull/5597).
       2. Open a second larger PR that physically removes the source files. [Example](https://github.com/camunda/camunda-docs/pull/5601).
    2. [Publish a new patch release of the main docs](./release-procedure.md#perform-a-patch-release).
+
+</details>
+<details>
+    <summary>Isolate version reference materials</summary>
+
+- 8.5 archival video (old): You can view a video of the 8.5 archival process in the documentation team Google Drive folder (requires access to Teams > Documentation > Processes > Archival > Archival steps).
+- [Very large PR](https://github.com/camunda/camunda-docs/pull/5586)
+- [Much smaller PR](https://github.com/camunda/camunda-docs/pull/5587)
 
 </details>
 

--- a/howtos/versioning.md
+++ b/howtos/versioning.md
@@ -135,6 +135,18 @@ You can view a video of the archival process in the documentation team Google Dr
 
 Make the manual changes described by the output of the `allSteps.sh` script in a new PR. See [this PR](https://github.com/camunda/camunda-docs/pull/6586) as an example. You may need to remove generated API reference docs, and tidy up any broken links in this step, to get the build green and successful.
 
+Postprocess the docs to help automate some of the changes you need to make in this step:
+
+```sh
+cd hacks/archiveVersion
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python 2-postprocess.py
+```
+
+Read the docstring in the postprocess file for details.
+
 ### Merge all PRs
 
 Merge all the pull requests submitted so far. Then, confirm these changes are successfully published to the associated staging location: `https://stage.unsupported.docs.camunda.io/8.x/`.


### PR DESCRIPTION
## Description

This PR makes the following improvements to the archival process:

- [x] Rewrite the steps to give more direct instruction, rather than relying heavily on parsing old PRs.
- [x] Moves all historical and reference material to the end of the archival guide.
- [x] Provides a lot more code samples and in-line examples.
- [x] Moves all automations in a make file for consistency.
- [x] Automated steps to reduce manual processing.
- [x] Fixed to work on linux and mac flavors of unix.
- [x] Replaces homepage with simplified version without dependencies (algolia, kapa, /docs, etc).
- [x] Removed vale from workflow for unmaintained docs, as this is expected to fail anyway.
- [x] Fixed API reference docs in unmaintained documentation.
- [x] Fixed language in "unmaintained docs" banner

I didn't have time to get to two big pieces of the archival proces: redirect automations and "step 4". I'd like to return to those before the next archival process.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
