### PR TITLE
docs: make diagnostic script take java thread dumps from pods

### DIFF
--- a/docs/self-managed/deployment/helm/operational-tasks/diagnostics.md
+++ b/docs/self-managed/deployment/helm/operational-tasks/diagnostics.md
@@ -141,6 +141,27 @@ for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":me
   kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
 done
 
+echo "  - Collecting java threaddumps ..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  if ! kubectl exec -n "$namespace" "$pod" -- which java > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as java not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which jattach > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as jattach not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which pgrep > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as pgrep not installed"
+    continue
+  fi
+  java_pids=$(kubectl exec -n "$namespace" "$pod" -- pgrep java 2> /dev/null)
+  for java_pid in $java_pids; do
+    echo "    - Collecting threaddump from pod: ${pod}, java process: ${java_pid}"
+    kubectl exec -n "$namespace" "$pod" -- jattach $java_pid threaddump > "${pod}-pid-${java_pid}.jstack" 2>/dev/null
+  done
+done
+
 # Collect Helm resources
 echo "  - Collecting information via Helm..."
 release_name=`helm list -n "$namespace" --no-headers -q` 2>/dev/null

--- a/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -141,6 +141,27 @@ for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":me
   kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
 done
 
+echo "  - Collecting java threaddumps ..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  if ! kubectl exec -n "$namespace" "$pod" -- which java > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as java not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which jattach > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as jattach not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which pgrep > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as pgrep not installed"
+    continue
+  fi
+  java_pids=$(kubectl exec -n "$namespace" "$pod" -- pgrep java 2> /dev/null)
+  for java_pid in $java_pids; do
+    echo "    - Collecting threaddump from pod: ${pod}, java process: ${java_pid}"
+    kubectl exec -n "$namespace" "$pod" -- jattach $java_pid threaddump > "${pod}-pid-${java_pid}.jstack" 2>/dev/null
+  done
+done
+
 # Collect Helm resources
 echo "  - Collecting information via Helm..."
 release_name=`helm list -n "$namespace" --no-headers -q` 2>/dev/null

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/diagnostics.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/diagnostics.md
@@ -141,6 +141,27 @@ for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":me
   kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
 done
 
+echo "  - Collecting java threaddumps ..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  if ! kubectl exec -n "$namespace" "$pod" -- which java > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as java not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which jattach > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as jattach not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which pgrep > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as pgrep not installed"
+    continue
+  fi
+  java_pids=$(kubectl exec -n "$namespace" "$pod" -- pgrep java 2> /dev/null)
+  for java_pid in $java_pids; do
+    echo "    - Collecting threaddump from pod: ${pod}, java process: ${java_pid}"
+    kubectl exec -n "$namespace" "$pod" -- jattach $java_pid threaddump > "${pod}-pid-${java_pid}.jstack" 2>/dev/null
+  done
+done
+
 # Collect Helm resources
 echo "  - Collecting information via Helm..."
 release_name=`helm list -n "$namespace" --no-headers -q` 2>/dev/null

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/diagnostics.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/diagnostics.md
@@ -141,6 +141,27 @@ for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":me
   kubectl describe pod -n "$namespace" "$pod" > "describe-$pod.log" 2>/dev/null
 done
 
+echo "  - Collecting java threaddumps ..."
+for pod in $(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name"); do
+  if ! kubectl exec -n "$namespace" "$pod" -- which java > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as java not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which jattach > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as jattach not installed"
+    continue
+  fi
+  if ! kubectl exec -n "$namespace" "$pod" -- which pgrep > /dev/null 2>&1; then
+    echo "    - Skipping pod: $pod as pgrep not installed"
+    continue
+  fi
+  java_pids=$(kubectl exec -n "$namespace" "$pod" -- pgrep java 2> /dev/null)
+  for java_pid in $java_pids; do
+    echo "    - Collecting threaddump from pod: ${pod}, java process: ${java_pid}"
+    kubectl exec -n "$namespace" "$pod" -- jattach $java_pid threaddump > "${pod}-pid-${java_pid}.jstack" 2>/dev/null
+  done
+done
+
 # Collect Helm resources
 echo "  - Collecting information via Helm..."
 release_name=`helm list -n "$namespace" --no-headers -q` 2>/dev/null


### PR DESCRIPTION
java thread dumps can provide a lot of useful information, so it makes sense to include them in the diagnostic scripts.

this is done only for pods that have java and jattach (and pgrep) available, which means usually we will only get thread dumps for the camunda pods. older images might not have jattach available, so we might not always be able to get thread dumps via this script.  potentially we can use `kill -SIGQUIT` for that, but we do not want to use that indiscriminately (as it could cause non-Java process to exit).

example output when running the command:

```
  - Collecting Java threaddumps ...
    - Collecting threaddump from pod: camunda-0, java process: 1
    - Collecting threaddump from pod: camunda-1, java process: 1
    - Collecting threaddump from pod: camunda-2, java process: 1
    - Skipping pod: connectors-775fbcbcb-tbg7d as jattach not installed
    - Skipping pod: customer-notification-77b776876b-chvhr as jattach not installed
    - Skipping pod: dispute-process-request-get-vendor-info-8568797df5-6tbs6 as jattach not installed
    - Skipping pod: dispute-process-request-proof-from-vendor-b89fd84f6-clxvp as jattach not installed
    - Skipping pod: elastic-0 as jattach not installed
    - Skipping pod: elastic-1 as jattach not installed
    - Skipping pod: elastic-2 as jattach not installed
    - Skipping pod: extract-data-from-document-845468cb8f-zx22z as jattach not installed
    - Skipping pod: identity-548769bf95-vfhdf as jattach not installed
    - Skipping pod: identity-548769bf95-zfn9x as java not installed
    - Skipping pod: inform-about-successful-claim-9dfbc6bd5-w9bdm as jattach not installed
    - Skipping pod: keycloak-0 as jattach not installed
    - Skipping pod: keycloak-postgresql-0 as java not installed
    - Skipping pod: leader-balancer-29696270-jvpj8 as java not installed
    - Skipping pod: leader-balancer-29696280-s28pd as java not installed
    - Skipping pod: leader-balancer-29696290-wz5tz as java not installed
    - Skipping pod: metrics-exporter-749fdff578-8sxgd as java not installed
    - Skipping pod: optimize-88bd46974-mwlkk as jattach not installed
    - Skipping pod: prom-els-exporter-864fc59c5f-6jkvn as java not installed
    - Skipping pod: refunding-646d878967-bj9tx as jattach not installed
    - Skipping pod: starter-7bf9fd7c57-7ctcp as jattach not installed
```

https://github.com/camunda/camunda/issues/55031

## Description

<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
