### PR TITLE
Add business key runtime migration to docs

### DIFF
--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
@@ -22,7 +22,7 @@ Audit data migration might need to look at a huge amount of data, which can take
 You can run audit data migration alongside normal operations (for example, after the successful big bang migration of runtime process instances) so that it doesn't require downtime and as such, the performance might not be as critical as for runtime instance migration.
 
 During history migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
-If no business key is present (or it is blank), the process instance is migrated without a business ID.
+If no business key is present, or if it is blank, the process instance is migrated without a business ID.
 
 During migration, the History Data Migrator sets a `legacyId` variable in the process instances to link them to their original Camunda 7 process instances.
 

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
@@ -21,6 +21,9 @@ The History Data Migrator can copy this audit data to Camunda 8. For process ins
 Audit data migration might need to look at a huge amount of data, which can take time to migrate.
 You can run audit data migration alongside normal operations (for example, after the successful big bang migration of runtime process instances) so that it doesn't require downtime and as such, the performance might not be as critical as for runtime instance migration.
 
+During history migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
+If no business key is present (or it is blank), the process instance is migrated without a business ID.
+
 During migration, the History Data Migrator sets a `legacyId` variable in the process instances to link them to their original Camunda 7 process instances.
 
 ## Requirements and limitations

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
@@ -26,7 +26,7 @@ Migration details are summarized as follows:
 ## Key features
 
 - Preserves the execution state of running process instances during migration.
-- Maps Camunda 7 process instance `businessKey` to Camunda 8 `businessId`. Both for runtime and history migration, this mapping is supported.
+- Maps Camunda 7 process instance `businessKey` to Camunda 8 `businessId`. This mapping is supported for both runtime and history migration.
 - Converts and migrates process variables, decision inputs, and decision outputs with proper type handling.
 - Supports customizable variable interceptors for both runtime and history migration contexts.
 - Validates data before migration to help ensure a successful run.

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
@@ -26,7 +26,7 @@ Migration details are summarized as follows:
 ## Key features
 
 - Preserves the execution state of running process instances during migration.
-- Maps Camunda 7 process instance `businessKey` to Camunda 8 `businessId` in runtime migration.
+- Maps Camunda 7 process instance `businessKey` to Camunda 8 `businessId`. Both for runtime and history migration, this mapping is supported.
 - Converts and migrates process variables, decision inputs, and decision outputs with proper type handling.
 - Supports customizable variable interceptors for both runtime and history migration contexts.
 - Validates data before migration to help ensure a successful run.

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
@@ -26,6 +26,7 @@ Migration details are summarized as follows:
 ## Key features
 
 - Preserves the execution state of running process instances during migration.
+- Maps Camunda 7 process instance `businessKey` to Camunda 8 `businessId` in runtime migration.
 - Converts and migrates process variables, decision inputs, and decision outputs with proper type handling.
 - Supports customizable variable interceptors for both runtime and history migration contexts.
 - Validates data before migration to help ensure a successful run.

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/runtime.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/runtime.md
@@ -15,7 +15,7 @@ Migrate currently running process instances.
 Running refers to process instances in Camunda 7 that are not yet ended and are currently waiting in a [wait-state](https://docs.camunda.org/manual/latest/user-guide/process-engine/transactions-in-processes/#wait-states). This state is persisted in the database, and a corresponding data entry must be created in Camunda 8 so the process instance can continue from that state in the new solution.
 
 During runtime migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
-If no business key is present (or it is blank), the process instance is migrated without a business ID.
+If no business key is present, or if it is blank, the process instance is migrated without a business ID.
 
 ## Requirements and limitations
 

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/runtime.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/runtime.md
@@ -14,6 +14,9 @@ Migrate currently running process instances.
 
 Running refers to process instances in Camunda 7 that are not yet ended and are currently waiting in a [wait-state](https://docs.camunda.org/manual/latest/user-guide/process-engine/transactions-in-processes/#wait-states). This state is persisted in the database, and a corresponding data entry must be created in Camunda 8 so the process instance can continue from that state in the new solution.
 
+During runtime migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
+If no business key is present (or it is blank), the process instance is migrated without a business ID.
+
 ## Requirements and limitations
 
 The following requirements and limitations apply:

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
@@ -22,7 +22,7 @@ Audit data migration might need to look at a huge amount of data, which can take
 You can run audit data migration alongside normal operations (for example, after the successful big bang migration of runtime process instances) so that it doesn't require downtime and as such, the performance might not be as critical as for runtime instance migration.
 
 During history migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
-If no business key is present (or it is blank), the process instance is migrated without a business ID.
+If no business key is present, or if it is blank, the process instance is migrated without a business ID.
 
 During migration, the History Data Migrator sets a `legacyId` variable in the process instances to link them to their original Camunda 7 process instances.
 

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
@@ -21,6 +21,9 @@ The History Data Migrator can copy this audit data to Camunda 8. For process ins
 Audit data migration might need to look at a huge amount of data, which can take time to migrate.
 You can run audit data migration alongside normal operations (for example, after the successful big bang migration of runtime process instances) so that it doesn't require downtime and as such, the performance might not be as critical as for runtime instance migration.
 
+During history migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
+If no business key is present (or it is blank), the process instance is migrated without a business ID.
+
 During migration, the History Data Migrator sets a `legacyId` variable in the process instances to link them to their original Camunda 7 process instances.
 
 ## Requirements and limitations

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/index.md
@@ -26,6 +26,7 @@ Migration details are summarized as follows:
 ## Key features
 
 - Preserves the execution state of running process instances during migration.
+- Maps Camunda 7 process instance `businessKey` to Camunda 8 `businessId` for finished processes.
 - Converts and migrates process variables, decision inputs, and decision outputs with proper type handling.
 - Supports customizable variable interceptors for both runtime and history migration contexts.
 - Validates data before migration to help ensure a successful run.


### PR DESCRIPTION
## Description

Runtime migration will take care of migrating business keys to C8 business IDs. Let the documentation mention it.
The feature itself is implemented in https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1359#issuecomment-4648940630

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.


- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
