### PR TITLE
docs: align migrator compatibility matrix with Camunda 8 supported DBs

### DIFF
--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
@@ -40,7 +40,7 @@ The migrator supports the following SQL databases:
 | **PostgreSQL**           | 15, 16, 17, 18 | `org.postgresql.Driver`                        | Recommended for production |
 | **Oracle**               | 19c, 23ai      | `oracle.jdbc.OracleDriver`                     | Recommended for production |
 | **Microsoft SQL Server** | 2022           | `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended for production |
-| **MariaDB**              | 10.6, 11.8     | `org.mariadb.jdbc.Driver`                      | Recommended for production |
+| **MariaDB**              | 11.8           | `org.mariadb.jdbc.Driver`                      | Recommended for production |
 
 The migrator supports migration only within the same database vendor:
 

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
@@ -37,11 +37,9 @@ The migrator supports the following SQL databases:
 
 | Database                 | Version        | JDBC Driver                                    | Notes                      |
 | ------------------------ | -------------- | ---------------------------------------------- | -------------------------- |
-| **H2**                   | 2.3.232        | `org.h2.Driver`                                | Default, good for testing  |
 | **PostgreSQL**           | 15, 16, 17, 18 | `org.postgresql.Driver`                        | Recommended for production |
 | **Oracle**               | 19c, 23ai      | `oracle.jdbc.OracleDriver`                     | Recommended for production |
 | **Microsoft SQL Server** | 2022           | `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended for production |
-| **MySQL**                | 8.0            | `com.mysql.cj.jdbc.Driver`                     | Recommended for production |
 | **MariaDB**              | 10.6, 11.8     | `org.mariadb.jdbc.Driver`                      | Recommended for production |
 
 The migrator supports migration only within the same database vendor:

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
@@ -41,7 +41,7 @@ The migrator supports the following SQL databases:
 | **PostgreSQL**           | 15, 16, 17, 18 | `org.postgresql.Driver`                        | Recommended for production |
 | **Oracle**               | 19c, 23ai      | `oracle.jdbc.OracleDriver`                     | Recommended for production |
 | **Microsoft SQL Server** | 2022           | `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended for production |
-| **MariaDB**              | 10.6, 11.8     | `org.mariadb.jdbc.Driver`                      | Recommended for production |
+| **MariaDB**              | 11.8           | `org.mariadb.jdbc.Driver`                      | Recommended for production |
 
 The migrator supports migration only within the same database vendor:
 

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/database.md
@@ -41,7 +41,6 @@ The migrator supports the following SQL databases:
 | **PostgreSQL**           | 15, 16, 17, 18 | `org.postgresql.Driver`                        | Recommended for production |
 | **Oracle**               | 19c, 23ai      | `oracle.jdbc.OracleDriver`                     | Recommended for production |
 | **Microsoft SQL Server** | 2022           | `com.microsoft.sqlserver.jdbc.SQLServerDriver` | Recommended for production |
-| **MySQL**                | 8.0            | `com.mysql.cj.jdbc.Driver`                     | Recommended for production |
 | **MariaDB**              | 10.6, 11.8     | `org.mariadb.jdbc.Driver`                      | Recommended for production |
 
 The migrator supports migration only within the same database vendor:


### PR DESCRIPTION
## Summary

The Data Migrator can only migrate to database versions supported by both Camunda 7 and Camunda 8. Cross-referencing the [Camunda 7.24 supported databases](https://docs.camunda.org/manual/7.24/introduction/supported-environments/#supported-database-products) against the C8 8.10 / 8.9 support policy:

Closes https://github.com/camunda/camunda/issues/53741