### PR TITLE
fix(self-managed): use java -jar for connector runtime bundle in install docs

### DIFF
--- a/docs/self-managed/deployment/manual/install.md
+++ b/docs/self-managed/deployment/manual/install.md
@@ -510,14 +510,22 @@ Consider the following file structure:
 
 ```shell
 /home/user/connectors $
-├── connector-runtime-(application|bundle)-x.y.z(-with-dependencies).jar
-└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+└── connector-runtime-(application|bundle)-x.y.z-with-dependencies.jar
 ```
 
-To start connectors bundle with all custom connectors locally, run:
+To start the connector runtime locally, run:
 
 ```shell
-java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+java -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
+```
+
+The runtime bundle is packaged as a Spring Boot uber-jar (with its dependencies under `BOOT-INF/lib/`), so it must be launched with `java -jar`. The older flat-classpath invocation (`java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"`) no longer works as of connector runtime 8.9.4.
+
+To load additional custom connectors, place their JARs in a separate directory and point Spring Boot's loader at it:
+
+```shell
+java -Dloader.path=/home/user/custom-connectors \
+  -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
 ```
 
 This starts a Zeebe client, registering the defined connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.

--- a/versioned_docs/version-8.8/self-managed/deployment/manual/install.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/manual/install.md
@@ -510,14 +510,22 @@ Consider the following file structure:
 
 ```shell
 /home/user/connectors $
-├── connector-runtime-(application|bundle)-x.y.z(-with-dependencies).jar
-└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+└── connector-runtime-(application|bundle)-x.y.z-with-dependencies.jar
 ```
 
-To start connectors bundle with all custom connectors locally, run:
+To start the connector runtime locally, run:
 
 ```shell
-java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+java -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
+```
+
+The runtime bundle is packaged as a Spring Boot uber-jar (with its dependencies under `BOOT-INF/lib/`), so it must be launched with `java -jar`. The older flat-classpath invocation (`java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"`) no longer works as of connector runtime 8.9.4.
+
+To load additional custom connectors, place their JARs in a separate directory and point Spring Boot's loader at it:
+
+```shell
+java -Dloader.path=/home/user/custom-connectors \
+  -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
 ```
 
 This starts a Zeebe client, registering the defined connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.

--- a/versioned_docs/version-8.8/self-managed/deployment/manual/install.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/manual/install.md
@@ -519,7 +519,7 @@ To start the connector runtime locally, run:
 java -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
 ```
 
-The runtime bundle is packaged as a Spring Boot uber-jar (with its dependencies under `BOOT-INF/lib/`), so it must be launched with `java -jar`. The older flat-classpath invocation (`java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"`) no longer works as of connector runtime 8.9.4.
+The runtime bundle is packaged as a Spring Boot uber-jar (with its dependencies under `BOOT-INF/lib/`), so it must be launched with `java -jar`. The older flat-classpath invocation (`java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"`) no longer works as of connector runtime 8.8.12
 
 To load additional custom connectors, place their JARs in a separate directory and point Spring Boot's loader at it:
 

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/install.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/install.md
@@ -510,14 +510,22 @@ Consider the following file structure:
 
 ```shell
 /home/user/connectors $
-├── connector-runtime-(application|bundle)-x.y.z(-with-dependencies).jar
-└── my-custom-connector-0.1.0-SNAPSHOT-with-dependencies.jar
+└── connector-runtime-(application|bundle)-x.y.z-with-dependencies.jar
 ```
 
-To start connectors bundle with all custom connectors locally, run:
+To start the connector runtime locally, run:
 
 ```shell
-java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+java -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
+```
+
+The runtime bundle is packaged as a Spring Boot uber-jar (with its dependencies under `BOOT-INF/lib/`), so it must be launched with `java -jar`. The older flat-classpath invocation (`java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"`) no longer works as of connector runtime 8.9.4.
+
+To load additional custom connectors, place their JARs in a separate directory and point Spring Boot's loader at it:
+
+```shell
+java -Dloader.path=/home/user/custom-connectors \
+  -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar
 ```
 
 This starts a Zeebe client, registering the defined connector as a job worker. By default, it connects to a local Zeebe instance at port `26500`.


### PR DESCRIPTION
## Summary

- Replace the broken flat-classpath connector launch (`java -cp "/home/user/connectors/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"`) with `java -jar /home/user/connectors/connector-runtime-bundle-x.y.z-with-dependencies.jar` in:
  - `docs/self-managed/deployment/manual/install.md` (Next)
  - `versioned_docs/version-8.9/self-managed/deployment/manual/install.md`
  - `versioned_docs/version-8.8/self-managed/deployment/manual/install.md`
- Add a short note explaining why (Spring Boot uber-jar layout under `BOOT-INF/lib/`) and a follow-up snippet showing how to load custom connectors via `-Dloader.path=`.

`versioned_docs/version-8.7/...` is **not** updated: the 8.7 line of `connector-runtime-bundle` (up to 8.7.9 at time of writing) still ships the flat classpath layout, so the existing `java -cp` invocation works as documented for that version.

## Why

Starting with `connector-runtime-bundle` 8.9.4, the bundle was repackaged as a standard Spring Boot uber-jar — `Main-Class: org.springframework.boot.loader.launch.JarLauncher` and dependencies under `BOOT-INF/lib/`. The flat-classpath form silently breaks (JVM `ClassNotFoundException` chain) the moment anyone follows the docs against a 8.9.4+ bundle.

This was already fixed in [`camunda/camunda-deployment-references`](https://github.com/camunda/camunda-deployment-references) by vendoring a `java -jar` launcher in the Debian compute install script (commit `ac9129ec` on main). This PR brings the same fix to the docs that users follow when running connectors outside of that reference.

## Test plan

- [x] Verified `Main-Class` on `connector-runtime-bundle-8.7.9-with-dependencies.jar` is `io.camunda.connector.runtime.app.ConnectorRuntimeApplication` (flat) → 8.7 docs left as-is.
- [x] Verified `Main-Class` on `connector-runtime-bundle-8.8.0-with-dependencies.jar` is the same (also accepts `java -jar`).
- [x] `npx prettier --write` reports the three files unchanged.
- [ ] Preview deployment validates rendering of the new code blocks.