### PR TITLE
docs(8.8): add pod networking configuration page

### DIFF
--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-release-notes.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-release-notes.md
@@ -1637,3 +1637,22 @@ Camunda backups have been improved and made easier to use. The web application b
 #### Spring SDK and Orchestration Cluster REST API Migration
 
 The Connectors experience is enhanced with the migration from the Spring Zeebe to the Orchestration Cluster REST API, and the removal of dependency on the Operate client.
+
+### Self-Managed
+
+#### Host network support for orchestration cluster pods
+
+<!-- https://github.com/camunda/camunda-platform-helm/pull/6247 -->
+
+<div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Helm">Helm</span></div>
+
+The 8.8 Helm chart adds `orchestration.hostNetwork` (default: `false`), which lets orchestration cluster pods share the host node's network namespace. This is useful in bare-metal or restricted network environments where pods must be reachable directly via the node IP rather than a cluster overlay network.
+
+When `orchestration.hostNetwork` is set to `true` and `orchestration.dnsPolicy` is not set, the chart automatically uses `dnsPolicy: ClusterFirstWithHostNet` to preserve in-cluster DNS resolution. You can override this by setting `orchestration.dnsPolicy` explicitly.
+
+```yaml
+orchestration:
+  hostNetwork: true
+```
+
+For details, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
@@ -18,6 +18,8 @@ The following tables show the **top-level configuration sections** in `values.ya
 | `global`        | Configures shared settings that apply across components |
 | `orchestration` | Configures orchestration cluster settings               |
 
+For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
+
 ### Other Camunda applications
 
 | Section      | Purpose                                             |

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-networking.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-networking.md
@@ -1,0 +1,110 @@
+---
+id: pod-networking
+sidebar_label: Pod networking
+title: Configure pod networking
+description: Configure DNS policy, custom DNS resolution, and host network access for Camunda component pods in Self-Managed Helm deployments.
+---
+
+The Camunda Helm chart exposes values that control how component pods connect to the network. Use these settings when your infrastructure requires custom DNS resolution behavior, or when orchestration cluster pods need to share the host node's network namespace.
+
+## DNS policy
+
+Every Camunda component supports a `dnsPolicy` value that controls how DNS resolution works for its pods. It maps directly to the Kubernetes [`dnsPolicy` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
+
+The following components support `dnsPolicy`:
+
+| Component              | Value key                         |
+| ---------------------- | --------------------------------- |
+| Orchestration cluster  | `orchestration.dnsPolicy`         |
+| Identity               | `identity.dnsPolicy`              |
+| Connectors             | `connectors.dnsPolicy`            |
+| Optimize               | `optimize.dnsPolicy`              |
+| Console                | `console.dnsPolicy`               |
+| Web Modeler REST API   | `webModeler.restapi.dnsPolicy`    |
+| Web Modeler WebSockets | `webModeler.websockets.dnsPolicy` |
+
+Example — setting a custom DNS policy for the orchestration cluster:
+
+```yaml
+orchestration:
+  dnsPolicy: ClusterFirst
+```
+
+If you don't set `dnsPolicy` for a component, Kubernetes applies its default (`ClusterFirst`).
+
+Common values:
+
+| Value                     | Behavior                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `ClusterFirst`            | In-cluster DNS takes priority; unresolved names fall back to the upstream nameserver. Default for most pods. |
+| `ClusterFirstWithHostNet` | Same as `ClusterFirst`, but required when `hostNetwork: true` to preserve in-cluster DNS resolution.         |
+| `Default`                 | Pods inherit the DNS configuration of the node they run on.                                                  |
+| `None`                    | DNS is configured entirely via `dnsConfig`.                                                                  |
+
+## Custom DNS configuration
+
+Every Camunda component also supports a `dnsConfig` value that lets you supply custom DNS nameservers, search domains, and resolver options. It maps directly to the Kubernetes [`dnsConfig` pod spec field](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).
+
+The following components support `dnsConfig`:
+
+| Component              | Value key                         |
+| ---------------------- | --------------------------------- |
+| Orchestration cluster  | `orchestration.dnsConfig`         |
+| Identity               | `identity.dnsConfig`              |
+| Connectors             | `connectors.dnsConfig`            |
+| Optimize               | `optimize.dnsConfig`              |
+| Console                | `console.dnsConfig`               |
+| Web Modeler REST API   | `webModeler.restapi.dnsConfig`    |
+| Web Modeler WebSockets | `webModeler.websockets.dnsConfig` |
+
+Use `dnsConfig` when you need to override or extend the default DNS resolver — for example, to add a private nameserver or a custom search domain:
+
+```yaml
+connectors:
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - 192.168.1.100
+    searches:
+      - my-namespace.svc.cluster.local
+      - svc.cluster.local
+    options:
+      - name: ndots
+        value: "5"
+```
+
+## Host network (orchestration cluster only)
+
+Setting `orchestration.hostNetwork` to `true` makes orchestration cluster pods use the host node's network namespace instead of the default pod network. In this mode, pods share the node's IP address and port space rather than receiving their own cluster IP.
+
+This option is available only for the orchestration cluster (a StatefulSet). It's useful in environments where:
+
+- Pods must be reachable directly via the node IP (for example, bare-metal deployments without a CNI overlay network).
+- A network plugin or firewall requires pods to appear as node-level processes.
+- You're integrating with infrastructure that doesn't support pod-level IP routing.
+
+```yaml
+orchestration:
+  hostNetwork: true
+```
+
+When `hostNetwork` is enabled and you haven't set `orchestration.dnsPolicy`, the chart automatically sets `dnsPolicy` to `ClusterFirstWithHostNet`. This ensures pods on the host network can still resolve in-cluster DNS names (for example, Kubernetes `Service` names). If you set `orchestration.dnsPolicy` explicitly, that value always takes precedence.
+
+:::note
+Using `hostNetwork: true` means all ports opened by the orchestration cluster pods are bound directly on the node. Make sure the required ports are not already in use on the node, and review your network policies accordingly.
+:::
+
+### Combining host network with custom DNS
+
+To fully control DNS on a host-network pod:
+
+```yaml
+orchestration:
+  hostNetwork: true
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - 10.96.0.10
+    searches:
+      - cluster.local
+```

--- a/versioned_sidebars/version-8.8-sidebars.json
+++ b/versioned_sidebars/version-8.8-sidebars.json
@@ -2925,6 +2925,7 @@
               },
               "items": [
                 "self-managed/deployment/helm/configure/application-configs",
+                "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/enable-additional-components",
                 "self-managed/deployment/helm/configure/data-retention",
                 {


### PR DESCRIPTION
## Description

Backport of #8944 to versioned 8.8 docs.

Adds the **Configure pod networking** page to `versioned_docs/version-8.8/`, documenting `orchestration.hostNetwork`, `orchestration.dnsPolicy`, and `orchestration.dnsConfig` — plus `dnsPolicy`/`dnsConfig` on all other Camunda components.

The corresponding Helm chart backport (camunda/camunda-platform-helm#6247) is already merged.

### Changes

- **New page**: `versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-networking.md`
- **Sidebar**: Added `pod-networking` entry to `versioned_sidebars/version-8.8-sidebars.json` under the Configure section.
- **chart-parameters.md**: Added discovery link from the orchestration row.
- **880-release-notes.md**: Added `hostNetwork` release note entry under Self-Managed.

## Related

- #8944 (8.10 original, pending merge)
- #8946 (8.9 backport)
- camunda/camunda-platform-helm#6247 (8.8 Helm chart backport, merged)