### PR TITLE
docs(zeebe-process-test): document Spring Boot 4 support (8.7 + 8.8)

### DIFF
--- a/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
@@ -126,7 +126,7 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 
 ### Spring Boot 4 support
 
-`spring-boot-starter-camunda-test` transitively depends on `spring-boot-starter-camunda-sdk`, which targets Spring Boot 3. To use it in a Spring Boot 4 project, exclude that starter and add the dedicated Spring Boot 4 starter (`camunda-spring-boot-4-starter`) at the same version:
+`spring-boot-starter-camunda-test` transitively depends on `spring-boot-starter-camunda-sdk`, which targets Spring Boot 3. To use it in a Spring Boot 4 project, exclude that starter and add the dedicated [Spring Boot 4 starter](../spring-zeebe-sdk/getting-started.md#spring-boot-40-support) (`camunda-spring-boot-4-starter`, available from the `8.7.24` patch release) at the same version:
 
 ```xml
 <dependency>

--- a/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
@@ -149,7 +149,7 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 </dependency>
 ```
 
-If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. JUnit 6 (required by Spring Boot 4) is provided automatically by your Spring Boot 4 dependency management.
+If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. No other changes are required: your Spring Boot 4 dependency management supplies the matching JUnit version automatically.
 
 ### Usage
 

--- a/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
@@ -149,7 +149,7 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 </dependency>
 ```
 
-If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. No other changes are required: your Spring Boot 4 dependency management supplies the matching JUnit version automatically.
+If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`.
 
 ### Usage
 

--- a/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
+++ b/versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md
@@ -124,6 +124,33 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 </dependency>
 ```
 
+### Spring Boot 4 support
+
+`spring-boot-starter-camunda-test` transitively depends on `spring-boot-starter-camunda-sdk`, which targets Spring Boot 3. To use it in a Spring Boot 4 project, exclude that starter and add the dedicated Spring Boot 4 starter (`camunda-spring-boot-4-starter`) at the same version:
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>spring-boot-starter-camunda-test</artifactId>
+  <version>X.Y.Z</version>
+  <scope>test</scope>
+  <exclusions>
+    <exclusion>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-spring-boot-4-starter</artifactId>
+  <version>X.Y.Z</version>
+  <scope>test</scope>
+</dependency>
+```
+
+If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. JUnit 6 (required by Spring Boot 4) is provided automatically by your Spring Boot 4 dependency management.
+
 ### Usage
 
 Add the `@ZeebeSpringTest` annotation to your Spring Boot test case to make the engine and a client available in your test case.

--- a/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
+++ b/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
@@ -130,6 +130,33 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 </dependency>
 ```
 
+### Spring Boot 4 support
+
+`spring-boot-starter-camunda-test` transitively depends on `camunda-spring-boot-starter`, which targets Spring Boot 3. To use it in a Spring Boot 4 project, exclude that starter and add the dedicated Spring Boot 4 starter (`camunda-spring-boot-4-starter`) at the same version:
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>spring-boot-starter-camunda-test</artifactId>
+  <version>X.Y.Z</version>
+  <scope>test</scope>
+  <exclusions>
+    <exclusion>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-starter</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-spring-boot-4-starter</artifactId>
+  <version>X.Y.Z</version>
+  <scope>test</scope>
+</dependency>
+```
+
+If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. JUnit 6 (required by Spring Boot 4) is provided automatically by your Spring Boot 4 dependency management.
+
 ### Usage
 
 Add the `@ZeebeSpringTest` annotation to your Spring Boot test case to make the engine and a client available in your test case.

--- a/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
+++ b/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
@@ -155,7 +155,7 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 </dependency>
 ```
 
-If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. No other changes are required: your Spring Boot 4 dependency management supplies the matching JUnit version automatically.
+If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`.
 
 ### Usage
 

--- a/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
+++ b/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
@@ -132,7 +132,7 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 
 ### Spring Boot 4 support
 
-`spring-boot-starter-camunda-test` transitively depends on `camunda-spring-boot-starter`, which targets Spring Boot 3. To use it in a Spring Boot 4 project, exclude that starter and add the dedicated Spring Boot 4 starter (`camunda-spring-boot-4-starter`) at the same version:
+`spring-boot-starter-camunda-test` transitively depends on `camunda-spring-boot-starter`, which targets Spring Boot 3. To use it in a Spring Boot 4 project, exclude that starter and add the dedicated [Spring Boot 4 starter](../camunda-spring-boot-starter/getting-started.md#spring-boot-40-support) (`camunda-spring-boot-4-starter`, available from the `8.8.9` patch release) at the same version:
 
 ```xml
 <dependency>

--- a/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
+++ b/versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md
@@ -155,7 +155,7 @@ To integrate a testcontainer engine and use assertions, add the following Maven 
 </dependency>
 ```
 
-If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. JUnit 6 (required by Spring Boot 4) is provided automatically by your Spring Boot 4 dependency management.
+If you use the testcontainers module, apply the same exclusion to `spring-boot-starter-camunda-test-testcontainer`. No other changes are required: your Spring Boot 4 dependency management supplies the matching JUnit version automatically.
 
 ### Usage
 


### PR DESCRIPTION
## Description

Documents how to use **zeebe-process-test**'s Spring support (`spring-boot-starter-camunda-test`) in a **Spring Boot 4** project, for the 8.8 and 8.7 docs.

The library transitively pulls the Spring Boot 3 Camunda Spring SDK starter, whose actuator auto-configuration fails under Spring Boot 4 (`@ConditionalOnMissingBean` → `BeanTypeDeductionException`). The fix for consumers is to exclude that SB3 starter and add the dedicated `camunda-spring-boot-4-starter` at the same version.

The SB3 starter artifact name differs per line, so the exclusion target differs:
- **8.8** → exclude `io.camunda:camunda-spring-boot-starter`
- **8.7** → exclude `io.camunda:spring-boot-starter-camunda-sdk`

JUnit 6 (required by Spring Boot 4) is supplied automatically by the consumer's Spring Boot 4 dependency management, so no extra step is needed.

## Pages changed
- `versioned_docs/version-8.8/apis-tools/testing/zeebe-process-test.md`
- `versioned_docs/version-8.7/apis-tools/java-client/zeebe-process-test.md`

## Validation
Verified against the **published** `8.8.26` and `8.7.30` artifacts with a minimal Spring Boot `4.0.1` consumer project: a `@SpringBootTest @ZeebeSpringTest` smoke test boots the ApplicationContext successfully with the documented dependency setup (and fails without it). Works with already-released artifacts.

## Context
Part of the Spring Boot 4 support initiative (camunda/camunda#41279). Companion to zeebe-process-test#2306 / camunda/zeebe-process-test#2307, which makes ZPT's own CI actually test Spring Boot 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
