### PR TITLE
update zeebe gateway usage

### DIFF
--- a/docs/apis-tools/camunda-spring-boot-starter/configuration.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/configuration.md
@@ -84,7 +84,7 @@ The connection to Camunda API is determined by `camunda.client.grpc-address` and
 
 #### gRPC address
 
-Define the address of the [gRPC API](/apis-tools/zeebe-api/grpc.md) exposed by the [Zeebe Gateway](/self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md):
+Define the address of the [gRPC API](/apis-tools/zeebe-api/grpc.md) exposed by the [Zeebe Gateway](/reference/glossary.md#zeebe-gateway):
 
 ```yaml
 camunda:
@@ -98,7 +98,7 @@ You must add the `http://` scheme to the URL to avoid a `java.lang.NullPointerEx
 
 #### REST address
 
-Define address of the [Orchestration Cluster REST API](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md) exposed by the [Zeebe Gateway](/self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md):
+Define address of the [Orchestration Cluster REST API](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md) exposed by the Zeebe Gateway:
 
 ```yaml
 camunda:

--- a/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
+++ b/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
@@ -145,7 +145,7 @@ In the Camunda Console, go to your cluster, and in the Cluster Details, find you
 
 #### Self-Managed
 
-Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is `http://localhost:8080/v2/`.
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For Ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is `http://localhost:8080/v2/`.
 
 ### Versioning
 

--- a/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
+++ b/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
@@ -145,7 +145,7 @@ In the Camunda Console, go to your cluster, and in the Cluster Details, find you
 
 #### Self-Managed
 
-Use the host and path defined in your Zeebe Gateway [configuration](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is: `http://localhost:8080/v2/`
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is `http://localhost:8080/v2/`.
 
 ### Versioning
 

--- a/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-swagger.md
+++ b/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-swagger.md
@@ -42,13 +42,13 @@ If your Region ID is `bru-2` and Cluster ID is `abc123-def456-ghi789`, your Swag
 
 ### Self-Managed
 
-For Self-Managed deployments, Swagger UI is available at your configured Zeebe Gateway endpoint.
+For Self-Managed deployments, Swagger UI is available at your configured [Zeebe Gateway](/reference/glossary.md#zeebe-gateway) endpoint.
 
 **Default setup:**
 `http://localhost:8080/swagger`
 
 **Custom configuration:**
-Use the host and path defined in your Zeebe Gateway [configuration](/self-managed/deployment/helm/configure/ingress/ingress-setup.md), then append `/swagger`.
+Use the host and path defined for your Zeebe Gateway in the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md), then append `/swagger`.
 
 **Example with custom domain:**
 `https://your-zeebe-gateway.company.com/swagger`

--- a/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -22,7 +22,7 @@ Example path: `https://${REGION}.api.camunda.io:443/${CLUSTER_ID}/v1/`
 
 ### Self-Managed
 
-The context path should match the host and path defined in your Zeebe Gateway [configuration](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
 
 Example path: `http://localhost:8080/v1/`
 

--- a/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/docs/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -22,7 +22,7 @@ Example path: `https://${REGION}.api.camunda.io:443/${CLUSTER_ID}/v1/`
 
 ### Self-Managed
 
-Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For Ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
 
 Example path: `http://localhost:8080/v1/`
 

--- a/docs/components/concepts/conditionals.md
+++ b/docs/components/concepts/conditionals.md
@@ -131,7 +131,7 @@ The behavior of conditional boundary events depends on where the variable is upd
 You can evaluate root-level conditional start events by using:
 
 - The Orchestration Cluster REST API. See [evaluate root-level conditional start events](../../apis-tools/orchestration-cluster-api-rest/specifications/evaluate-conditionals.api.mdx).
-- The Zeebe gateway gRPC API. See [`EvaluateConditional` RPC](../../apis-tools/zeebe-api/gateway-service.md#evaluateconditional-rpc).
+- The [Zeebe Gateway](/reference/glossary.md#zeebe-gateway) gRPC API. See [`EvaluateConditional` RPC](../../apis-tools/zeebe-api/gateway-service.md#evaluateconditional-rpc).
 - Client SDKs. For example, use `newEvaluateConditionalCommand()` in the Java client.
 
 When you evaluate conditional start events:

--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -761,7 +761,7 @@ A [critical bug in 8.9-alpha5](https://github.com/camunda/camunda/issues/47955) 
 
 The Operate, Tasklist, and Identity application profiles are now merged into the existing gateway profile to provide a simplified but flexible deployment model.
 
-- These components are now treated as UIs served by the gateway.
+- These components are now treated as UIs served by the Zeebe Gateway.
 - Control their inclusion via configuration properties (for example, `camunda.webapps.enabled=operate,identity`).
 
 #### Amazon ECS (EC2+Fargate) support

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -261,7 +261,11 @@ In a clustered environment, a [broker](#zeebe-broker) which is not a [leader](#l
 
 ### Gateway
 
-See [Zeebe Gateway](#zeebe-gateway).
+Gateway can refer to different concepts in Camunda docs, depending on the context:
+
+- In BPMN, a gateway controls how a process flow branches, merges, or synchronizes.
+- In runtime and API contexts, the [Zeebe Gateway](#zeebe-gateway) is the component that exposes APIs and routes requests to Zeebe brokers.
+- In Kubernetes deployment docs, Gateway can also refer to Kubernetes Gateway API resources.
 
 ### Generative AI
 
@@ -751,4 +755,4 @@ The Zeebe Exporter system provides an event stream of state changes within Zeebe
 
 The Zeebe Gateway is a component of the [Zeebe cluster](#zeebe-cluster); it can be considered the contact point for the Zeebe cluster that allows [Zeebe clients](#zeebe-client) to communicate with [Zeebe brokers](#zeebe-broker) inside a Zeebe cluster.
 
-- [Zeebe Gateway](self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md)
+- [Zeebe Gateway](/self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md)

--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -900,8 +900,8 @@ When parsing unknown fields in the Protobuf Java Lite and Full library, a malici
 program crash.
 
 - As Zeebe makes extensive use of Protobuf, this could lead to denial-of-service (DoS) issues on the server side.
-- This issue allows an attacker to send specific payloads that will always result in `StackOverflowException`. This could lead to gateway performance issues and affect system availability.
-- Although the gateway will not crash, it will spend more time working on these requests. An attacker could use this opportunity to slow it down and make it unusable by sending a large number of requests within a short time frame.
+- This issue allows an attacker to send specific payloads that will always result in `StackOverflowException`. This could lead to Zeebe Gateway performance issues and affect system availability.
+- Although the Zeebe Gateway will not crash, it will spend more time working on these requests. An attacker could use this opportunity to slow it down and make it unusable by sending a large number of requests within a short time frame.
 
 No data is leaked, lost, or corrupted. This issue only affects application availability.
 
@@ -929,7 +929,7 @@ Camunda Zeebe
 
 ### Impact
 
-Some Camunda Zeebe versions were affected by a vulnerability that allowed a malicious attacker to craft network packets that could crash the gateway.
+Some Camunda Zeebe versions were affected by a vulnerability that allowed a malicious attacker to craft network packets that could crash the Zeebe Gateway.
 
 ### How to determine if the installation is affected
 

--- a/docs/self-managed/components/connectors/connectors-configuration.md
+++ b/docs/self-managed/components/connectors/connectors-configuration.md
@@ -61,7 +61,7 @@ camunda:
 
 ### HTTPS configuration
 
-If using an HTTPS connection, you may need to provide a certificate to validate the gateway's certificate chain.
+If using an HTTPS connection, you may need to provide a certificate to validate the Zeebe Gateway's certificate chain.
 
 <Tabs groupId="https-config" defaultValue="environment-variables" queryString values={[
 {label: 'Environment variables', value: 'environment-variables' },
@@ -311,11 +311,11 @@ When no prefix is configured, the connector runtime logs a warning that this mod
 
 The following environment variables can be used to configure the default secret provider:
 
-| Name                                                      | Description                                                                                                                                                       | Default value |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`    | Whether the default secret provider is enabled.                                                                                                                   | `true`        |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`     | Prefix applied to the secret name before lookup. Only environment variables starting with this prefix are available as secrets. Set to empty to disable (unsafe). | `SECRET_`     |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE`| Whether the secret provider should be tenant-aware.                                                                                                               | `false`       |
+| Name                                                       | Description                                                                                                                                                       | Default value |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`     | Whether the default secret provider is enabled.                                                                                                                   | `true`        |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`      | Prefix applied to the secret name before lookup. Only environment variables starting with this prefix are available as secrets. Set to empty to disable (unsafe). | `SECRET_`     |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE` | Whether the secret provider should be tenant-aware.                                                                                                               | `false`       |
 
 If the secret provider is set to be tenant-aware, the secret format will change to `${prefix}${tenantId}_${secretName}`:
 

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md
@@ -6,7 +6,7 @@ description: "Scale an existing cluster by adding or removing brokers."
 
 Zeebe allows scaling an existing cluster by adding or removing brokers and by adding new partitions. Partitions are automatically redistributed over the set of brokers to spread the load evenly.
 
-Zeebe provides a REST API to manage the cluster scaling. The cluster management API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#actuator.endpoints). This is accessible via the management port of the gateway.
+Zeebe provides a REST API to manage the cluster scaling. The cluster management API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#actuator.endpoints). This is accessible via the management port of the Zeebe Gateway.
 
 :::important
 

--- a/docs/self-managed/components/orchestration-cluster/zeebe/security/secure-client-communication.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/security/secure-client-communication.md
@@ -53,7 +53,7 @@ server:
 
 ## Clients
 
-Unlike the gateway, TLS is enabled by default in all of Zeebe's supported clients. The following sections show how to disable or properly configure each client.
+Unlike the Zeebe Gateway, TLS is enabled by default in all of Zeebe's supported clients. The following sections show how to disable or properly configure each client.
 
 :::note
 Disabling TLS should only be done for testing or development. During production deployments, clients and gateways should be properly configured to establish secure connections.
@@ -61,7 +61,7 @@ Disabling TLS should only be done for testing or development. During production 
 
 ### Java
 
-Without any configuration, the client looks in the system's certificate store for a CA certificate with which to validate the gateway's certificate chain. If you wish to use TLS without having to install a certificate in client's system, you can specify a CA certificate:
+Without any configuration, the client looks in the system's certificate store for a CA certificate with which to validate the Zeebe Gateway's certificate chain. If you wish to use TLS without having to install a certificate in client's system, you can specify a CA certificate:
 
 ```java
 public class SecureClient {

--- a/docs/self-managed/deployment/helm/install/quick-install.md
+++ b/docs/self-managed/deployment/helm/install/quick-install.md
@@ -135,25 +135,26 @@ Starting with Camunda 8.9, the Helm chart no longer provisions Elasticsearch by 
 
    **Verify the installation:**
 
-   Test the Zeebe Gateway HTTP endpoint (Orchestration Cluster REST API):
+Test the [Zeebe Gateway](/reference/glossary.md#zeebe-gateway) HTTP endpoint (Orchestration Cluster REST API):
 
-   ```bash
-   curl -u demo:demo http://localhost:8080/v2/topology
-   ```
+```bash
+curl -u demo:demo http://localhost:8080/v2/topology
+```
 
-   You should see a JSON response with the cluster topology information.
+You should see a JSON response with the cluster topology information.
 
-   Available services:
-   - **Operate:** [http://localhost:8080/operate](http://localhost:8080/operate) - Monitor process instances
-   - **Tasklist:** [http://localhost:8080/tasklist](http://localhost:8080/tasklist) - Complete user tasks
-   - **Admin:** [http://localhost:8080/admin](http://localhost:8080/admin) - User and permission management
-   - **Connectors:** [http://localhost:8088](http://localhost:8088) - External system integrations
-   - **Zeebe Gateway (gRPC):** localhost:26500 - Process deployment and execution
-   - **Zeebe Gateway (HTTP):** [http://localhost:8080](http://localhost:8080) - Orchestration Cluster REST API
+Available services:
 
-   :::note
-   In Camunda 8.8+, Operate, Tasklist, and Admin are integrated into the Orchestration Cluster and share the same endpoint (port 8080).
-   :::
+- **Operate:** [http://localhost:8080/operate](http://localhost:8080/operate) - Monitor process instances
+- **Tasklist:** [http://localhost:8080/tasklist](http://localhost:8080/tasklist) - Complete user tasks
+- **Admin:** [http://localhost:8080/admin](http://localhost:8080/admin) - User and permission management
+- **Connectors:** [http://localhost:8088](http://localhost:8088) - External system integrations
+- **Zeebe Gateway (gRPC):** localhost:26500 - Process deployment and execution
+- **Zeebe Gateway (HTTP):** [http://localhost:8080](http://localhost:8080) - Orchestration Cluster REST API
+
+:::note
+In Camunda 8.8+, Operate, Tasklist, and Admin are integrated into the Orchestration Cluster and share the same endpoint (port 8080).
+:::
 
 ## Full Cluster
 

--- a/docs/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
+++ b/docs/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
@@ -173,7 +173,7 @@ desired={<img src={Five} alt="Desired state diagram" style={{border: 'none', tra
 
 #### Procedure
 
-Start with creating a port-forward to the `Zeebe Gateway` in the surviving region to the local host to interact with the Gateway.
+Start with creating a port-forward to the `Zeebe Gateway` in the surviving region to the local host so you can interact with the Zeebe Gateway.
 
 The following alternatives to port-forwarding are possible:
 

--- a/docs/self-managed/operational-guides/backup-restore/zeebe-backup-and-restore.md
+++ b/docs/self-managed/operational-guides/backup-restore/zeebe-backup-and-restore.md
@@ -17,7 +17,7 @@ Back up a running Zeebe cluster using the Backup Management API.
 A backup of a Zeebe cluster comprises a consistent snapshot of all partitions. The backup is taken asynchronously in the background while Zeebe is processing. Thus, backups can be taken with minimal impact on typical processing. Backups can be used to restore a cluster in case of failures that lead to full data loss or data corruption.
 
 Zeebe provides a REST API to create, query, and manage backups.
-The backup management API is a custom endpoint `backups`, available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints). It is accessible via the management port of the gateway. The API documentation is also available as an [OpenAPI specification](https://github.com/camunda/camunda/blob/main/dist/src/main/resources/api/backup-management-api.yaml).
+The backup management API is a custom endpoint `backups`, available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints). It is accessible via the management port of the Zeebe Gateway. The API documentation is also available as an [OpenAPI specification](https://github.com/camunda/camunda/blob/main/dist/src/main/resources/api/backup-management-api.yaml).
 
 :::warning
 Usage of this API requires the backup store to be configured for the component.

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/configuration.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/configuration.md
@@ -84,7 +84,7 @@ The connection to Camunda API is determined by `camunda.client.grpc-address` and
 
 #### gRPC address
 
-Define the address of the [gRPC API](/apis-tools/zeebe-api/grpc.md) exposed by the [Zeebe Gateway](/self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md):
+Define the address of the [gRPC API](/apis-tools/zeebe-api/grpc.md) exposed by the [Zeebe Gateway](/reference/glossary.md#zeebe-gateway):
 
 ```yaml
 camunda:
@@ -98,7 +98,7 @@ You must add the `http://` scheme to the URL to avoid a `java.lang.NullPointerEx
 
 #### REST address
 
-Define address of the [Orchestration Cluster REST API](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md) exposed by the [Zeebe Gateway](/self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md):
+Define address of the [Orchestration Cluster REST API](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md) exposed by the Zeebe Gateway:
 
 ```yaml
 camunda:

--- a/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
+++ b/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
@@ -145,7 +145,7 @@ In the Camunda Console, go to your cluster, and in the Cluster Details, find you
 
 #### Self-Managed
 
-Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is `http://localhost:8080/v2/`.
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For Ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is `http://localhost:8080/v2/`.
 
 ### Versioning
 

--- a/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
+++ b/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md
@@ -145,7 +145,7 @@ In the Camunda Console, go to your cluster, and in the Cluster Details, find you
 
 #### Self-Managed
 
-Use the host and path defined in your Zeebe Gateway [configuration](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is: `http://localhost:8080/v2/`
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). If you're using the default setup, the `${BASE_URL}` is `http://localhost:8080/v2/`.
 
 ### Versioning
 

--- a/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-swagger.md
+++ b/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-swagger.md
@@ -42,13 +42,13 @@ If your Region ID is `bru-2` and Cluster ID is `abc123-def456-ghi789`, your Swag
 
 ### Self-Managed
 
-For Self-Managed deployments, Swagger UI is available at your configured Zeebe Gateway endpoint.
+For Self-Managed deployments, Swagger UI is available at your configured [Zeebe Gateway](/reference/glossary.md#zeebe-gateway) endpoint.
 
 **Default setup:**
 `http://localhost:8080/swagger`
 
 **Custom configuration:**
-Use the host and path defined in your Zeebe Gateway [configuration](/self-managed/deployment/helm/configure/ingress/ingress-setup.md), then append `/swagger`.
+Use the host and path defined for your Zeebe Gateway in the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md), then append `/swagger`.
 
 **Example with custom domain:**
 `https://your-zeebe-gateway.company.com/swagger`

--- a/versioned_docs/version-8.9/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/versioned_docs/version-8.9/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -22,7 +22,7 @@ Example path: `https://${REGION}.api.camunda.io:443/${CLUSTER_ID}/v1/`
 
 ### Self-Managed
 
-The context path should match the host and path defined in your Zeebe Gateway [configuration](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
 
 Example path: `http://localhost:8080/v1/`
 

--- a/versioned_docs/version-8.9/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
+++ b/versioned_docs/version-8.9/apis-tools/zeebe-api-rest/zeebe-api-rest-overview.md
@@ -22,7 +22,7 @@ Example path: `https://${REGION}.api.camunda.io:443/${CLUSTER_ID}/v1/`
 
 ### Self-Managed
 
-Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
+Use the host and path defined for your [Zeebe Gateway](/reference/glossary.md#zeebe-gateway). For Ingress and routing details, see the [configuration guide](/self-managed/deployment/helm/configure/ingress/ingress-setup.md). The path used here is the default.
 
 Example path: `http://localhost:8080/v1/`
 

--- a/versioned_docs/version-8.9/components/concepts/conditionals.md
+++ b/versioned_docs/version-8.9/components/concepts/conditionals.md
@@ -131,7 +131,7 @@ The behavior of conditional boundary events depends on where the variable is upd
 You can evaluate root-level conditional start events by using:
 
 - The Orchestration Cluster REST API. See [evaluate root-level conditional start events](../../apis-tools/orchestration-cluster-api-rest/specifications/evaluate-conditionals.api.mdx).
-- The Zeebe gateway gRPC API. See [`EvaluateConditional` RPC](../../apis-tools/zeebe-api/gateway-service.md#evaluateconditional-rpc).
+- The [Zeebe Gateway](/reference/glossary.md#zeebe-gateway) gRPC API. See [`EvaluateConditional` RPC](../../apis-tools/zeebe-api/gateway-service.md#evaluateconditional-rpc).
 - Client SDKs. For example, use `newEvaluateConditionalCommand()` in the Java client.
 
 When you evaluate conditional start events:

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -757,7 +757,7 @@ A [critical bug in 8.9-alpha5](https://github.com/camunda/camunda/issues/47955) 
 
 The Operate, Tasklist, and Identity application profiles are now merged into the existing gateway profile to provide a simplified but flexible deployment model.
 
-- These components are now treated as UIs served by the gateway.
+- These components are now treated as UIs served by the Zeebe Gateway.
 - Control their inclusion via configuration properties (for example, `camunda.webapps.enabled=operate,identity`).
 
 #### Amazon ECS (EC2+Fargate) support

--- a/versioned_docs/version-8.9/reference/glossary.md
+++ b/versioned_docs/version-8.9/reference/glossary.md
@@ -255,7 +255,11 @@ In a clustered environment, a [broker](#zeebe-broker) which is not a [leader](#l
 
 ### Gateway
 
-See [Zeebe Gateway](#zeebe-gateway).
+Gateway can refer to different concepts in Camunda docs, depending on the context:
+
+- In BPMN, a gateway controls how a process flow branches, merges, or synchronizes.
+- In runtime and API contexts, the [Zeebe Gateway](#zeebe-gateway) is the component that exposes APIs and routes requests to Zeebe brokers.
+- In Kubernetes deployment docs, Gateway can also refer to Kubernetes Gateway API resources.
 
 ### Generative AI
 
@@ -733,4 +737,4 @@ The Zeebe Exporter system provides an event stream of state changes within Zeebe
 
 The Zeebe Gateway is a component of the [Zeebe cluster](#zeebe-cluster); it can be considered the contact point for the Zeebe cluster that allows [Zeebe clients](#zeebe-client) to communicate with [Zeebe brokers](#zeebe-broker) inside a Zeebe cluster.
 
-- [Zeebe Gateway](self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md)
+- [Zeebe Gateway](/self-managed/components/orchestration-cluster/zeebe/zeebe-gateway/zeebe-gateway-overview.md)

--- a/versioned_docs/version-8.9/reference/notices.md
+++ b/versioned_docs/version-8.9/reference/notices.md
@@ -900,8 +900,8 @@ When parsing unknown fields in the Protobuf Java Lite and Full library, a malici
 program crash.
 
 - As Zeebe makes extensive use of Protobuf, this could lead to denial-of-service (DoS) issues on the server side.
-- This issue allows an attacker to send specific payloads that will always result in `StackOverflowException`. This could lead to gateway performance issues and affect system availability.
-- Although the gateway will not crash, it will spend more time working on these requests. An attacker could use this opportunity to slow it down and make it unusable by sending a large number of requests within a short time frame.
+- This issue allows an attacker to send specific payloads that will always result in `StackOverflowException`. This could lead to Zeebe Gateway performance issues and affect system availability.
+- Although the Zeebe Gateway will not crash, it will spend more time working on these requests. An attacker could use this opportunity to slow it down and make it unusable by sending a large number of requests within a short time frame.
 
 No data is leaked, lost, or corrupted. This issue only affects application availability.
 
@@ -929,7 +929,7 @@ Camunda Zeebe
 
 ### Impact
 
-Some Camunda Zeebe versions were affected by a vulnerability that allowed a malicious attacker to craft network packets that could crash the gateway.
+Some Camunda Zeebe versions were affected by a vulnerability that allowed a malicious attacker to craft network packets that could crash the Zeebe Gateway.
 
 ### How to determine if the installation is affected
 

--- a/versioned_docs/version-8.9/self-managed/components/connectors/connectors-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/connectors/connectors-configuration.md
@@ -61,7 +61,7 @@ camunda:
 
 ### HTTPS configuration
 
-If using an HTTPS connection, you may need to provide a certificate to validate the gateway's certificate chain.
+If using an HTTPS connection, you may need to provide a certificate to validate the Zeebe Gateway's certificate chain.
 
 <Tabs groupId="https-config" defaultValue="environment-variables" queryString values={[
 {label: 'Environment variables', value: 'environment-variables' },
@@ -311,10 +311,10 @@ When no prefix is configured, the connector runtime logs a warning that this mod
 
 The following environment variables can be used to configure the default secret provider:
 
-| Name                                                      | Description                                                                                                                                                       | Default value |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`    | Whether the default secret provider is enabled.                                                                                                                   | `true`        |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`     | Prefix applied to the secret name before lookup. Only environment variables starting with this prefix are available as secrets. Set to empty to disable (unsafe). | `SECRET_`     |
+| Name                                                       | Description                                                                                                                                                       | Default value |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`     | Whether the default secret provider is enabled.                                                                                                                   | `true`        |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`      | Prefix applied to the secret name before lookup. Only environment variables starting with this prefix are available as secrets. Set to empty to disable (unsafe). | `SECRET_`     |
 | `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE` | Whether the secret provider should be tenant-aware.                                                                                                               | `false`       |
 
 If the secret provider is set to be tenant-aware, the secret format will change to `${prefix}${tenantId}_${secretName}`:

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md
@@ -6,7 +6,7 @@ description: "Scale an existing cluster by adding or removing brokers."
 
 Zeebe allows scaling an existing cluster by adding or removing brokers and by adding new partitions. Partitions are automatically redistributed over the set of brokers to spread the load evenly.
 
-Zeebe provides a REST API to manage the cluster scaling. The cluster management API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#actuator.endpoints). This is accessible via the management port of the gateway.
+Zeebe provides a REST API to manage the cluster scaling. The cluster management API is a custom endpoint available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/3.1.x/reference/htmlsingle/#actuator.endpoints). This is accessible via the management port of the Zeebe Gateway.
 
 :::important
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/security/secure-client-communication.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/security/secure-client-communication.md
@@ -53,7 +53,7 @@ server:
 
 ## Clients
 
-Unlike the gateway, TLS is enabled by default in all of Zeebe's supported clients. The following sections show how to disable or properly configure each client.
+Unlike the Zeebe Gateway, TLS is enabled by default in all of Zeebe's supported clients. The following sections show how to disable or properly configure each client.
 
 :::note
 Disabling TLS should only be done for testing or development. During production deployments, clients and gateways should be properly configured to establish secure connections.
@@ -61,7 +61,7 @@ Disabling TLS should only be done for testing or development. During production 
 
 ### Java
 
-Without any configuration, the client looks in the system's certificate store for a CA certificate with which to validate the gateway's certificate chain. If you wish to use TLS without having to install a certificate in client's system, you can specify a CA certificate:
+Without any configuration, the client looks in the system's certificate store for a CA certificate with which to validate the Zeebe Gateway's certificate chain. If you wish to use TLS without having to install a certificate in client's system, you can specify a CA certificate:
 
 ```java
 public class SecureClient {

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/install/quick-install.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/install/quick-install.md
@@ -135,25 +135,26 @@ Starting with Camunda 8.9, the Helm chart no longer provisions Elasticsearch by 
 
    **Verify the installation:**
 
-   Test the Zeebe Gateway HTTP endpoint (Orchestration Cluster REST API):
+Test the [Zeebe Gateway](/reference/glossary.md#zeebe-gateway) HTTP endpoint (Orchestration Cluster REST API):
 
-   ```bash
-   curl -u demo:demo http://localhost:8080/v2/topology
-   ```
+```bash
+curl -u demo:demo http://localhost:8080/v2/topology
+```
 
-   You should see a JSON response with the cluster topology information.
+You should see a JSON response with the cluster topology information.
 
-   Available services:
-   - **Operate:** [http://localhost:8080/operate](http://localhost:8080/operate) - Monitor process instances
-   - **Tasklist:** [http://localhost:8080/tasklist](http://localhost:8080/tasklist) - Complete user tasks
-   - **Admin:** [http://localhost:8080/admin](http://localhost:8080/admin) - User and permission management
-   - **Connectors:** [http://localhost:8088](http://localhost:8088) - External system integrations
-   - **Zeebe Gateway (gRPC):** localhost:26500 - Process deployment and execution
-   - **Zeebe Gateway (HTTP):** [http://localhost:8080](http://localhost:8080) - Orchestration Cluster REST API
+Available services:
 
-   :::note
-   In Camunda 8.8+, Operate, Tasklist, and Admin are integrated into the Orchestration Cluster and share the same endpoint (port 8080).
-   :::
+- **Operate:** [http://localhost:8080/operate](http://localhost:8080/operate) - Monitor process instances
+- **Tasklist:** [http://localhost:8080/tasklist](http://localhost:8080/tasklist) - Complete user tasks
+- **Admin:** [http://localhost:8080/admin](http://localhost:8080/admin) - User and permission management
+- **Connectors:** [http://localhost:8088](http://localhost:8088) - External system integrations
+- **Zeebe Gateway (gRPC):** localhost:26500 - Process deployment and execution
+- **Zeebe Gateway (HTTP):** [http://localhost:8080](http://localhost:8080) - Orchestration Cluster REST API
+
+:::note
+In Camunda 8.8+, Operate, Tasklist, and Admin are integrated into the Orchestration Cluster and share the same endpoint (port 8080).
+:::
 
 ## Full Cluster
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
@@ -173,7 +173,7 @@ desired={<img src={Five} alt="Desired state diagram" style={{border: 'none', tra
 
 #### Procedure
 
-Start with creating a port-forward to the `Zeebe Gateway` in the surviving region to the local host to interact with the Gateway.
+Start with creating a port-forward to the `Zeebe Gateway` in the surviving region to the local host so you can interact with the Zeebe Gateway.
 
 The following alternatives to port-forwarding are possible:
 

--- a/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/zeebe-backup-and-restore.md
+++ b/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/zeebe-backup-and-restore.md
@@ -17,7 +17,7 @@ Back up a running Zeebe cluster using the Backup Management API.
 A backup of a Zeebe cluster comprises a consistent snapshot of all partitions. The backup is taken asynchronously in the background while Zeebe is processing. Thus, backups can be taken with minimal impact on typical processing. Backups can be used to restore a cluster in case of failures that lead to full data loss or data corruption.
 
 Zeebe provides a REST API to create, query, and manage backups.
-The backup management API is a custom endpoint `backups`, available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints). It is accessible via the management port of the gateway. The API documentation is also available as an [OpenAPI specification](https://github.com/camunda/camunda/blob/main/dist/src/main/resources/api/backup-management-api.yaml).
+The backup management API is a custom endpoint `backups`, available via [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#actuator.endpoints). It is accessible via the management port of the Zeebe Gateway. The API documentation is also available as an [OpenAPI specification](https://github.com/camunda/camunda/blob/main/dist/src/main/resources/api/backup-management-api.yaml).
 
 :::warning
 Usage of this API requires the backup store to be configured for the component.


### PR DESCRIPTION
## Summary

Clarify ambiguous uses of "gateway" in authored documentation and update beginner-facing pages to use "Zeebe Gateway" where that specific runtime component is meant.

This PR also:
- adds glossary clarification for `Gateway` and `Zeebe Gateway`
- links the first Zeebe Gateway reference in beginner-facing docs to the glossary
- normalizes lowercase `Zeebe gateway` to `Zeebe Gateway`

These changes are applied in both Next and 8.9 docs.

Closes https://github.com/camunda/documentation-team/issues/420.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
