### PR TITLE
docs(dx): remove dynamic security group

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -40,19 +40,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           DOCS_SITE_URL: https://docs.camunda.io
           DOCS_SITE_BASE_URL: /
-      - name: Add self-hosted GitHub runner IPs to security group so we can publish
-        uses: docker://amazon/aws-cli:2.35.4
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        with:
-          # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
-          args: >
-            ec2 authorize-security-group-ingress
-            --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
-            --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
-            --output off
       - name: Publish
         uses: burnett01/rsync-deployments@8.0.5
         with:
@@ -63,20 +50,6 @@ jobs:
           remote_user: ${{ secrets.AWS_PROD_PUBLISH_USER }}
           # vvvvv Intentionally missing the AWS_ prefix vvvvv
           remote_key: ${{ secrets.PUBLISH_PROD_KEY }}
-      - name: Remove self-hosted GitHub runner IPs from security group
-        uses: docker://amazon/aws-cli:2.35.4
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        with:
-          # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
-          args: >
-            ec2 revoke-security-group-ingress
-            --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
-            --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
-            --output off
-        if: always()
   trigger-crawl:
     runs-on: ubuntu-latest
     needs: publish

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "fix-publish-pipelines"
     tags-ignore:
       - "*"
 
@@ -31,19 +32,19 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           DOCS_SITE_URL: https://stage.docs.camunda.io
           DOCS_SITE_BASE_URL: /
-      - name: Add self-hosted GitHub runner IPs to security group so we can publish
-        uses: docker://amazon/aws-cli:2.35.4
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        with:
-          # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
-          args: >
-            ec2 authorize-security-group-ingress
-            --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
-            --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
-            --output off
+      # - name: Add self-hosted GitHub runner IPs to security group so we can publish
+      #   uses: docker://amazon/aws-cli:2.35.4
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      #   with:
+      #     # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
+      #     args: >
+      #       ec2 authorize-security-group-ingress
+      #       --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
+      #       --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
+      #       --output off
       - name: Publish
         uses: burnett01/rsync-deployments@8.0.5
         with:
@@ -54,17 +55,17 @@ jobs:
           remote_user: ${{ secrets.AWS_STAGE_PUBLISH_USER }}
           # vvvvv Intentionally missing the AWS_ prefix vvvvv
           remote_key: ${{ secrets.PUBLISH_STAGE_KEY }}
-      - name: Remove self-hosted GitHub runner IPs from security group
-        uses: docker://amazon/aws-cli:2.35.4
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        with:
-          # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
-          args: >
-            ec2 revoke-security-group-ingress
-            --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
-            --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
-            --output off
-        if: always()
+      # - name: Remove self-hosted GitHub runner IPs from security group
+      #   uses: docker://amazon/aws-cli:2.35.4
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      #   with:
+      #     # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
+      #     args: >
+      #       ec2 revoke-security-group-ingress
+      #       --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
+      #       --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
+      #       --output off
+      #   if: always()

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "fix-publish-pipelines"
     tags-ignore:
       - "*"
 
@@ -32,19 +31,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           DOCS_SITE_URL: https://stage.docs.camunda.io
           DOCS_SITE_BASE_URL: /
-      # - name: Add self-hosted GitHub runner IPs to security group so we can publish
-      #   uses: docker://amazon/aws-cli:2.35.4
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      #   with:
-      #     # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
-      #     args: >
-      #       ec2 authorize-security-group-ingress
-      #       --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
-      #       --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
-      #       --output off
       - name: Publish
         uses: burnett01/rsync-deployments@8.0.5
         with:
@@ -55,17 +41,3 @@ jobs:
           remote_user: ${{ secrets.AWS_STAGE_PUBLISH_USER }}
           # vvvvv Intentionally missing the AWS_ prefix vvvvv
           remote_key: ${{ secrets.PUBLISH_STAGE_KEY }}
-      # - name: Remove self-hosted GitHub runner IPs from security group
-      #   uses: docker://amazon/aws-cli:2.35.4
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      #   with:
-      #     # PUBLISH_IPS needs to be in the form {CidrIp=XXX.XXX.XXX.XXX/32},{CidrIp=XXX.XXX.XXX.XXX/32} Ask infra for the list of IPs
-      #     args: >
-      #       ec2 revoke-security-group-ingress
-      #       --group-id ${{ secrets.AWS_SECURITY_GROUP_NAME }}
-      #       --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[${{ secrets.PUBLISH_IPS }}]
-      #       --output off
-      #   if: always()


### PR DESCRIPTION
## Description

Removed unnecessary—and sometimes blocking—dynamic security group configuration. This should prevent some already infrequent publish-prod and publish-stage race conditions resulting in failed builds.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
