### PR TITLE
docs(byok): update AWS role ARN format in BYOK setup guide

### DIFF
--- a/docs/components/saas/byok/aws-kms-setup.md
+++ b/docs/components/saas/byok/aws-kms-setup.md
@@ -33,7 +33,11 @@ Learn how to configure encryption at rest for your Camunda 8 SaaS Orchestration 
    ![external option encryption at rest](./img/external-encryption.png)
 6. Click **Create cluster**.
 
-After creation, note the **AWS Role ARN** displayed in the Console for your cluster.
+After creation, note the **AWS Role ARN** displayed in the Console for your cluster. The ARN uses the following format:
+
+```
+arn:aws:iam::<account-id>:role/c8-cluster/c8-apps-<uuid>
+```
 
 ## Step 2: Create and configure an AWS KMS key
 

--- a/versioned_docs/version-8.7/components/concepts/byok/aws-kms-setup.md
+++ b/versioned_docs/version-8.7/components/concepts/byok/aws-kms-setup.md
@@ -16,9 +16,10 @@ Learn how to configure encryption at rest for your Camunda 8 SaaS cluster using 
 | Technical familiarity | Some experience with the AWS Management Console, IAM roles, and AWS KMS.    |
 
 :::warning Important
+
 - Deleting or disabling your AWS KMS key will make your cluster and data inaccessible. To understand how Camunda behaves if a key is disabled, deleted, or its policy is changed, see [key state behavior](/components/concepts/byok/key-state-behavior.md).
 - Key management is fully customer-side in AWS KMS. Camunda cannot rotate keys.
-:::
+  :::
 
 ## Step 1: Create a Camunda 8 SaaS cluster
 
@@ -31,7 +32,11 @@ Learn how to configure encryption at rest for your Camunda 8 SaaS cluster using 
    ![external option encryption at rest](./img/external-encryption.png)
 6. Click **Create cluster**.
 
-After creation, note the **AWS Role ARN** displayed in the Console for your cluster.
+After creation, note the **AWS Role ARN** displayed in the Console for your cluster. The ARN uses the following format:
+
+```
+arn:aws:iam::<account-id>:role/c8-cluster/c8-apps-<uuid>
+```
 
 ## Step 2: Create and configure an AWS KMS key
 

--- a/versioned_docs/version-8.8/components/saas/byok/aws-kms-setup.md
+++ b/versioned_docs/version-8.8/components/saas/byok/aws-kms-setup.md
@@ -16,9 +16,10 @@ Learn how to configure encryption at rest for your Camunda 8 SaaS Orchestration 
 | Technical familiarity | Some experience with the AWS Management Console, IAM roles, and AWS KMS.    |
 
 :::warning Important
+
 - Deleting or disabling your AWS KMS key will make your cluster and data inaccessible. To understand how Camunda behaves if a key is disabled, deleted, or its policy is changed, see [key state behavior](/components/saas/byok/key-state-behavior.md).
 - Key management is fully customer-side in AWS KMS. Camunda cannot rotate keys.
-:::
+  :::
 
 ## Step 1: Create a Camunda 8 SaaS Orchestration cluster
 
@@ -31,7 +32,11 @@ Learn how to configure encryption at rest for your Camunda 8 SaaS Orchestration 
    ![external option encryption at rest](./img/external-encryption.png)
 6. Click **Create cluster**.
 
-After creation, note the **AWS Role ARN** displayed in the Console for your cluster.
+After creation, note the **AWS Role ARN** displayed in the Console for your cluster. The ARN uses the following format:
+
+```
+arn:aws:iam::<account-id>:role/c8-cluster/c8-apps-<uuid>
+```
 
 ## Step 2: Create and configure an AWS KMS key
 

--- a/versioned_docs/version-8.9/components/saas/byok/aws-kms-setup.md
+++ b/versioned_docs/version-8.9/components/saas/byok/aws-kms-setup.md
@@ -33,7 +33,11 @@ Learn how to configure encryption at rest for your Camunda 8 SaaS Orchestration 
    ![external option encryption at rest](./img/external-encryption.png)
 6. Click **Create cluster**.
 
-After creation, note the **AWS Role ARN** displayed in the Console for your cluster.
+After creation, note the **AWS Role ARN** displayed in the Console for your cluster. The ARN uses the following format:
+
+```
+arn:aws:iam::<account-id>:role/c8-cluster/c8-apps-<uuid>
+```
 
 ## Step 2: Create and configure an AWS KMS key
 


### PR DESCRIPTION
## Description

Updates the AWS BYOK setup guide to reflect the new AWS IAM role name format used by Camunda.

The AWS role ARN for BYOK has changed from:
- `arn:aws:iam::<account-id>:role/<uuid>`

To:
- `arn:aws:iam::<account-id>:role/c8-cluster/c8-apps-<uuid>`

Added an example in Step 1 showing the new ARN format so users can identify and use the correct role ARN when configuring their KMS key policy.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.