### PR TITLE
docs(c8run): update docs for bundled JRE (8.10)

### DIFF
--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -46,17 +46,9 @@ Additional changes for 8.10 will be added here as the 8.10 documentation is upda
 
 :::
 
-<!-- ## Feature 1
+## Camunda 8 Run no longer requires Java
 
-Description for feature 1.
-
-### Feature 1 details 1
-
-Description for feature 1 details 1.
-
-### Feature 1 details 2
-
-Description for feature 1 details 2. -->
+Camunda 8 Run now ships with a bundled Java runtime. You no longer need to install OpenJDK or set `JAVA_HOME` before starting it.
 
 ## Upgrade guides {#upgrade-guides}
 

--- a/docs/self-managed/quickstart/developer-quickstart/c8run-troubleshooting.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run-troubleshooting.md
@@ -48,21 +48,20 @@ If you configured external Elasticsearch, inspect that deployment's logs separat
 
 ### Java version issues
 
-**Problem:** Camunda 8 Run fails to start due to incorrect Java version or missing `JAVA_HOME`.
+**Problem:** Camunda 8 Run fails to start with a Java-related error.
 
 **Solution:**
 
-1. Verify Java is installed (OpenJDK 21–25 required):
+Camunda 8 Run includes a bundled Java runtime. In most cases, no Java installation is needed. If the bundled runtime is missing or corrupted, Camunda 8 Run falls back to the system JDK.
 
-   ```bash
-   java -version
-   ```
+1. Re-download and extract the Camunda 8 Run archive to restore the bundled runtime.
 
-2. Ensure `JAVA_HOME` is set:
+2. If you want to use a system JDK instead, ensure `JAVA_HOME` points to OpenJDK 21–25 and verify it is set correctly:
 
    ```bash
    # macOS/Linux
    echo $JAVA_HOME
+   java -version
 
    # Windows
    echo %JAVA_HOME%
@@ -81,7 +80,13 @@ If you configured external Elasticsearch, inspect that deployment's logs separat
    setx JAVA_HOME "C:\Program Files\Java\jdk-21"
    ```
 
-Replace `21` in the examples with the version you installed (21–25), and open a new terminal after setting `JAVA_HOME`.
+   Replace `21` with your installed version (21–25), and open a new terminal after setting `JAVA_HOME`.
+
+### Unexpected JVM flags in logs
+
+**Problem:** Camunda 8 Run appends `--enable-native-access=ALL-UNNAMED` and `--sun-misc-unsafe-memory-access=allow` to `JDK_JAVA_OPTIONS` when using Java 25 or newer. This may appear in logs or interfere with tools that inspect JVM options.
+
+**Solution:** This is expected behavior. These flags are required for Java 25 compatibility and are appended automatically. Any values you set in `JDK_JAVA_OPTIONS` beforehand are preserved.
 
 ### Incomplete startup
 

--- a/docs/self-managed/quickstart/developer-quickstart/c8run/configuration.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run/configuration.md
@@ -163,10 +163,9 @@ For more information, see the [metrics](/self-managed/operational-guides/monitor
 
 The following advanced configuration options can be provided via environment variables:
 
-| Variable           | Description                                                                                                                                                                                                                     |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `JAVA_OPTS`        | Allows you to override Java command line parameters for Camunda.                                                                                                                                                                |
-| `JDK_JAVA_OPTIONS` | Passed directly to the JVM. When the resolved runtime is Java 25 or newer, Camunda 8 Run automatically appends `--enable-native-access=ALL-UNNAMED` and `--sun-misc-unsafe-memory-access=allow`. Existing values are preserved. |
+| Variable    | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
+| `JAVA_OPTS` | Allows you to override Java command line parameters for Camunda. |
 
 ## Next steps
 

--- a/docs/self-managed/quickstart/developer-quickstart/c8run/configuration.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run/configuration.md
@@ -163,9 +163,10 @@ For more information, see the [metrics](/self-managed/operational-guides/monitor
 
 The following advanced configuration options can be provided via environment variables:
 
-| Variable    | Description                                                      |
-| ----------- | ---------------------------------------------------------------- |
-| `JAVA_OPTS` | Allows you to override Java command line parameters for Camunda. |
+| Variable           | Description                                                                                                                                                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JAVA_OPTS`        | Allows you to override Java command line parameters for Camunda.                                                                                                                                                                |
+| `JDK_JAVA_OPTIONS` | Passed directly to the JVM. When the resolved runtime is Java 25 or newer, Camunda 8 Run automatically appends `--enable-native-access=ALL-UNNAMED` and `--sun-misc-unsafe-memory-access=allow`. Existing values are preserved. |
 
 ## Next steps
 

--- a/docs/self-managed/quickstart/developer-quickstart/c8run/install-start.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run/install-start.md
@@ -14,14 +14,11 @@ Use this page to install Camunda 8 Run locally, start it on macOS, Linux, or Win
 
 ## Prerequisites
 
-- **OpenJDK 21–25**: Required for running Camunda 8 as a Java application.
 - **[Desktop Modeler](/components/modeler/desktop-modeler/install-the-modeler.md)**
 - **If using Ubuntu**: Ubuntu 22.04 or newer
 
 :::note
-After installing OpenJDK, ensure `JAVA_HOME` is set by running `java -version` in a **new** terminal.
-
-If no version of Java is found, follow your chosen installation's instructions for setting `JAVA_HOME` before continuing.
+Camunda 8 Run includes a bundled Java runtime. No Java installation is required.
 :::
 
 ## Install and start Camunda 8 Run

--- a/docs/self-managed/quickstart/developer-quickstart/c8run/install-start.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run/install-start.md
@@ -17,10 +17,6 @@ Use this page to install Camunda 8 Run locally, start it on macOS, Linux, or Win
 - **[Desktop Modeler](/components/modeler/desktop-modeler/install-the-modeler.md)**
 - **If using Ubuntu**: Ubuntu 22.04 or newer
 
-:::note
-Camunda 8 Run includes a bundled Java runtime. No Java installation is required.
-:::
-
 ## Install and start Camunda 8 Run
 
 1. Download the latest release of <C8Run/> for your operating system and architecture. Opening the `.tgz` file extracts the Camunda 8 Run script into a new directory.


### PR DESCRIPTION
## Description

Updates Camunda 8 Run documentation to reflect the bundled JRE shipped in 8.10 via jlink ([camunda/camunda#51402](https://github.com/camunda/camunda/pull/51402)).

**Changes:**
- `install-start.md`: Remove OpenJDK 21–25 prerequisite and the JAVA_HOME setup note. Replace with a note that a Java runtime is bundled and no installation is required.
- `configuration.md`: No user-facing env var changes needed (Java 25 flag injection is an internal detail).
- `c8run-troubleshooting.md`: Update "Java version issues" to reflect the bundled JRE fallback behavior. Add new "Unexpected JVM flags in logs" entry for the automatic Java 25 `JDK_JAVA_OPTIONS` injection.

## When should this change go live?

- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers`