### PR TITLE
docs(saas): update Web Modeler data location from GCP Belgium to AWS Germany

### DIFF
--- a/docs/components/saas/data-locations.md
+++ b/docs/components/saas/data-locations.md
@@ -49,7 +49,7 @@ Connector secrets are optional. This information only applies if you use connect
 | Host location            | Data handled                                 | Personal data processing                                                                                                                                                        |
 | :----------------------- | :------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | <p>Germany, EU (AWS)</p> | Stores administrative metadata and settings. | Limited to account/authentication data to access Camunda Platform SaaS. It does not include personal data in scope of [Data Processing Agreements](https://legal.camunda.com/). |
-| Belgium, EU (GCP)        | Stores process models (diagrams/designs).    | Not intended for personal data processing.                                                                                                                                      |
+| Germany, EU (AWS)        | Stores process models (diagrams/designs).    | Not intended for personal data processing.                                                                                                                                      |
 
 You can use Camunda Hub and/or the [Desktop Modeler](/components/modeler/desktop-modeler/index.md) with Camunda Self‑Managed if you want to control the hosting location.
 

--- a/versioned_docs/version-8.7/reference/data-locations.md
+++ b/versioned_docs/version-8.7/reference/data-locations.md
@@ -93,4 +93,4 @@ You can use the Camunda‑hosted [Web Modeler](/components/modeler/web-modeler/l
 
 | Host location     | Data handled                                   | Personal data processing                   |
 | :---------------- | :--------------------------------------------- | :----------------------------------------- |
-| Belgium, EU (GCP) | Only stores process models (diagrams/designs). | Not intended for personal data processing. |
+| Germany, EU (AWS) | Only stores process models (diagrams/designs). | Not intended for personal data processing. |

--- a/versioned_docs/version-8.8/components/saas/data-locations.md
+++ b/versioned_docs/version-8.8/components/saas/data-locations.md
@@ -104,4 +104,4 @@ You can use the Camunda‑hosted [Web Modeler](/components/modeler/web-modeler/i
 
 | Host location     | Data handled                                   | Personal data processing                   |
 | :---------------- | :--------------------------------------------- | :----------------------------------------- |
-| Belgium, EU (GCP) | Only stores process models (diagrams/designs). | Not intended for personal data processing. |
+| Germany, EU (AWS) | Only stores process models (diagrams/designs). | Not intended for personal data processing. |

--- a/versioned_docs/version-8.9/components/saas/data-locations.md
+++ b/versioned_docs/version-8.9/components/saas/data-locations.md
@@ -104,4 +104,4 @@ You can use the Camunda‑hosted [Web Modeler](/components/modeler/web-modeler/i
 
 | Host location     | Data handled                                   | Personal data processing                   |
 | :---------------- | :--------------------------------------------- | :----------------------------------------- |
-| Belgium, EU (GCP) | Only stores process models (diagrams/designs). | Not intended for personal data processing. |
+| Germany, EU (AWS) | Only stores process models (diagrams/designs). | Not intended for personal data processing. |


### PR DESCRIPTION
## Summary

Web Modeler has fully migrated from GCP Belgium to AWS Frankfurt (eu-central-1). Updates the data locations table in the Camunda Hub / Web Modeler section across current and versioned docs.