### PR TITLE
docs(self-managed): document KEYCLOAK_TARGET_MODE=external for Bitnami migration (8.9)

### DIFF
--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
@@ -18,7 +18,7 @@ Migrate a Camunda 8 Helm installation from Bitnami-managed infrastructure to **c
 
 - **PostgreSQL**: AWS RDS, Azure Database for PostgreSQL, Google Cloud SQL, or any managed PostgreSQL service
 - **Elasticsearch**: Elastic Cloud or any managed Elasticsearch service
-- **Keycloak**: This guide does not assume a managed Keycloak service. Keep Keycloak on the [Keycloak Operator](https://www.keycloak.org/operator/installation), or replace it with an [external OIDC provider](/self-managed/deployment/helm/configure/authentication-and-authorization/external-oidc-provider.md) if that better fits your environment.
+- **Keycloak**: Keep Keycloak on the [Keycloak Operator](https://www.keycloak.org/operator/installation), replace it with an [external OIDC provider](/self-managed/deployment/helm/configure/authentication-and-authorization/external-oidc-provider.md), or migrate the bundled realm onto an external, standalone, or Helm-managed Keycloak with `KEYCLOAK_TARGET_MODE=external` (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
 
 ## When to use this guide
 
@@ -172,6 +172,58 @@ export EXTERNAL_ES_SECRET="external-es"
 </details>
 
 You can use the same managed PostgreSQL host for all components—each database is separate. This is common when using a single RDS instance with multiple databases.
+
+### Migrate Keycloak to an external instance {#migrate-keycloak-to-an-external-instance}
+
+By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom resource. To instead point Camunda at a pre-existing external, standalone, or Helm-managed Keycloak, set `KEYCLOAK_TARGET_MODE=external`. The scripts migrate the realm into the external Keycloak database and rewire Camunda to the external endpoint. They do not deploy or manage the Keycloak instance itself.
+
+:::note
+`KEYCLOAK_TARGET_MODE=external` requires `PG_TARGET_MODE=external`, because the external Keycloak serves the migrated realm from the external Keycloak database (`EXTERNAL_PG_KEYCLOAK_*`). This flow is intended for a data-only cutover: set `SKIP_HELM_UPGRADE=true` and let your upgrade pipeline run the `helm upgrade` that points Camunda at the external Keycloak.
+:::
+
+Configure the external Keycloak connection variables in `env.sh`:
+
+| Variable                         | Default                    | Description                                                                           |
+| -------------------------------- | -------------------------- | ------------------------------------------------------------------------------------- |
+| `KEYCLOAK_TARGET_MODE`           | `operator`                 | Set to `external` to skip the operator and rewire Camunda to a pre-existing Keycloak. |
+| `EXTERNAL_KEYCLOAK_PROTOCOL`     | `http`                     | Protocol of the external Keycloak.                                                    |
+| `EXTERNAL_KEYCLOAK_HOST`         | (empty)                    | Host of the external Keycloak.                                                        |
+| `EXTERNAL_KEYCLOAK_PORT`         | `80`                       | Port of the external Keycloak.                                                        |
+| `EXTERNAL_KEYCLOAK_CONTEXT_PATH` | `/auth`                    | Context path of the external Keycloak.                                                |
+| `EXTERNAL_KEYCLOAK_REALM`        | `/realms/camunda-platform` | Realm path served by the external Keycloak.                                           |
+| `EXTERNAL_KEYCLOAK_ADMIN_SECRET` | (empty)                    | Kubernetes secret in `NAMESPACE` holding the Keycloak admin `password`.               |
+
+<details>
+<summary>Show details: external Keycloak configuration example</summary>
+
+```bash
+# Migrate the Keycloak realm onto an external Keycloak (data-only cutover)
+export KEYCLOAK_TARGET_MODE="external"
+export PG_TARGET_MODE="external"
+export SKIP_HELM_UPGRADE="true"
+
+export EXTERNAL_KEYCLOAK_PROTOCOL="http"
+export EXTERNAL_KEYCLOAK_HOST="keycloak"
+export EXTERNAL_KEYCLOAK_PORT="80"
+export EXTERNAL_KEYCLOAK_CONTEXT_PATH="/auth"
+export EXTERNAL_KEYCLOAK_REALM="/realms/camunda-platform"
+export EXTERNAL_KEYCLOAK_ADMIN_SECRET="external-keycloak-admin"
+```
+
+</details>
+
+#### Source database names that differ from the target
+
+The bundled Bitnami Keycloak subchart defaults to database `bitnami_keycloak` and user `bn_keycloak`, which differ from the migration target names. When the source names differ, set the `*_SOURCE_DB_NAME` and `*_SOURCE_DB_USER` overrides. They default to the target names, so you only set them when the source differs:
+
+```bash
+export KEYCLOAK_SOURCE_DB_NAME="bitnami_keycloak"
+export KEYCLOAK_SOURCE_DB_USER="bn_keycloak"
+export KEYCLOAK_DB_NAME="keycloak"
+export KEYCLOAK_DB_USER="keycloak"
+```
+
+The same pattern applies to the `IDENTITY_SOURCE_DB_*` and `WEBMODELER_SOURCE_DB_*` variables.
 
 ### Create custom Helm values
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
@@ -181,6 +181,8 @@ By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom res
 Setting `KEYCLOAK_TARGET_MODE=external` is a **data-only** migration. When you source `env.sh`, it automatically derives `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database, `EXTERNAL_PG_KEYCLOAK_*`) and `SKIP_HELM_UPGRADE=true` — you do not set those yourself. The scripts migrate the realm database and stop with Camunda still frozen on the old backends; your upgrade pipeline then runs the `helm upgrade` that switches Camunda to the external Keycloak and wires its authentication credentials.
 :::
 
+In this mode, the per-phase behavior changes accordingly: Phase 1 skips the Keycloak Operator deployment, Phase 3 runs the data migration but stops before the final `helm upgrade` (your pipeline owns it), and Phase 4 skips the Keycloak Custom Resource health check. The PostgreSQL and Elasticsearch phases are unchanged.
+
 Configure the external Keycloak connection variables in `env.sh`:
 
 | Variable                         | Default                    | Description                                                                           |
@@ -222,6 +224,10 @@ export KEYCLOAK_DB_USER="keycloak"
 ```
 
 The same pattern applies to the `IDENTITY_SOURCE_DB_*` and `WEBMODELER_SOURCE_DB_*` variables.
+
+#### Transient Keycloak cluster data is excluded automatically
+
+When the realm database is backed up, the scripts automatically exclude the data in Keycloak's `JGROUPS_PING` table — the transient JDBC_PING cluster-discovery table whose rows hold the source cluster's node addresses. Restoring those rows into the target Keycloak would make it fail on startup with a duplicate-key violation on `constraint_jgroups_ping`, leaving the migrated Keycloak in `CrashLoopBackOff`. The table schema is preserved and restored empty, so the external Keycloak re-registers its own cluster membership on startup. You do not need to configure anything for this.
 
 ### Create custom Helm values
 
@@ -328,7 +334,7 @@ What happens:
 
 - When `PG_TARGET_MODE=external`, the CloudNativePG (CNPG) operator is not installed; your managed PostgreSQL is used directly.
 - When `ES_TARGET_MODE=external`, the Elastic Cloud on Kubernetes (ECK) operator is not installed; your managed Elasticsearch target is used directly.
-- The Keycloak Operator is still deployed with a Custom Resource pointing to your managed PostgreSQL.
+- The Keycloak Operator is still deployed with a Custom Resource pointing to your managed PostgreSQL. When `KEYCLOAK_TARGET_MODE=external`, the operator is not deployed and Camunda is pointed at your existing Keycloak instead (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
 - The script validates connectivity to each external endpoint before proceeding.
 
 ### Phase 2: Initial backup (no downtime)
@@ -429,7 +435,7 @@ If you cannot configure `reindex.remote.whitelist` on the managed target, or pre
 bash 4-validate.sh
 ```
 
-The validation script checks that all Camunda deployments and StatefulSets are ready, and that the Keycloak Custom Resource is healthy. For external PostgreSQL and Elasticsearch targets, it verifies connectivity to the managed service endpoints rather than checking CNPG/ECK cluster status. A migration report is generated at `.state/migration-report.md`.
+The validation script checks that all Camunda deployments and StatefulSets are ready, and that the Keycloak Custom Resource is healthy (skipped when `KEYCLOAK_TARGET_MODE=external`, where there is no operator-managed Custom Resource). For external PostgreSQL and Elasticsearch targets, it verifies connectivity to the managed service endpoints rather than checking CNPG/ECK cluster status. A migration report is generated at `.state/migration-report.md`.
 
 :::warning Wait before cleanup
 Do not move on to the next phase immediately after validation. Operate with the new infrastructure through at least one full business cycle (for example, a complete weekday with peak traffic) before cleanup. Once Bitnami resources are deleted, rollback is no longer possible without restoring from backup. If you need to fail back, run `bash rollback.sh` **before** this phase (see [rollback](#rollback)).

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
@@ -175,24 +175,22 @@ You can use the same managed PostgreSQL host for all components—each database 
 
 ### Migrate Keycloak to an external instance {#migrate-keycloak-to-an-external-instance}
 
-By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom resource. To instead point Camunda at a pre-existing external, standalone, or Helm-managed Keycloak, set `KEYCLOAK_TARGET_MODE=external`. The scripts migrate the realm into the external Keycloak database and rewire Camunda to the external endpoint. They do not deploy or manage the Keycloak instance itself.
+By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom resource. To instead point Camunda at a pre-existing external, standalone, or Helm-managed Keycloak, set `KEYCLOAK_TARGET_MODE=external`. The scripts migrate the realm into the external Keycloak database, but they do not deploy or manage the Keycloak instance itself, and they do not repoint Camunda — your upgrade pipeline performs that cutover.
 
-:::note
-Setting `KEYCLOAK_TARGET_MODE=external` is a **data-only** migration. When you source `env.sh`, it automatically derives `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database, `EXTERNAL_PG_KEYCLOAK_*`) and `SKIP_HELM_UPGRADE=true` — you do not set those yourself. The scripts migrate the realm database and stop with Camunda still frozen on the old backends; your upgrade pipeline then runs the `helm upgrade` that switches Camunda to the external Keycloak and wires its authentication credentials.
-:::
+Setting `KEYCLOAK_TARGET_MODE=external` is a **data-only** migration. When you source `env.sh`, it automatically derives `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database, `EXTERNAL_PG_KEYCLOAK_*`) and `SKIP_HELM_UPGRADE=true` — you do not set those yourself. The scripts migrate the realm database and stop with Camunda still frozen on the old backends. Your upgrade pipeline then runs the `helm upgrade` that switches Camunda to the external Keycloak and wires its authentication credentials.
 
 In this mode, the per-phase behavior changes accordingly: Phase 1 skips the Keycloak Operator deployment, Phase 3 runs the data migration but stops before the final `helm upgrade` (your pipeline owns it), and Phase 4 skips the Keycloak Custom Resource health check. The PostgreSQL and Elasticsearch phases are unchanged.
 
 Configure the external Keycloak connection variables in `env.sh`:
 
-| Variable                         | Default                    | Description                                                                           |
-| -------------------------------- | -------------------------- | ------------------------------------------------------------------------------------- |
-| `KEYCLOAK_TARGET_MODE`           | `operator`                 | Set to `external` to skip the operator and rewire Camunda to a pre-existing Keycloak. |
-| `EXTERNAL_KEYCLOAK_PROTOCOL`     | `http`                     | Protocol of the external Keycloak.                                                    |
-| `EXTERNAL_KEYCLOAK_HOST`         | (empty)                    | Host of the external Keycloak.                                                        |
-| `EXTERNAL_KEYCLOAK_PORT`         | `80`                       | Port of the external Keycloak.                                                        |
-| `EXTERNAL_KEYCLOAK_CONTEXT_PATH` | `/auth`                    | Context path of the external Keycloak.                                                |
-| `EXTERNAL_KEYCLOAK_REALM`        | `/realms/camunda-platform` | Realm path served by the external Keycloak.                                           |
+| Variable                         | Default                    | Description                                                                              |
+| -------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------- |
+| `KEYCLOAK_TARGET_MODE`           | `operator`                 | Set to `external` to skip the operator and migrate the realm to a pre-existing Keycloak. |
+| `EXTERNAL_KEYCLOAK_PROTOCOL`     | `http`                     | Protocol of the external Keycloak.                                                       |
+| `EXTERNAL_KEYCLOAK_HOST`         | (empty)                    | Host of the external Keycloak.                                                           |
+| `EXTERNAL_KEYCLOAK_PORT`         | `80`                       | Port of the external Keycloak.                                                           |
+| `EXTERNAL_KEYCLOAK_CONTEXT_PATH` | `/auth`                    | Context path of the external Keycloak.                                                   |
+| `EXTERNAL_KEYCLOAK_REALM`        | `/realms/camunda-platform` | Realm path served by the external Keycloak.                                              |
 
 <details>
 <summary>Show details: external Keycloak configuration example</summary>
@@ -334,7 +332,7 @@ What happens:
 
 - When `PG_TARGET_MODE=external`, the CloudNativePG (CNPG) operator is not installed; your managed PostgreSQL is used directly.
 - When `ES_TARGET_MODE=external`, the Elastic Cloud on Kubernetes (ECK) operator is not installed; your managed Elasticsearch target is used directly.
-- The Keycloak Operator is still deployed with a Custom Resource pointing to your managed PostgreSQL. When `KEYCLOAK_TARGET_MODE=external`, the operator is not deployed and Camunda is pointed at your existing Keycloak instead (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
+- The Keycloak Operator is still deployed with a Custom Resource pointing to your managed PostgreSQL. When `KEYCLOAK_TARGET_MODE=external`, the operator is not deployed; Camunda is repointed to your existing Keycloak later, when your pipeline runs the `helm upgrade` (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
 - The script validates connectivity to each external endpoint before proceeding.
 
 ### Phase 2: Initial backup (no downtime)

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
@@ -18,7 +18,7 @@ Migrate a Camunda 8 Helm installation from Bitnami-managed infrastructure to **c
 
 - **PostgreSQL**: AWS RDS, Azure Database for PostgreSQL, Google Cloud SQL, or any managed PostgreSQL service
 - **Elasticsearch**: Elastic Cloud or any managed Elasticsearch service
-- **Keycloak**: Keep Keycloak on the [Keycloak Operator](https://www.keycloak.org/operator/installation), replace it with an [external OIDC provider](/self-managed/deployment/helm/configure/authentication-and-authorization/external-oidc-provider.md), or migrate the bundled realm onto an external, standalone, or Helm-managed Keycloak with `KEYCLOAK_TARGET_MODE=external` (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
+- **Keycloak**: Keep Keycloak on the [Keycloak Operator](https://www.keycloak.org/operator/installation), replace it with an [external OIDC provider](/self-managed/deployment/helm/configure/authentication-and-authorization/external-oidc-provider.md), or migrate the bundled realm to an external, standalone, or Helm-managed Keycloak with `KEYCLOAK_TARGET_MODE=external` (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
 
 ## When to use this guide
 
@@ -175,11 +175,17 @@ You can use the same managed PostgreSQL host for all components—each database 
 
 ### Migrate Keycloak to an external instance {#migrate-keycloak-to-an-external-instance}
 
-By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom resource. To instead point Camunda at a pre-existing external, standalone, or Helm-managed Keycloak, set `KEYCLOAK_TARGET_MODE=external`. The scripts migrate the realm into the external Keycloak database, but they do not deploy or manage the Keycloak instance itself, and they do not repoint Camunda — your upgrade pipeline performs that cutover.
+By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom resource. To instead point Camunda at a pre-existing external, standalone, or Helm-managed Keycloak, set `KEYCLOAK_TARGET_MODE=external`. The scripts migrate the realm into the external Keycloak database, but they do not deploy or manage the Keycloak instance itself, and they do not repoint Camunda. Your upgrade pipeline performs that cutover.
 
-Setting `KEYCLOAK_TARGET_MODE=external` is a **data-only** migration. When you source `env.sh`, it automatically derives `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database, `EXTERNAL_PG_KEYCLOAK_*`) and `SKIP_HELM_UPGRADE=true` — you do not set those yourself. The scripts migrate the realm database and stop with Camunda still frozen on the old backends. Your upgrade pipeline then runs the `helm upgrade` that switches Camunda to the external Keycloak and wires its authentication credentials.
+Setting `KEYCLOAK_TARGET_MODE=external` is a data-only migration. When you source `env.sh`, it automatically derives `PG_TARGET_MODE=external` and `SKIP_HELM_UPGRADE=true`. You do not set these yourself. The external Keycloak serves the migrated realm from the Keycloak database configured with `EXTERNAL_PG_KEYCLOAK_*`. The scripts migrate the realm database and exit. Camunda remains frozen on the old backends until your upgrade pipeline runs the `helm upgrade` that switches Camunda to the external Keycloak and configures its authentication settings.
 
-In this mode, the per-phase behavior changes accordingly: Phase 1 skips the Keycloak Operator deployment, Phase 3 runs the data migration but stops before the final `helm upgrade` (your pipeline owns it), and Phase 4 skips the Keycloak Custom Resource health check. The PostgreSQL and Elasticsearch phases are unchanged.
+In this mode, phase behavior changes as follows:
+
+- Phase 1: Skips the Keycloak Operator deployment.
+- Phase 3: Runs the realm data migration and exits before the final `helm upgrade`. Your pipeline owns the cutover.
+- Phase 4: Skips the Keycloak Custom Resource health check.
+
+The PostgreSQL and Elasticsearch phases are unchanged.
 
 Configure the external Keycloak connection variables in `env.sh`:
 
@@ -221,11 +227,11 @@ export KEYCLOAK_DB_NAME="keycloak"
 export KEYCLOAK_DB_USER="keycloak"
 ```
 
-The same pattern applies to the `IDENTITY_SOURCE_DB_*` and `WEBMODELER_SOURCE_DB_*` variables.
+The same pattern applies to the Identity and Web Modeler source database variables: `IDENTITY_SOURCE_DB_NAME`, `IDENTITY_SOURCE_DB_USER`, `WEBMODELER_SOURCE_DB_NAME`, and `WEBMODELER_SOURCE_DB_USER`. They default to the corresponding target names.
 
 #### Transient Keycloak cluster data is excluded automatically
 
-When the realm database is backed up, the scripts automatically exclude the data in Keycloak's `JGROUPS_PING` table — the transient JDBC_PING cluster-discovery table whose rows hold the source cluster's node addresses. Restoring those rows into the target Keycloak would make it fail on startup with a duplicate-key violation on `constraint_jgroups_ping`, leaving the migrated Keycloak in `CrashLoopBackOff`. The table schema is preserved and restored empty, so the external Keycloak re-registers its own cluster membership on startup. You do not need to configure anything for this.
+When the realm database is backed up, the scripts automatically exclude the data in Keycloak's `JGROUPS_PING` table,  the transient JDBC_PING cluster-discovery table whose rows hold the source cluster's node addresses. Restoring those rows into the target Keycloak would make it fail on startup with a duplicate-key violation on `constraint_jgroups_ping`, leaving the migrated Keycloak in `CrashLoopBackOff`. The table schema is preserved and restored empty, so the external Keycloak re-registers its own cluster membership on startup.
 
 ### Create custom Helm values
 
@@ -332,7 +338,7 @@ What happens:
 
 - When `PG_TARGET_MODE=external`, the CloudNativePG (CNPG) operator is not installed; your managed PostgreSQL is used directly.
 - When `ES_TARGET_MODE=external`, the Elastic Cloud on Kubernetes (ECK) operator is not installed; your managed Elasticsearch target is used directly.
-- The Keycloak Operator is still deployed with a Custom Resource pointing to your managed PostgreSQL. When `KEYCLOAK_TARGET_MODE=external`, the operator is not deployed; Camunda is repointed to your existing Keycloak later, when your pipeline runs the `helm upgrade` (see [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance)).
+- The Keycloak Operator is still deployed with a Custom Resource pointing to your managed PostgreSQL. If you set `KEYCLOAK_TARGET_MODE=external`, the operator is not deployed. Your pipeline repoints Camunda to the external Keycloak when it runs the `helm upgrade`. See [Migrate Keycloak to an external instance](#migrate-keycloak-to-an-external-instance).
 - The script validates connectivity to each external endpoint before proceeding.
 
 ### Phase 2: Initial backup (no downtime)
@@ -433,7 +439,7 @@ If you cannot configure `reindex.remote.whitelist` on the managed target, or pre
 bash 4-validate.sh
 ```
 
-The validation script checks that all Camunda deployments and StatefulSets are ready, and that the Keycloak Custom Resource is healthy (skipped when `KEYCLOAK_TARGET_MODE=external`, where there is no operator-managed Custom Resource). For external PostgreSQL and Elasticsearch targets, it verifies connectivity to the managed service endpoints rather than checking CNPG/ECK cluster status. A migration report is generated at `.state/migration-report.md`.
+The validation script checks that all Camunda deployments and StatefulSets are ready, and that the Keycloak Custom Resource is healthy. This check is skipped when `KEYCLOAK_TARGET_MODE=external` is set, because there is no operator-managed Custom Resource in that mode. For external PostgreSQL and Elasticsearch targets, it verifies connectivity to the managed service endpoints rather than checking CNPG/ECK cluster status. A migration report is generated at `.state/migration-report.md`.
 
 :::warning Wait before cleanup
 Do not move on to the next phase immediately after validation. Operate with the new infrastructure through at least one full business cycle (for example, a complete weekday with peak traffic) before cleanup. Once Bitnami resources are deleted, rollback is no longer possible without restoring from backup. If you need to fail back, run `bash rollback.sh` **before** this phase (see [rollback](#rollback)).

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/bitnami-to-managed-services.md
@@ -178,7 +178,7 @@ You can use the same managed PostgreSQL host for all components—each database 
 By default, the scripts deploy the Keycloak Operator and a `Keycloak` custom resource. To instead point Camunda at a pre-existing external, standalone, or Helm-managed Keycloak, set `KEYCLOAK_TARGET_MODE=external`. The scripts migrate the realm into the external Keycloak database and rewire Camunda to the external endpoint. They do not deploy or manage the Keycloak instance itself.
 
 :::note
-`KEYCLOAK_TARGET_MODE=external` requires `PG_TARGET_MODE=external`, because the external Keycloak serves the migrated realm from the external Keycloak database (`EXTERNAL_PG_KEYCLOAK_*`). This flow is intended for a data-only cutover: set `SKIP_HELM_UPGRADE=true` and let your upgrade pipeline run the `helm upgrade` that points Camunda at the external Keycloak.
+Setting `KEYCLOAK_TARGET_MODE=external` is a **data-only** migration. When you source `env.sh`, it automatically derives `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database, `EXTERNAL_PG_KEYCLOAK_*`) and `SKIP_HELM_UPGRADE=true` — you do not set those yourself. The scripts migrate the realm database and stop with Camunda still frozen on the old backends; your upgrade pipeline then runs the `helm upgrade` that switches Camunda to the external Keycloak and wires its authentication credentials.
 :::
 
 Configure the external Keycloak connection variables in `env.sh`:
@@ -191,23 +191,21 @@ Configure the external Keycloak connection variables in `env.sh`:
 | `EXTERNAL_KEYCLOAK_PORT`         | `80`                       | Port of the external Keycloak.                                                        |
 | `EXTERNAL_KEYCLOAK_CONTEXT_PATH` | `/auth`                    | Context path of the external Keycloak.                                                |
 | `EXTERNAL_KEYCLOAK_REALM`        | `/realms/camunda-platform` | Realm path served by the external Keycloak.                                           |
-| `EXTERNAL_KEYCLOAK_ADMIN_SECRET` | (empty)                    | Kubernetes secret in `NAMESPACE` holding the Keycloak admin `password`.               |
 
 <details>
 <summary>Show details: external Keycloak configuration example</summary>
 
 ```bash
-# Migrate the Keycloak realm onto an external Keycloak (data-only cutover)
+# Migrate the Keycloak realm onto an external Keycloak (data-only cutover).
+# Set this one flag plus the EXTERNAL_KEYCLOAK_* connection variables — sourcing
+# env.sh then auto-derives PG_TARGET_MODE=external and SKIP_HELM_UPGRADE=true.
 export KEYCLOAK_TARGET_MODE="external"
-export PG_TARGET_MODE="external"
-export SKIP_HELM_UPGRADE="true"
 
 export EXTERNAL_KEYCLOAK_PROTOCOL="http"
 export EXTERNAL_KEYCLOAK_HOST="keycloak"
 export EXTERNAL_KEYCLOAK_PORT="80"
 export EXTERNAL_KEYCLOAK_CONTEXT_PATH="/auth"
 export EXTERNAL_KEYCLOAK_REALM="/realms/camunda-platform"
-export EXTERNAL_KEYCLOAK_ADMIN_SECRET="external-keycloak-admin"
 ```
 
 </details>


### PR DESCRIPTION
## Description

Documents the new `KEYCLOAK_TARGET_MODE=external` migration mode for the **Bitnami → managed services** guide (8.9). It pairs with two migration-script PRs: camunda/camunda-deployment-references#2620 (adds the capability) and camunda/camunda-deployment-references#2658 (excludes the transient `JGROUPS_PING` data from the realm dump).

Changes (versioned 8.9 only):

- Update the **Keycloak** bullet at the top of `bitnami-to-managed-services.md` — the guide previously stated it "does not assume a managed Keycloak service"; it now points to the new external/standalone/Helm-managed Keycloak option.
- New subsection **Migrate Keycloak to an external instance** documenting `KEYCLOAK_TARGET_MODE` and the `EXTERNAL_KEYCLOAK_*` connection variables. It explains the mode is **data-only**: sourcing `env.sh` auto-derives `PG_TARGET_MODE=external` and `SKIP_HELM_UPGRADE=true`, and the caller owns the Helm upgrade (including wiring Camunda's Keycloak auth).
- New subsection **Source database names that differ from the target** documenting the `*_SOURCE_DB_NAME` / `*_SOURCE_DB_USER` overrides (the bundled Bitnami Keycloak defaults to `bitnami_keycloak` / `bn_keycloak`).
- New subsection **Transient Keycloak cluster data is excluded automatically** documenting why the `JGROUPS_PING` table data is dropped from the realm dump (its schema is preserved and restored empty), avoiding a `constraint_jgroups_ping` duplicate-key crash on the target Keycloak.

> [!NOTE]
> Content is aligned with the final merged script contract: `EXTERNAL_KEYCLOAK_ADMIN_SECRET` was removed and the coupled flags are auto-derived (camunda/camunda-deployment-references#2620), and the transient `JGROUPS_PING` data is excluded from the realm dump (camunda/camunda-deployment-references#2658). Both script PRs are now merged on `stable/8.9`.

Scope note: this PR intentionally targets **`versioned_docs/version-8.9` only** (the migration tooling lives on `stable/8.9`).

## When should this change go live?

- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using `{type}(scope): {description}` commit message(s)
- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] Engineering team review
  - [x] Technical writer review via `@camunda/tech-writers` unless working with an embedded writer.
