### PR TITLE
docs: add document store IRSA setup section to EKS IRSA page

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
@@ -211,7 +211,7 @@ Overall, this will disable the role assumption of the node for the Kubernetes po
 
 ## Document store (S3)
 
-When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and enables Camunda components to assume an IAM role through their service account.
 
 ### Prerequisites
 
@@ -311,9 +311,9 @@ With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK re
    You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
 3. Upload and download a document to confirm S3 access works end to end.
 
-## Backup-related
+## Elasticsearch backup with IRSA
 
-When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.
+When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for Elasticsearch in your Camunda deployment, you can use IRSA to securely access S3 buckets.
 
 ### Bitnami Elasticsearch chart configuration
 

--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
@@ -209,6 +209,108 @@ More details can be found in the [AWS documentation on modifying IMDS for existi
 
 Overall, this will disable the role assumption of the node for the Kubernetes pod.
 
+## Document store (S3)
+
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+
+### Prerequisites
+
+- An [IAM OIDC provider associated with your EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+- An existing S3 bucket for documents.
+
+### Create the IAM role and policies
+
+Following the [AWS IRSA documentation](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html), create an IAM role that the Camunda service accounts can assume.
+
+Attach a **permission policy** that grants the required S3 actions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": ["arn:aws:s3:::<your-bucket>", "arn:aws:s3:::<your-bucket>/*"]
+    }
+  ]
+}
+```
+
+The role's **trust policy** must allow the relevant Kubernetes service accounts to assume it through web identity. Replace the account ID, region, OIDC provider ID, namespace, and release name with your values:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<oidc-id>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": [
+            "system:serviceaccount:<namespace>:<release-name>-orchestration",
+            "system:serviceaccount:<namespace>:<release-name>-connectors"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### Configure the Helm chart
+
+Set `global.documentStore.type.aws.irsa.enabled` to `true` so the chart does not inject `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` into the pods, and annotate the service account of each component that accesses the document store with the IAM role ARN:
+
+```yaml
+global:
+  documentStore:
+    activeStoreId: "aws"
+    type:
+      aws:
+        enabled: true
+        irsa:
+          enabled: true
+        bucket: "<your-bucket>"
+        region: "<your-region>"
+
+orchestration:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+
+connectors:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+```
+
+:::note
+With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK resolves credentials through its [default provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html), which picks up the IRSA web identity token. Annotate the service account of every component you have enabled to use the document store; otherwise that component cannot reach S3.
+:::
+
+### Verify
+
+1. Confirm the pods start successfully without an AWS credentials secret:
+   ```bash
+   kubectl get pods -n <namespace>
+   ```
+2. Confirm the IRSA environment variables are injected and the static credentials are absent:
+   ```bash
+   kubectl exec -n <namespace> <orchestration-pod> -- env | grep AWS
+   ```
+   You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
+3. Upload and download a document to confirm S3 access works end to end.
+
 ## Backup-related
 
 When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/irsa.md
@@ -211,7 +211,7 @@ Overall, this will disable the role assumption of the node for the Kubernetes po
 
 ## Document store (S3)
 
-When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and enables Camunda components to assume an IAM role through their service account.
 
 ### Prerequisites
 
@@ -311,9 +311,9 @@ With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK re
    You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
 3. Upload and download a document to confirm S3 access works end to end.
 
-## Backup-related
+## Elasticsearch backup with IRSA
 
-When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.
+When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for Elasticsearch in your Camunda deployment, you can use IRSA to securely access S3 buckets.
 
 ### Bitnami Elasticsearch chart configuration
 

--- a/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.7/self-managed/setup/deploy/amazon/amazon-eks/irsa.md
@@ -209,6 +209,108 @@ More details can be found in the [AWS documentation on modifying IMDS for existi
 
 Overall, this will disable the role assumption of the node for the Kubernetes pod.
 
+## Document store (S3)
+
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+
+### Prerequisites
+
+- An [IAM OIDC provider associated with your EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+- An existing S3 bucket for documents.
+
+### Create the IAM role and policies
+
+Following the [AWS IRSA documentation](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html), create an IAM role that the Camunda service accounts can assume.
+
+Attach a **permission policy** that grants the required S3 actions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": ["arn:aws:s3:::<your-bucket>", "arn:aws:s3:::<your-bucket>/*"]
+    }
+  ]
+}
+```
+
+The role's **trust policy** must allow the relevant Kubernetes service accounts to assume it through web identity. Replace the account ID, region, OIDC provider ID, namespace, and release name with your values:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<oidc-id>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": [
+            "system:serviceaccount:<namespace>:<release-name>-zeebe",
+            "system:serviceaccount:<namespace>:<release-name>-connectors"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### Configure the Helm chart
+
+Set `global.documentStore.type.aws.irsa.enabled` to `true` so the chart does not inject `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` into the pods, and annotate the service account of each component that accesses the document store with the IAM role ARN:
+
+```yaml
+global:
+  documentStore:
+    activeStoreId: "aws"
+    type:
+      aws:
+        enabled: true
+        irsa:
+          enabled: true
+        bucket: "<your-bucket>"
+        region: "<your-region>"
+
+zeebe:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+
+connectors:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+```
+
+:::note
+With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK resolves credentials through its [default provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html), which picks up the IRSA web identity token. Annotate the service account of every component you have enabled to use the document store (for example `tasklist`); otherwise that component cannot reach S3.
+:::
+
+### Verify
+
+1. Confirm the pods start successfully without an AWS credentials secret:
+   ```bash
+   kubectl get pods -n <namespace>
+   ```
+2. Confirm the IRSA environment variables are injected and the static credentials are absent:
+   ```bash
+   kubectl exec -n <namespace> <zeebe-pod> -- env | grep AWS
+   ```
+   You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
+3. Upload and download a document to confirm S3 access works end to end.
+
 ## Backup-related
 
 When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
@@ -211,7 +211,7 @@ Overall, this will disable the role assumption of the node for the Kubernetes po
 
 ## Document store (S3)
 
-When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and enables Camunda components to assume an IAM role through their service account.
 
 ### Prerequisites
 
@@ -311,9 +311,9 @@ With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK re
    You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
 3. Upload and download a document to confirm S3 access works end to end.
 
-## Backup-related
+## Elasticsearch backup with IRSA
 
-When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.
+When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for Elasticsearch in your Camunda deployment, you can use IRSA to securely access S3 buckets.
 
 ### Bitnami Elasticsearch chart configuration
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
@@ -209,6 +209,108 @@ More details can be found in the [AWS documentation on modifying IMDS for existi
 
 Overall, this will disable the role assumption of the node for the Kubernetes pod.
 
+## Document store (S3)
+
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+
+### Prerequisites
+
+- An [IAM OIDC provider associated with your EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+- An existing S3 bucket for documents.
+
+### Create the IAM role and policies
+
+Following the [AWS IRSA documentation](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html), create an IAM role that the Camunda service accounts can assume.
+
+Attach a **permission policy** that grants the required S3 actions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": ["arn:aws:s3:::<your-bucket>", "arn:aws:s3:::<your-bucket>/*"]
+    }
+  ]
+}
+```
+
+The role's **trust policy** must allow the relevant Kubernetes service accounts to assume it through web identity. Replace the account ID, region, OIDC provider ID, namespace, and release name with your values:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<oidc-id>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": [
+            "system:serviceaccount:<namespace>:<release-name>-orchestration",
+            "system:serviceaccount:<namespace>:<release-name>-connectors"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### Configure the Helm chart
+
+Set `global.documentStore.type.aws.irsa.enabled` to `true` so the chart does not inject `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` into the pods, and annotate the service account of each component that accesses the document store with the IAM role ARN:
+
+```yaml
+global:
+  documentStore:
+    activeStoreId: "aws"
+    type:
+      aws:
+        enabled: true
+        irsa:
+          enabled: true
+        bucket: "<your-bucket>"
+        region: "<your-region>"
+
+orchestration:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+
+connectors:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+```
+
+:::note
+With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK resolves credentials through its [default provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html), which picks up the IRSA web identity token. Annotate the service account of every component you have enabled to use the document store; otherwise that component cannot reach S3.
+:::
+
+### Verify
+
+1. Confirm the pods start successfully without an AWS credentials secret:
+   ```bash
+   kubectl get pods -n <namespace>
+   ```
+2. Confirm the IRSA environment variables are injected and the static credentials are absent:
+   ```bash
+   kubectl exec -n <namespace> <orchestration-pod> -- env | grep AWS
+   ```
+   You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
+3. Upload and download a document to confirm S3 access works end to end.
+
 ## Backup-related
 
 When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
@@ -211,7 +211,7 @@ Overall, this will disable the role assumption of the node for the Kubernetes po
 
 ## Document store (S3)
 
-When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and enables Camunda components to assume an IAM role through their service account.
 
 ### Prerequisites
 
@@ -311,9 +311,9 @@ With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK re
    You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
 3. Upload and download a document to confirm S3 access works end to end.
 
-## Backup-related
+## Elasticsearch backup with IRSA
 
-When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.
+When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for Elasticsearch in your Camunda deployment, you can use IRSA to securely access S3 buckets.
 
 ### Bitnami Elasticsearch chart configuration
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/irsa.md
@@ -209,6 +209,108 @@ More details can be found in the [AWS documentation on modifying IMDS for existi
 
 Overall, this will disable the role assumption of the node for the Kubernetes pod.
 
+## Document store (S3)
+
+When using the [AWS S3 document store](/self-managed/concepts/document-handling/configuration/helm.md) on Amazon EKS, you can authenticate to S3 with IRSA instead of static AWS credentials. This removes long-lived access keys from your Kubernetes secrets and lets Camunda components assume an IAM role through their service account.
+
+### Prerequisites
+
+- An [IAM OIDC provider associated with your EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+- An existing S3 bucket for documents.
+
+### Create the IAM role and policies
+
+Following the [AWS IRSA documentation](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html), create an IAM role that the Camunda service accounts can assume.
+
+Attach a **permission policy** that grants the required S3 actions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": ["arn:aws:s3:::<your-bucket>", "arn:aws:s3:::<your-bucket>/*"]
+    }
+  ]
+}
+```
+
+The role's **trust policy** must allow the relevant Kubernetes service accounts to assume it through web identity. Replace the account ID, region, OIDC provider ID, namespace, and release name with your values:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<oidc-id>"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.<region>.amazonaws.com/id/<oidc-id>:sub": [
+            "system:serviceaccount:<namespace>:<release-name>-orchestration",
+            "system:serviceaccount:<namespace>:<release-name>-connectors"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+### Configure the Helm chart
+
+Set `global.documentStore.type.aws.irsa.enabled` to `true` so the chart does not inject `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` into the pods, and annotate the service account of each component that accesses the document store with the IAM role ARN:
+
+```yaml
+global:
+  documentStore:
+    activeStoreId: "aws"
+    type:
+      aws:
+        enabled: true
+        irsa:
+          enabled: true
+        bucket: "<your-bucket>"
+        region: "<your-region>"
+
+orchestration:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+
+connectors:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<iam-role-arn>
+```
+
+:::note
+With `irsa.enabled: true`, no AWS credentials secret is required. The AWS SDK resolves credentials through its [default provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html), which picks up the IRSA web identity token. Annotate the service account of every component you have enabled to use the document store; otherwise that component cannot reach S3.
+:::
+
+### Verify
+
+1. Confirm the pods start successfully without an AWS credentials secret:
+   ```bash
+   kubectl get pods -n <namespace>
+   ```
+2. Confirm the IRSA environment variables are injected and the static credentials are absent:
+   ```bash
+   kubectl exec -n <namespace> <orchestration-pod> -- env | grep AWS
+   ```
+   You should see `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and no `AWS_ACCESS_KEY_ID`.
+3. Upload and download a document to confirm S3 access works end to end.
+
 ## Backup-related
 
 When implementing [backup and restore procedures](/self-managed/operational-guides/backup-restore/backup-and-restore.md) for **Elasticsearch** in your **Camunda** deployment, you can leverage **AWS IAM Roles for Service Accounts (IRSA)** to securely access **S3 buckets**.


### PR DESCRIPTION
## Description

Adds a **Document store (S3)** section to the Amazon EKS IRSA page describing how to authenticate the AWS S3 document store with IRSA instead of static AWS credentials. It covers:

- IAM role with an S3 permission policy and a web-identity trust policy scoped to the Camunda service accounts.
- The `global.documentStore.type.aws.irsa.enabled` Helm value and the required service account `eks.amazonaws.com/role-arn` annotations.
- Verification steps (pod startup, IRSA env vars present / static credentials absent, document upload/download).

The `irsa.enabled` option was added to the chart in camunda/camunda-platform-helm#5026 (versions 8.7–8.10). This section gives EKS users the end-to-end setup guide.

Epic: camunda/product-hub#3388 (Self-Managed: Support for IRSA Document store)

Companion to camunda/camunda-docs#9131, which documents the `irsa.enabled` value on the document-handling Helm configuration page.

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
