### PR TITLE
docs: migrate EKS Single Region ingress from ingress-nginx to Contour

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -69,7 +69,7 @@ To demonstrate how to deploy with a custom domain, the following stack is also i
 
 - **cert-manager**: Automates TLS certificate management with [Let's Encrypt](https://letsencrypt.org/)
 - **external-dns**: Manages DNS record in Route53 for domain ownership confirmation
-- **ingress-nginx**: Provides HTTP/HTTPS load balancing and routing to Kubernetes services
+- **Contour**: Ingress controller backed by the Envoy proxy, providing HTTP/HTTPS load balancing and routing to Kubernetes services
 
 <SingleNamespaceDeployment />
 
@@ -135,7 +135,7 @@ Throughout the rest of this installation guide, we will refer to configurations 
 
 In this section, we provide an optional setup guide for configuring an Ingress with TLS and DNS management, allowing you to access your application through a specified domain. If you haven't set up an Ingress, refer to the [Kubernetes Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/) for more details. In Kubernetes, an Ingress is an API object that manages external access to services in a cluster, typically over HTTP, and can also handle TLS encryption for secure connections.
 
-To monitor your Ingress setup using Amazon CloudWatch, you may also find the official AWS guide on [monitoring nginx workloads with CloudWatch Container Insights and Prometheus](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads-nginx.html) helpful. Additionally, for detailed steps on exposing Kubernetes applications with the nginx ingress controller, refer to the [official AWS tutorial](https://aws.amazon.com/fr/blogs/containers/exposing-kubernetes-applications-part-3-nginx-ingress-controller/).
+For more details on the Ingress controller used here and its configuration options, refer to the [Contour documentation](https://projectcontour.io/docs/). Contour uses the [Envoy proxy](https://www.envoyproxy.io/) as its data plane to route and load balance Ingress traffic.
 
 ### Export Values
 
@@ -151,14 +151,14 @@ Additionally, obtain these values by following the guide for either [eksctl](./e
 - `CERT_MANAGER_IRSA_ARN`
 - `REGION`
 
-### ingress-nginx
+### Contour
 
-[Ingress-nginx](https://github.com/kubernetes/ingress-nginx) is an open-source Kubernetes Ingress controller that provides a way to manage external access to services within a Kubernetes cluster. It acts as a reverse proxy and load balancer, routing incoming traffic to the appropriate services based on rules defined in the Ingress resource.
+[Contour](https://projectcontour.io/) is a CNCF Incubating, open-source Kubernetes Ingress controller that uses the [Envoy proxy](https://www.envoyproxy.io/) as its data plane. It manages external access to services within a Kubernetes cluster, acting as a reverse proxy and load balancer that routes incoming traffic to the appropriate services based on rules defined in the Ingress resource.
 
-The following installs `ingress-nginx` in the `ingress-nginx` namespace via Helm. For more configuration options, consult the [Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx).
+The following installs `contour` in the `projectcontour` namespace via Helm. For more configuration options, consult the [Contour Helm chart](https://projectcontour.github.io/helm-charts/).
 
 ```shell reference
-https://github.com/camunda/camunda-deployment-references/blob/main/aws/kubernetes/eks-single-region/procedure/install-ingress-nginx.sh
+https://github.com/camunda/camunda-deployment-references/blob/main/aws/kubernetes/eks-single-region/procedure/install-contour.sh
 ```
 
 ### external-dns

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -69,7 +69,7 @@ To demonstrate how to deploy with a custom domain, the following stack is also i
 
 - **cert-manager**: Automates TLS certificate management with [Let's Encrypt](https://letsencrypt.org/)
 - **external-dns**: Manages DNS record in Route53 for domain ownership confirmation
-- **ingress-nginx**: Provides HTTP/HTTPS load balancing and routing to Kubernetes services
+- **Contour**: Ingress controller backed by the Envoy proxy, providing HTTP/HTTPS load balancing and routing to Kubernetes services
 
 <SingleNamespaceDeployment />
 
@@ -135,7 +135,7 @@ Throughout the rest of this installation guide, we will refer to configurations 
 
 In this section, we provide an optional setup guide for configuring an Ingress with TLS and DNS management, allowing you to access your application through a specified domain. If you haven't set up an Ingress, refer to the [Kubernetes Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/) for more details. In Kubernetes, an Ingress is an API object that manages external access to services in a cluster, typically over HTTP, and can also handle TLS encryption for secure connections.
 
-To monitor your Ingress setup using Amazon CloudWatch, you may also find the official AWS guide on [monitoring nginx workloads with CloudWatch Container Insights and Prometheus](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads-nginx.html) helpful. Additionally, for detailed steps on exposing Kubernetes applications with the nginx ingress controller, refer to the [official AWS tutorial](https://aws.amazon.com/fr/blogs/containers/exposing-kubernetes-applications-part-3-nginx-ingress-controller/).
+For more details on the Ingress controller used here and its configuration options, refer to the [Contour documentation](https://projectcontour.io/docs/). Contour uses the [Envoy proxy](https://www.envoyproxy.io/) as its data plane to route and load balance Ingress traffic.
 
 ### Export Values
 
@@ -151,14 +151,14 @@ Additionally, obtain these values by following the guide for either [eksctl](./e
 - `CERT_MANAGER_IRSA_ARN`
 - `REGION`
 
-### ingress-nginx
+### Contour
 
-[Ingress-nginx](https://github.com/kubernetes/ingress-nginx) is an open-source Kubernetes Ingress controller that provides a way to manage external access to services within a Kubernetes cluster. It acts as a reverse proxy and load balancer, routing incoming traffic to the appropriate services based on rules defined in the Ingress resource.
+[Contour](https://projectcontour.io/) is a CNCF Incubating, open-source Kubernetes Ingress controller that uses the [Envoy proxy](https://www.envoyproxy.io/) as its data plane. It manages external access to services within a Kubernetes cluster, acting as a reverse proxy and load balancer that routes incoming traffic to the appropriate services based on rules defined in the Ingress resource.
 
-The following installs `ingress-nginx` in the `ingress-nginx` namespace via Helm. For more configuration options, consult the [Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx).
+The following installs `contour` in the `projectcontour` namespace via Helm. For more configuration options, consult the [Contour Helm chart](https://projectcontour.github.io/helm-charts/).
 
 ```shell reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/aws/kubernetes/eks-single-region/procedure/install-ingress-nginx.sh
+https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/aws/kubernetes/eks-single-region/procedure/install-contour.sh
 ```
 
 ### external-dns


### PR DESCRIPTION
## Description

Updates the **EKS Single Region** reference architecture docs to replace **ingress-nginx** with **Contour** (CNCF Incubating, Envoy proxy data plane), for the **current** version and **version 8.9**.

ingress-nginx was officially retired in March 2026, so the reference architecture is moving to Contour.

Source change: camunda/camunda-deployment-references#2276 (`feat/eks-sr-contour-migration`, resolves camunda/camunda-deployment-references#2103).

### What changed

Only `eks-helm.md` needed edits (current + 8.9). The guide pulls the install script and values files **live from GitHub** via `reference` code blocks, so the following update automatically once the source repo change merges — no doc edits required:

- `className: nginx` → `className: contour` (HTTP + gRPC ingress)
- gRPC backend protocol: `nginx.ingress.kubernetes.io/backend-protocol: GRPC` → the `projectcontour.io/upstream-protocol.h2c: '26500'` **service** annotation
- NLB annotations moved to `envoy.service.annotations.*`
- new `CONTOUR_HELM_CHART_VERSION` in `export-ingress-setup-vars.sh`

Manual edits in this PR (per version):

- Architecture bullet `ingress-nginx` → `Contour`
- Removed the two nginx-specific AWS links (CloudWatch nginx monitoring + nginx ingress tutorial); replaced with Contour/Envoy documentation links
- Section heading `### ingress-nginx` → `### Contour` + updated description (namespace `projectcontour`, Contour Helm chart)
- Install-script reference URL `install-ingress-nginx.sh` → `install-contour.sh`

## ⚠️ Dependencies / merge sequencing

This PR **must not merge before** the following land, or the `reference` blocks will 404 and break the build:

1. **Current docs** point to `blob/main/.../install-contour.sh` — exists only after **camunda/camunda-deployment-references#2276** merges to `main`.
2. **8.9 docs** point to `blob/stable/8.9/.../install-contour.sh` — this file does **not** exist on `stable/8.9` yet. The Contour migration **must be backported to `stable/8.9`** of camunda-deployment-references before this PR merges.

## Out of scope

These files mention nginx **generically** (not the EKS Single Region architecture) and are intentionally left unchanged here. Flagging as possible follow-ups:

- `docs/.../helm/configure/ingress/ingress-setup.md` (+ 8.9) — generic nginx annotation examples
- `docs/.../helm/configure/ingress/gateway-api-setup.md` — already documents the nginx retirement
- `docs/.../reference-architecture/kubernetes.md` — generic Ingress-nginx compatibility note
- `docs/.../helm/install/production/index.md` — generic nginx prerequisite
- `docs/.../operational-guides/troubleshooting.md` — generic nginx gRPC annotation guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)