### PR TITLE
docs: warn that custom exporters must acknowledge record positions

### DIFF
--- a/docs/self-managed/concepts/exporters.md
+++ b/docs/self-managed/concepts/exporters.md
@@ -40,6 +40,19 @@ If no exporters are configured, Zeebe automatically deletes data when it's no lo
 
 :::
 
+:::warning
+A custom exporter that does not acknowledge record positions prevents log compaction and can take down the broker.
+
+Because compaction only advances up to the **lowest** acknowledged position across all exporters, a single exporter that never advances its position pins the log indefinitely. The event log then grows without bound until it fills the disk, which stops the broker.
+
+When implementing or activating a custom exporter:
+
+- **Verify that record acknowledgment is done.** Confirm the exporter calls `controller.updateLastExportedRecordPosition(record.getPosition())` after it has successfully processed each record (see [Custom exporter to filter specific records](#custom-exporter-to-filter-specific-records)), and that the acknowledged position keeps advancing during normal operation.
+- **Check disk (PVC) sizing before activating a new exporter.** A newly configured exporter starts from the current log position and temporarily becomes the lowest acknowledged position. Until it catches up, the log cannot be compacted past that point, so ensure the broker has enough disk headroom and that the exporter keeps pace with the record stream.
+
+To detect this early, monitor the broker's disk usage and the exporter throughput metric (`zeebe_exporter_events_total`). See [metrics](../operational-guides/monitoring/metrics.md) for details.
+:::
+
 All exporters—whether loaded from an external JAR or not—interact with the broker through the [exporter interface](https://github.com/camunda/camunda/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading

--- a/versioned_docs/version-8.7/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/exporters.md
@@ -38,6 +38,19 @@ If no exporters are configured, Zeebe automatically deletes data when it's no lo
 
 :::
 
+:::warning
+A custom exporter that does not acknowledge record positions prevents log compaction and can take down the broker.
+
+Because compaction only advances up to the **lowest** acknowledged position across all exporters, a single exporter that never advances its position pins the log indefinitely. The event log then grows without bound until it fills the disk, which stops the broker.
+
+When implementing or activating a custom exporter:
+
+- **Verify that record acknowledgment is done.** Confirm the exporter calls `controller.updateLastExportedRecordPosition(record.getPosition())` after it has successfully processed each record (see [Custom exporter to filter specific records](#custom-exporter-to-filter-specific-records)), and that the acknowledged position keeps advancing during normal operation.
+- **Check disk (PVC) sizing before activating a new exporter.** A newly configured exporter starts from the current log position and temporarily becomes the lowest acknowledged position. Until it catches up, the log cannot be compacted past that point, so ensure the broker has enough disk headroom and that the exporter keeps pace with the record stream.
+
+To detect this early, monitor the broker's disk usage and the exporter throughput metric (`zeebe_exporter_events_total`). See [metrics](../operational-guides/monitoring/metrics.md) for details.
+:::
+
 All exporters interact with the broker through the [exporter interface](https://github.com/camunda/camunda/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java), regardless of whether they are loaded from an external JAR (or not).
 
 ## Loading

--- a/versioned_docs/version-8.8/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/exporters.md
@@ -38,6 +38,19 @@ If no exporters are configured, Zeebe automatically deletes data when it's no lo
 
 :::
 
+:::warning
+A custom exporter that does not acknowledge record positions prevents log compaction and can take down the broker.
+
+Because compaction only advances up to the **lowest** acknowledged position across all exporters, a single exporter that never advances its position pins the log indefinitely. The event log then grows without bound until it fills the disk, which stops the broker.
+
+When implementing or activating a custom exporter:
+
+- **Verify that record acknowledgment is done.** Confirm the exporter calls `controller.updateLastExportedRecordPosition(record.getPosition())` after it has successfully processed each record (see [Custom exporter to filter specific records](#custom-exporter-to-filter-specific-records)), and that the acknowledged position keeps advancing during normal operation.
+- **Check disk (PVC) sizing before activating a new exporter.** A newly configured exporter starts from the current log position and temporarily becomes the lowest acknowledged position. Until it catches up, the log cannot be compacted past that point, so ensure the broker has enough disk headroom and that the exporter keeps pace with the record stream.
+
+To detect this early, monitor the broker's disk usage and the exporter throughput metric (`zeebe_exporter_events_total`). See [metrics](../operational-guides/monitoring/metrics.md) for details.
+:::
+
 All exporters—whether loaded from an external JAR or not—interact with the broker through the [exporter interface](https://github.com/camunda/camunda/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading

--- a/versioned_docs/version-8.9/self-managed/concepts/exporters.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/exporters.md
@@ -40,6 +40,19 @@ If no exporters are configured, Zeebe automatically deletes data when it's no lo
 
 :::
 
+:::warning
+A custom exporter that does not acknowledge record positions prevents log compaction and can take down the broker.
+
+Because compaction only advances up to the **lowest** acknowledged position across all exporters, a single exporter that never advances its position pins the log indefinitely. The event log then grows without bound until it fills the disk, which stops the broker.
+
+When implementing or activating a custom exporter:
+
+- **Verify that record acknowledgment is done.** Confirm the exporter calls `controller.updateLastExportedRecordPosition(record.getPosition())` after it has successfully processed each record (see [Custom exporter to filter specific records](#custom-exporter-to-filter-specific-records)), and that the acknowledged position keeps advancing during normal operation.
+- **Check disk (PVC) sizing before activating a new exporter.** A newly configured exporter starts from the current log position and temporarily becomes the lowest acknowledged position. Until it catches up, the log cannot be compacted past that point, so ensure the broker has enough disk headroom and that the exporter keeps pace with the record stream.
+
+To detect this early, monitor the broker's disk usage and the exporter throughput metric (`zeebe_exporter_events_total`). See [metrics](../operational-guides/monitoring/metrics.md) for details.
+:::
+
 All exporters—whether loaded from an external JAR or not—interact with the broker through the [exporter interface](https://github.com/camunda/camunda/blob/main/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/Exporter.java).
 
 ## Loading


### PR DESCRIPTION
Adds a warning to the Camunda exporters concept page, in the log stream compaction section, explaining that a custom exporter which never acknowledges record positions prevents log compaction. Because compaction only advances to the lowest acknowledged position across all exporters, one exporter that never advances its position pins the log indefinitely until the disk fills and the broker stops.

This came out of a support incident where a customer's custom exporter did not call `controller.updateLastExportedRecordPosition(...)`, which silently pinned the log and eventually filled the disk. The mechanism was already documented in scattered low-emphasis notes, but the operational consequence was not called out where the compaction behavior is explained. The warning also reminds operators to verify acknowledgment works and to check disk (PVC) sizing before activating a new exporter, since a freshly configured exporter temporarily becomes the lowest acknowledged position until it catches up.