### PR TITLE
docs: document FEEL expression support for versionTag in business rule tasks

### DIFF
--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -46,7 +46,7 @@ The `bindingType` attribute determines which version of the called decision is e
 
 - `latest`: The latest deployed version at the moment the business rule task is activated.
 - `deployment`: The version that was deployed together with the currently running version of the process.
-- `versionTag`: The latest deployed version that is annotated with the version tag specified in the `versionTag` attribute.
+- `versionTag`: The latest deployed version that is annotated with the version tag specified in the `versionTag` attribute. Usually, the `versionTag` is defined as a [static value](/components/concepts/expressions.md#expressions-vs-static-values) (e.g. `v1.0`), but it can also be defined as an [expression](/components/concepts/expressions.md) (e.g. `= "v" + version`). The expression is evaluated on activating the business rule task (or when an incident at the business rule task is resolved) after input mappings have been applied. The expression must result in a `string`.
 
 To learn more about choosing binding types, see [choosing the resource binding type](/components/best-practices/modeling/choosing-the-resource-binding-type.md).
 
@@ -125,13 +125,25 @@ A business rule task with a called decision that uses the `deployment` binding t
 </bpmn:businessRuleTask>
 ```
 
-A business rule task with a called decision that uses the `versionTag` binding type:
+A business rule task with a called decision that uses the `versionTag` binding type with a static version tag:
 
 ```xml
 <bpmn:businessRuleTask id="determine-box-size" name="Determine shipping box size">
   <bpmn:extensionElements>
     <zeebe:calledDecision decisionId="shipping_box_size"
                           bindingType="versionTag" versionTag="v1.0"
+                          resultVariable="boxSize" />
+  </bpmn:extensionElements>
+</bpmn:businessRuleTask>
+```
+
+A business rule task with a called decision that uses the `versionTag` binding type with expressions for both `decisionId` and `versionTag`:
+
+```xml
+<bpmn:businessRuleTask id="determine-box-size" name="Determine shipping box size">
+  <bpmn:extensionElements>
+    <zeebe:calledDecision decisionId="= \"shipping_box_size_\" + countryCode"
+                          bindingType="versionTag" versionTag="= decisionVersion"
                           resultVariable="boxSize" />
   </bpmn:extensionElements>
 </bpmn:businessRuleTask>

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -36,9 +36,9 @@ a [decision literal expression](/components/modeler/dmn/decision-literal-express
 `zeebe:calledDecision` extension element.
 
 A business rule task must define the [DMN decision id](/components/modeler/dmn/decision-table.md#decision-id) of the
-called decision as `decisionId`. Usually, the `decisionId` is defined as a [static value](/components/concepts/expressions.md#expressions-vs-static-values) (e.g. `shipping_box_size`), but
+called decision as `decisionId`. Usually, the `decisionId` is defined as a [static value](/components/concepts/expressions.md#expressions-vs-static-values) (for example, `shipping_box_size`), but
 it can also be defined as an [expression](/components/concepts/expressions.md) (
-e.g. `= "shipping_box_size_" + countryCode`). The expression is evaluated on activating the business rule task (or when
+for example, `= "shipping_box_size_" + countryCode`). The expression is evaluated on activating the business rule task (or when
 an incident at the business rule task is resolved) after input mappings have been applied. The expression must result in
 a `string`.
 
@@ -46,7 +46,7 @@ The `bindingType` attribute determines which version of the called decision is e
 
 - `latest`: The latest deployed version at the moment the business rule task is activated.
 - `deployment`: The version that was deployed together with the currently running version of the process.
-- `versionTag`: The latest deployed version that is annotated with the version tag specified in the `versionTag` attribute. Usually, the `versionTag` is defined as a [static value](/components/concepts/expressions.md#expressions-vs-static-values) (e.g. `v1.0`), but it can also be defined as an [expression](/components/concepts/expressions.md) (e.g. `= "v" + version`). The expression is evaluated on activating the business rule task (or when an incident at the business rule task is resolved) after input mappings have been applied. The expression must result in a `string`.
+- `versionTag`: The latest deployed version that is annotated with the version tag specified in the `versionTag` attribute. Usually, the `versionTag` is defined as a [static value](/components/concepts/expressions.md#expressions-vs-static-values) (for example, `v1.0`), but it can also be defined as an [expression](/components/concepts/expressions.md) (for example, `= "v" + version`). The expression is evaluated on activating the business rule task or when an incident at the business rule task is resolved, after input mappings have been applied. The expression must result in a `string`.
 
 To learn more about choosing binding types, see [choosing the resource binding type](/components/best-practices/modeling/choosing-the-resource-binding-type.md).
 
@@ -94,7 +94,7 @@ and process them. When the job is completed, the process instance continues.
 A business rule task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. This is used as reference to specify which job workers request the respective business rule task job. For example, `order-items`. Note that `type` can be specified as any static value (`myType`) or as a FEEL [expression](../../../concepts/expressions.md) prefixed by `=` that evaluates to any FEEL string; for example, `= "order-" + priorityGroup`.
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
-worker (e.g. the key of the decision to evaluate).
+worker (for example, the key of the decision to evaluate).
 
 Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
 the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)


### PR DESCRIPTION
## Description

- Documents that `versionTag` in `zeebe:calledDecision` supports FEEL expressions in addition to static values
- Adds an XML example showing `versionTag` with an expression (`= decisionVersion`)
- Mirrors the existing pattern used to document `decisionId` expression support

closes https://github.com/camunda/camunda/issues/54297

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the docs directory (version 8.10).
- [ ] My changes are for an **already released minor** and are in a versioned_docs directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
