### PR TITLE
chore(agents): make AGENTS.md the source of truth for agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,33 +1,3 @@
 # Copilot instructions for camunda-docs
 
-These instructions apply to all AI agents (Claude Code, Copilot, OpenAI Codex, and similar tools) interactions in this repository.
-
-## Before editing
-
-Read the relevant files in `.github/instructions/`:
-
-- **`content.instructions.md`** — language and grammar, punctuation, formatting, links, product terminology, and the documentation PR review checklist. Read before any Markdown content change.
-- **`repo.instructions.md`** — file and repo structure, PR workflow, build and validation commands, and commit message conventions. Applies to all files.
-
-Do not recursively read the full style guide (`/howtos/technical-writing-styleguide.md`) or contributor guide (`/howtos/documentation-guidelines.md`) unless the task requires details not covered by these instruction files.
-
-## Scope
-
-Prefer the smallest safe change that satisfies the user request.
-
-For documentation-only tasks:
-
-- Edit only the files named in the task, plus any sibling files explicitly required by repo conventions (for example, the corresponding versioned file when editing `/docs/`).
-- Do not run broad repository searches unless the target files are unknown.
-- Do not run baseline validation before editing.
-- Do not run security scans unless the task involves code, dependencies, generated artifacts, or security-sensitive configuration.
-
-## Validation
-
-For documentation-only changes, prefer lightweight validation first:
-
-- Run formatting only for the changed files if a targeted command is available.
-- Run the full docs build (`npm run build`) only after final changes, and only when the build trigger conditions in `repo.instructions.md` apply or the user explicitly asks for a full build.
-- If full validation is too slow or unavailable, state what validation was skipped and why.
-
-Do not spend more than a few minutes on validation setup for small Markdown-only changes. If validation setup is slow or blocked, make the requested edit and report the limitation.
+`AGENTS.md` is the source of truth for all AI agent instructions in this repository. Read and follow `AGENTS.md` before making any changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,33 @@
 # Agent instructions for camunda-docs
 
-This file provides instructions for AI agents (Claude Code, OpenAI Codex, and similar tools) working autonomously in this repository.
+This file provides instructions for all AI agents (Claude Code, GitHub Copilot, OpenAI Codex, and similar tools) working autonomously in this repository.
 
-Read and follow `.github/copilot-instructions.md` and associated instruction files before making any changes.
-They are the source of truth for contribution standards. They apply to all AI agents.
+## Before editing
+
+Read the relevant files in `.github/instructions/`:
+
+- **`content.instructions.md`** — language and grammar, punctuation, formatting, links, product terminology, and the documentation PR review checklist. Read before any Markdown content change.
+- **`repo.instructions.md`** — file and repo structure, PR workflow, build and validation commands, and commit message conventions. Applies to all files.
+
+Do not recursively read the full style guide (`/howtos/technical-writing-styleguide.md`) or contributor guide (`/howtos/documentation-guidelines.md`) unless the task requires details not covered by these instruction files.
+
+## Scope
+
+Prefer the smallest safe change that satisfies the user request.
+
+For documentation-only tasks:
+
+- Edit only the files named in the task, plus any sibling files explicitly required by repo conventions (for example, the corresponding versioned file when editing `/docs/`).
+- Do not run broad repository searches unless the target files are unknown.
+- Do not run baseline validation before editing.
+- Do not run security scans unless the task involves code, dependencies, generated artifacts, or security-sensitive configuration.
+
+## Validation
+
+For documentation-only changes, prefer lightweight validation first:
+
+- Run formatting only for the changed files if a targeted command is available.
+- Run the full docs build (`npm run build`) only after final changes, and only when the build trigger conditions in `repo.instructions.md` apply or the user explicitly asks for a full build.
+- If full validation is too slow or unavailable, state what validation was skipped and why.
+
+Do not spend more than a few minutes on validation setup for small Markdown-only changes. If validation setup is slow or blocked, make the requested edit and report the limitation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-# Claude instructions for camunda-docs
-
-This file provides instructions for Claude Code working autonomously in this repository.
-
-Read and follow [`AGENTS.md`](AGENTS.md) before making any changes.
+@AGENTS.md


### PR DESCRIPTION
## Description

Addresses task 1 from camunda/documentation-team#520 — make `AGENTS.md` the canonical source of truth for all AI agent instructions in this repository.

**Changes:**

- `AGENTS.md`: promoted the full substance from `.github/copilot-instructions.md` (scope rules, validation rules, and the "before editing" pointer to `.github/instructions/`). Now the canonical root for all agents (Claude Code, GitHub Copilot, Codex, etc.).
- `.github/copilot-instructions.md`: reduced to a one-line delegation to `AGENTS.md`, reversing the previous direction.
- `CLAUDE.md`: switched from a soft "read and follow" directive to `@AGENTS.md` — a Claude Code harness-level include (see below).

The `.github/instructions/` files (`content.instructions.md`, `repo.instructions.md`) are unchanged and stay in `.github/instructions/`.

**Why `CLAUDE.md` is now just `@AGENTS.md`**

Claude Code resolves `@filename` references in `CLAUDE.md` at session start and inlines the content automatically — it's a harness-level include, not a model instruction. The previous "read and follow `AGENTS.md`" wording was a soft directive that the model could skip or defer; `@AGENTS.md` guarantees the content is in context before the first message.

**Why `.github/instructions/` stays where it is**

The `applyTo` frontmatter in `content.instructions.md` and `repo.instructions.md` is a VS Code / GitHub Copilot convention. Copilot automatically injects matching instruction files from `.github/instructions/` based on the glob — move them out and that auto-injection silently breaks. For Claude Code the location is irrelevant since `AGENTS.md` references them by explicit path, so keeping them in `.github/instructions/` preserves Copilot compatibility at no cost.

## When should this change go live?

- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.