### PR TITLE
docs: add missing argument to MCP proxy

### DIFF
--- a/docs/apis-tools/processes-mcp/processes-mcp-setup.md
+++ b/docs/apis-tools/processes-mcp/processes-mcp-setup.md
@@ -125,7 +125,7 @@ For example, use the following in `claude_desktop_config.json` for Claude Code:
     "camunda-processes": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@camunda8/cli", "mcp-proxy"],
+      "args": ["-y", "@camunda8/cli", "mcp-proxy", "/mcp/processes"],
       "env": {
         "CAMUNDA_BASE_URL": "https://<cluster-base-url>",
         "CAMUNDA_CLIENT_ID": "<client-id>",


### PR DESCRIPTION
## Description

Fix the instruction on how to connect to the Processes MCP server via c8ctl MCP proxy.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
