### PR TITLE
docs(dual-region): update OpenSearch support statement across all versions

### DIFF
--- a/docs/self-managed/concepts/multi-region/dual-region.md
+++ b/docs/self-managed/concepts/multi-region/dual-region.md
@@ -161,7 +161,7 @@ The currently supported Camunda 8 Self-Managed components are:
 Two Kubernetes clusters are required for the Helm chart installation.
 
 :::note
-OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
+OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use Basic authentication instead.
 :::
 
 :::note

--- a/docs/self-managed/concepts/multi-region/dual-region.md
+++ b/docs/self-managed/concepts/multi-region/dual-region.md
@@ -161,7 +161,7 @@ The currently supported Camunda 8 Self-Managed components are:
 Two Kubernetes clusters are required for the Helm chart installation.
 
 :::note
-OpenSearch is **not supported** in dual-region configurations.
+OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
 :::
 
 :::note

--- a/versioned_docs/version-8.7/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/multi-region/dual-region.md
@@ -85,7 +85,7 @@ Operate and Tasklist store some data in the active region, as they write directl
 
 Two Kubernetes clusters are required for the Helm chart installation.
 
-Amazon OpenSearch is **not supported** in dual-region configurations.
+Amazon OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
 
 #### Network requirements
 

--- a/versioned_docs/version-8.7/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/multi-region/dual-region.md
@@ -85,7 +85,7 @@ Operate and Tasklist store some data in the active region, as they write directl
 
 Two Kubernetes clusters are required for the Helm chart installation.
 
-Amazon OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
+Amazon OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use Basic authentication instead.
 
 #### Network requirements
 

--- a/versioned_docs/version-8.8/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/multi-region/dual-region.md
@@ -153,7 +153,7 @@ The currently supported Camunda 8 Self-Managed components are:
 
 Two Kubernetes clusters are required for the Helm chart installation.
 
-Amazon OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
+Amazon OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use Basic authentication instead.
 
 #### Network requirements
 

--- a/versioned_docs/version-8.8/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/multi-region/dual-region.md
@@ -153,7 +153,7 @@ The currently supported Camunda 8 Self-Managed components are:
 
 Two Kubernetes clusters are required for the Helm chart installation.
 
-Amazon OpenSearch is **not supported** in dual-region configurations.
+Amazon OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
 
 #### Network requirements
 

--- a/versioned_docs/version-8.9/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/multi-region/dual-region.md
@@ -161,7 +161,7 @@ The currently supported Camunda 8 Self-Managed components are:
 Two Kubernetes clusters are required for the Helm chart installation.
 
 :::note
-OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
+OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use Basic authentication instead.
 :::
 
 :::note

--- a/versioned_docs/version-8.9/self-managed/concepts/multi-region/dual-region.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/multi-region/dual-region.md
@@ -161,7 +161,7 @@ The currently supported Camunda 8 Self-Managed components are:
 Two Kubernetes clusters are required for the Helm chart installation.
 
 :::note
-OpenSearch is **not supported** in dual-region configurations.
+OpenSearch is supported in dual-region configurations. However, IRSA (IAM Roles for Service Accounts) authentication is not supported across two separate clusters — use basic auth instead.
 :::
 
 :::note


### PR DESCRIPTION
## Description

Closes #9075

The dual-region docs incorrectly stated OpenSearch is not supported. This was a legacy note reflecting absent test coverage, not a real technical constraint. Internally confirmed: OpenSearch works in dual-region.

**Change:** Remove "not supported" note. Replace with accurate statement that OpenSearch is supported, with a caveat that IRSA auth does not work cross-cluster — basic auth must be used.

**Versions updated:** 8.7, 8.8, 8.9, next

## Review checklist

- [ ] Wording confirmed by internal SME
- [ ] IRSA caveat accurate and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)