### PR TITLE
Document differences of version concepts within Camunda 8

### DIFF
--- a/docs/components/best-practices/modeling/choosing-the-resource-binding-type.md
+++ b/docs/components/best-practices/modeling/choosing-the-resource-binding-type.md
@@ -75,7 +75,7 @@ Camunda 8 supports the following binding types:
               You can set the version tag for a BPMN process, DMN decision, or Form in the Modeler's properties panel.
             </p>
           </li>
-          <li><p>A version tag is different from the numeric process definition version assigned by the Orchestration Cluster. See <a href="/reference/glossary.md#version">version</a>.</p></li>
+          <li><p>A version tag is different from the numeric process definition version assigned by the Orchestration Cluster.</p></li>
           <li><p>Using the <code>versionTag</code> binding option ensures that the right version of the target resource is always used, regardless of future deployments, by pinning the dependency to a specific version.</p></li>
           <li><p>The option is ideal for managing external or shared dependencies.</p></li>
         </ul>

--- a/docs/components/best-practices/modeling/choosing-the-resource-binding-type.md
+++ b/docs/components/best-practices/modeling/choosing-the-resource-binding-type.md
@@ -75,6 +75,7 @@ Camunda 8 supports the following binding types:
               You can set the version tag for a BPMN process, DMN decision, or Form in the Modeler's properties panel.
             </p>
           </li>
+          <li><p>A version tag is different from the numeric process definition version assigned by the Orchestration Cluster. See <a href="/reference/glossary.md#version">version</a>.</p></li>
           <li><p>Using the <code>versionTag</code> binding option ensures that the right version of the target resource is always used, regardless of future deployments, by pinning the dependency to a specific version.</p></li>
           <li><p>The option is ideal for managing external or shared dependencies.</p></li>
         </ul>

--- a/docs/components/hub/workspace/manage-projects/project-versioning.md
+++ b/docs/components/hub/workspace/manage-projects/project-versioning.md
@@ -11,6 +11,8 @@ import VersionListImg from './img/web-modeler-version-view-process-application-v
 
 Projects support versioning, allowing you to create distinct versions for the entire project. You can use versioning to save a single snapshot of all the project files in one action. This helps you track a project throughout its development lifecycle and ensures the correct version is referenced.
 
+In this context, a version is a Web Modeler project snapshot, not a deployed process definition version. See [version](/reference/glossary.md#version).
+
 ## Version creation
 
 To create a project version:

--- a/docs/components/hub/workspace/modeler/modeling/versions.md
+++ b/docs/components/hub/workspace/modeler/modeling/versions.md
@@ -10,7 +10,7 @@ description: Work with versions in Web Modeler.
 With 8.7, "milestone" has been renamed to "version". To learn more about this change, see [the related release note](/reference/announcements-release-notes/870/870-release-notes.md#web-modeler-milestones-renamed-to-versions).
 :::
 
-You can create a version at any time to save a snapshot of your BPMN or DMN diagram.
+You can create a version at any time to save a snapshot of your BPMN or DMN diagram. This version is a Web Modeler snapshot version, not a deployed process definition version. See [version](/reference/glossary.md#version).
 
 You can restore a version to revert to a previous snapshot of your diagram, for example if you make a mistake while modeling. You can also compare two versions to see the differences between them.
 

--- a/docs/components/modeler/desktop-modeler/flags/flags.md
+++ b/docs/components/modeler/desktop-modeler/flags/flags.md
@@ -162,6 +162,8 @@ Additional information adapted from the [upstream documentation](https://nodejs.
 
 ### Default execution platform version
 
+This setting controls the [execution platform version](/reference/glossary.md#execution-platform-version) used by Desktop Modeler. It does not change the version of a deployed cluster or process definition.
+
 To change default execution platform version, configure your `flags.json` as follows:
 
 ```json

--- a/docs/components/modeler/desktop-modeler/settings/settings.md
+++ b/docs/components/modeler/desktop-modeler/settings/settings.md
@@ -26,8 +26,8 @@ The following Desktop Modeler settings are available:
 | Enable new context pad      | Enables the alternative context pad interface.                                                                                                                                                                     |
 | Disable plugins             | Disables all installed plugins when running Desktop Modeler.                                                                                                                                                       |
 | Disable connector templates | If checked, Desktop Modeler will not automatically download or use Camunda connector templates. See [automatic connector template fetching](../use-connectors/#automatic-connector-template-fetching) for details. |
-| Default Camunda 8 version   | Sets the default Camunda 8 execution platform version for new diagrams.                                                                                                                                            |
-| Default Camunda 7 version   | Sets the default Camunda 7 execution platform version for new diagrams.                                                                                                                                            |
+| Default Camunda 8 version   | Sets the default Camunda 8 [execution platform version](/reference/glossary.md#execution-platform-version) for new diagrams.                                                                                       |
+| Default Camunda 7 version   | Sets the default Camunda 7 [execution platform version](/reference/glossary.md#execution-platform-version) for new diagrams.                                                                                       |
 
 :::note
 Plugins may also provide their own settings in the **Settings** window.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -225,7 +225,7 @@ An event represents a state change associated with an aspect of an executing [pr
 
 ### Execution platform version
 
-In Desktop Modeler, the execution platform version is the Camunda runtime version that a new diagram targets. It determines which execution semantics and validation rules Modeler applies.
+In Desktop Modeler and Web Modeler, the execution platform version is the Camunda runtime version that a diagram targets. It determines which execution semantics and validation rules are applied during modeling.
 
 The execution platform version is not a deployed process definition version, a Web Modeler version, or a SaaS cluster generation.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -33,7 +33,7 @@ Explore and understand definitions for key Camunda 8 terms and abbreviations.
     <div class="letter-link"><a href="#s">S</a></div>
     <div class="letter-link"><a href="#t">T</a></div>
     <div class="letter-link"><a href="#u">U</a></div>
-    <div class="letter-link">V</div>
+    <div class="letter-link"><a href="#v">V</a></div>
     <div class="letter-link"><a href="#w">W</a></div>
     <div class="letter-link">X</div>
     <div class="letter-link">Y</div>
@@ -223,6 +223,14 @@ An event represents a state change associated with an aspect of an executing [pr
 
 - [Internal processing](/components/zeebe/technical-concepts/internal-processing.md#events-and-commands)
 
+### Execution platform version
+
+In Desktop Modeler, the execution platform version is the Camunda runtime version that a new diagram targets. It determines which execution semantics and validation rules Modeler applies.
+
+The execution platform version is not a deployed process definition version, a Web Modeler version, or a SaaS cluster generation.
+
+- [Desktop Modeler flags](/components/modeler/desktop-modeler/flags/flags.md#default-execution-platform-version)
+
 ### Execution listener
 
 An execution listener is a mechanism that allows users to execute custom logic at specific points during [workflow](#workflow) execution. Execution listeners can be attached to [BPMN elements](#element) to react to lifecycle events, such as when an element starts or ends. This feature facilitates pre-processing and post-processing tasks without cluttering the BPMN model, functioning similarly to [job workers](#job-worker) by leveraging the same infrastructure.
@@ -258,6 +266,14 @@ See [Zeebe Gateway](#zeebe-gateway).
 ### Generative AI
 
 Any AI system that can produce new content, such as text, images, or audio, in response to prompts. Generative AI doesn’t just analyze existing data; it creates original output that is often contextually relevant to the input.
+
+### Generation
+
+In Camunda 8 SaaS, a generation is the release identifier for the version set running in a cluster. Console uses generations instead of a single engine version because the underlying component versions can change independently.
+
+A generation is not a process definition version, a version tag, or a Web Modeler version.
+
+- [Generation names](/reference/announcements-release-notes/release-policy.md#generation-names)
 
 ## H
 
@@ -432,6 +448,15 @@ Identified by:
 - **version**: Version number assigned by the engine
 
 The engine uses process definitions to start [process instances](#process-instance).
+
+### Process definition version
+
+A process definition version is the numeric version assigned by the Orchestration Cluster each time you deploy a process definition with the same process ID.
+
+Operate, Optimize, and APIs often shorten this to version. A process definition version is different from a version tag, which is a user-defined label, and from a Web Modeler version, which is a saved file or project snapshot.
+
+- [Process definition](#process-definition)
+- [Migrate process instances](/components/operate/userguide/process-instance-migration.md)
 
 ### Process instance
 
@@ -620,6 +645,32 @@ Camunda recommends using Camunda user tasks in your process definitions. With 8.
 A user task listener allows users to execute custom logic in response to specific user task lifecycle events, such as assigning or completing a task. User task listeners are attached to BPMN user tasks and facilitate validation, custom task assignment, and other operations during user task execution. They operate similarly to [job workers](#job-worker), leveraging the same infrastructure for processing external logic.
 
 - [User task listeners](/components/concepts/user-task-listeners.md)
+
+## V
+
+### Version
+
+In Camunda 8, version is an overloaded term. Depending on context, it can refer to a [process definition version](#process-definition-version), a [version tag](#version-tag), a [Web Modeler version](#web-modeler-version), an [execution platform version](#execution-platform-version), or a SaaS [generation](#generation).
+
+### Version tag
+
+A version tag is a user-defined string label for a specific resource or snapshot.
+
+For deployed BPMN, DMN, and form resources, a version tag can be used to identify a resource version and to resolve dependencies with `versionTag` binding. In Web Modeler project versioning, a version tag labels a saved project snapshot.
+
+A version tag is not generated automatically and does not replace the numeric process definition version.
+
+- [Resource binding types](/components/best-practices/modeling/choosing-the-resource-binding-type.md#versiontag)
+- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
+
+### Web Modeler version
+
+A Web Modeler version is a saved snapshot of a BPMN or DMN file, or of an entire project. Diagram versions were previously called milestones.
+
+Web Modeler versions help you compare, restore, review, and deploy snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
+
+- [Versions](/components/hub/workspace/modeler/modeling/versions.md)
+- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
 
 ## W
 

--- a/versioned_docs/version-8.9/components/best-practices/modeling/choosing-the-resource-binding-type.md
+++ b/versioned_docs/version-8.9/components/best-practices/modeling/choosing-the-resource-binding-type.md
@@ -75,7 +75,7 @@ Camunda 8 supports the following binding types:
               You can set the version tag for a BPMN process, DMN decision, or Form in the Modeler's properties panel.
             </p>
           </li>
-          <li><p>A version tag is different from the numeric process definition version assigned by the Orchestration Cluster. See <a href="/reference/glossary.md#version">version</a>.</p></li>
+          <li><p>A version tag is different from the numeric process definition version assigned by the Orchestration Cluster.</p></li>
           <li><p>Using the <code>versionTag</code> binding option ensures that the right version of the target resource is always used, regardless of future deployments, by pinning the dependency to a specific version.</p></li>
           <li><p>The option is ideal for managing external or shared dependencies.</p></li>
         </ul>

--- a/versioned_docs/version-8.9/components/best-practices/modeling/choosing-the-resource-binding-type.md
+++ b/versioned_docs/version-8.9/components/best-practices/modeling/choosing-the-resource-binding-type.md
@@ -75,6 +75,7 @@ Camunda 8 supports the following binding types:
               You can set the version tag for a BPMN process, DMN decision, or Form in the Modeler's properties panel.
             </p>
           </li>
+          <li><p>A version tag is different from the numeric process definition version assigned by the Orchestration Cluster. See <a href="/reference/glossary.md#version">version</a>.</p></li>
           <li><p>Using the <code>versionTag</code> binding option ensures that the right version of the target resource is always used, regardless of future deployments, by pinning the dependency to a specific version.</p></li>
           <li><p>The option is ideal for managing external or shared dependencies.</p></li>
         </ul>

--- a/versioned_docs/version-8.9/components/modeler/desktop-modeler/flags/flags.md
+++ b/versioned_docs/version-8.9/components/modeler/desktop-modeler/flags/flags.md
@@ -162,6 +162,8 @@ Additional information adapted from the [upstream documentation](https://nodejs.
 
 ### Default execution platform version
 
+This setting controls the [execution platform version](/reference/glossary.md#execution-platform-version) used by Desktop Modeler. It does not change the version of a deployed cluster or process definition.
+
 To change default execution platform version, configure your `flags.json` as follows:
 
 ```json

--- a/versioned_docs/version-8.9/components/modeler/desktop-modeler/settings/settings.md
+++ b/versioned_docs/version-8.9/components/modeler/desktop-modeler/settings/settings.md
@@ -26,8 +26,8 @@ The following Desktop Modeler settings are available:
 | Enable new context pad      | Enables the alternative context pad interface.                                                                                                                                                                     |
 | Disable plugins             | Disables all installed plugins when running Desktop Modeler.                                                                                                                                                       |
 | Disable connector templates | If checked, Desktop Modeler will not automatically download or use Camunda connector templates. See [automatic connector template fetching](../use-connectors/#automatic-connector-template-fetching) for details. |
-| Default Camunda 8 version   | Sets the default Camunda 8 execution platform version for new diagrams.                                                                                                                                            |
-| Default Camunda 7 version   | Sets the default Camunda 7 execution platform version for new diagrams.                                                                                                                                            |
+| Default Camunda 8 version   | Sets the default Camunda 8 [execution platform version](/reference/glossary.md#execution-platform-version) for new diagrams.                                                                                       |
+| Default Camunda 7 version   | Sets the default Camunda 7 [execution platform version](/reference/glossary.md#execution-platform-version) for new diagrams.                                                                                       |
 
 :::note
 Plugins may also provide their own settings in the **Settings** window.

--- a/versioned_docs/version-8.9/components/modeler/web-modeler/modeling/versions.md
+++ b/versioned_docs/version-8.9/components/modeler/web-modeler/modeling/versions.md
@@ -10,7 +10,7 @@ description: Work with versions in Web Modeler.
 With 8.7, "milestone" has been renamed to "version". To learn more about this change, see [the related release note](/reference/announcements-release-notes/870/870-release-notes.md#web-modeler-milestones-renamed-to-versions).
 :::
 
-You can create a version at any time to save a snapshot of your BPMN or DMN diagram.
+You can create a version at any time to save a snapshot of your BPMN or DMN diagram. This version is a Web Modeler snapshot version, not a deployed process definition version. See [version](/reference/glossary.md#version).
 
 You can restore a version to revert to a previous snapshot of your diagram, for example if you make a mistake while modeling. You can also compare two versions to see the differences between them.
 

--- a/versioned_docs/version-8.9/reference/glossary.md
+++ b/versioned_docs/version-8.9/reference/glossary.md
@@ -644,12 +644,12 @@ In Camunda 8, version is an overloaded term. Depending on context, it can refer 
 
 A version tag is a user-defined string label for a specific resource or snapshot.
 
-For deployed BPMN, DMN, and form resources, a version tag can be used to identify a resource version and to resolve dependencies with `versionTag` binding. In Web Modeler project versioning, a version tag labels a saved project snapshot.
+For deployed BPMN, DMN, and form resources, a version tag can be used to identify a resource version and to resolve dependencies with `versionTag` binding. In Web Modeler process application versioning, a version tag labels a saved process application snapshot.
 
 A version tag is not generated automatically and does not replace the numeric process definition version.
 
 - [Resource binding types](/components/best-practices/modeling/choosing-the-resource-binding-type.md#versiontag)
-- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
+- [Process application versioning](/components/modeler/web-modeler/process-applications/process-application-versioning.md)
 
 ### Web Modeler version
 
@@ -657,8 +657,8 @@ A Web Modeler version is a saved snapshot of a BPMN or DMN file, or of an entire
 
 Web Modeler versions help you compare, restore, review, and deploy snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
 
-- [Versions](/components/hub/workspace/modeler/modeling/versions.md)
-- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
+- [Versions](/components/modeler/web-modeler/modeling/versions.md)
+- [Process application versioning](/components/modeler/web-modeler/process-applications/process-application-versioning.md)
 
 ## W
 

--- a/versioned_docs/version-8.9/reference/glossary.md
+++ b/versioned_docs/version-8.9/reference/glossary.md
@@ -219,7 +219,7 @@ An event represents a state change associated with an aspect of an executing [pr
 
 ### Execution platform version
 
-In Desktop Modeler, the execution platform version is the Camunda runtime version that a new diagram targets. It determines which execution semantics and validation rules Modeler applies.
+In Desktop Modeler and Web Modeler, the execution platform version is the Camunda runtime version that a diagram targets. It determines which execution semantics and validation rules are applied during modeling.
 
 The execution platform version is not a deployed process definition version, a Web Modeler version, or a SaaS cluster generation.
 

--- a/versioned_docs/version-8.9/reference/glossary.md
+++ b/versioned_docs/version-8.9/reference/glossary.md
@@ -33,7 +33,7 @@ Explore and understand definitions for key Camunda 8 terms and abbreviations.
     <div class="letter-link"><a href="#s">S</a></div>
     <div class="letter-link"><a href="#t">T</a></div>
     <div class="letter-link"><a href="#u">U</a></div>
-    <div class="letter-link">V</div>
+    <div class="letter-link"><a href="#v">V</a></div>
     <div class="letter-link"><a href="#w">W</a></div>
     <div class="letter-link">X</div>
     <div class="letter-link">Y</div>
@@ -217,6 +217,14 @@ An event represents a state change associated with an aspect of an executing [pr
 
 - [Internal processing](/components/zeebe/technical-concepts/internal-processing.md#events-and-commands)
 
+### Execution platform version
+
+In Desktop Modeler, the execution platform version is the Camunda runtime version that a new diagram targets. It determines which execution semantics and validation rules Modeler applies.
+
+The execution platform version is not a deployed process definition version, a Web Modeler version, or a SaaS cluster generation.
+
+- [Desktop Modeler flags](/components/modeler/desktop-modeler/flags/flags.md#default-execution-platform-version)
+
 ### Execution listener
 
 An execution listener is a mechanism that allows users to execute custom logic at specific points during [workflow](#workflow) execution. Execution listeners can be attached to [BPMN elements](#element) to react to lifecycle events, such as when an element starts or ends. This feature facilitates pre-processing and post-processing tasks without cluttering the BPMN model, functioning similarly to [job workers](#job-worker) by leveraging the same infrastructure.
@@ -252,6 +260,14 @@ See [Zeebe Gateway](#zeebe-gateway).
 ### Generative AI
 
 Any AI system that can produce new content, such as text, images, or audio, in response to prompts. Generative AI doesn’t just analyze existing data; it creates original output that is often contextually relevant to the input.
+
+### Generation
+
+In Camunda 8 SaaS, a generation is the release identifier for the version set running in a cluster. Console uses generations instead of a single engine version because the underlying component versions can change independently.
+
+A generation is not a process definition version, a version tag, or a Web Modeler version.
+
+- [Generation names](/reference/announcements-release-notes/release-policy.md#generation-names)
 
 ## H
 
@@ -426,6 +442,15 @@ Identified by:
 - **version**: Version number assigned by the engine
 
 The engine uses process definitions to start [process instances](#process-instance).
+
+### Process definition version
+
+A process definition version is the numeric version assigned by the Orchestration Cluster each time you deploy a process definition with the same process ID.
+
+Operate, Optimize, and APIs often shorten this to version. A process definition version is different from a version tag, which is a user-defined label, and from a Web Modeler version, which is a saved file or project snapshot.
+
+- [Process definition](#process-definition)
+- [Migrate process instances](/components/operate/userguide/process-instance-migration.md)
 
 ### Process instance
 
@@ -608,6 +633,32 @@ Camunda recommends using Camunda user tasks in your process definitions. With 8.
 A user task listener allows users to execute custom logic in response to specific user task lifecycle events, such as assigning or completing a task. User task listeners are attached to BPMN user tasks and facilitate validation, custom task assignment, and other operations during user task execution. They operate similarly to [job workers](#job-worker), leveraging the same infrastructure for processing external logic.
 
 - [User task listeners](/components/concepts/user-task-listeners.md)
+
+## V
+
+### Version
+
+In Camunda 8, version is an overloaded term. Depending on context, it can refer to a [process definition version](#process-definition-version), a [version tag](#version-tag), a [Web Modeler version](#web-modeler-version), an [execution platform version](#execution-platform-version), or a SaaS [generation](#generation).
+
+### Version tag
+
+A version tag is a user-defined string label for a specific resource or snapshot.
+
+For deployed BPMN, DMN, and form resources, a version tag can be used to identify a resource version and to resolve dependencies with `versionTag` binding. In Web Modeler project versioning, a version tag labels a saved project snapshot.
+
+A version tag is not generated automatically and does not replace the numeric process definition version.
+
+- [Resource binding types](/components/best-practices/modeling/choosing-the-resource-binding-type.md#versiontag)
+- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
+
+### Web Modeler version
+
+A Web Modeler version is a saved snapshot of a BPMN or DMN file, or of an entire project. Diagram versions were previously called milestones.
+
+Web Modeler versions help you compare, restore, review, and deploy snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
+
+- [Versions](/components/hub/workspace/modeler/modeling/versions.md)
+- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
 
 ## W
 


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/camunda-docs/issues/4985.

Clarify overloaded version terminology across Camunda docs.

## What changed

- add glossary definitions for key version concepts, including process definition version, version tag, Web Modeler version, execution platform version, and SaaS generation
- add targeted clarifications in Desktop Modeler and Web Modeler docs where version is most ambiguous
- clarify that `versionTag` is different from the numeric process definition version
- mirror the relevant glossary and doc updates in 8.9

## Why

Camunda uses the term version for several different concepts across products and docs. These changes create one canonical reference point and add small clarifications in the main entry-point pages so users can quickly understand which type of version is meant in context.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
