### PR TITLE
docs(self-managed/openshift): supported versions follow Red Hat life cycle

### DIFF
--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -281,7 +281,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** lifecycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
+
+:::caution Versions compatibility
+
+Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support lifecycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -279,19 +279,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported versions
 
-We conduct testing and ensure compatibility with the following OpenShift versions:
+Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
-| OpenShift version |
-| ----------------- |
-| 4.19.x            |
-| 4.18.x            |
-| 4.17.x            |
-| 4.16.x            |
-| 4.15.x            |
+This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
 
-:::caution Versions compatibility
+:::note Continuous validation
 
-Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support life cycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 
 :::
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -283,7 +283,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
-Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 
 :::
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -279,11 +279,9 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported versions
 
-Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+:::info Supported versions
 
-This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
-
-:::note Continuous validation
+Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -281,7 +281,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -221,19 +221,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported Versions
 
-We conduct testing and ensure compatibility against the following OpenShift versions:
+Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
-| OpenShift Version |
-| ----------------- |
-| 4.18.x            |
-| 4.17.x            |
-| 4.16.x            |
-| 4.15.x            |
-| 4.14.x            |
+This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
 
-:::caution Versions compatibility
+:::note Continuous validation
 
-Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support life cycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 
 :::
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -223,7 +223,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -219,11 +219,17 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
   - 1,000 - 3,000 IOPS per volume
   - throughput of 1,000 MB/s per volume
 
-#### Supported Versions
+#### Supported versions
 
 :::info Supported versions
 
-As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** lifecycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
+
+:::caution Versions compatibility
+
+Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support lifecycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -221,11 +221,9 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported Versions
 
-Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+:::info Supported versions
 
-This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
-
-:::note Continuous validation
+Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -225,7 +225,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
-Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 
 :::
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -273,7 +273,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
-Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 
 :::
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -271,7 +271,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -269,11 +269,9 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported versions
 
-Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+:::info Supported versions
 
-This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
-
-:::note Continuous validation
+Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -269,19 +269,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported versions
 
-We conduct testing and ensure compatibility with the following OpenShift versions:
+Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
-| OpenShift version |
-| ----------------- |
-| 4.19.x            |
-| 4.18.x            |
-| 4.17.x            |
-| 4.16.x            |
-| 4.15.x            |
+This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
 
-:::caution Versions compatibility
+:::note Continuous validation
 
-Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support life cycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 
 :::
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -271,7 +271,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** lifecycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
+
+:::caution Versions compatibility
+
+Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support lifecycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -281,7 +281,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** lifecycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
+
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
+
+:::caution Versions compatibility
+
+Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support lifecycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -279,19 +279,13 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported versions
 
-We conduct testing and ensure compatibility with the following OpenShift versions:
+Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
 
-| OpenShift version |
-| ----------------- |
-| 4.19.x            |
-| 4.18.x            |
-| 4.17.x            |
-| 4.16.x            |
-| 4.15.x            |
+This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
 
-:::caution Versions compatibility
+:::note Continuous validation
 
-Camunda 8 supports OpenShift versions in the Red Hat General Availability, Full Support, and Maintenance Support life cycle phases. For more information, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 
 :::
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -283,7 +283,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
-Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
+Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 
 :::
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -279,11 +279,9 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 #### Supported versions
 
-Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
+:::info Supported versions
 
-This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
-
-:::note Continuous validation
+Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -281,7 +281,7 @@ Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www
 
 :::info Supported versions
 
-Camunda 8 supports any OpenShift version in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)). This aligns with the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/).
+As stated in the general [supported environments](/reference/supported-environments.md) policy, Camunda 8 Self-Managed runs on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/) distribution. For OpenShift specifically, this means any release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases (see the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)), within the upstream [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. Newly released OpenShift minor versions are evaluated and validated shortly after their GA.
 


### PR DESCRIPTION
## Summary

The "Supported versions" section of the OpenShift reference architecture page contained two contradictory statements:

1. A static table listing five OpenShift minor releases (4.15.x — 4.19.x on `main`/8.9/8.8, 4.14.x — 4.18.x on 8.7) presented as **the** supported set.
2. A caution admonition explaining that Camunda actually supports any OpenShift release in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases.

In practice customers read the table first and conclude that newer Red Hat GA releases (today: 4.20, 4.21 — both within Full Support) are "unsupported", and open support tickets to ask whether they can stay on a supported Camunda 8.7/8.8 while upgrading their cluster. The page should answer that question by itself.

Customer report: (Camunda 8.7 / 8.8 Self-Managed with OpenShift 4.20 / 4.21).

## Changes

- Drop the hardcoded version table.
- State the policy directly: GA / Full Support / Maintenance Support, with a link to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
- Reference the upstream [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/), which our compatibility window already follows.
- Add a short *Continuous validation* note clarifying that our reference architectures are tested against the latest GA OpenShift release and that new GA minor releases do not need a docs update to be considered supported.

Applied identically to:

- `docs/self-managed/reference-architecture/kubernetes.md` (next / 8.10)
- `versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md`
- `versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md`
- `versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md`

## Rendered preview (excerpt)

> #### Supported versions
>
> Camunda 8 supports any OpenShift version that is in the Red Hat **General Availability**, **Full Support**, or **Maintenance Support** life cycle phases. For the current life cycle status of each release, refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift).
>
> This aligns with the [Kubernetes version skew and supportability policy](https://kubernetes.io/releases/version-skew-policy/): as long as the OpenShift release is supported by Red Hat (and ships a Kubernetes version supported by the upstream community), it is supported for running Camunda 8.
>
> :::note Continuous validation
>
> Our reference architectures are continuously validated against the latest stable OpenShift release available in Red Hat's GA channel. New OpenShift minor releases are picked up as soon as they become generally available and do not require a documentation update to be considered supported.
>
> :::

## Context

- Related infra side: camunda/camunda-deployment-references is being unblocked so Renovate picks up OpenShift 4.21.x for ROSA HCP (separate PR there).
- Red Hat life cycle page already lists 4.20 in Full Support and 4.21 as GA; both are de-facto supported targets for Camunda 8.7/8.8/8.9/8.10.
