### PR TITLE
docs: clarify Helm upload size configuration

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -18,7 +18,7 @@ The `maxMessageSize` default value is 4MB for raw Zeebe deployments (10MB for He
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
 If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
-this value to the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP
+this value to the Zeebe Gateway and broker message size, the REST multipart file and request size, and the Tomcat HTTP
 form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if you need a
 value other than 10MB.
 
@@ -34,7 +34,7 @@ response, not HTTP 413.
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.
 
-If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
+If you are not using Helm and increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration
 

--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -38,7 +38,7 @@ If you are not using Helm and increase this value, you must also adjust the conf
 
 ### REST API server configuration
 
-If you're using the REST API and submitting files via multipart upload (e.g., using `POST /v2/deployments`), make sure your application is configured to accept the updated request sizes. If you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
+If you're increasing the `maxMessageSize` and using the REST API for multipart uploads (for example, using `POST /v2/deployments`), you must configure your application to accept the updated request sizes. If you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
 
 For Spring Boot applications:
 

--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -12,19 +12,24 @@ This guide walks you through adjusting these settings.
 
 ### Gateway and Broker configuration
 
-The `maxMessageSize` default value is 4MB. You can configure this setting in the:
+The `maxMessageSize` default value is 4MB for raw Zeebe deployments (10MB for Helm). You can configure this setting in the:
 
 - [Gateway config](../orchestration-cluster/zeebe/configuration/gateway.md#zeebegatewaynetwork)
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
-If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
-size. If you expose the REST API through Ingress, keep
-`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
+this value to the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP
+form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if you need a
+value other than 10MB.
+
+If you expose the REST API through Ingress, you must also explicitly set
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` to the same value.
+This annotation is not propagated automatically from `requestBodySize`.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
-follow-up records exceed the engine batch limit.
+follow-up records exceed the engine batch limit. This engine-level rejection returns an HTTP 500
+response, not HTTP 413.
 
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.

--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -19,7 +19,7 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
 the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
-size. If you expose the REST API through ingress, keep
+size. If you expose the REST API through Ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments

--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -6,7 +6,7 @@ description: "Learn how to configure upload limits and multipart handling for Or
 
 ## Deployment configuration
 
-The Orchestration Cluster REST API supports file and multipart uploads when deploying BPMN diagrams and other resources. By default, the maximum allowed request size is 4MB. You can increase this limit in Self-Managed cluster through configuration of the Zeebe Gateway, Broker, and the REST layer (e.g. Spring Boot + Tomcat).
+The Orchestration Cluster REST API supports file and multipart uploads when deploying BPMN diagrams and other resources. By default, the maximum allowed request size is 4MB. You can increase this limit in Self-Managed cluster through configuration of the Zeebe Gateway, Broker, and the REST layer, for example, Spring Boot and Tomcat.
 
 This guide walks you through adjusting these settings.
 
@@ -18,13 +18,13 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe message size and the REST multipart file and request size. If you expose the REST API
-through ingress, keep
+the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
+size. If you expose the REST API through ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
-This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
-be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
-exceed the engine batch limit.
+This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
+can still be rejected by Zeebe's internal record batch processing if the deployed resources and
+follow-up records exceed the engine batch limit.
 
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
@@ -37,6 +37,7 @@ For Spring Boot applications:
 ```properties
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+server.tomcat.max-http-form-post-size=10MB
 ```
 
 ### Tomcat multipart settings

--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -17,6 +17,15 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 - [Gateway config](../orchestration-cluster/zeebe/configuration/gateway.md#zeebegatewaynetwork)
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
+If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
+the Zeebe message size and the REST multipart file and request size. If you expose the REST API
+through ingress, keep
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+
+This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
+be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
+exceed the engine batch limit.
+
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration

--- a/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/docs/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -26,6 +26,9 @@ This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport l
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
 follow-up records exceed the engine batch limit.
 
+Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
+Set these limits slightly above the largest file you expect users or Connectors to upload.
+
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration

--- a/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -34,14 +34,22 @@ You can also directly [download the OpenAPI specification](https://github.com/ca
 
 You can change the `maxMessageSize` default value of 4MB in the [Gateway](../../self-managed/zeebe-deployment/configuration/gateway.md#zeebegatewaynetwork) and [Broker](../../self-managed/zeebe-deployment/configuration/broker.md#zeebebrokernetwork) configuration.
 
-If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe Gateway, broker message size, REST multipart file and request size, and Tomcat HTTP form
-post size. If you expose the REST API through Ingress, keep
-`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
+this value to the Zeebe Gateway and broker message size, REST multipart file and request size, and
+the Tomcat HTTP form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if
+you need a value other than 10MB.
+
+If you expose the REST API through Ingress, you must also explicitly set
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` to the same value.
+This annotation is not propagated automatically from `requestBodySize`. If you use
+`zeebeGateway.ingress.rest` to expose the REST endpoint directly, also set
+`nginx.ingress.kubernetes.io/proxy-body-size` in `zeebeGateway.ingress.rest.annotations`, as that
+Ingress object does not inherit from `global.ingress.annotations`.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
-follow-up records exceed the engine batch limit.
+follow-up records exceed the engine batch limit. This engine-level rejection returns an HTTP 500
+response, not HTTP 413.
 
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.

--- a/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -36,7 +36,7 @@ You can change the `maxMessageSize` default value of 4MB in the [Gateway](../../
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
 the Zeebe Gateway, broker message size, REST multipart file and request size, and Tomcat HTTP form
-post size. If you expose the REST API through ingress, keep
+post size. If you expose the REST API through Ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments

--- a/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -35,13 +35,13 @@ You can also directly [download the OpenAPI specification](https://github.com/ca
 You can change the `maxMessageSize` default value of 4MB in the [Gateway](../../self-managed/zeebe-deployment/configuration/gateway.md#zeebegatewaynetwork) and [Broker](../../self-managed/zeebe-deployment/configuration/broker.md#zeebebrokernetwork) configuration.
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe Gateway, broker message size, and REST multipart file and request size. If you expose the REST API
-through ingress, keep
+the Zeebe Gateway, broker message size, REST multipart file and request size, and Tomcat HTTP form
+post size. If you expose the REST API through ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
-This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
-be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
-exceed the engine batch limit.
+This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
+can still be rejected by Zeebe's internal record batch processing if the deployed resources and
+follow-up records exceed the engine batch limit.
 
 If you do change this value, it is recommended that you also configure the [Deploy resources](./specifications/deploy-resources.api.mdx) REST endpoint appropriately. By default, this endpoint allows single file upload and overall data up to 4MB.
 
@@ -50,6 +50,7 @@ You can adjust this configuration via the following properties:
 ```properties
 spring.servlet.multipart.max-file-size=4MB
 spring.servlet.multipart.max-request-size=4MB
+server.tomcat.max-http-form-post-size=4MB
 ```
 
 For example, if you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.

--- a/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -34,6 +34,15 @@ You can also directly [download the OpenAPI specification](https://github.com/ca
 
 You can change the `maxMessageSize` default value of 4MB in the [Gateway](../../self-managed/zeebe-deployment/configuration/gateway.md#zeebegatewaynetwork) and [Broker](../../self-managed/zeebe-deployment/configuration/broker.md#zeebebrokernetwork) configuration.
 
+If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
+the Zeebe Gateway, broker message size, and REST multipart file and request size. If you expose the REST API
+through ingress, keep
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+
+This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
+be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
+exceed the engine batch limit.
+
 If you do change this value, it is recommended that you also configure the [Deploy resources](./specifications/deploy-resources.api.mdx) REST endpoint appropriately. By default, this endpoint allows single file upload and overall data up to 4MB.
 
 You can adjust this configuration via the following properties:

--- a/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
+++ b/versioned_docs/version-8.7/apis-tools/camunda-api-rest/camunda-api-rest-overview.md
@@ -43,6 +43,9 @@ This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport l
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
 follow-up records exceed the engine batch limit.
 
+Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
+Set these limits slightly above the largest file you expect users or Connectors to upload.
+
 If you do change this value, it is recommended that you also configure the [Deploy resources](./specifications/deploy-resources.api.mdx) REST endpoint appropriately. By default, this endpoint allows single file upload and overall data up to 4MB.
 
 You can adjust this configuration via the following properties:

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -18,7 +18,7 @@ The `maxMessageSize` default value is 4MB for raw Zeebe deployments (10MB for He
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
 If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
-this value to the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP
+this value to the Zeebe Gateway and broker message size, the REST multipart file and request size, and the Tomcat HTTP
 form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if you need a
 value other than 10MB.
 
@@ -34,7 +34,7 @@ response, not HTTP 413.
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.
 
-If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
+If you are not using Helm and increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -38,7 +38,7 @@ If you are not using Helm and increase this value, you must also adjust the conf
 
 ### REST API server configuration
 
-If you're using the REST API and submitting files via multipart upload (e.g., using `POST /v2/deployments`), make sure your application is configured to accept the updated request sizes. If you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
+If you're increasing the `maxMessageSize` and using the REST API for multipart uploads (for example, using `POST /v2/deployments`), you must configure your application to accept the updated request sizes. If you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
 
 For Spring Boot applications:
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -12,19 +12,24 @@ This guide walks you through adjusting these settings.
 
 ### Gateway and Broker configuration
 
-The `maxMessageSize` default value is 4MB. You can configure this setting in the:
+The `maxMessageSize` default value is 4MB for raw Zeebe deployments (10MB for Helm). You can configure this setting in the:
 
 - [Gateway config](../orchestration-cluster/zeebe/configuration/gateway.md#zeebegatewaynetwork)
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
-If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
-size. If you expose the REST API through Ingress, keep
-`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
+this value to the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP
+form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if you need a
+value other than 10MB.
+
+If you expose the REST API through Ingress, you must also explicitly set
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` to the same value.
+This annotation is not propagated automatically from `requestBodySize`.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
-follow-up records exceed the engine batch limit.
+follow-up records exceed the engine batch limit. This engine-level rejection returns an HTTP 500
+response, not HTTP 413.
 
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -19,7 +19,7 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
 the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
-size. If you expose the REST API through ingress, keep
+size. If you expose the REST API through Ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -6,7 +6,7 @@ description: "Learn how to configure upload limits and multipart handling for Or
 
 ## Deployment configuration
 
-The Orchestration Cluster REST API supports file and multipart uploads when deploying BPMN diagrams and other resources. By default, the maximum allowed request size is 4MB. You can increase this limit in Self-Managed cluster through configuration of the Zeebe Gateway, Broker, and the REST layer (e.g. Spring Boot + Tomcat).
+The Orchestration Cluster REST API supports file and multipart uploads when deploying BPMN diagrams and other resources. By default, the maximum allowed request size is 4MB. You can increase this limit in Self-Managed cluster through configuration of the Zeebe Gateway, Broker, and the REST layer, for example, Spring Boot and Tomcat.
 
 This guide walks you through adjusting these settings.
 
@@ -18,13 +18,13 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe message size and the REST multipart file and request size. If you expose the REST API
-through ingress, keep
+the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
+size. If you expose the REST API through ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
-This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
-be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
-exceed the engine batch limit.
+This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
+can still be rejected by Zeebe's internal record batch processing if the deployed resources and
+follow-up records exceed the engine batch limit.
 
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
@@ -37,6 +37,7 @@ For Spring Boot applications:
 ```properties
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+server.tomcat.max-http-form-post-size=10MB
 ```
 
 ### Tomcat multipart settings

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -17,6 +17,15 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 - [Gateway config](../orchestration-cluster/zeebe/configuration/gateway.md#zeebegatewaynetwork)
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
+If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
+the Zeebe message size and the REST multipart file and request size. If you expose the REST API
+through ingress, keep
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+
+This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
+be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
+exceed the engine batch limit.
+
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -26,6 +26,9 @@ This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport l
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
 follow-up records exceed the engine batch limit.
 
+Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
+Set these limits slightly above the largest file you expect users or Connectors to upload.
+
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -18,7 +18,7 @@ The `maxMessageSize` default value is 4MB for raw Zeebe deployments (10MB for He
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
 If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
-this value to the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP
+this value to the Zeebe Gateway and broker message size, the REST multipart file and request size, and the Tomcat HTTP
 form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if you need a
 value other than 10MB.
 
@@ -34,7 +34,7 @@ response, not HTTP 413.
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.
 
-If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
+If you are not using Helm and increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -38,7 +38,7 @@ If you are not using Helm and increase this value, you must also adjust the conf
 
 ### REST API server configuration
 
-If you're using the REST API and submitting files via multipart upload (e.g., using `POST /v2/deployments`), make sure your application is configured to accept the updated request sizes. If you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
+If you're increasing the `maxMessageSize` and using the REST API for multipart uploads (for example, using `POST /v2/deployments`), you must configure your application to accept the updated request sizes. If you increase the `maxMessageSize` to 10MB, increase these property values to 10MB as well.
 
 For Spring Boot applications:
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -12,19 +12,24 @@ This guide walks you through adjusting these settings.
 
 ### Gateway and Broker configuration
 
-The `maxMessageSize` default value is 4MB. You can configure this setting in the:
+The `maxMessageSize` default value is 4MB for raw Zeebe deployments (10MB for Helm). You can configure this setting in the:
 
 - [Gateway config](../orchestration-cluster/zeebe/configuration/gateway.md#zeebegatewaynetwork)
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
-If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
-size. If you expose the REST API through Ingress, keep
-`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+If you deploy with Helm, the chart defaults to 10MB via `global.config.requestBodySize`, applying
+this value to the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP
+form post size on the Zeebe Gateway. Change `global.config.requestBodySize` only if you need a
+value other than 10MB.
+
+If you expose the REST API through Ingress, you must also explicitly set
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` to the same value.
+This annotation is not propagated automatically from `requestBodySize`.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
-follow-up records exceed the engine batch limit.
+follow-up records exceed the engine batch limit. This engine-level rejection returns an HTTP 500
+response, not HTTP 413.
 
 Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
 Set these limits slightly above the largest file you expect users or Connectors to upload.

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -19,7 +19,7 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
 the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
-size. If you expose the REST API through ingress, keep
+size. If you expose the REST API through Ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
 This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -6,7 +6,7 @@ description: "Learn how to configure upload limits and multipart handling for Or
 
 ## Deployment configuration
 
-The Orchestration Cluster REST API supports file and multipart uploads when deploying BPMN diagrams and other resources. By default, the maximum allowed request size is 4MB. You can increase this limit in Self-Managed cluster through configuration of the Zeebe Gateway, Broker, and the REST layer (e.g. Spring Boot + Tomcat).
+The Orchestration Cluster REST API supports file and multipart uploads when deploying BPMN diagrams and other resources. By default, the maximum allowed request size is 4MB. You can increase this limit in Self-Managed cluster through configuration of the Zeebe Gateway, Broker, and the REST layer, for example, Spring Boot and Tomcat.
 
 This guide walks you through adjusting these settings.
 
@@ -18,13 +18,13 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
 If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
-the Zeebe message size and the REST multipart file and request size. If you expose the REST API
-through ingress, keep
+the Zeebe message size, the REST multipart file and request size, and the Tomcat HTTP form post
+size. If you expose the REST API through ingress, keep
 `global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
 
-This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
-be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
-exceed the engine batch limit.
+This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport limits. Deployments
+can still be rejected by Zeebe's internal record batch processing if the deployed resources and
+follow-up records exceed the engine batch limit.
 
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
@@ -37,6 +37,7 @@ For Spring Boot applications:
 ```properties
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+server.tomcat.max-http-form-post-size=10MB
 ```
 
 ### Tomcat multipart settings

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -17,6 +17,15 @@ The `maxMessageSize` default value is 4MB. You can configure this setting in the
 - [Gateway config](../orchestration-cluster/zeebe/configuration/gateway.md#zeebegatewaynetwork)
 - [Broker config](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokernetwork)
 
+If you deploy with Helm, set `global.config.requestBodySize`. The chart applies this value to
+the Zeebe message size and the REST multipart file and request size. If you expose the REST API
+through ingress, keep
+`global.ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` aligned with the same size.
+
+This setting aligns the HTTP, multipart, Gateway, and Broker transport limits. Deployments can still
+be rejected by Zeebe's internal record batch processing if the deployed resources and follow-up records
+exceed the engine batch limit.
+
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/orchestration-cluster-api-rest-deployment-configuration.md
@@ -26,6 +26,9 @@ This setting aligns the HTTP, multipart, Tomcat, Gateway, and Broker transport l
 can still be rejected by Zeebe's internal record batch processing if the deployed resources and
 follow-up records exceed the engine batch limit.
 
+Multipart requests include metadata and boundary overhead in addition to the uploaded file content.
+Set these limits slightly above the largest file you expect users or Connectors to upload.
+
 If you increase this value, you must also adjust the configuration for the deployment REST endpoint to match.
 
 ### REST API server configuration


### PR DESCRIPTION
## Summary
- Documents that Helm users should set `global.config.requestBodySize` to align REST multipart limits and Zeebe message size.
- Adds ingress alignment guidance for `nginx.ingress.kubernetes.io/proxy-body-size`.
- Clarifies that Zeebe internal record-batch processing can still reject deployments even when transport limits are aligned.

## Root Cause
Root cause is in the Helm chart: `global.config.requestBodySize` configured Spring multipart upload limits at `10MB`, but Zeebe Gateway/Broker message size remained at the product default `4MB`.

## Validation
- Not run: `npm run format:check` could not run locally because docs dependencies are not installed (`prettier: not found`).
- Content was updated in Next, 8.9, 8.8, and 8.7 docs trees.

## GKE Evidence From Helm PR
Baseline 8.9 chart deployed to `support32927base-89-keyco-inst-gke`:
- Small BPMN upload to `/orchestration/v2/deployments`: HTTP 200.
- ~5MB BPMN upload: HTTP 400, `Request size is above configured maxMessageSize.`

Fixed 8.9 chart deployed to `support32927fix-89-keyco-inst-gke`:
- Runtime config includes `spring.servlet.multipart.max-file-size`, `spring.servlet.multipart.max-request-size`, `camunda.cluster.network.max-message-size`, `camunda.api.grpc.max-message-size`, and legacy `zeebe.broker.network.maxMessageSize` at `10MB`.
- Valid 4.2MB BPMN upload to `/orchestration/v2/deployments`: HTTP 200.
- Valid 5MB BPMN no longer fails with `maxMessageSize`, but still hits Zeebe engine `EXCEEDED_BATCH_RECORD_SIZE`. This appears to be a separate product/engine record-batch limit, not the Helm transport-limit bug.

## Related PRs
- Helm PR: https://github.com/camunda/camunda-platform-helm/pull/6279

## Notes
- Originating nightly run URL: not available in this session; SUPPORT-32927 was reproduced manually on GKE.
- Merge order: Helm first, docs second.