### PR TITLE
docs: add pod networking configuration page for orchestration cluster (8.10)

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -187,21 +187,19 @@ For details, see [`cancel` listeners](/components/concepts/execution-listeners.m
 
 ### Self-Managed
 
-#### Host network and DNS configuration support for Helm chart components
+#### Host network support for orchestration cluster pods
 
 <!-- https://github.com/camunda/camunda-platform-helm/pull/6210 -->
 
 <div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Helm">Helm</span></div>
 
-The 8.10 Helm chart adds DNS configuration support and host network access for component pods.
+The 8.10 Helm chart adds `orchestration.hostNetwork` (default: `false`), which lets orchestration cluster pods share the host node's network namespace. This is useful in bare-metal or restricted network environments where pods must be reachable directly via the node IP rather than a cluster overlay network.
 
-**DNS policy and custom DNS** — Every Camunda component now exposes `dnsPolicy` and `dnsConfig` values, letting you control DNS resolution behavior per component. Use these when running in environments that require a private nameserver, custom search domains, or specific resolver options. Supported components include the orchestration cluster, Identity, Connectors, Optimize, Console, and Web Modeler.
-
-**Host network** (orchestration cluster only) — `orchestration.hostNetwork` (default: `false`) lets orchestration cluster pods share the host node's network namespace. When set to `true` and `orchestration.dnsPolicy` is not set, the chart automatically uses `dnsPolicy: ClusterFirstWithHostNet` to preserve in-cluster DNS resolution.
+When `orchestration.hostNetwork` is set to `true` and `orchestration.dnsPolicy` is not set, the chart automatically uses `dnsPolicy: ClusterFirstWithHostNet` to preserve in-cluster DNS resolution. You can override this by setting `orchestration.dnsPolicy` explicitly.
 
 ```yaml
 orchestration:
   hostNetwork: true
 ```
 
-For full details and configuration examples, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
+For details, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).

--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -184,3 +184,22 @@ This change helps navigate more complex data during operations and troubleshooti
 Execution listeners now support a `cancel` event type on the process element. Cancel listeners run when a process instance is terminated — useful for cleanup, audit logging, or notifying external systems.
 
 For details, see [`cancel` listeners](/components/concepts/execution-listeners.md#cancel-listeners).
+
+### Self-Managed
+
+#### Host network support for orchestration cluster pods
+
+<!-- https://github.com/camunda/camunda-platform-helm/pull/6210 -->
+
+<div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Helm">Helm</span></div>
+
+The 8.10 Helm chart adds `orchestration.hostNetwork` (default: `false`), which lets orchestration cluster pods share the host node's network namespace. This is useful in bare-metal or restricted network environments where pods must be reachable directly via the node IP rather than a cluster overlay network.
+
+When `orchestration.hostNetwork` is set to `true` and `orchestration.dnsPolicy` is not set, the chart automatically uses `dnsPolicy: ClusterFirstWithHostNet` so that in-cluster DNS resolution continues to work. You can override this by setting `orchestration.dnsPolicy` explicitly.
+
+```yaml
+orchestration:
+  hostNetwork: true
+```
+
+For full details and configuration examples, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).

--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -187,15 +187,17 @@ For details, see [`cancel` listeners](/components/concepts/execution-listeners.m
 
 ### Self-Managed
 
-#### Host network support for orchestration cluster pods
+#### Host network and DNS configuration support for Helm chart components
 
 <!-- https://github.com/camunda/camunda-platform-helm/pull/6210 -->
 
 <div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Helm">Helm</span></div>
 
-The 8.10 Helm chart adds `orchestration.hostNetwork` (default: `false`), which lets orchestration cluster pods share the host node's network namespace. This is useful in bare-metal or restricted network environments where pods must be reachable directly via the node IP rather than a cluster overlay network.
+The 8.10 Helm chart adds DNS configuration support and host network access for component pods.
 
-When `orchestration.hostNetwork` is set to `true` and `orchestration.dnsPolicy` is not set, the chart automatically uses `dnsPolicy: ClusterFirstWithHostNet` so that in-cluster DNS resolution continues to work. You can override this by setting `orchestration.dnsPolicy` explicitly.
+**DNS policy and custom DNS** — Every Camunda component now exposes `dnsPolicy` and `dnsConfig` values, letting you control DNS resolution behavior per component. Use these when running in environments that require a private nameserver, custom search domains, or specific resolver options. Supported components include the orchestration cluster, Identity, Connectors, Optimize, Console, and Web Modeler.
+
+**Host network** (orchestration cluster only) — `orchestration.hostNetwork` (default: `false`) lets orchestration cluster pods share the host node's network namespace. When set to `true` and `orchestration.dnsPolicy` is not set, the chart automatically uses `dnsPolicy: ClusterFirstWithHostNet` to preserve in-cluster DNS resolution.
 
 ```yaml
 orchestration:

--- a/docs/self-managed/deployment/helm/chart-parameters.md
+++ b/docs/self-managed/deployment/helm/chart-parameters.md
@@ -24,7 +24,7 @@ The following tables show the **top-level configuration sections** in `values.ya
 | `global`        | Configures shared settings that apply across components |
 | `orchestration` | Configures orchestration cluster settings               |
 
-For pod-level networking options such as `hostNetwork`, `dnsPolicy`, and `dnsConfig`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
+For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
 ### Other Camunda applications
 

--- a/docs/self-managed/deployment/helm/chart-parameters.md
+++ b/docs/self-managed/deployment/helm/chart-parameters.md
@@ -24,6 +24,8 @@ The following tables show the **top-level configuration sections** in `values.ya
 | `global`        | Configures shared settings that apply across components |
 | `orchestration` | Configures orchestration cluster settings               |
 
+For pod-level networking options such as `hostNetwork`, `dnsPolicy`, and `dnsConfig`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
+
 ### Other Camunda applications
 
 | Section      | Purpose                                             |

--- a/docs/self-managed/deployment/helm/configure/pod-networking.md
+++ b/docs/self-managed/deployment/helm/configure/pod-networking.md
@@ -47,14 +47,14 @@ Every Camunda component also supports a `dnsConfig` value that lets you supply c
 
 The following components support `dnsConfig`:
 
-| Component | Value key |
-|---|---|
-| Orchestration cluster | `orchestration.dnsConfig` |
-| Identity | `identity.dnsConfig` |
-| Connectors | `connectors.dnsConfig` |
-| Optimize | `optimize.dnsConfig` |
-| Console | `console.dnsConfig` |
-| Web Modeler REST API | `webModeler.restapi.dnsConfig` |
+| Component              | Value key                         |
+| ---------------------- | --------------------------------- |
+| Orchestration cluster  | `orchestration.dnsConfig`         |
+| Identity               | `identity.dnsConfig`              |
+| Connectors             | `connectors.dnsConfig`            |
+| Optimize               | `optimize.dnsConfig`              |
+| Console                | `console.dnsConfig`               |
+| Web Modeler REST API   | `webModeler.restapi.dnsConfig`    |
 | Web Modeler WebSockets | `webModeler.websockets.dnsConfig` |
 
 Use `dnsConfig` when you need to override or extend the default DNS resolver — for example, to add a private nameserver or a custom search domain:

--- a/docs/self-managed/deployment/helm/configure/pod-networking.md
+++ b/docs/self-managed/deployment/helm/configure/pod-networking.md
@@ -34,12 +34,12 @@ If you don't set `dnsPolicy` for a component, Kubernetes applies its default (`C
 
 Common values:
 
-| Value | Behavior |
-|---|---|
-| `ClusterFirst` | In-cluster DNS takes priority; unresolved names fall back to the upstream nameserver. Default for most pods. |
-| `ClusterFirstWithHostNet` | Same as `ClusterFirst`, but required when `hostNetwork: true` to preserve in-cluster DNS resolution. |
-| `Default` | Pods inherit the DNS configuration of the node they run on. |
-| `None` | DNS is configured entirely via `dnsConfig`. |
+| Value                     | Behavior                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `ClusterFirst`            | In-cluster DNS takes priority; unresolved names fall back to the upstream nameserver. Default for most pods. |
+| `ClusterFirstWithHostNet` | Same as `ClusterFirst`, but required when `hostNetwork: true` to preserve in-cluster DNS resolution.         |
+| `Default`                 | Pods inherit the DNS configuration of the node they run on.                                                  |
+| `None`                    | DNS is configured entirely via `dnsConfig`.                                                                  |
 
 ## Custom DNS configuration
 

--- a/docs/self-managed/deployment/helm/configure/pod-networking.md
+++ b/docs/self-managed/deployment/helm/configure/pod-networking.md
@@ -2,42 +2,35 @@
 id: pod-networking
 sidebar_label: Pod networking
 title: Configure pod networking
-description: Configure host network access, DNS policy, and DNS resolution for orchestration cluster pods in Camunda Self-Managed Helm deployments.
+description: Configure DNS policy, custom DNS resolution, and host network access for Camunda component pods in Self-Managed Helm deployments.
 ---
 
-The Camunda Helm chart exposes several values that control how orchestration cluster pods connect to the network. Use these settings when your infrastructure requires pods to share the host network namespace, or when you need to customize DNS resolution behavior.
-
-## Host network
-
-Setting `orchestration.hostNetwork` to `true` makes orchestration cluster pods use the host node's network namespace instead of the default pod network. In this mode, pods share the node's IP address and port space rather than receiving their own cluster IP.
-
-This is useful in environments where:
-
-- Pods must be reachable directly via the node IP (for example, bare-metal deployments without a CNI overlay network).
-- A network plugin or firewall requires pods to appear as node-level processes.
-- You're integrating with infrastructure that doesn't support pod-level IP routing.
-
-```yaml
-orchestration:
-  hostNetwork: true
-```
-
-When `hostNetwork` is enabled and you haven't set `orchestration.dnsPolicy`, the chart automatically sets `dnsPolicy` to `ClusterFirstWithHostNet`. This ensures that pods on the host network can still resolve in-cluster DNS names (for example, Kubernetes `Service` names). If you set `orchestration.dnsPolicy` explicitly, that value always takes precedence.
-
-:::note
-Using `hostNetwork: true` means all ports opened by the orchestration cluster pods are bound directly on the node. Make sure the required ports are not already in use on the node, and review your network policies accordingly.
-:::
+The Camunda Helm chart exposes values that control how component pods connect to the network. Use these settings when your infrastructure requires custom DNS resolution behavior, or when orchestration cluster pods need to share the host node's network namespace.
 
 ## DNS policy
 
-`orchestration.dnsPolicy` controls how DNS resolution works for orchestration cluster pods. It maps directly to the Kubernetes [`dnsPolicy` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
+Every Camunda component supports a `dnsPolicy` value that controls how DNS resolution works for its pods. It maps directly to the Kubernetes [`dnsPolicy` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
+
+The following components support `dnsPolicy`:
+
+| Component | Value key |
+|---|---|
+| Orchestration cluster | `orchestration.dnsPolicy` |
+| Identity | `identity.dnsPolicy` |
+| Connectors | `connectors.dnsPolicy` |
+| Optimize | `optimize.dnsPolicy` |
+| Console | `console.dnsPolicy` |
+| Web Modeler REST API | `webModeler.restapi.dnsPolicy` |
+| Web Modeler WebSockets | `webModeler.websockets.dnsPolicy` |
+
+Example — setting a custom DNS policy for the orchestration cluster:
 
 ```yaml
 orchestration:
   dnsPolicy: ClusterFirst
 ```
 
-If you enable `hostNetwork` without setting `dnsPolicy`, the chart uses `ClusterFirstWithHostNet` automatically. If you don't enable `hostNetwork` and don't set `dnsPolicy`, Kubernetes applies its default (`ClusterFirst`).
+If you don't set `dnsPolicy` for a component, Kubernetes applies its default (`ClusterFirst`).
 
 Common values:
 
@@ -50,12 +43,24 @@ Common values:
 
 ## Custom DNS configuration
 
-`orchestration.dnsConfig` lets you supply custom DNS nameservers, search domains, and resolver options. It maps directly to the Kubernetes [`dnsConfig` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).
+Every Camunda component also supports a `dnsConfig` value that lets you supply custom DNS nameservers, search domains, and resolver options. It maps directly to the Kubernetes [`dnsConfig` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).
 
-Use this when you need to override or extend the default DNS resolver — for example, to add a private nameserver or a custom search domain.
+The following components support `dnsConfig`:
+
+| Component | Value key |
+|---|---|
+| Orchestration cluster | `orchestration.dnsConfig` |
+| Identity | `identity.dnsConfig` |
+| Connectors | `connectors.dnsConfig` |
+| Optimize | `optimize.dnsConfig` |
+| Console | `console.dnsConfig` |
+| Web Modeler REST API | `webModeler.restapi.dnsConfig` |
+| Web Modeler WebSockets | `webModeler.websockets.dnsConfig` |
+
+Use `dnsConfig` when you need to override or extend the default DNS resolver — for example, to add a private nameserver or a custom search domain:
 
 ```yaml
-orchestration:
+connectors:
   dnsPolicy: None
   dnsConfig:
     nameservers:
@@ -68,16 +73,28 @@ orchestration:
         value: "5"
 ```
 
-## Combining settings
+## Host network (orchestration cluster only)
 
-The three values are designed to work together. A typical pattern for host network deployments:
+Setting `orchestration.hostNetwork` to `true` makes orchestration cluster pods use the host node's network namespace instead of the default pod network. In this mode, pods share the node's IP address and port space rather than receiving their own cluster IP.
+
+This option is available only for the orchestration cluster (a StatefulSet). It's useful in environments where:
+
+- Pods must be reachable directly via the node IP (for example, bare-metal deployments without a CNI overlay network).
+- A network plugin or firewall requires pods to appear as node-level processes.
+- You're integrating with infrastructure that doesn't support pod-level IP routing.
 
 ```yaml
 orchestration:
   hostNetwork: true
-  # dnsPolicy defaults to ClusterFirstWithHostNet automatically — no need to set it explicitly
-  # unless you want a different value
 ```
+
+When `hostNetwork` is enabled and you haven't set `orchestration.dnsPolicy`, the chart automatically sets `dnsPolicy` to `ClusterFirstWithHostNet`. This ensures pods on the host network can still resolve in-cluster DNS names (for example, Kubernetes `Service` names). If you set `orchestration.dnsPolicy` explicitly, that value always takes precedence.
+
+:::note
+Using `hostNetwork: true` means all ports opened by the orchestration cluster pods are bound directly on the node. Make sure the required ports are not already in use on the node, and review your network policies accordingly.
+:::
+
+### Combining host network with custom DNS
 
 To fully control DNS on a host-network pod:
 

--- a/docs/self-managed/deployment/helm/configure/pod-networking.md
+++ b/docs/self-managed/deployment/helm/configure/pod-networking.md
@@ -13,14 +13,14 @@ Every Camunda component supports a `dnsPolicy` value that controls how DNS resol
 
 The following components support `dnsPolicy`:
 
-| Component | Value key |
-|---|---|
-| Orchestration cluster | `orchestration.dnsPolicy` |
-| Identity | `identity.dnsPolicy` |
-| Connectors | `connectors.dnsPolicy` |
-| Optimize | `optimize.dnsPolicy` |
-| Console | `console.dnsPolicy` |
-| Web Modeler REST API | `webModeler.restapi.dnsPolicy` |
+| Component              | Value key                         |
+| ---------------------- | --------------------------------- |
+| Orchestration cluster  | `orchestration.dnsPolicy`         |
+| Identity               | `identity.dnsPolicy`              |
+| Connectors             | `connectors.dnsPolicy`            |
+| Optimize               | `optimize.dnsPolicy`              |
+| Console                | `console.dnsPolicy`               |
+| Web Modeler REST API   | `webModeler.restapi.dnsPolicy`    |
 | Web Modeler WebSockets | `webModeler.websockets.dnsPolicy` |
 
 Example — setting a custom DNS policy for the orchestration cluster:

--- a/docs/self-managed/deployment/helm/configure/pod-networking.md
+++ b/docs/self-managed/deployment/helm/configure/pod-networking.md
@@ -1,0 +1,93 @@
+---
+id: pod-networking
+sidebar_label: Pod networking
+title: Configure pod networking
+description: Configure host network access, DNS policy, and DNS resolution for orchestration cluster pods in Camunda Self-Managed Helm deployments.
+---
+
+The Camunda Helm chart exposes several values that control how orchestration cluster pods connect to the network. Use these settings when your infrastructure requires pods to share the host network namespace, or when you need to customize DNS resolution behavior.
+
+## Host network
+
+Setting `orchestration.hostNetwork` to `true` makes orchestration cluster pods use the host node's network namespace instead of the default pod network. In this mode, pods share the node's IP address and port space rather than receiving their own cluster IP.
+
+This is useful in environments where:
+
+- Pods must be reachable directly via the node IP (for example, bare-metal deployments without a CNI overlay network).
+- A network plugin or firewall requires pods to appear as node-level processes.
+- You're integrating with infrastructure that doesn't support pod-level IP routing.
+
+```yaml
+orchestration:
+  hostNetwork: true
+```
+
+When `hostNetwork` is enabled and you haven't set `orchestration.dnsPolicy`, the chart automatically sets `dnsPolicy` to `ClusterFirstWithHostNet`. This ensures that pods on the host network can still resolve in-cluster DNS names (for example, Kubernetes `Service` names). If you set `orchestration.dnsPolicy` explicitly, that value always takes precedence.
+
+:::note
+Using `hostNetwork: true` means all ports opened by the orchestration cluster pods are bound directly on the node. Make sure the required ports are not already in use on the node, and review your network policies accordingly.
+:::
+
+## DNS policy
+
+`orchestration.dnsPolicy` controls how DNS resolution works for orchestration cluster pods. It maps directly to the Kubernetes [`dnsPolicy` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
+
+```yaml
+orchestration:
+  dnsPolicy: ClusterFirst
+```
+
+If you enable `hostNetwork` without setting `dnsPolicy`, the chart uses `ClusterFirstWithHostNet` automatically. If you don't enable `hostNetwork` and don't set `dnsPolicy`, Kubernetes applies its default (`ClusterFirst`).
+
+Common values:
+
+| Value | Behavior |
+|---|---|
+| `ClusterFirst` | In-cluster DNS takes priority; unresolved names fall back to the upstream nameserver. Default for most pods. |
+| `ClusterFirstWithHostNet` | Same as `ClusterFirst`, but required when `hostNetwork: true` to preserve in-cluster DNS resolution. |
+| `Default` | Pods inherit the DNS configuration of the node they run on. |
+| `None` | DNS is configured entirely via `dnsConfig`. |
+
+## Custom DNS configuration
+
+`orchestration.dnsConfig` lets you supply custom DNS nameservers, search domains, and resolver options. It maps directly to the Kubernetes [`dnsConfig` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).
+
+Use this when you need to override or extend the default DNS resolver — for example, to add a private nameserver or a custom search domain.
+
+```yaml
+orchestration:
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - 192.168.1.100
+    searches:
+      - my-namespace.svc.cluster.local
+      - svc.cluster.local
+    options:
+      - name: ndots
+        value: "5"
+```
+
+## Combining settings
+
+The three values are designed to work together. A typical pattern for host network deployments:
+
+```yaml
+orchestration:
+  hostNetwork: true
+  # dnsPolicy defaults to ClusterFirstWithHostNet automatically — no need to set it explicitly
+  # unless you want a different value
+```
+
+To fully control DNS on a host-network pod:
+
+```yaml
+orchestration:
+  hostNetwork: true
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - 10.96.0.10
+    searches:
+      - cluster.local
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -1726,6 +1726,7 @@ module.exports = {
                 //   ],
                 // },
                 "self-managed/deployment/helm/configure/application-configs",
+                "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/operator-based-infrastructure",
                 "self-managed/deployment/helm/configure/enable-additional-components",
                 "self-managed/deployment/helm/configure/data-retention",


### PR DESCRIPTION
## Description

Adds a new **Configure pod networking** page under **Helm chart configuration** documenting the `orchestration.hostNetwork`, `orchestration.dnsPolicy`, and `orchestration.dnsConfig` values introduced in the 8.10 Helm chart (camunda-platform-helm#6210).

### Changes

- **New page**: `docs/self-managed/deployment/helm/configure/pod-networking.md`
  - Documents all three values with use cases, default behavior, and examples.
  - Explains the auto-defaulting behavior: when `hostNetwork: true` and `dnsPolicy` is not set, the chart automatically uses `ClusterFirstWithHostNet` to preserve in-cluster DNS.
- **Sidebar**: Added `pod-networking` entry to `sidebars.js` under the configure section.
- **chart-parameters.md**: Added a discovery link from the orchestration row in the parameters table.

### Backports

- #8945 — 8.8 backport (camunda-platform-helm#6247 merged)
- #8946 — 8.9 backport (camunda-platform-helm#6248 merged)

## Related

- camunda-platform-helm#6210 (8.10 Helm PR, merged)
- camunda-platform-helm#6247 (8.8 backport, merged)
- camunda-platform-helm#6248 (8.9 backport, merged)