### PR TITLE
Fix migration manual for Camunda 8.9

### DIFF
--- a/docs/apis-tools/migration-manuals/migrate-to-89.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-89.md
@@ -45,11 +45,11 @@ If you already performed these migrations during your 8.8 upgrade, proceed to [C
 
 | 8.9 status                                                 | Component/Use                                                                                                           | Migrate to                  | Migrate by          |
 | :--------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :-------------------------- | :------------------ |
-| <span className="label-highlight yellow">Deprecated</span> | [V1 component APIs](../migration-manuals/migrate-to-camunda-api.md)                                                     | Orchestration Cluster API   | Before Camunda 8.10 |
-| <span className="label-highlight yellow">Deprecated</span> | [ZeebeClient](/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-to-camunda-java-client.md)               | Camunda Java Client         | Before Camunda 8.10 |
-| <span className="label-highlight yellow">Deprecated</span> | [Spring Zeebe SDK](/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-to-camunda-process-test.md)         | Camunda Spring Boot Starter | Before Camunda 8.10 |
-| <span className="label-highlight yellow">Deprecated</span> | [Zeebe Process Test (ZPT)](/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-to-camunda-process-test.md) | Camunda Process Test (CPT)  | Before Camunda 8.10 |
-| <span className="label-highlight yellow">Deprecated</span> | [Job-based user tasks](/versioned_docs/version-8.8/apis-tools/migration-manuals/migrate-to-camunda-user-tasks.md)       | Camunda user tasks          | Before Camunda 8.10 |
+| <span className="label-highlight yellow">Deprecated</span> | [V1 component APIs](../migration-manuals/migrate-to-camunda-api.md)                 | Orchestration Cluster API   | Before Camunda 8.10 |
+| <span className="label-highlight yellow">Deprecated</span> | [ZeebeClient](../migration-manuals/migrate-to-camunda-java-client.md)               | Camunda Java Client         | Before Camunda 8.10 |
+| <span className="label-highlight yellow">Deprecated</span> | [Spring Zeebe SDK](../migration-manuals/migrate-to-camunda-spring-boot-starter.md)  | Camunda Spring Boot Starter | Before Camunda 8.10 |
+| <span className="label-highlight yellow">Deprecated</span> | [Zeebe Process Test (ZPT)](../migration-manuals/migrate-to-camunda-process-test.md) | Camunda Process Test (CPT)  | Before Camunda 8.10 |
+| <span className="label-highlight yellow">Deprecated</span> | [Job-based user tasks](../migration-manuals/migrate-to-camunda-user-tasks.md)       | Camunda user tasks          | Before Camunda 8.10 |
 
 :::tip
 Learn more about API changes in the blog post [Upcoming API Changes in Camunda 8: A Unified and Streamlined Experience](https://camunda.com/blog/2024/12/api-changes-in-camunda-8-a-unified-and-streamlined-experience/).


### PR DESCRIPTION
This PR fixes two things:
1. The link to "Camunda Spring Boot Starter" was mistakenly going to "Camunda Process Test (CPT)"
2. Most of the linkes were hard-coded linked to the documentation of Version 8.8. I replaced those with relative links.

Please also merge this to to 8.9 docs (only fixing "next" here in the PR). 8.8 and older are not affected.

This PR is ready for review

@christinaausley : I cannot set the assignee - therefore I'm tagging you here. 