### PR TITLE
fix design of hover feature

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1878,6 +1878,8 @@ ul ul .table-of-contents__link--active {
   display: inline;
   position: relative;
   --glossary-term-accent: var(--ifm-color-primary);
+  --glossary-term-arrow-size: 0.75rem;
+  --glossary-term-arrow-overlap: 0.375rem;
 }
 
 .glossary-term__link {
@@ -1916,10 +1918,10 @@ ul ul .table-of-contents__link--active {
 .glossary-term__tooltip::after {
   content: "";
   position: absolute;
-  top: 100%;
+  top: calc(100% - var(--glossary-term-arrow-overlap));
   left: 50%;
-  width: 0.75rem;
-  height: 0.75rem;
+  width: var(--glossary-term-arrow-size);
+  height: var(--glossary-term-arrow-size);
   border-right: 1px solid var(--glossary-term-accent);
   border-bottom: 1px solid var(--glossary-term-accent);
   background: var(--ifm-background-surface-color);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1941,8 +1941,9 @@ ul ul .table-of-contents__link--active {
 
 [data-theme="dark"] .glossary-term__link {
   font-weight: 600;
-  text-decoration-thickness: auto;
-  text-underline-offset: auto;
+  text-decoration: underline dotted currentColor;
+  text-decoration-thickness: 0.07em;
+  text-underline-offset: 0.12em;
 }
 
 .glossary-term:focus-within .glossary-term__tooltip {


### PR DESCRIPTION
## Description

Fix the glossary hover tooltip arrow so it visually connects to the tooltip box. I also updated the underline in dark mode so it's dotted, like in light mode.

This PR adjusts the glossary tooltip styling to remove the gap between the highlighted term's caret and the tooltip container.

- This is a CSS-only change

From this and this:

<img width="388" height="177" alt="Screenshot 2026-05-13 at 7 30 38 AM" src="https://github.com/user-attachments/assets/ba4bbd71-2095-496a-92d6-be4c4844710f" /> 
<img width="83" height="50" alt="Screenshot 2026-05-13 at 7 34 32 AM" src="https://github.com/user-attachments/assets/eb6c2872-0a9d-4fc5-a4a0-da94540f6859" />

To this and this:

<img width="380" height="186" alt="Screenshot 2026-05-13 at 7 30 56 AM" src="https://github.com/user-attachments/assets/9b0a2768-ee1f-402a-ab22-d4f3963eed58" /> 
<img width="91" height="58" alt="Screenshot 2026-05-13 at 7 34 53 AM" src="https://github.com/user-attachments/assets/251c441d-d6de-4179-a87e-a0b02b01df83" />

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
