### PR TITLE
fix(redirects): unshadow /next/ web-modeler rename rules after hub move

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -182,6 +182,33 @@ RewriteRule ^docs/next/components/modeler/web-modeler/web-modeler-settings/?$ /d
 RewriteRule ^docs/next/components/modeler/web-modeler/integrate-web-modeler-in-ci-cd/?$ /docs/next/components/hub/workspace/modeler/integrate-modeler-in-ci-cd/ [R=301,L]
 RewriteRule ^docs/next/components/modeler/web-modeler/element-templates/using-templates-in-web-modeler/?$ /docs/next/components/hub/workspace/modeler/element-templates/using-templates-in-modeler/ [R=301,L]
 
+# Web Modeler moved to Hub Workspace Modeler - subpages reorganized into modeling/, validation/, manage-projects/.
+# These must come before the general catch-all below; otherwise its [R=301,L]
+# externally redirects to a path that does not exist (the new pages live under
+# modeling/, validation/, or manage-projects/).
+RewriteRule ^docs/next/components/modeler/web-modeler/play-your-process/?$ /docs/next/components/hub/workspace/modeler/validation/play-your-process/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/collaboration/play-your-process/?$ /docs/next/components/hub/workspace/modeler/validation/play-your-process/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/task-testing/?$ /docs/next/components/hub/workspace/modeler/validation/task-testing/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/token-simulation/?$ /docs/next/components/hub/workspace/modeler/validation/token-simulation/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/test-scenario-files/?$ /docs/next/components/hub/workspace/modeler/validation/test-scenario-files/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/business-rule-task-linking/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/business-rule-task-linking/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/call-activity-linking/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/call-activity-linking/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/camunda-docs-ai/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/camunda-docs-ai/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/form-linking/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/form-linking/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/process-documentation-with-readme-files/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/process-documentation-with-readme-files/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/publish-public-processes/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/publish-public-processes/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/advanced-modeling/refactoring-suggestions/?$ /docs/next/components/hub/workspace/modeler/modeling/advanced-modeling/refactoring-suggestions/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/camunda-marketplace/?$ /docs/next/components/hub/workspace/modeler/modeling/camunda-marketplace/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/file-download/?$ /docs/next/components/hub/workspace/modeler/modeling/file-download/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/fix-problems-in-your-diagram/?$ /docs/next/components/hub/workspace/modeler/modeling/fix-problems-in-your-diagram/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/import-diagram/?$ /docs/next/components/hub/workspace/modeler/modeling/import-diagram/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/model-your-first-diagram/?$ /docs/next/components/hub/workspace/modeler/modeling/model-your-first-diagram/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/versions/?$ /docs/next/components/hub/workspace/modeler/modeling/versions/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/git-sync/?$ /docs/next/components/hub/workspace/manage-projects/git-sync/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/process-application-pipeline/?$ /docs/next/components/hub/workspace/manage-projects/project-pipeline/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/process-application-versioning/?$ /docs/next/components/hub/workspace/manage-projects/project-versioning/ [R=301,L]
+RewriteRule ^docs/next/components/modeler/web-modeler/process-applications/?$ /docs/next/components/hub/workspace/manage-projects/ [R=301,L]
+
 # Web Modeler moved to Hub Workspace Modeler - general redirect
 RewriteRule ^docs/next/components/modeler/web-modeler/(.*)$ /docs/next/components/hub/workspace/modeler/$1 [R=301,L]
 


### PR DESCRIPTION
## Summary

Closes #8816.

The catch-all on `static/.htaccess` line 186

```
RewriteRule ^docs/next/components/modeler/web-modeler/(.*)$ /docs/next/components/hub/workspace/modeler/$1 [R=301,L]
```

fires with `[R=301,L]` before the rename rules at lines 425-444, so any page reorganized into `modeling/`, `validation/`, or `manage-projects/` during the hub restructure 301s to a path that 404s.

This PR inserts explicit single-hop rules for those renamed pages **directly above the catch-all**, so each request lands at the canonical hub URL in one redirect.

## Repro before fix

```
$ curl -sIL https://docs.camunda.io/docs/next/components/modeler/web-modeler/play-your-process/ | grep -E '^HTTP|^[Ll]ocation'
HTTP/1.1 301 Moved Permanently
Location: https://docs.camunda.io/docs/next/components/hub/workspace/modeler/play-your-process/
HTTP/1.1 404 Not Found
```

## Pages covered

- `play-your-process/` (and `collaboration/play-your-process/`) → `modeler/validation/play-your-process/`
- `task-testing/`, `token-simulation/` → `modeler/validation/...`
- `advanced-modeling/test-scenario-files/` → `modeler/validation/test-scenario-files/`
- `advanced-modeling/<topic>/` → `modeler/modeling/advanced-modeling/<topic>/` (business-rule-task-linking, call-activity-linking, camunda-docs-ai, form-linking, process-documentation-with-readme-files, publish-public-processes, refactoring-suggestions)
- `camunda-marketplace/`, `file-download/`, `fix-problems-in-your-diagram/`, `import-diagram/`, `model-your-first-diagram/`, `versions/` → `modeler/modeling/...`
- `git-sync/`, `process-application-pipeline/`, `process-application-versioning/`, `process-applications/` → `manage-projects/...`

## Verification

After deploy, each old URL above should return a single 301 to the listed target with HTTP 200 final.

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week.
- [ ] This is on a specific schedule.
- [ ] This is part of a scheduled alpha or minor.
- [ ] There is no urgency with this change.

## PR Checklist

- [x] The commit history of this PR is cleaned up, using `{type}(scope): {description}` commit message(s).
- [x] My changes are for an upcoming minor release and are in the `/docs` directory (or in this case `static/`).
- [ ] My changes are for an already released minor and are in a `/versioned_docs` directory.

## Notes

- Draft PR. Not yet approved by docs team — they may prefer the alternative of converting the catch-all to internal `[L]` rewrite (no `R=301`), which is a smaller diff but changes user-visible URL behavior.
- Companion fix in `camunda/web-modeler` updates the frontend hard-coded URLs so the fix doesn't depend on these redirects long-term.