### PR TITLE
correct indentation for identity migration 880

### DIFF
--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880.md
@@ -1208,16 +1208,16 @@ The Identity Migration App requires `read` access to Management Identity. Create
 
    ```yaml
    orchestration:
-   migration:
-     identity:
-       enabled: true
-       # In case of Microsoft Entra ID, you can use the `azp` claim that contains the client_id value
-       claimName: azp
-       claimValue: <YOUR_IDENTITY_CLIENT_ID>
-       clientId: <YOUR_IDENTITY_CLIENT_ID>
-       secret:
-         existingSecret: identity-migration-secret
-         existingSecretKey: password
+     migration:
+       identity:
+         enabled: true
+         # In case of Microsoft Entra ID, you can use the `azp` claim that contains the client_id value
+         claimName: azp
+         claimValue: <YOUR_IDENTITY_CLIENT_ID>
+         clientId: <YOUR_IDENTITY_CLIENT_ID>
+         secret:
+           existingSecret: identity-migration-secret
+           existingSecretKey: password
    ```
 
 </TabItem>
@@ -1248,13 +1248,13 @@ To authorize the Identity Migration App with your Keycloak instance, you need to
 
    ```yaml
    migration:
-   identity:
-     enabled: true
-     secret:
-       existingSecret: identity-migration-secret
-       existingSecretKey: password
-       # Only required if resource authorizations are used
-       resourceAuthorizationsEnabled: true
+     identity:
+       enabled: true
+       secret:
+         existingSecret: identity-migration-secret
+         existingSecretKey: password
+         # Only required if resource authorizations are used
+         resourceAuthorizationsEnabled: true
    ```
 
 The Helm chart creates a dedicated Keycloak client with read-only access to your Identity Resource Server. If you override your Identity clients, follow the Helm chart section in [Common configuration for the Identity Migration application](/self-managed/upgrade/components/870-to-880.md#common-configuration-for-the-identity-migration-application) to set up the required `migration` client.


### PR DESCRIPTION
## Summary

Fix YAML indentation in the 8.8 Helm upgrade guide for Identity migration examples.

## Changes

- Corrected the `OIDC` example under `Identity migration (recommended)` so `identity` is properly nested under `orchestration.migration`
- Corrected the `OAuth with Keycloak` example so `identity` is properly nested under `migration`

## Validation

- Verified the corrected `OIDC` structure matches the larger migration example earlier in the same guide

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
