### PR TITLE
Explain how to assign a value to a variable with FEEL

### DIFF
--- a/docs/components/modeler/feel/language-guide/feel-variables.md
+++ b/docs/components/modeler/feel/language-guide/feel-variables.md
@@ -12,6 +12,8 @@ Learn how to access variables, follow valid variable naming rules, and safely us
 
 Access the value of a variable by its [variable name](#variable-names).
 
+FEEL doesn't use a separate assignment operator to create or update process variables. Instead, FEEL evaluates variables that are already available in the current context, or you can define local values with [context entries](/components/modeler/feel/language-guide/feel-context-expressions.md).
+
 ```feel
 a + b
 ```

--- a/versioned_docs/version-8.9/components/modeler/feel/language-guide/feel-variables.md
+++ b/versioned_docs/version-8.9/components/modeler/feel/language-guide/feel-variables.md
@@ -12,6 +12,8 @@ Learn how to access variables, follow valid variable naming rules, and safely us
 
 Access the value of a variable by its [variable name](#variable-names).
 
+FEEL doesn't use a separate assignment operator to create or update process variables. Instead, FEEL evaluates variables that are already available in the current context, or you can define local values with [context entries](/components/modeler/feel/language-guide/feel-context-expressions.md).
+
 ```feel
 a + b
 ```


### PR DESCRIPTION
## Summary

Add a short explanation to the FEEL variables guide about how variable values are assigned.

This update clarifies that FEEL does not use a separate assignment operator to create or update process variables. Instead, FEEL evaluates variables that are already available in the current context, and local values can be defined with context entries.

These changes are applied in both Next and 8.9 docs.

Closes https://github.com/camunda/camunda-docs/issues/5410.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
