### PR TITLE
docs: add IRSA option to AWS document store Helm config

### DIFF
--- a/docs/self-managed/concepts/document-handling/configuration/helm.md
+++ b/docs/self-managed/concepts/document-handling/configuration/helm.md
@@ -35,6 +35,10 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
+                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                irsa:
+                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no AWS credentials are injected into pods, allowing IRSA to be used for authentication. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"
                 ## @param global.documentStore.type.aws.region AWS region for the S3 bucket. (example: us-east-1)

--- a/versioned_docs/version-8.7/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/document-handling/configuration/helm.md
@@ -8,7 +8,6 @@ keywords: ["document handling", "document storage configuration"]
 Helm offers external cloud file bucket storage options (recommended for production use when deploying with Helm) and in-memory storage (not suitable for production use):
 
 - By using **external cloud file bucket storage options**, documents can be stored in a secure, and scalable way. Buckets are integrated per cluster to ensure proper isolation and environment-specific management. The following file bucket storage options are supported:
-
   - [**Google Cloud Platform (GCP)**](https://cloud.google.com/storage)
   - [**AWS S3**](https://aws.amazon.com/s3/).
 
@@ -30,6 +29,10 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
+                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                irsa:
+                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no AWS credentials are injected into pods, allowing IRSA to be used for authentication. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"
                 ## @param global.documentStore.type.aws.region AWS region for the S3 bucket. (example: us-east-1)

--- a/versioned_docs/version-8.8/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/document-handling/configuration/helm.md
@@ -30,6 +30,10 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
+                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                irsa:
+                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no AWS credentials are injected into pods, allowing IRSA to be used for authentication. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"
                 ## @param global.documentStore.type.aws.region AWS region for the S3 bucket. (example: us-east-1)

--- a/versioned_docs/version-8.9/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/document-handling/configuration/helm.md
@@ -35,6 +35,10 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
+                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                irsa:
+                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no AWS credentials are injected into pods, allowing IRSA to be used for authentication. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"
                 ## @param global.documentStore.type.aws.region AWS region for the S3 bucket. (example: us-east-1)


### PR DESCRIPTION
## Description

Documents the `global.documentStore.type.aws.irsa.enabled` Helm value on the **Document handling configuration in Helm** page. When set to `true`, no AWS credentials are injected into pods, allowing the AWS SDK credential chain to use IRSA (IAM Roles for Service Accounts) for S3 document store authentication.

The option was added to the chart in camunda/camunda-platform-helm#5026 and is present in chart versions 8.7–8.10, but was not yet reflected in the docs. This PR adds it to the AWS document-store values block, matching the chart `values.yaml` `@param` text verbatim.

Epic: camunda/product-hub#3388 (Self-Managed: Support for IRSA Document store)

This PR covers the values-reference gap only. Follow-up docs (EKS IRSA setup section for the document store, credential precedence, and a static-keys→IRSA migration guide) are tracked separately.

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
