### PR TITLE
docs: document Zeebe exporter retention.managePolicy option

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -313,14 +313,19 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option      | Description                                                                  | Default                         |
-| ----------- | ---------------------------------------------------------------------------- | ------------------------------- |
-| enabled     | If `true` the ILM Policy is created and applied to the index templates       | `false`                         |
-| minimum-age | Specifies how old the data must be, before the data is deleted as a duration | `30d`                           |
-| policy-name | The name of the created and applied ILM policy                               | `zeebe-record-retention-policy` |
+| Option         | Description                                                                                                                                                                                  | Default                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled        | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimum-age    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policy-name    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| manage-policy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
+:::
+
+:::note
+Set `manage-policy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policy-name` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -313,19 +313,15 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option         | Description                                                                                                                                                                                  | Default                         |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| enabled        | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
-| minimum-age    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
-| policy-name    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
-| manage-policy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
+| Option        | Description                                                                                                                                                                                  | Default                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled       | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimum-age   | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policy-name   | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| manage-policy | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
-:::
-
-:::note
-Set `manage-policy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policy-name` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -319,10 +319,6 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
-:::note
-Set `manage-policy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
-:::
-
 </TabItem>
 
 <TabItem value="authentication">

--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -306,16 +306,21 @@ With the default configuration, the exporter would aggregate records and flush t
 A retention policy can be set up to delete old data.
 When enabled, this creates an Index State Management (ISM) policy that deletes the data after the specified `minimumAge`. All index templates created by this exporter apply the created ISM policy.
 
-| Option             | Description                                                                   | Default                         |
-| ------------------ | ----------------------------------------------------------------------------- | ------------------------------- |
-| enabled            | If `true` the ISM policy is created and applied to the index templates.       | `false`                         |
-| minimum-age        | Specifies how old the data must be, before the data is deleted as a duration. | `30d`                           |
-| policy-name        | The name of the created and applied ISM policy.                               | `zeebe-record-retention-policy` |
-| policy-description | The description of the created and applied ISM policy.                        | `Zeebe record retention policy` |
+| Option             | Description                                                                                                                                                                                   | Default                         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled            | If `true` the ISM policy is created and applied to the index templates.                                                                                                                       | `false`                         |
+| minimum-age        | Specifies how old the data must be, before the data is deleted as a duration.                                                                                                                 | `30d`                           |
+| policy-name        | The name of the created and applied ISM policy.                                                                                                                                               | `zeebe-record-retention-policy` |
+| policy-description | The description of the created and applied ISM policy.                                                                                                                                        | `Zeebe record retention policy` |
+| manage-policy      | If `true` the exporter creates, updates, and removes the ISM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it). | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or
 nanoseconds `nanos`.
+:::
+
+:::note
+Set `manage-policy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
 :::
 
 </TabItem>

--- a/docs/self-managed/concepts/databases/elasticsearch/opensearch-without-cluster-privileges.md
+++ b/docs/self-managed/concepts/databases/elasticsearch/opensearch-without-cluster-privileges.md
@@ -195,6 +195,7 @@ zeebe.broker.exporters:
         createTemplate: false
       retention:
         enabled: false
+        managePolicy: false
       authentication:
         username: camunda-app
         password: camunda123
@@ -253,6 +254,7 @@ orchestration:
             create-template: false
           retention:
             enabled: false
+            manage-policy: false
 ```
 
 ### Minor version upgrades with the standalone schema manager {#minor-upgrades}

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
@@ -56,6 +56,25 @@ camunda.tasklist:
 
 This ILM Policy works on Elasticsearch 7 as well, and can function as a replacement for the Elasticsearch Curator.
 
+### Externally managed ILM/ISM policies
+
+By default Tasklist creates and updates the ILM/ISM policy resource itself when `ilmEnabled` is `true`, and removes the policy from existing indices when `ilmEnabled` is `false`. When the policy is managed externally (for example by a separate provisioning step that runs before Tasklist starts), set `ilmManagePolicy` to `false`:
+
+```yaml
+camunda.tasklist:
+  archiver:
+    ilmEnabled: true
+    ilmManagePolicy: false
+    ilmMinAgeForDeleteArchivedIndices: 30d
+```
+
+With `ilmManagePolicy: false`, Tasklist:
+
+- Does not create or update the ILM/ISM policy resource on startup (it assumes the policy already exists under the configured name).
+- Does not detach the policy from existing indices when `ilmEnabled` is `false`.
+
+The default is `true`, which preserves the historical behavior.
+
 :::note
 Only indices containing dates in their suffix may be deleted.
 :::

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
@@ -146,19 +146,15 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option        | Description                                                                                                                                                                                  | Default                         |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| enabled       | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
-| minimumAge    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
-| policyName    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
-| managePolicy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
+| Option       | Description                                                                                                                                                                                  | Default                         |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled      | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimumAge   | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policyName   | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| managePolicy | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
-:::
-
-:::note
-Set `managePolicy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policyName` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
@@ -146,14 +146,19 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option     | Description                                                                  | Default                         |
-| ---------- | ---------------------------------------------------------------------------- | ------------------------------- |
-| enabled    | If `true` the ILM Policy is created and applied to the index templates       | `false`                         |
-| minimumAge | Specifies how old the data must be, before the data is deleted as a duration | `30d`                           |
-| policyName | The name of the created and applied ILM policy                               | `zeebe-record-retention-policy` |
+| Option        | Description                                                                                                                                                                                  | Default                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled       | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimumAge    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policyName    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| managePolicy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
+:::
+
+:::note
+Set `managePolicy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policyName` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
@@ -146,16 +146,21 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index State Management (ISM) policy that deletes the data after the
 specified `minimumAge`. All index templates created by this exporter apply the created ISM policy.
 
-| Option            | Description                                                                   | Default                         |
-| ----------------- | ----------------------------------------------------------------------------- | ------------------------------- |
-| enabled           | If `true` the ISM policy is created and applied to the index templates.       | `false`                         |
-| minimumAge        | Specifies how old the data must be, before the data is deleted as a duration. | `30d`                           |
-| policyName        | The name of the created and applied ISM policy.                               | `zeebe-record-retention-policy` |
-| policyDescription | The description of the created and applied ISM policy.                        | `Zeebe record retention policy` |
+| Option            | Description                                                                                                                                                                                   | Default                         |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled           | If `true` the ISM policy is created and applied to the index templates.                                                                                                                       | `false`                         |
+| minimumAge        | Specifies how old the data must be, before the data is deleted as a duration.                                                                                                                 | `30d`                           |
+| policyName        | The name of the created and applied ISM policy.                                                                                                                                               | `zeebe-record-retention-policy` |
+| policyDescription | The description of the created and applied ISM policy.                                                                                                                                        | `Zeebe record retention policy` |
+| managePolicy      | If `true` the exporter creates, updates, and removes the ISM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it). | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or
 nanoseconds `nanos`.
+:::
+
+:::note
+Set `managePolicy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
@@ -159,10 +159,6 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
-:::note
-Set `managePolicy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
-:::
-
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -165,14 +165,19 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimum-age`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option      | Description                                                                  | Default                         |
-| ----------- | ---------------------------------------------------------------------------- | ------------------------------- |
-| enabled     | If `true` the ILM Policy is created and applied to the index templates       | `false`                         |
-| minimum-age | Specifies how old the data must be, before the data is deleted as a duration | `30d`                           |
-| policy-name | The name of the created and applied ILM policy                               | `zeebe-record-retention-policy` |
+| Option         | Description                                                                                                                                                                                  | Default                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled        | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimum-age    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policy-name    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| manage-policy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
+:::
+
+:::note
+Set `manage-policy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policy-name` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -165,19 +165,15 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimum-age`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option         | Description                                                                                                                                                                                  | Default                         |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| enabled        | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
-| minimum-age    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
-| policy-name    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
-| manage-policy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
+| Option        | Description                                                                                                                                                                                  | Default                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled       | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimum-age   | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policy-name   | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| manage-policy | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
-:::
-
-:::note
-Set `manage-policy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policy-name` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -166,16 +166,21 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index State Management (ISM) policy that deletes the data after the
 specified `minimum-age`. All index templates created by this exporter apply the created ISM policy.
 
-| Option             | Description                                                                   | Default                         |
-| ------------------ | ----------------------------------------------------------------------------- | ------------------------------- |
-| enabled            | If `true` the ISM policy is created and applied to the index templates.       | `false`                         |
-| minimum-age        | Specifies how old the data must be, before the data is deleted as a duration. | `30d`                           |
-| policy-name        | The name of the created and applied ISM policy.                               | `zeebe-record-retention-policy` |
-| policy-description | The description of the created and applied ISM policy.                        | `Zeebe record retention policy` |
+| Option             | Description                                                                                                                                                                                   | Default                         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled            | If `true` the ISM policy is created and applied to the index templates.                                                                                                                       | `false`                         |
+| minimum-age        | Specifies how old the data must be, before the data is deleted as a duration.                                                                                                                 | `30d`                           |
+| policy-name        | The name of the created and applied ISM policy.                                                                                                                                               | `zeebe-record-retention-policy` |
+| policy-description | The description of the created and applied ISM policy.                                                                                                                                        | `Zeebe record retention policy` |
+| manage-policy      | If `true` the exporter creates, updates, and removes the ISM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it). | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or
 nanoseconds `nanos`.
+:::
+
+:::note
+Set `manage-policy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -179,10 +179,6 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
-:::note
-Set `manage-policy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
-:::
-
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -265,14 +265,19 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option      | Description                                                                  | Default                         |
-| ----------- | ---------------------------------------------------------------------------- | ------------------------------- |
-| enabled     | If `true` the ILM Policy is created and applied to the index templates       | `false`                         |
-| minimum-age | Specifies how old the data must be, before the data is deleted as a duration | `30d`                           |
-| policy-name | The name of the created and applied ILM policy                               | `zeebe-record-retention-policy` |
+| Option         | Description                                                                                                                                                                                  | Default                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled        | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimum-age    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policy-name    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| manage-policy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
+:::
+
+:::note
+Set `manage-policy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policy-name` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -265,19 +265,15 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index Lifecycle Management (ILM) Policy that deletes the data after the specified `minimumAge`.
 All index templates created by this exporter apply the created ILM Policy.
 
-| Option         | Description                                                                                                                                                                                  | Default                         |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| enabled        | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
-| minimum-age    | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
-| policy-name    | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
-| manage-policy  | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
+| Option        | Description                                                                                                                                                                                  | Default                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled       | If `true` the ILM Policy is created and applied to the index templates                                                                                                                       | `false`                         |
+| minimum-age   | Specifies how old the data must be, before the data is deleted as a duration                                                                                                                 | `30d`                           |
+| policy-name   | The name of the created and applied ILM policy                                                                                                                                               | `zeebe-record-retention-policy` |
+| manage-policy | If `true` the exporter creates, updates, and removes the ILM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it) | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
-:::
-
-:::note
-Set `manage-policy: false` when the ILM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ILM policy resource and does not detach the policy from existing indices when retention is disabled. The configured `policy-name` is still written into newly rendered index templates so future rolled indices inherit it.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -254,16 +254,21 @@ A retention policy can be set up to delete old data.
 When enabled, this creates an Index State Management (ISM) policy that deletes the data after the
 specified `minimumAge`. All index templates created by this exporter apply the created ISM policy.
 
-| Option             | Description                                                                   | Default                         |
-| ------------------ | ----------------------------------------------------------------------------- | ------------------------------- |
-| enabled            | If `true` the ISM policy is created and applied to the index templates.       | `false`                         |
-| minimum-age        | Specifies how old the data must be, before the data is deleted as a duration. | `30d`                           |
-| policy-name        | The name of the created and applied ISM policy.                               | `zeebe-record-retention-policy` |
-| policy-description | The description of the created and applied ISM policy.                        | `Zeebe record retention policy` |
+| Option             | Description                                                                                                                                                                                   | Default                         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| enabled            | If `true` the ISM policy is created and applied to the index templates.                                                                                                                       | `false`                         |
+| minimum-age        | Specifies how old the data must be, before the data is deleted as a duration.                                                                                                                 | `30d`                           |
+| policy-name        | The name of the created and applied ISM policy.                                                                                                                                               | `zeebe-record-retention-policy` |
+| policy-description | The description of the created and applied ISM policy.                                                                                                                                        | `Zeebe record retention policy` |
+| manage-policy      | If `true` the exporter creates, updates, and removes the ISM policy on its own. Set to `false` to leave an externally managed policy untouched (the exporter neither creates nor removes it). | `true`                          |
 
 :::note
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or
 nanoseconds `nanos`.
+:::
+
+:::note
+Set `manage-policy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
 :::
 
 </TabItem>

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -267,10 +267,6 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
-:::note
-Set `manage-policy: false` when the ISM policy is managed externally (for example by a separate provisioning step or by your platform team). With this option, the exporter does not modify the ISM policy resource and does not detach the policy from existing indices when retention is disabled.
-:::
-
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.9/self-managed/concepts/databases/elasticsearch/opensearch-without-cluster-privileges.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/databases/elasticsearch/opensearch-without-cluster-privileges.md
@@ -195,6 +195,7 @@ zeebe.broker.exporters:
         createTemplate: false
       retention:
         enabled: false
+        managePolicy: false
       authentication:
         username: camunda-app
         password: camunda123
@@ -253,6 +254,7 @@ orchestration:
             create-template: false
           retention:
             enabled: false
+            manage-policy: false
 ```
 
 ### Minor version upgrades with the standalone schema manager {#minor-upgrades}


### PR DESCRIPTION
## Summary

Documents the new `managePolicy` boolean on the Zeebe Elasticsearch and OpenSearch exporter retention configuration.

When `retention.enabled=true` and `managePolicy=true` (the defaults), the exporter behaves as it does today — it creates, updates, and removes the ILM/ISM policy resource itself, and writes the policy name into rendered index templates.

When `managePolicy=false`, the exporter:
- Does not create or update the ILM/ISM policy resource on startup (assumed externally managed).
- Does not detach the policy from existing indices when retention is disabled.
- Still writes the configured `policyName` into rendered index templates so future rolled indices inherit the externally managed policy.

This addresses the customer-impacting case described in [camunda/camunda#28571](https://github.com/camunda/camunda/issues/28571) where the `camunda-app` user lacks permission to mutate ILM/ISM policies (403 on `_plugins/_ism/remove/...`) and where every restart silently strips an externally managed policy from existing indices.

## Updated pages

- `docs/.../zeebe/exporters/elasticsearch-exporter.md` (next release)
- `docs/.../zeebe/exporters/opensearch-exporter.md` (next release)
- `versioned_docs/version-8.9/.../elasticsearch-exporter.md`
- `versioned_docs/version-8.9/.../opensearch-exporter.md`
- `versioned_docs/version-8.8/.../elasticsearch-exporter.md`
- `versioned_docs/version-8.8/.../opensearch-exporter.md`
- `versioned_docs/version-8.7/.../elasticsearch-exporter.md`
- `versioned_docs/version-8.7/.../opensearch-exporter.md`

The 8.7 doc uses camelCase property names (`managePolicy`) to match the surrounding `policyName` / `minimumAge` keys on that page; 8.8 and newer use kebab-case (`manage-policy`) to match the surrounding `policy-name` / `minimum-age` keys.

## Related

- camunda/camunda#28571 — the underlying bug
- camunda/camunda#53505 — fix merged on stable/8.7
- camunda/camunda#53590 — fix on main (with backport label for stable/8.9)
- camunda/camunda#53592 — dedicated backport PR on stable/8.8

## Checklist

- [ ] Prose follows the [technical writing style guide](https://github.com/camunda/camunda-docs/blob/main/howtos/technical-writing-styleguide.md)
- [x] All internal links include `.md` extension (no new cross-page links added)
- [x] No new pages added; existing tables extended, no sidebars.js change needed
- [x] No images added