### PR TITLE
docs(8.8): document Zeebe TLS migration settings

### DIFF
--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md
@@ -29,7 +29,7 @@ The following changes are specific to dual-region setups and should be reviewed 
 | **Exporter keys**              | Replace `global.elasticsearch.disableExporter: false` | Use `orchestration.exporters.camunda.enabled: false` and `orchestration.exporters.zeebe.enabled: false`                                                                       |
 | **New Camunda Exporter**       | Define for both regions                               | Configure [Camunda Exporter](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md)                                                        |
 | **Legacy Exporter**            | Keep enabled during migration                         | Keep the old [Elasticsearch / OpenSearch Exporter](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) definitions                      |
-| **Environment variables**      | Rename gateway prefixes                               | Change `ZEEBE_GATEWAY_*` to `ZEEBE_BROKER_GATEWAY_*` (embedded gateway architecture)                                                                                          |
+| **Environment variables**      | Rename gateway prefixes                               | Change `ZEEBE_GATEWAY_*` to `ZEEBE_BROKER_GATEWAY_*` for the embedded gateway, and keep standalone gateway TLS settings for migration pods.                                   |
 | **Message compression**        | Add to orchestration configuration                    | Required for migration jobs to communicate with the Zeebe cluster                                                                                                             |
 | **Basic authentication users** | Migrate manually                                      | Users defined in `camunda.operate` or `camunda.tasklist` require manual migration to [embedded Identity](/self-managed/components/orchestration-cluster/identity/overview.md) |
 | **API security**               | Review defaults                                       | gRPC and REST APIs are secured by default in 8.8                                                                                                                              |
@@ -71,7 +71,7 @@ orchestration:
 
 ## Update gateway environment variables
 
-In 8.8, the Zeebe Gateway is embedded in the Orchestration Cluster. As a result, gateway-related environment variables use a new prefix.
+In 8.8, the Zeebe Gateway is embedded in the Orchestration Cluster. As a result, gateway-related environment variables use a new prefix for the broker and embedded gateway.
 
 - **Before:** `ZEEBE_GATEWAY_*`
 - **After:** `ZEEBE_BROKER_GATEWAY_*`
@@ -80,6 +80,70 @@ In 8.8, the Zeebe Gateway is embedded in the Orchestration Cluster. As a result,
 `ZEEBE_GATEWAY_CLUSTER_MESSAGECOMPRESSION` → `ZEEBE_BROKER_GATEWAY_CLUSTER_MESSAGECOMPRESSION`
 
 If your dual-region setup uses cluster message compression (which is typical), ensure this variable is also defined under `orchestration.env`. Migration jobs use a standalone gateway and require this setting to communicate with the Zeebe cluster.
+
+### Configure migration pods for Zeebe TLS
+
+During the 8.7 to 8.8 migration, the data migration uses a separate migration importer deployment. The migration importer runs with the standalone gateway configuration, even though the 8.8 orchestration cluster uses the embedded gateway.
+
+If your Zeebe cluster uses TLS for internal communication, configure both sets of TLS environment variables in `orchestration.env`:
+
+- `ZEEBE_BROKER_NETWORK_SECURITY_*` for broker-to-broker communication.
+- `ZEEBE_BROKER_GATEWAY_CLUSTER_SECURITY_*` for the embedded gateway in the orchestration pod.
+- `ZEEBE_GATEWAY_CLUSTER_SECURITY_*` for the standalone migration importer gateway.
+
+Mount the same certificate Secret in the orchestration pod, migration importer deployment, and data migration job. These pods use separate Helm values for additional volumes and volume mounts.
+
+```yaml
+orchestration:
+  extraVolumes:
+    - name: zeebe-tls
+      secret:
+        secretName: camunda-zeebe-tls
+  extraVolumeMounts:
+    - name: zeebe-tls
+      readOnly: true
+      mountPath: /etc/tls/
+  importer:
+    extraVolumes:
+      - name: zeebe-tls
+        secret:
+          secretName: camunda-zeebe-tls
+    extraVolumeMounts:
+      - name: zeebe-tls
+        readOnly: true
+        mountPath: /etc/tls/
+  migration:
+    data:
+      extraVolumes:
+        - name: zeebe-tls
+          secret:
+            secretName: camunda-zeebe-tls
+      extraVolumeMounts:
+        - name: zeebe-tls
+          readOnly: true
+          mountPath: /etc/tls/
+  env:
+    - name: ZEEBE_BROKER_NETWORK_SECURITY_ENABLED
+      value: "true"
+    - name: ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH
+      value: /etc/tls/chainZeebeCluster.pem
+    - name: ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH
+      value: /etc/tls/zeebeCluster.key
+    - name: ZEEBE_BROKER_GATEWAY_CLUSTER_SECURITY_ENABLED
+      value: "true"
+    - name: ZEEBE_BROKER_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH
+      value: /etc/tls/chainZeebeCluster.pem
+    - name: ZEEBE_BROKER_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH
+      value: /etc/tls/zeebeCluster.key
+    - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED
+      value: "true"
+    - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH
+      value: /etc/tls/chainZeebeCluster.pem
+    - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH
+      value: /etc/tls/zeebeCluster.key
+```
+
+If you omit the `ZEEBE_GATEWAY_CLUSTER_SECURITY_*` variables or don't mount the TLS certificate in `orchestration.importer`, the migration importer starts its gateway cluster transport without TLS and can't connect to TLS-enabled brokers.
 
 ## Handle authentication changes
 

--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md
@@ -29,7 +29,7 @@ The following changes are specific to dual-region setups and should be reviewed 
 | **Exporter keys**              | Replace `global.elasticsearch.disableExporter: false` | Use `orchestration.exporters.camunda.enabled: false` and `orchestration.exporters.zeebe.enabled: false`                                                                       |
 | **New Camunda Exporter**       | Define for both regions                               | Configure [Camunda Exporter](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md)                                                        |
 | **Legacy Exporter**            | Keep enabled during migration                         | Keep the old [Elasticsearch / OpenSearch Exporter](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) definitions                      |
-| **Environment variables**      | Rename gateway prefixes                               | Change `ZEEBE_GATEWAY_*` to `ZEEBE_BROKER_GATEWAY_*` for the embedded gateway, and keep standalone gateway TLS settings for migration pods.                                   |
+| **Environment variables**      | Rename gateway prefixes                               | Change `ZEEBE_GATEWAY_*` to `ZEEBE_BROKER_GATEWAY_*` for the embedded gateway, and keep standalone gateway TLS settings for migration pods                                    |
 | **Message compression**        | Add to orchestration configuration                    | Required for migration jobs to communicate with the Zeebe cluster                                                                                                             |
 | **Basic authentication users** | Migrate manually                                      | Users defined in `camunda.operate` or `camunda.tasklist` require manual migration to [embedded Identity](/self-managed/components/orchestration-cluster/identity/overview.md) |
 | **API security**               | Review defaults                                       | gRPC and REST APIs are secured by default in 8.8                                                                                                                              |
@@ -83,15 +83,15 @@ If your dual-region setup uses cluster message compression (which is typical), e
 
 ### Configure migration pods for Zeebe TLS
 
-During the 8.7 to 8.8 migration, the data migration uses a separate migration importer deployment. The migration importer runs with the standalone gateway configuration, even though the 8.8 orchestration cluster uses the embedded gateway.
+During the 8.7 to 8.8 migration, the Orchestration Cluster runs a separate migration importer deployment alongside the data migration job. The migration importer uses the standalone gateway configuration, even though the 8.8 Orchestration Cluster uses the embedded gateway.
 
-If your Zeebe cluster uses TLS for internal communication, configure both sets of TLS environment variables in `orchestration.env`:
+If your Zeebe cluster uses TLS for internal communication, configure all three sets of TLS environment variables in `orchestration.env`:
 
 - `ZEEBE_BROKER_NETWORK_SECURITY_*` for broker-to-broker communication.
 - `ZEEBE_BROKER_GATEWAY_CLUSTER_SECURITY_*` for the embedded gateway in the orchestration pod.
 - `ZEEBE_GATEWAY_CLUSTER_SECURITY_*` for the standalone migration importer gateway.
 
-Mount the same certificate Secret in the orchestration pod, migration importer deployment, and data migration job. These pods use separate Helm values for additional volumes and volume mounts.
+Mount the same certificate secret in the orchestration pod, migration importer deployment, and data migration job. Each of these pods uses its own Helm values for additional volumes and volume mounts.
 
 ```yaml
 orchestration:
@@ -145,6 +145,8 @@ orchestration:
 
 If you omit the `ZEEBE_GATEWAY_CLUSTER_SECURITY_*` variables or don't mount the TLS certificate in `orchestration.importer`, the migration importer starts its gateway cluster transport without TLS and can't connect to TLS-enabled brokers.
 
+If you also run [Identity migration](./870-to-880.md#identity-migration-recommended), mount the certificates it needs using the equivalent `orchestration.migration.identity.extraVolumes` and `orchestration.migration.identity.extraVolumeMounts` values.
+
 ## Handle authentication changes
 
 In 8.8, Basic authentication applies at the Orchestration Cluster level. If you previously defined users using `camunda.operate.userId` or `camunda.tasklist.userId`, you must migrate them manually.
@@ -187,7 +189,7 @@ Dual-region setups vary. The following scenarios may affect how you run the upgr
 
 - **Identity migration:**  
   If Identity is enabled:
-  - Enable [Identity migration](./870-to-880.md#identity-migration).
+  - Enable [Identity migration](./870-to-880.md#identity-migration-recommended).
   - Follow the [secret extraction guidance](/self-managed/deployment/helm/configure/secret-management.md#extract-plaintext-values-and-reference-them-as-kubernetes-secrets).
 
 - **Helm-managed single region exporters:**  


### PR DESCRIPTION
## Summary
- Documents the standalone migration importer TLS settings needed during 8.7 -> 8.8 dual-region upgrades.
- Clarifies that embedded gateway TLS settings do not replace `ZEEBE_GATEWAY_CLUSTER_SECURITY_*` for migration pods.
- Shows the separate TLS Secret mounts for orchestration, importer, and data migration pods.

## Validation
- `npx prettier --check versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md`
- Helm counterpart GKE repo-backed validation passed for `esss` upgrade in 11m31s
- Seeded-data GKE validation passed in namespace `inc33081-h7-data-gke`:
  - deployed 8.7 with Elasticsearch self-signed TLS plus Zeebe TLS
  - seeded real process data with `tests/SM-8.7/smoke-tests.spec.ts` / `Most Common Flow User Flow With All Apps`
  - upgraded the same namespace to 8.8 with features `migrator,zeebe-tls`
  - migration job completed with `operate-import-position-8.3.0_ total=36 pending=0` and `tasklist-import-position-8.2.0_ total=19 pending=0`
  - importer logs showed gateway cluster messaging started `using TLS`

## Links
- Originating issue: SUPPORT-33081 / INC-5824
- Helm counterpart: https://github.com/camunda/camunda-platform-helm/pull/6281
- E2E counterpart: not needed


Fixes https://github.com/camunda/camunda-platform-helm/issues/6058