### PR TITLE
docs: add 8.9 to 8.10 helm upgrade page for bitnami subchart removal

### DIFF
--- a/docs/self-managed/upgrade/helm/890-to-8100.md
+++ b/docs/self-managed/upgrade/helm/890-to-8100.md
@@ -1,0 +1,55 @@
+---
+id: 890-to-8100
+sidebar_label: Upgrade 8.9 to 8.10
+title: Upgrade Camunda 8.9 to 8.10 using Helm
+description: Upgrade a Camunda 8 Self-Managed deployment from version 8.9 to 8.10 using Helm, including required configuration and migration steps.
+toc_max_heading_level: 3
+---
+
+<!--
+TODO (8.10):
+- Camunda 8.10 is unreleased. This page currently covers only the confirmed Bitnami subchart
+  removal. Add the remaining 8.9 -> 8.10 upgrade requirements (values changes, run helm upgrade,
+  validation) as they are finalized, following the 8.8 -> 8.9 guide structure.
+-->
+
+:::note
+This page is a work in progress for Camunda 8.10 (unreleased) and will be updated as upgrade
+requirements are finalized. It currently documents only the Bitnami subchart removal.
+:::
+
+Upgrade a Helm-managed Camunda 8 Self-Managed deployment from version 8.9 to 8.10.
+
+## Prerequisites
+
+Before upgrading:
+
+- Confirm your deployment is running the latest `8.9.x` patch. If you are upgrading from a version earlier than 8.9, upgrade one minor version at a time.
+- Review [Prepare for upgrade](/self-managed/upgrade/prepare-for-upgrade.md) to confirm upgrade eligibility and complete any required pre-upgrade actions.
+- Camunda 8.10 (chart 15.x) requires the **Helm CLI v4**. Switch to the Helm v4 CLI before you run `helm upgrade`; no release-state migration is required. See [Move from the Helm v3 CLI to v4](/self-managed/deployment/helm/operational-tasks/moving-helm-v3-to-v4.md).
+- Review the Camunda Helm chart [version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) and confirm the chart version that deploys Camunda 8.10 is supported for your Kubernetes and Helm client versions.
+- Create and verify backups for your Camunda data.
+
+## Bitnami subcharts removed
+
+The four bundled Bitnami subcharts that were deprecated in 8.9 are **removed in 8.10**. Setting any of the following keys now makes `helm template` (and `helm upgrade`) fail with a migration error:
+
+| Removed key            | Previously bundled   | Replace with                                                         |
+| ---------------------- | -------------------- | -------------------------------------------------------------------- |
+| `identityKeycloak`     | Keycloak             | External Keycloak (operator, managed IdP, or customer-owned image)   |
+| `identityPostgresql`   | Identity database    | External PostgreSQL (operator such as CloudNativePG, or managed)     |
+| `webModelerPostgresql` | Web Modeler database | External PostgreSQL (operator such as CloudNativePG, or managed)     |
+| `elasticsearch`        | Search               | External Elasticsearch/OpenSearch (operator such as ECK, or managed) |
+
+From 8.10, Camunda owns the workload chart; you provide and manage the database, search engine,
+and identity provider. **Before upgrading to 8.10**, migrate each bundled component to externally
+managed infrastructure while still on 8.9, then upgrade.
+
+Follow the [Migration from Bitnami](/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/index.md)
+guide for per-component migration paths (PostgreSQL, Elasticsearch, Keycloak), including
+zero-downtime and managed-service options.
+
+<!--
+TODO (8.10): document the remaining values changes and the `helm upgrade` invocation once 8.10
+upgrade requirements are finalized.
+-->

--- a/docs/self-managed/upgrade/helm/index.md
+++ b/docs/self-managed/upgrade/helm/index.md
@@ -37,6 +37,10 @@ helm search repo camunda/camunda-platform --versions
 
 ## Upgrade notes
 
+### Bitnami subcharts removed in 8.10
+
+The four bundled Bitnami subcharts (`identityKeycloak`, `identityPostgresql`, `webModelerPostgresql`, `elasticsearch`), deprecated in 8.9, are removed in 8.10. Setting any of these keys makes `helm upgrade` fail. Migrate each component to externally managed infrastructure before upgrading — see [Upgrade 8.9 to 8.10](/self-managed/upgrade/helm/890-to-8100.md) and the [Migration from Bitnami](/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/index.md) guide.
+
 ### Bitnami Docker repository migration
 
 On August 28, 2025, Bitnami migrated its container images from [bitnami](https://hub.docker.com/u/bitnami) to [bitnamilegacy](https://hub.docker.com/u/bitnamilegacy). The Camunda Helm charts have been updated to use the new repository.

--- a/docs/self-managed/upgrade/react-components/_card-data.js
+++ b/docs/self-managed/upgrade/react-components/_card-data.js
@@ -28,6 +28,13 @@ export const overviewCards = [
 
 export const helmIndexCards = [
   {
+    link: "./890-to-8100",
+    title: "Upgrade Camunda 8.9 to 8.10 using Helm",
+    image: IconArrow,
+    description:
+      "Upgrade a Helm-managed Camunda 8.9 deployment to 8.10, including the Bitnami subchart removal.",
+  },
+  {
     link: "./880-to-890",
     title: "Upgrade Camunda 8.8 to 8.9 using Helm",
     image: IconArrow,

--- a/sidebars.js
+++ b/sidebars.js
@@ -2495,7 +2495,10 @@ module.exports = {
             type: "doc",
             id: "self-managed/upgrade/helm/index",
           },
-          items: ["self-managed/upgrade/helm/880-to-890"],
+          items: [
+            "self-managed/upgrade/helm/880-to-890",
+            "self-managed/upgrade/helm/890-to-8100",
+          ],
         },
         "self-managed/upgrade/manual/index",
         {


### PR DESCRIPTION
Adds the 8.9 → 8.10 Helm upgrade page (currently a 404), scoped to the Bitnami subchart removal landed in camunda/camunda-platform-helm#6146.

8.10 is unreleased/alpha, so the page is an intentionally minimal work-in-progress that mirrors the early life of the 8.8 → 8.9 page: it documents only the confirmed breaking change — the four bundled Bitnami subcharts (`identityKeycloak`, `identityPostgresql`, `webModelerPostgresql`, `elasticsearch`) are removed in 8.10 — and links the existing Migration from Bitnami guide. Remaining 8.9 → 8.10 upgrade steps are left as TODOs to fill in as requirements finalize.

Also adds a "Bitnami subcharts removed in 8.10" note to the Helm upgrade index, plus a sidebar entry and an upgrade card.

Relates to camunda/camunda-platform-helm#5988. Epic: camunda/team-distribution#774.
