### PR TITLE
docs(reference): clarify Helm v4 only for Camunda 8.10

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -185,13 +185,24 @@ Execution listeners now support a `cancel` event type on the process element. Ca
 
 For details, see [`cancel` listeners](/components/concepts/execution-listeners.md#cancel-listeners).
 
-### Self-Managed
+### Helm chart deployment
+
+<div class="release"><span class="badge badge--medium" title="This feature affects Helm charts">Helm charts</span><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span></div>
+
+#### Helm v4 required
+
+Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Earlier Camunda versions are the last to support the Helm v3 CLI.
+
+Switching CLIs does not require a release-state migration; Helm is client-side only. Before you run `helm upgrade` to 8.10, install the Helm v4 CLI.
+
+<ul>
+  <li><span class="link-arrow">[Move from the Helm v3 CLI to v4](/self-managed/deployment/helm/operational-tasks/moving-helm-v3-to-v4.md)</span></li>
+  <li><span class="link-arrow">[Helm 4](/self-managed/deployment/helm/operational-tasks/helm-v4.md)</span></li>
+</ul>
 
 #### Host network support for orchestration cluster pods
 
 <!-- https://github.com/camunda/camunda-platform-helm/pull/6210 -->
-
-<div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Helm">Helm</span></div>
 
 The 8.10 Helm chart adds `orchestration.hostNetwork` (default: `false`), which lets orchestration cluster pods share the host node's network namespace. This is useful in bare-metal or restricted network environments where pods must be reachable directly via the node IP rather than a cluster overlay network.
 

--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -28,17 +28,6 @@ Upgrading to Camunda 8.10 delivers significant benefits and keeps your installat
 
 Important changes in Camunda 8.10 are summarized as follows:
 
-<table className="table-callout">
-<tr>
-    <td width="25%">**Theme**</td>
-    <td>**Highlights**</td>
-</tr>
-<tr>
-    <td>[Helm chart deployment](#helm-chart-deployment)</td>
-    <td>Helm CLI v4 is required for Camunda 8.10 (chart 15.x), and orchestration cluster pods can now share the host node's network namespace.</td>
-</tr>
-</table>
-
 :::note
 Additional changes for 8.10 will be added here as the 8.10 documentation is updated.
 :::

--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -28,11 +28,16 @@ Upgrading to Camunda 8.10 delivers significant benefits and keeps your installat
 
 Important changes in Camunda 8.10 are summarized as follows:
 
-:::warning Breaking change: Helm v4 required
-Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Camunda 8.9 (chart 14.x) is the last minor that supports the Helm v3 CLI.
-
-Switching CLIs does not require a release-state migration; Helm is client-side only. Before you run `helm upgrade` to 8.10, install the Helm v4 CLI. See [Move from the Helm v3 CLI to v4](/self-managed/deployment/helm/operational-tasks/moving-helm-v3-to-v4.md) and [Helm 4](/self-managed/deployment/helm/operational-tasks/helm-v4.md).
-:::
+<table className="table-callout">
+<tr>
+    <td width="25%">**Theme**</td>
+    <td>**Highlights**</td>
+</tr>
+<tr>
+    <td>[Helm chart deployment](#helm-chart-deployment)</td>
+    <td>Helm CLI v4 is required for Camunda 8.10 (chart 15.x), and orchestration cluster pods can now share the host node's network namespace.</td>
+</tr>
+</table>
 
 :::note
 Additional changes for 8.10 will be added here as the 8.10 documentation is updated.
@@ -57,6 +62,29 @@ Description for feature 1 details 1.
 ### Feature 1 details 2
 
 Description for feature 1 details 2. -->
+
+## Helm chart deployment
+
+Important changes to Helm chart deployment in 8.10 are as follows:
+
+### Helm v4 required
+
+:::warning Breaking change
+Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Earlier Camunda versions are the last to support the Helm v3 CLI.
+:::
+
+Switching CLIs does not require a release-state migration; Helm is client-side only. Before you run `helm upgrade` to 8.10, install the Helm v4 CLI.
+
+<ul>
+  <li><span class="link-arrow">[Move from the Helm v3 CLI to v4](/self-managed/deployment/helm/operational-tasks/moving-helm-v3-to-v4.md)</span></li>
+  <li><span class="link-arrow">[Helm 4](/self-managed/deployment/helm/operational-tasks/helm-v4.md)</span></li>
+</ul>
+
+### Host network support for orchestration cluster pods
+
+The 8.10 Helm chart adds `orchestration.hostNetwork` (default: `false`), which lets orchestration cluster pods share the host node's network namespace. This is useful in bare-metal or restricted network environments where pods must be reachable directly via the node IP rather than a cluster overlay network.
+
+<p class="link-arrow">[Configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md)</p>
 
 ## Upgrade guides {#upgrade-guides}
 

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -45,10 +45,7 @@ For example, 1.2+ means support for the minor version 2, and any higher minors (
 - **Zeebe Java Client**: OpenJDK 8+
 - **Connector SDK**: OpenJDK 17+
 - **Camunda Spring Boot Starter**: OpenJDK 17+, Spring Boot 4.0.x
-- **Helm CLI**:
-  - v4.x is the only supported version for Camunda 8.10 (chart 15.x) and later.
-  - v3.x is supported for earlier Camunda versions — see the [version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) for minimum patch versions.
-  - See [Helm 4](/self-managed/deployment/helm/operational-tasks/helm-v4.md) for details.
+- **Helm CLI**: v4.x is required for Camunda 8.10 (chart 15.x) and later. See [Helm 4](/self-managed/deployment/helm/operational-tasks/helm-v4.md) for details, and the [version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) for minimum patch versions.
 
 ## Camunda 8 Self-Managed
 
@@ -109,7 +106,7 @@ Regardless of the type, the network storage volumes you use must meet these requ
 
 ### Helm charts version matrix
 
-Camunda Helm chart version `15.x.x` works with Camunda version `8.10.x` and requires the Helm v4 CLI. Camunda 8.9 (chart 14.x) is the last minor that supports the Helm v3 CLI. Check the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) for more details.
+Camunda Helm chart version `15.x.x` works with Camunda version `8.10.x` and requires the Helm v4 CLI. Check the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) for more details.
 
 ## Component requirements
 

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -46,8 +46,8 @@ For example, 1.2+ means support for the minor version 2, and any higher minors (
 - **Connector SDK**: OpenJDK 17+
 - **Camunda Spring Boot Starter**: OpenJDK 17+, Spring Boot 4.0.x
 - **Helm CLI**:
-  - v4.x required for Camunda 8.10 (chart 15.x) and later.
-  - v3.x supported for Camunda 8.9 (chart 14.x) and earlier — see the [version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) for minimum patch versions.
+  - v4.x is the only supported version for Camunda 8.10 (chart 15.x) and later.
+  - v3.x is supported for earlier Camunda versions — see the [version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) for minimum patch versions.
   - See [Helm 4](/self-managed/deployment/helm/operational-tasks/helm-v4.md) for details.
 
 ## Camunda 8 Self-Managed


### PR DESCRIPTION
## Description

Updates the Helm CLI entry in [Supported environments](docs/reference/supported-environments.md) to state that Camunda 8.10 (chart 15.x) only supports Helm v4. Generalizes the Helm v3 compatibility note to cover earlier Camunda versions rather than pinning it to 8.9.

## When should this change go live?

- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)