### PR TITLE
docs: document policy_id and missing-policy failure modes for managePolicy

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -324,6 +324,14 @@ All index templates created by this exporter apply the created ILM Policy.
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `manage-policy: false`, the exporter still attaches the policy named by `policy-name` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your Elasticsearch cluster under that name when the exporter starts.
+
+If the policy does not exist, Elasticsearch silently accepts the dangling `index.lifecycle.name` setting. The exporter starts successfully, but ILM logs `policy_not_found` warnings on each cycle and skips retention actions until the policy is created. Once you create the policy under the configured name, ILM picks it up retroactively on its next cycle.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -319,6 +319,14 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `manage-policy: false`, the exporter still attaches the policy named by `policy-name` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your OpenSearch cluster under that name when the exporter starts.
+
+If the policy does not exist, OpenSearch's ISM `add` API rejects the call and the exporter fails to start with `OpensearchExporterException: Failed to add policy to indices`. Provision the ISM policy before starting Camunda when using `manage-policy: false`.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
@@ -70,10 +70,21 @@ camunda.tasklist:
 
 With `ilmManagePolicy: false`, Tasklist:
 
-- Does not create or update the ILM/ISM policy resource on startup (it assumes the policy already exists under the configured name).
+- Does not create or update the ILM/ISM policy resource on startup (it assumes the policy already exists under the expected name).
 - Does not detach the policy from existing indices when `ilmEnabled` is `false`.
 
 The default is `true`, which preserves the historical behavior.
+
+:::caution Policy name is hardcoded
+
+Tasklist attaches the policy named `tasklist_delete_archived_indices` to archived indices. This name is **not configurable**. When `ilmManagePolicy: false`, the external policy must already exist in your cluster under exactly that name.
+
+If the policy does not exist when `ilmEnabled: true`:
+
+- **Elasticsearch**: Tasklist starts successfully, but ILM logs `policy_not_found` warnings on each cycle and skips retention actions on the affected indices. Once the policy is created externally under the configured name, ILM picks it up retroactively on its next cycle.
+- **OpenSearch**: Tasklist logs an error for each index it cannot attach the policy to and continues. The affected indices remain unmanaged until the policy is provisioned and Tasklist runs the attach step again.
+
+:::
 
 :::note
 Only indices containing dates in their suffix may be deleted.

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md
@@ -157,6 +157,14 @@ All index templates created by this exporter apply the created ILM Policy.
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `managePolicy: false`, the exporter still attaches the policy named by `policyName` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your Elasticsearch cluster under that name when the exporter starts.
+
+If the policy does not exist, Elasticsearch silently accepts the dangling `index.lifecycle.name` setting. The exporter starts successfully, but ILM logs `policy_not_found` warnings on each cycle and skips retention actions until the policy is created. Once you create the policy under the configured name, ILM picks it up retroactively on its next cycle.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/exporters/opensearch-exporter.md
@@ -159,6 +159,14 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `managePolicy: false`, the exporter still attaches the policy named by `policyName` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your OpenSearch cluster under that name when the exporter starts.
+
+If the policy does not exist, OpenSearch's ISM `add` API rejects the call and the exporter fails to start with `OpensearchExporterException: Failed to add policy to indices`. Provision the ISM policy before starting Camunda when using `managePolicy: false`.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -176,6 +176,14 @@ All index templates created by this exporter apply the created ILM Policy.
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `manage-policy: false`, the exporter still attaches the policy named by `policy-name` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your Elasticsearch cluster under that name when the exporter starts.
+
+If the policy does not exist, Elasticsearch silently accepts the dangling `index.lifecycle.name` setting. The exporter starts successfully, but ILM logs `policy_not_found` warnings on each cycle and skips retention actions until the policy is created. Once you create the policy under the configured name, ILM picks it up retroactively on its next cycle.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -179,6 +179,14 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `manage-policy: false`, the exporter still attaches the policy named by `policy-name` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your OpenSearch cluster under that name when the exporter starts.
+
+If the policy does not exist, OpenSearch's ISM `add` API rejects the call and the exporter fails to start with `OpensearchExporterException: Failed to add policy to indices`. Provision the ISM policy before starting Camunda when using `manage-policy: false`.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -276,6 +276,14 @@ All index templates created by this exporter apply the created ILM Policy.
 The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, milliseconds `ms`, and/or nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `manage-policy: false`, the exporter still attaches the policy named by `policy-name` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your Elasticsearch cluster under that name when the exporter starts.
+
+If the policy does not exist, Elasticsearch silently accepts the dangling `index.lifecycle.name` setting. The exporter starts successfully, but ILM logs `policy_not_found` warnings on each cycle and skips retention actions until the policy is created. Once you create the policy under the configured name, ILM picks it up retroactively on its next cycle.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -267,6 +267,14 @@ The duration can be specified in days `d`, hours `h`, minutes `m`, seconds `s`, 
 nanoseconds `nanos`.
 :::
 
+:::note Externally managed policy
+
+When `manage-policy: false`, the exporter still attaches the policy named by `policy-name` (default `zeebe-record-retention-policy`) to the indices it creates. The policy must already exist in your OpenSearch cluster under that name when the exporter starts.
+
+If the policy does not exist, OpenSearch's ISM `add` API rejects the call and the exporter fails to start with `OpensearchExporterException: Failed to add policy to indices`. Provision the ISM policy before starting Camunda when using `manage-policy: false`.
+
+:::
+
 </TabItem>
 
 <TabItem value="authentication">


### PR DESCRIPTION
## Summary

Follow-up to #8883 addressing the review feedback from @zeitiger on [camunda/camunda#28571](https://github.com/camunda/camunda/issues/28571#issuecomment-4507559258):

> @RomanJRW - (enabled: true, managePolicy: false) need a documentation about the policy_id values, because you need to know which policy_id will be applied. And a reference to ElasticSearch and OpenSearch what happen if the policy is missing.

Two clarifications were missing from the previous PR — both verified against the implementation before drafting:

### 1. Which `policy_id` is used

| Component | Source | Configurable? |
|---|---|---|
| Zeebe ES exporter (all versions) | `retention.policyName` / `policy-name` | **Yes**, default `zeebe-record-retention-policy` |
| Zeebe OS exporter (all versions) | `retention.policyName` / `policy-name` | **Yes**, default `zeebe-record-retention-policy` |
| Tasklist (8.7 only) | `TASKLIST_DELETE_ARCHIVED_INDICES` constant | **No**, hardcoded as `tasklist_delete_archived_indices` |

### 2. What happens when the external policy is missing

- **Elasticsearch**: silent. The `_settings` PUT accepts `index.lifecycle.name` referencing a non-existent policy. ILM logs `policy_not_found` warnings on each cycle and skips retention. Once the policy is created externally, ILM picks it up retroactively. **Camunda startup succeeds.**
- **OpenSearch (Zeebe exporter)**: fail-fast. `OpensearchClient.bulkAddISMPolicyToAllZeebeIndices` calls `/_plugins/_ism/add`; if the policy doesn't exist, OpenSearch returns an error, the Java client throws, and the exporter rethrows `OpensearchExporterException: Failed to add policy to indices`. **Broker startup fails.**
- **OpenSearch (Tasklist 8.7)**: per-index error. `addISMPolicyToIndex` is called inside a try/catch loop in `ILMPolicyUpdateOpenSearch.applyIlmPolicyToExistingIndices`. Failures are logged and the loop continues. Affected indices remain unmanaged.

## Updated pages

- `docs/.../zeebe/exporters/elasticsearch-exporter.md` (next release)
- `docs/.../zeebe/exporters/opensearch-exporter.md` (next release)
- `versioned_docs/version-8.9/.../elasticsearch-exporter.md`
- `versioned_docs/version-8.9/.../opensearch-exporter.md`
- `versioned_docs/version-8.8/.../elasticsearch-exporter.md`
- `versioned_docs/version-8.8/.../opensearch-exporter.md`
- `versioned_docs/version-8.7/.../elasticsearch-exporter.md`
- `versioned_docs/version-8.7/.../opensearch-exporter.md`
- `versioned_docs/version-8.7/.../tasklist-deployment/data-retention.md`

Each exporter page gets a new `:::note Externally managed policy` block under the retention options table. The Tasklist page gets a `:::caution` block calling out the hardcoded name plus both engines' failure modes.

## Related

- #8883 — the original docs PR (merged) that introduced the `managePolicy` flag documentation
- camunda/camunda#28571 — original bug and the @zeitiger review comment driving this follow-up
- camunda/camunda#53505 / #53590 / #53592 — the code changes this documents

## Checklist

- [x] Failure mode statements verified against code (`OpensearchClient.java:296-308`, `ElasticsearchExporterClient.java:289-314`, `ILMPolicyUpdateOpenSearch.java:147-163`)
- [x] No new pages added; no `sidebars.js` change needed
- [x] All internal callouts use `:::note` / `:::caution` Docusaurus syntax already used on these pages