### PR TITLE
docs(hub): reflect duplicate ID resolution in projects

### DIFF
--- a/docs/components/hub/workspace/manage-projects/create-a-project.md
+++ b/docs/components/hub/workspace/manage-projects/create-a-project.md
@@ -59,5 +59,6 @@ You can also create subfolders to organize files within the project.
 <p><img src={FileListImg} alt="Project file list" /></p>
 
 :::note
-Process IDs, decision IDs, and form IDs must be unique across all files within a project. This avoids ambiguity and conflicts when you link resources and deploy the project.
+Keep process IDs, decision IDs, form IDs and RPA script IDs unique across all files within a project. A project with duplicate IDs will fail to deploy.
+Web Modeler flags the conflicting resources IDs in the resource's problems panel to help you fix them.
 :::


### PR DESCRIPTION
## Description

Updates the Web Modeler "create a project" docs to reflect the removal of save-time unique-ID enforcement in Web Modeler. Process, decision, and form IDs are no longer rejected when saving; instead, duplicate IDs are surfaced by the modeler's duplicate ID linter. The uniqueness note is reworded to clarify that ambiguous or duplicate IDs cannot be deployed and must be resolved first.

Relates to camunda/camunda-hub#25283
Relates to camunda/camunda-hub#24613

## When should this change go live?

- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
