### PR TITLE
docs: update JSON response format provider support for AI Agent connector

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -45,7 +45,7 @@ Support for JSON responses varies by provider and model:
 - **OpenAI**: Selecting the JSON response format is equivalent to using the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a JSON Schema instructs the model to return [structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
 - **Anthropic**: JSON response format requires a JSON Schema. See [Anthropic's structured outputs documentation](https://platform.claude.com/docs/en/build-with-claude/structured-outputs).
 - **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
-- **Other providers**: Use the text response format with the **Parse text as JSON** option instead.
+- **Other providers**: Consult the provider's documentation to check if JSON response format is supported. If not, use the text response format with the **Parse text as JSON** option instead.
 
 | Field                     | Required | Description                                                                                                                                                                                                                                                           |
 | :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -47,10 +47,10 @@ Support for JSON responses varies by provider and model:
 - **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
 - **Other providers**: Consult the provider's documentation to check if JSON response format is supported. If not, use the text response format with the **Parse text as JSON** option instead.
 
-| Field                     | Required | Description                                                                                                                                                                                                                                                           |
-| :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Response JSON schema      | No       | <p>Describes the desired response format as [JSON Schema](https://json-schema.org/).</p><p><ul><li>See [OpenAI's structured outputs documentation](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#introduction) for examples.</li></ul></p> |
-| Response JSON schema name | No       | <p>Depending on the provider, the schema must be configured with a name for the schema (such as `Person`).</p><p>Ideally this name describes the purpose of the schema to make the model aware of the expected data.</p>                                              |
+| Field                     | Required | Description                                                                                                                                                                                                                                         |
+| :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Response JSON schema      | No       | <p>Describes the desired response format as [JSON Schema](https://json-schema.org/).</p><p>See [OpenAI's structured outputs documentation](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#introduction) for examples.</p> |
+| Response JSON schema name | No       | <p>Depending on the provider, the schema must be configured with a name for the schema (such as `Person`).</p><p>Ideally this name describes the purpose of the schema to make the model aware of the expected data.</p>                            |
 
 For example, the following shows an example JSON Schema describing the expected response format for a user profile:
 

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -21,9 +21,9 @@ The outcome of an LLM call is stored as an **assistant message** designed to con
 If not configured otherwise, this format is used by default and returns a `responseText` string as part of the
 connector response.
 
-| Field              | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| :----------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Parse text as JSON | No       | <p>If this option is selected, the connector will attempt to parse the response text as JSON and return the parsed object as `responseJson` in the connector response.</p><p><ul><li><p>Use this option for models that do not support setting JSON as response format (such as Anthropic models) in combination with a prompt instructing the model to return a JSON response.</p></li><li><p>If parsing fails, the connector does not return an `responseJson` object, but only returns the original response text as `responseText`.</p></li></ul></p> |
+| Field              | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :----------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parse text as JSON | No       | <p>If this option is selected, the connector will attempt to parse the response text as JSON and return the parsed object as `responseJson` in the connector response.</p><p><ul><li><p>Use this option for models that do not support the JSON response format in combination with a prompt instructing the model to return a JSON response.</p></li><li><p>If parsing fails, the connector does not return an `responseJson` object, but only returns the original response text as `responseText`.</p></li></ul></p> |
 
 For an example prompt that instructs the model to return a JSON response,
 (see [Anthropic documenation](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/increase-consistency#example-enhancing-it-support-consistency)):
@@ -34,25 +34,18 @@ Output in JSON format with keys: "sentiment" (positive/negative/neutral), "key_i
 
 #### JSON response format
 
-:::note
-
-The JSON response format is currently only supported for OpenAI and Google Vertex AI models. Use the text response format in combination with
-the **Parse text as JSON** option for other providers.
-
-:::
-
 If the model supports it, selecting JSON as response format instructs the model to always return a JSON response. If the model does not return a valid JSON response, the connector throws an error.
 
 To ensure the model generates data according to a specific JSON structure, you can optionally provide a
 [JSON Schema](https://json-schema.org/). Alternatively, you can instruct the model to return JSON following a specific
 structure as shown in the text example above.
 
-Support for JSON responses varies by provider and model.
+Support for JSON responses varies by provider and model:
 
-For OpenAI, selecting the JSON response format is equivalent to using
-the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a
-JSON Schema instructs the model to return
-[structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
+- **OpenAI**: Selecting the JSON response format is equivalent to using the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a JSON Schema instructs the model to return [structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
+- **Anthropic**: JSON response format requires a JSON Schema. See [Anthropic's structured outputs documentation](https://platform.claude.com/docs/en/build-with-claude/structured-outputs).
+- **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
+- **Other providers**: Use the text response format with the **Parse text as JSON** option instead.
 
 | Field                     | Required | Description                                                                                                                                                                                                                                                           |
 | :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -47,10 +47,10 @@ Support for JSON responses varies by provider and model:
 - **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
 - **Other providers**: Consult the provider's documentation to check if JSON response format is supported. If not, use the text response format with the **Parse text as JSON** option instead.
 
-| Field                     | Required | Description                                                                                                                                                                                                                                                           |
-| :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Response JSON schema      | No       | <p>Describes the desired response format as [JSON Schema](https://json-schema.org/).</p><p><ul><li>See [OpenAI's structured outputs documentation](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#introduction) for examples.</li></ul></p> |
-| Response JSON schema name | No       | <p>Depending on the provider, the schema must be configured with a name for the schema (such as `Person`).</p><p>Ideally this name describes the purpose of the schema to make the model aware of the expected data.</p>                                              |
+| Field                     | Required | Description                                                                                                                                                                                                                                         |
+| :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Response JSON schema      | No       | <p>Describes the desired response format as [JSON Schema](https://json-schema.org/).</p><p>See [OpenAI's structured outputs documentation](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#introduction) for examples.</p> |
+| Response JSON schema name | No       | <p>Depending on the provider, the schema must be configured with a name for the schema (such as `Person`).</p><p>Ideally this name describes the purpose of the schema to make the model aware of the expected data.</p>                            |
 
 For example, the following shows an example JSON Schema describing the expected response format for a user profile:
 

--- a/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -21,9 +21,9 @@ The outcome of an LLM call is stored as an **assistant message** designed to con
 If not configured otherwise, this format is used by default and returns a `responseText` string as part of the
 connector response.
 
-| Field              | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| :----------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Parse text as JSON | No       | <p>If this option is selected, the connector will attempt to parse the response text as JSON and return the parsed object as `responseJson` in the connector response.</p><p><ul><li><p>Use this option for models that do not support setting JSON as response format (such as Anthropic models) in combination with a prompt instructing the model to return a JSON response.</p></li><li><p>If parsing fails, the connector does not return an `responseJson` object, but only returns the original response text as `responseText`.</p></li></ul></p> |
+| Field              | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :----------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parse text as JSON | No       | <p>If this option is selected, the connector will attempt to parse the response text as JSON and return the parsed object as `responseJson` in the connector response.</p><p><ul><li><p>Use this option for models that do not support the JSON response format in combination with a prompt instructing the model to return a JSON response.</p></li><li><p>If parsing fails, the connector does not return an `responseJson` object, but only returns the original response text as `responseText`.</p></li></ul></p> |
 
 For an example prompt that instructs the model to return a JSON response,
 (see [Anthropic documenation](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/increase-consistency#example-enhancing-it-support-consistency)):
@@ -34,25 +34,18 @@ Output in JSON format with keys: "sentiment" (positive/negative/neutral), "key_i
 
 #### JSON response format
 
-:::note
-
-The JSON response format is currently only supported for OpenAI and Google Vertex AI models. Use the text response format in combination with
-the **Parse text as JSON** option for other providers.
-
-:::
-
 If the model supports it, selecting JSON as response format instructs the model to always return a JSON response. If the model does not return a valid JSON response, the connector throws an error.
 
 To ensure the model generates data according to a specific JSON structure, you can optionally provide a
 [JSON Schema](https://json-schema.org/). Alternatively, you can instruct the model to return JSON following a specific
 structure as shown in the text example above.
 
-Support for JSON responses varies by provider and model.
+Support for JSON responses varies by provider and model:
 
-For OpenAI, selecting the JSON response format is equivalent to using
-the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a
-JSON Schema instructs the model to return
-[structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
+- **OpenAI**: Selecting the JSON response format is equivalent to using the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a JSON Schema instructs the model to return [structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
+- **Anthropic**: JSON response format requires a JSON Schema. See [Anthropic's structured outputs documentation](https://platform.claude.com/docs/en/build-with-claude/structured-outputs).
+- **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
+- **Other providers**: Consult the provider's documentation to check if JSON response format is supported. If not, use the text response format with the **Parse text as JSON** option instead.
 
 | Field                     | Required | Description                                                                                                                                                                                                                                                           |
 | :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -47,10 +47,10 @@ Support for JSON responses varies by provider and model:
 - **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
 - **Other providers**: Consult the provider's documentation to check if JSON response format is supported. If not, use the text response format with the **Parse text as JSON** option instead.
 
-| Field                     | Required | Description                                                                                                                                                                                                                                                           |
-| :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Response JSON schema      | No       | <p>Describes the desired response format as [JSON Schema](https://json-schema.org/).</p><p><ul><li>See [OpenAI's structured outputs documentation](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#introduction) for examples.</li></ul></p> |
-| Response JSON schema name | No       | <p>Depending on the provider, the schema must be configured with a name for the schema (such as `Person`).</p><p>Ideally this name describes the purpose of the schema to make the model aware of the expected data.</p>                                              |
+| Field                     | Required | Description                                                                                                                                                                                                                                         |
+| :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Response JSON schema      | No       | <p>Describes the desired response format as [JSON Schema](https://json-schema.org/).</p><p>See [OpenAI's structured outputs documentation](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#introduction) for examples.</p> |
+| Response JSON schema name | No       | <p>Depending on the provider, the schema must be configured with a name for the schema (such as `Person`).</p><p>Ideally this name describes the purpose of the schema to make the model aware of the expected data.</p>                            |
 
 For example, the following shows an example JSON Schema describing the expected response format for a user profile:
 

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai/aiagent/configuration/_response.md
@@ -21,9 +21,9 @@ The outcome of an LLM call is stored as an **assistant message** designed to con
 If not configured otherwise, this format is used by default and returns a `responseText` string as part of the
 connector response.
 
-| Field              | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| :----------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Parse text as JSON | No       | <p>If this option is selected, the connector will attempt to parse the response text as JSON and return the parsed object as `responseJson` in the connector response.</p><p><ul><li><p>Use this option for models that do not support setting JSON as response format (such as Anthropic models) in combination with a prompt instructing the model to return a JSON response.</p></li><li><p>If parsing fails, the connector does not return an `responseJson` object, but only returns the original response text as `responseText`.</p></li></ul></p> |
+| Field              | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :----------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parse text as JSON | No       | <p>If this option is selected, the connector will attempt to parse the response text as JSON and return the parsed object as `responseJson` in the connector response.</p><p><ul><li><p>Use this option for models that do not support the JSON response format in combination with a prompt instructing the model to return a JSON response.</p></li><li><p>If parsing fails, the connector does not return an `responseJson` object, but only returns the original response text as `responseText`.</p></li></ul></p> |
 
 For an example prompt that instructs the model to return a JSON response,
 (see [Anthropic documenation](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/increase-consistency#example-enhancing-it-support-consistency)):
@@ -34,25 +34,18 @@ Output in JSON format with keys: "sentiment" (positive/negative/neutral), "key_i
 
 #### JSON response format
 
-:::note
-
-The JSON response format is currently only supported for OpenAI and Google Vertex AI models. Use the text response format in combination with
-the **Parse text as JSON** option for other providers.
-
-:::
-
 If the model supports it, selecting JSON as response format instructs the model to always return a JSON response. If the model does not return a valid JSON response, the connector throws an error.
 
 To ensure the model generates data according to a specific JSON structure, you can optionally provide a
 [JSON Schema](https://json-schema.org/). Alternatively, you can instruct the model to return JSON following a specific
 structure as shown in the text example above.
 
-Support for JSON responses varies by provider and model.
+Support for JSON responses varies by provider and model:
 
-For OpenAI, selecting the JSON response format is equivalent to using
-the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a
-JSON Schema instructs the model to return
-[structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
+- **OpenAI**: Selecting the JSON response format is equivalent to using the [JSON mode](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#json-mode). Providing a JSON Schema instructs the model to return [structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat#structured-outputs-vs-json-mode).
+- **Anthropic**: JSON response format requires a JSON Schema. See [Anthropic's structured outputs documentation](https://platform.claude.com/docs/en/build-with-claude/structured-outputs).
+- **AWS Bedrock**: JSON response format requires a JSON Schema. See [AWS Bedrock structured output documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html).
+- **Other providers**: Consult the provider's documentation to check if JSON response format is supported. If not, use the text response format with the **Parse text as JSON** option instead.
 
 | Field                     | Required | Description                                                                                                                                                                                                                                                           |
 | :------------------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description

The AI Agent connector docs incorrectly stated that the JSON response format is only supported for OpenAI and Google Vertex AI models. In the meantime, Anthropic and AWS Bedrock also added support for structured outputs.

This PR removes the false claim and replaces it with a per-provider breakdown linking to the relevant official docs:
- [Anthropic structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
- [AWS Bedrock structured output](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html)

Also removes the "(such as Anthropic models)" example in the "Parse text as JSON" description, which was equally incorrect.

Changes applied to `docs/` (next) and backported to `versioned_docs/version-8.9` and `versioned_docs/version-8.8`.

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
