### PR TITLE
docs(identity): document Standard flow requirement for OC OIDC client on 8.7→8.8 upgrade

### DIFF
--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
@@ -23,6 +23,22 @@ This page provides solutions to common issues encountered when configuring OIDC 
 Use `http://localhost:8080` in Helm values when users access via `https://camunda.example.com/orchestration`.
 :::
 
+## Standard flow is disabled for the client
+
+**Observed behavior:** Logging in to the Orchestration Cluster fails, and you see an error similar to:
+
+```text
+{"type":"about:blank","title":"Internal Server Error","status":500,"detail":"[unauthorized_client] Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.","instance":"/orchestration/sso-callback"}
+```
+
+**Why this happens:** The OIDC client configured for the Orchestration Cluster doesn't have the Authorization Code Flow enabled. Orchestration Cluster web applications require this flow for browser-based user login. This often occurs after upgrading from 8.7, where the reused `zeebe` client handled only machine-to-machine access and didn't need the flow.
+
+**How to fix:**
+
+1. In your identity provider, open the client used for the Orchestration Cluster OIDC configuration.
+2. Enable the Authorization Code Flow for the client. In Keycloak, enable the **Standard flow** option for the client.
+3. Retry the login.
+
 ## Invalid audience
 
 **Observed behavior:** Logs show "Invalid token" or "Audience mismatch" errors.

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
@@ -23,6 +23,22 @@ This page provides solutions to common issues encountered when configuring OIDC 
 Use `http://localhost:8080` in Helm values when users access via `https://camunda.example.com/orchestration`.
 :::
 
+## Standard flow is disabled for the client
+
+**Observed behavior:** Logging in to the Orchestration Cluster fails, and you see an error similar to:
+
+```text
+{"type":"about:blank","title":"Internal Server Error","status":500,"detail":"[unauthorized_client] Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.","instance":"/orchestration/sso-callback"}
+```
+
+**Why this happens:** The OIDC client configured for the Orchestration Cluster doesn't have the Authorization Code Flow enabled. Orchestration Cluster web applications require this flow for browser-based user login. This often occurs after upgrading from 8.7, where the reused `zeebe` client handled only machine-to-machine access and didn't need the flow.
+
+**How to fix:**
+
+1. In your identity provider, open the client used for the Orchestration Cluster OIDC configuration.
+2. Enable the Authorization Code Flow for the client. In Keycloak, enable the **Standard flow** option for the client.
+3. Retry the login.
+
 ## Invalid audience
 
 **Observed behavior:** Logs show "Invalid token" or "Audience mismatch" errors.

--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880.md
@@ -156,6 +156,12 @@ webModelerPostgresql:
 | `global.identity.auth.operate`           | Remove. Operate runs under the Orchestration Cluster in 8.8.                                                                                                                                                       |
 | `global.identity.auth.tasklist`          | Remove. Tasklist runs under the Orchestration Cluster in 8.8.                                                                                                                                                      |
 
+In 8.8, the Orchestration Cluster uses the client you configure under `orchestration.security.authentication.oidc.*` for browser-based user login through the OIDC [Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth). The 8.7 `zeebe` client typically handled only machine-to-machine access, so it might not have this flow enabled. Before upgrading, enable the Authorization Code Flow (called **Standard flow** in Keycloak) for this client in your identity provider. Otherwise, users can't log in to the Orchestration Cluster, and authentication fails with an error similar to:
+
+```
+[unauthorized_client] Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.
+```
+
 <details>
   <summary>View example values files</summary>
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
@@ -23,6 +23,22 @@ This page provides solutions to common issues encountered when configuring OIDC 
 Use `http://localhost:8080` in Helm values when users access via `https://camunda.example.com/orchestration`.
 :::
 
+## Standard flow is disabled for the client
+
+**Observed behavior:** Logging in to the Orchestration Cluster fails, and you see an error similar to:
+
+```text
+{"type":"about:blank","title":"Internal Server Error","status":500,"detail":"[unauthorized_client] Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.","instance":"/orchestration/sso-callback"}
+```
+
+**Why this happens:** The OIDC client configured for the Orchestration Cluster doesn't have the Authorization Code Flow enabled. Orchestration Cluster web applications require this flow for browser-based user login. This often occurs after upgrading from 8.7, where the reused `zeebe` client handled only machine-to-machine access and didn't need the flow.
+
+**How to fix:**
+
+1. In your identity provider, open the client used for the Orchestration Cluster OIDC configuration.
+2. Enable the Authorization Code Flow for the client. In Keycloak, enable the **Standard flow** option for the client.
+3. Retry the login.
+
 ## Invalid audience
 
 **Observed behavior:** Logs show "Invalid token" or "Audience mismatch" errors.


### PR DESCRIPTION
## Description

Documents that the OIDC client used for the Orchestration Cluster must have the Authorization Code Flow (called **Standard flow** in Keycloak) enabled, so users can perform browser-based login to the Orchestration Cluster web applications.

When upgrading Self-Managed from 8.7 to 8.8, the old `zeebe` OIDC client is reused as the Orchestration Cluster OIDC client. That client was often machine-to-machine only and didn't need the Authorization Code Flow, so login fails with:

```
[unauthorized_client] Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.
```

Changes:

- Add a note to the Helm 8.7→8.8 upgrade guide (Global Identity keys section) to enable the flow before upgrading.
- Add a "Standard flow is disabled for the client" entry to the OIDC troubleshooting page so users who hit the error by its symptom can find the fix. Applied to `/docs` (next), `version-8.8`, and `version-8.9`.

Closes #7841

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
