### PR TITLE
docs: add upgrade note for Web Modeler PVC claimName casing fix (8.9 and 8.10)

### DIFF
--- a/docs/self-managed/upgrade/helm/index.md
+++ b/docs/self-managed/upgrade/helm/index.md
@@ -49,6 +49,17 @@ If you are still using a Camunda Helm chart that references the old repository, 
 
 See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issues/83267) for details.
 
+### Web Modeler persistence PVC name
+
+In some 8.10 chart versions, the Web Modeler `restapi` deployment referenced a persistent volume claim named `<release>-webModeler-data` (camelCase), which did not match the chart-managed PVC `<release>-webmodeler-data` (lowercase). This name mismatch prevented the Web Modeler persistence volume from mounting. A patched 8.10 chart corrects the `claimName` so the `restapi` pod mounts the existing `<release>-webmodeler-data` PVC.
+
+**No action is required for most deployments.** The fix only corrects the deployment's claim reference; it does not rename the PVC. On upgrade, the `restapi` pod mounts the already-existing `<release>-webmodeler-data` PVC and no data migration is needed. The persisted volume holds only `/tmp` scratch and cache data — Web Modeler content is stored in PostgreSQL.
+
+If you manually created a `<release>-webModeler-data` (capital `M`) PVC as a workaround for the broken mount, the `restapi` pod stops using it after you upgrade to a patched chart. The manual PVC is not deleted; it remains orphaned and continues to consume storage until you act. Choose one of the following:
+
+- Set `webModeler.persistence.existingClaim` to your manually created PVC to keep using it, or
+- Delete the orphaned PVC after confirming the `restapi` pod successfully mounts `<release>-webmodeler-data`.
+
 ## Related resources
 
 - [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
@@ -49,6 +49,17 @@ If you are still using a Camunda Helm chart that references the old repository, 
 
 See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issues/83267) for details.
 
+### Web Modeler persistence PVC name
+
+In some 8.9 chart versions, the Web Modeler `restapi` deployment referenced a persistent volume claim named `<release>-webModeler-data` (camelCase), which did not match the chart-managed PVC `<release>-webmodeler-data` (lowercase). This name mismatch prevented the Web Modeler persistence volume from mounting. A patched 8.9 chart corrects the `claimName` so the `restapi` pod mounts the existing `<release>-webmodeler-data` PVC.
+
+**No action is required for most deployments.** The fix only corrects the deployment's claim reference; it does not rename the PVC. On upgrade, the `restapi` pod mounts the already-existing `<release>-webmodeler-data` PVC and no data migration is needed. The persisted volume holds only `/tmp` scratch and cache data — Web Modeler content is stored in PostgreSQL.
+
+If you manually created a `<release>-webModeler-data` (capital `M`) PVC as a workaround for the broken mount, the `restapi` pod stops using it after you upgrade to a patched chart. The manual PVC is not deleted; it remains orphaned and continues to consume storage until you act. Choose one of the following:
+
+- Set `webModeler.persistence.existingClaim` to your manually created PVC to keep using it, or
+- Delete the orphaned PVC after confirming the `restapi` pod successfully mounts `<release>-webmodeler-data`.
+
 ## Related resources
 
 - [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)


### PR DESCRIPTION
## Description

Adds a Self-Managed Helm upgrade note documenting the customer-facing behavior change introduced by the Web Modeler PVC `claimName` casing fix in the Helm charts.

In some 8.9 and 8.10 chart versions, the Web Modeler `restapi` deployment referenced a persistent volume claim named `<release>-webModeler-data` (camelCase) that did not match the chart-managed PVC `<release>-webmodeler-data` (lowercase), which broke the persistence mount. The chart fix corrects the `claimName`.

The note clarifies:

- **Most deployments need no action** — the fix corrects only the deployment's claim reference (no PVC rename, no data migration). The volume holds only `/tmp` scratch/cache; Web Modeler content lives in PostgreSQL.
- **One edge case requires action** — customers who manually created a `<release>-webModeler-data` (capital `M`) PVC as a workaround will have it left orphaned (lingering/costing) after upgrade. They should either set `webModeler.persistence.existingClaim` to point at it, or delete it.

Companion chart PR: camunda/camunda-platform-helm#5887
Tracks SUPPORT-30069

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
