### PR TITLE
docs: document candidate group resolution behavior and config properties

### DIFF
--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -43,7 +43,7 @@ Starting with Camunda 8.8, user task candidate groups should reference group IDs
 1. Confirm a group ID exists for the value.
 2. If no ID is found, find a group name for the value, and resolve its ID.
 
-This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker#zeebebrokerexperimentalenginecaches) for all related configuration properties.
+This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokerexperimentalenginecaches) for all related configuration properties.
 :::
 
 :::info

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -38,6 +38,15 @@ You can use this to define which user the task can be assigned to. You can speci
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
 :::info
+Starting with Camunda 8.8, user task candidate groups should reference group IDs instead of group names. The Zeebe engine will attempt to resolve a candidate group value in the following way:
+
+1. Confirm a group ID exists for the value.
+2. If no ID is found, find a group name for the value, and resolve its ID.
+
+This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker#zeebebrokerexperimentalenginecaches) for all related configuration properties.
+:::
+
+:::info
 Usernames and group IDs in the Orchestration Cluster are case-sensitive. When you set `assignee`, `candidateUsers`, or `candidateGroups`, always use the exact value from your identity provider or Identity user record, including case. For example, `abc@example.com` and `Abc@example.com` are treated as different users.
 
 Candidate users and candidate groups are not used by current Tasklist releases for task visibility or assignment. Use [user task authorization](/components/tasklist/user-task-authorization.md) and [authorization-based access control](/components/concepts/access-control/authorizations.md) to control who can see and work on a task.

--- a/docs/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md
@@ -958,6 +958,13 @@ See the experimental section of the [defaults.yaml](https://github.com/camunda/c
 
 Be aware that all configurations which are part of the experimental section are subject to change and can be dropped at any time.
 
+#### zeebe.broker.experimental.engine.caches
+
+| Field                        | Description                                                                                                                                                                                                                                                                                                                                        | Example value |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| groupNameCacheCapacity       | Maximum number of group names held in the in-memory name-to-ID cache used during candidate group resolution. This setting can also be overridden using the environment variable `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_GROUPNAMECACHECAPACITY`.                                                                                                  | 1000          |
+| candidateGroupNameResolution | If true, the Zeebe engine attempts to resolve user task candidate group names to group IDs at task creation. Set to false to disable this resolution and pass candidate group values through unchanged. This setting can also be overridden using the environment variable `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION`. | true          |
+
 ### Multitenancy configuration
 
 For an embedded gateway setup, any gateway property can be passed along to the `StandaloneBroker` by prefixing `zeebe.broker`.

--- a/versioned_docs/version-8.8/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/versioned_docs/version-8.8/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -39,6 +39,15 @@ attributes can be specified simultaneously:
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
 :::info
+Starting with Camunda 8.8, user task candidate groups should reference group IDs instead of group names. The Zeebe engine will attempt to resolve a candidate group value in the following way:
+
+1. Confirm a group ID exists for the value.
+2. If no ID is found, find a group name for the value, and resolve its ID.
+
+This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker#zeebebrokerexperimentalenginecaches) for all related configuration properties.
+:::
+
+:::info
 Usernames and group IDs in the Orchestration Cluster are case-sensitive. When you set `assignee`, `candidateUsers`, or `candidateGroups`, always use the exact value from your identity provider or Identity user record, including case. For example, `abc@example.com` and `Abc@example.com` are treated as different users.
 
 You can also use assignment resources to configure [user task access restrictions in Tasklist](/components/tasklist/user-task-access-restrictions.md) when using Tasklist V1, so that only the assignee, candidate users, and members of candidate groups can see and work on a task. In Tasklist V2, candidate users and candidate groups are not evaluated by Tasklist for task visibility or assignment. Tasklist V2 relies on authorization-based access control at the process-definition level only.

--- a/versioned_docs/version-8.8/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/versioned_docs/version-8.8/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -44,7 +44,7 @@ Starting with Camunda 8.8, user task candidate groups should reference group IDs
 1. Confirm a group ID exists for the value.
 2. If no ID is found, find a group name for the value, and resolve its ID.
 
-This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker#zeebebrokerexperimentalenginecaches) for all related configuration properties.
+This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokerexperimentalenginecaches) for all related configuration properties.
 :::
 
 :::info

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md
@@ -955,6 +955,13 @@ See the experimental section of the [broker.yaml.template](https://github.com/ca
 
 Be aware that all configurations which are part of the experimental section are subject to change and can be dropped at any time.
 
+#### zeebe.broker.experimental.engine.caches
+
+| Field                        | Description                                                                                                                                                                                                                                                                                                                                        | Example value |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| groupNameCacheCapacity       | Maximum number of group names held in the in-memory name-to-ID cache used during candidate group resolution. This setting can also be overridden using the environment variable `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_GROUPNAMECACHECAPACITY`.                                                                                                  | 1000          |
+| candidateGroupNameResolution | If true, the Zeebe engine attempts to resolve user task candidate group names to group IDs at task creation. Set to false to disable this resolution and pass candidate group values through unchanged. This setting can also be overridden using the environment variable `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION`. | true          |
+
 ### Multitenancy configuration
 
 For an embedded gateway setup, any gateway property can be passed along to the `StandaloneBroker` by prefixing `zeebe.broker`.

--- a/versioned_docs/version-8.9/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/versioned_docs/version-8.9/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -43,7 +43,7 @@ Starting with Camunda 8.8, user task candidate groups should reference group IDs
 1. Confirm a group ID exists for the value.
 2. If no ID is found, find a group name for the value, and resolve its ID.
 
-This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker#zeebebrokerexperimentalenginecaches) for all related configuration properties.
+This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md#zeebebrokerexperimentalenginecaches) for all related configuration properties.
 :::
 
 :::info

--- a/versioned_docs/version-8.9/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/versioned_docs/version-8.9/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -38,6 +38,15 @@ You can use this to define which user the task can be assigned to. You can speci
 - `candidateGroups`: Specifies the groups of users that the task can be assigned to.
 
 :::info
+Starting with Camunda 8.8, user task candidate groups should reference group IDs instead of group names. The Zeebe engine will attempt to resolve a candidate group value in the following way:
+
+1. Confirm a group ID exists for the value.
+2. If no ID is found, find a group name for the value, and resolve its ID.
+
+This behavior can be disabled by setting the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false` configuration property, so user task candidate group values are not checked by the Zeebe engine. See [zeebe.broker.experimental.engine.caches](/self-managed/components/orchestration-cluster/zeebe/configuration/broker#zeebebrokerexperimentalenginecaches) for all related configuration properties.
+:::
+
+:::info
 Usernames and group IDs in the Orchestration Cluster are case-sensitive. When you set `assignee`, `candidateUsers`, or `candidateGroups`, always use the exact value from your identity provider or Identity user record, including case. For example, `abc@example.com` and `Abc@example.com` are treated as different users.
 
 You can also use assignment resources to configure [user task access restrictions in Tasklist](/components/tasklist/user-task-access-restrictions.md) when using Tasklist V1, so that only the assignee, candidate users, and members of candidate groups can see and work on a task. In Tasklist V2, candidate users and candidate groups are not evaluated by Tasklist for task visibility or assignment. Tasklist V2 relies on authorization-based access control at the process-definition level only.

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/configuration/broker.md
@@ -958,6 +958,13 @@ See the experimental section of the [defaults.yaml](https://github.com/camunda/c
 
 Be aware that all configurations which are part of the experimental section are subject to change and can be dropped at any time.
 
+#### zeebe.broker.experimental.engine.caches
+
+| Field                        | Description                                                                                                                                                                                                                                                                                                                                        | Example value |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| groupNameCacheCapacity       | Maximum number of group names held in the in-memory name-to-ID cache used during candidate group resolution. This setting can also be overridden using the environment variable `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_GROUPNAMECACHECAPACITY`.                                                                                                  | 1000          |
+| candidateGroupNameResolution | If true, the Zeebe engine attempts to resolve user task candidate group names to group IDs at task creation. Set to false to disable this resolution and pass candidate group values through unchanged. This setting can also be overridden using the environment variable `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION`. | true          |
+
 ### Multitenancy configuration
 
 For an embedded gateway setup, any gateway property can be passed along to the `StandaloneBroker` by prefixing `zeebe.broker`.


### PR DESCRIPTION
## Summary

- Documents the 8.8 candidate group name→ID resolution behavior introduced by camunda/camunda#51918 (fixing camunda/camunda#51608)
- Adds the two new experimental broker configuration properties under `zeebe.broker.experimental.engine.caches`

Changes applied to **8.10 (main)**, **8.9**, and **8.8**.

### user-tasks.md (all 3 versions)

Added an `:::info` block under the `candidateGroups` assignment property explaining:
- Group names are resolved to IDs at task creation since 8.8
- Resolution algorithm (ID first, then name lookup)
- How to disable via `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_CACHES_CANDIDATEGROUPNAMERESOLUTION=false`
- Link to the new broker config section

### broker.md (all 3 versions)

Added `#### zeebe.broker.experimental.engine.caches` subsection documenting:
- `groupNameCacheCapacity` — size of the in-memory name→ID cache
- `candidateGroupNameResolution` — feature flag to disable name resolution

Relates to camunda/camunda#51608