### PR TITLE
Update build-with-camunda page for released Camunda skills

### DIFF
--- a/src/pages/build-with-camunda.js
+++ b/src/pages/build-with-camunda.js
@@ -559,8 +559,7 @@ function BuildWithCamunda() {
               <Link to={useBaseUrl("docs/apis-tools/c8ctl/getting-started/")}>
                 <CodeBlock>c8ctl</CodeBlock>
               </Link>{" "}
-              from npm and spin up a Self-Managed Camunda cluster on your
-              machine.
+              from npm and spin up a Self-Managed cluster on your machine.
             </p>
           </div>
           <div
@@ -906,16 +905,16 @@ $ claude plugin install camunda-skills@camunda-skills
 
 Available skills:
   /camunda-c8ctl                   — install and configure c8ctl
+  /camunda-ai-agent                — build AI agents in BPMN
   /camunda-bpmn                    — create and edit BPMN 2.0 processes
+  /camunda-connectors              — configure pre-built connectors
+  /camunda-connectors-development  — build custom connectors
+  /camunda-development             — choose the integration type
+  /camunda-docs                    — search the Camunda 8 docs
   /camunda-feel                    — write and debug FEEL expressions
   /camunda-forms                   — create Camunda Form schemas
-  /camunda-connectors              — configure pre-built connectors
-  /camunda-development             — pick the right development surface
   /camunda-job-workers             — implement job workers (Java, Spring, TypeScript)
-  /camunda-connectors-development  — build custom connectors
-  /camunda-process-mgmt            — deploy, operate, and debug processes
-  /camunda-ai-agent                — build AI agents in BPMN
-  /camunda-docs                    — look up the Camunda 8 docs`}
+  /camunda-process-mgmt            — deploy, operate, and debug processes`}
               </TerminalWindow>
             </div>
             <div className={styles.aiCard}>
@@ -982,8 +981,8 @@ Available skills:
               </div>
               <div className={styles.aiExampleItem}>
                 <span className={styles.aiPromptIcon}>💬</span>
-                "Build an AI agent that triages customer support tickets and
-                routes them to the right team"
+                "Build an AI agent to triage and route customer support tickets
+                to the correct team"
               </div>
               <div className={styles.aiExampleItem}>
                 <span className={styles.aiPromptIcon}>💬</span>
@@ -993,7 +992,7 @@ Available skills:
               <div className={styles.aiExampleItem}>
                 <span className={styles.aiPromptIcon}>💬</span>
                 "Investigate incidents on the payment-flow process and resolve
-                any that are due to missing payment details"
+                any that are caused by missing payment details"
               </div>
             </div>
           </div>

--- a/src/pages/build-with-camunda.js
+++ b/src/pages/build-with-camunda.js
@@ -977,12 +977,18 @@ Available skills:
             <div className={styles.aiExampleGrid}>
               <div className={styles.aiExampleItem}>
                 <span className={styles.aiPromptIcon}>💬</span>
-                "Deploy the order-process.bpmn and start an instance with
-                orderId=42"
+                "Create an invoice approval process with a user task for review
+                and an HTTP connector to notify accounting"
               </div>
               <div className={styles.aiExampleItem}>
                 <span className={styles.aiPromptIcon}>💬</span>
-                "Show me all incidents on the payment-flow process"
+                "Build an AI agent that triages customer support tickets and
+                routes them to the right team"
+              </div>
+              <div className={styles.aiExampleItem}>
+                <span className={styles.aiPromptIcon}>💬</span>
+                "Deploy order-process.bpmn and start an instance with
+                orderId=42"
               </div>
               <div className={styles.aiExampleItem}>
                 <span className={styles.aiPromptIcon}>💬</span>

--- a/src/pages/build-with-camunda.js
+++ b/src/pages/build-with-camunda.js
@@ -883,42 +883,39 @@ $ c8ctl resolve inc 2251799813685251`}
           </div>
           <div className={styles.aiGrid}>
             <div className={styles.aiCard}>
-              <h4 style={{ color: "inherit" }}>
-                Add Camunda skills as Claude plugin{" "}
+              <h4 style={{ display: "flex", alignItems: "center" }}>
+                Add Camunda skills as Claude plugin
                 <span
                   style={{
-                    marginLeft: "0.5rem",
-                    display: "inline-block",
-                    padding: "0.15rem 0.5rem",
-                    borderRadius: "999px",
-                    fontSize: "0.75rem",
-                    fontWeight: 700,
-                    letterSpacing: "0.02em",
-                    backgroundColor: "#fc5d0d",
-                    border: "1px solid #fc5d0d",
-                    color: "#ffffff",
-                    verticalAlign: "middle",
-                    lineHeight: 1.2,
+                    marginLeft: "auto",
+                    display: "flex",
+                    alignItems: "center",
                   }}
                 >
-                  Coming soon
+                  <Link
+                    to="https://github.com/camunda/skills"
+                    style={{ fontWeight: 400, fontSize: "0.85rem" }}
+                  >
+                    camunda/skills
+                  </Link>
                 </span>
               </h4>
               <TerminalWindow title="Terminal">
-                {`$ claude plugin add camunda/camunda-ai-dev-kit
+                {`$ claude plugin marketplace add camunda/skills
+$ claude plugin install camunda-skills@camunda-skills
 
 Available skills:
-  /new-project  — scaffold a new Camunda project
-  /new-process  — generate a BPMN process
-  /new-agent    — generate an agentic AI process (ad-hoc sub-process + AI Agent connector)
-  /new-dmn      — generate a DMN decision table
-  /new-form     — generate a Camunda Form
-  /new-worker   — generate a job worker
-  /deploy       — deploy resources to Camunda
-  /start        — start a process instance
-  /status       — check instance/incident status
-  /view-process       — visualize BPMN, DMN, or Form files
-  /setup-environment  — install and start Camunda 8 Run locally`}
+  /camunda-c8ctl                   — install and configure c8ctl
+  /camunda-bpmn                    — create and edit BPMN 2.0 processes
+  /camunda-feel                    — write and debug FEEL expressions
+  /camunda-forms                   — create Camunda Form schemas
+  /camunda-connectors              — configure pre-built connectors
+  /camunda-development             — pick the right development surface
+  /camunda-job-workers             — implement job workers (Java, Spring, TypeScript)
+  /camunda-connectors-development  — build custom connectors
+  /camunda-process-mgmt            — deploy, operate, and debug processes
+  /camunda-ai-agent                — build AI agents in BPMN
+  /camunda-docs                    — look up the Camunda 8 docs`}
               </TerminalWindow>
             </div>
             <div className={styles.aiCard}>

--- a/src/pages/build-with-camunda.module.css
+++ b/src/pages/build-with-camunda.module.css
@@ -233,7 +233,7 @@
 .sectionSub {
   font-size: 1.05rem;
   color: var(--muted-color);
-  max-width: 540px;
+  max-width: 740px;
   margin: 0 auto;
   line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- The Camunda skills Claude plugin ([camunda/skills](https://github.com/camunda/skills)) is now released, so remove the "Coming soon" badge on the *Add Camunda skills as Claude plugin* card on the build-with-camunda landing page.
- Replace the placeholder install command (`claude plugin add camunda/camunda-ai-dev-kit`) with the actual two-step Claude Code marketplace install from the repo README.
- Replace the speculative slash-command list (`/new-project`, `/new-process`, …) with the 11 skills actually shipped: `/camunda-c8ctl`, `/camunda-bpmn`, `/camunda-feel`, `/camunda-forms`, `/camunda-connectors`, `/camunda-development`, `/camunda-job-workers`, `/camunda-connectors-development`, `/camunda-process-mgmt`, `/camunda-ai-agent`, `/camunda-docs`.
- Add a `camunda/skills` repo link in the card header, matching the style of the neighboring MCP card.

> Note: The skills README labels them as a *technical preview* ("Skills depend on c8ctl features not yet released in a stable version"). I left this off the docs page to keep it simple — happy to add a subtle "Preview" badge if reviewers prefer.

## Test plan
- [x] Run `npm start` and visit `/build-with-camunda`; confirm the *Add Camunda skills as Claude plugin* card no longer shows "Coming soon" and instead links to `camunda/skills` in the top-right.
- [x] Confirm the terminal block shows the `claude plugin marketplace add camunda/skills` + `claude plugin install camunda-skills@camunda-skills` commands and the new skill list.
- [x] Verify rendering matches the neighboring *Connect to Camunda via MCP* card layout in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)