### PR TITLE
doc: fix business ID emptiness vs null-ness in migrator

### DIFF
--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
@@ -22,7 +22,7 @@ Audit data migration might need to look at a huge amount of data, which can take
 You can run audit data migration alongside normal operations (for example, after the successful big bang migration of runtime process instances) so that it doesn't require downtime and as such, the performance might not be as critical as for runtime instance migration.
 
 During history migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
-If no business key is present, or if it is blank, the process instance is migrated without a business ID.
+If no business key is present, the process instance is migrated without a business ID. If the business key is blank, it is migrated as a blank business ID.
 
 During migration, the History Data Migrator sets a `legacyId` variable in the process instances to link them to their original Camunda 7 process instances.
 

--- a/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/runtime.md
+++ b/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/runtime.md
@@ -15,7 +15,7 @@ Migrate currently running process instances.
 Running refers to process instances in Camunda 7 that are not yet ended and are currently waiting in a [wait-state](https://docs.camunda.org/manual/latest/user-guide/process-engine/transactions-in-processes/#wait-states). This state is persisted in the database, and a corresponding data entry must be created in Camunda 8 so the process instance can continue from that state in the new solution.
 
 During runtime migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
-If no business key is present, or if it is blank, the process instance is migrated without a business ID.
+If no business key is present, the process instance is migrated without a business ID. If the business key is blank, it is migrated as a blank business ID.
 
 ## Requirements and limitations
 

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/migration-tooling/data-migrator/history.md
@@ -22,7 +22,7 @@ Audit data migration might need to look at a huge amount of data, which can take
 You can run audit data migration alongside normal operations (for example, after the successful big bang migration of runtime process instances) so that it doesn't require downtime and as such, the performance might not be as critical as for runtime instance migration.
 
 During history migration, the Data Migrator maps the Camunda 7 process instance `businessKey` to Camunda 8 `businessId`.
-If no business key is present, or if it is blank, the process instance is migrated without a business ID.
+If no business key is present, the process instance is migrated without a business ID. If the business key is blank, it is migrated as a blank business ID.
 
 During migration, the History Data Migrator sets a `legacyId` variable in the process instances to link them to their original Camunda 7 process instances.
 


### PR DESCRIPTION
## Description

The distinction between null and empty was missed in the previous version of the doc.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
