### PR TITLE
docs: clarify soft-pause exporter operational risks and restore re-export behavior

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -94,7 +94,7 @@ POST actuator/exporting/pause?soft=true
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
 :::warning
-Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+Broker disk usage grows throughout the soft-pause window because log compaction is blocked. Keep the window as short as possible and resume exporting promptly once the backup completes.
 
 Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
 

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -93,6 +93,14 @@ POST actuator/exporting/pause?soft=true
 
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
+:::warning
+Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+
+Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
+
+For a real-world example of disk growth and recovery, see the [full-disk chaos day report](https://camunda.github.io/zeebe-chaos/2026/06/18/Full-disk-due-to-soft-pause-exporters).
+:::
+
 ## Exporters API
 
 The Exporters API allows for enabling, disabling or deleting configured exporters. By default, all configured exporters are enabled.

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
@@ -142,7 +142,7 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
-During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally blocked for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
 
 ### Effect on exporters of node failure
 

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
@@ -142,6 +142,8 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
+During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+
 ### Effect on exporters of node failure
 
 Only the leader of a partition exports events. Only committed events (events that have been replicated) are passed to exporters. The exporter then updates its read position. The exporter read position is only replicated between brokers in the snapshot. It is not itself written to the event log. This means _an exporter’s current position cannot be reconstructed from the replicated event log, only from a snapshot_.

--- a/docs/self-managed/operational-guides/backup-restore/elasticsearch/backup.md
+++ b/docs/self-managed/operational-guides/backup-restore/elasticsearch/backup.md
@@ -206,8 +206,8 @@ During a hot backup, the Zeebe cluster remains fully operational:
 
 - Zeebe continues to accept new client requests (for example, starting process instances) and to process existing workflow instances.
 - Job workers and other external workers continue to receive and complete jobs.
-- Exporters continue to export records. While soft pause is active, Zeebe temporarily does not advance the exporter position, which prevents log compaction and increases broker disk usage for the duration of the backup window. Ensure broker disks have enough free space.
-- If a broker restarts while soft pause is active, some already-exported records may be exported again after the restart. This is expected, because exporting always resumes from the last acknowledged exporter position.
+- Exporters continue to export records. While soft pause is active, Zeebe temporarily does not advance the exporter position, which prevents log compaction and increases broker disk usage for the duration of the backup window. Ensure broker disks have enough free space. Keep the backup window as short as possible and resume exporting promptly once the backup completes.
+- If a broker restarts while soft pause is active, some already-exported records may be exported again after the restart. This is expected, because exporting always resumes from the last acknowledged exporter position. The same behavior applies after a restore: exporters start from the last persisted position and re-export all records processed during the soft-pause window. This is the intended mechanism that bridges the Zeebe backup and the secondary storage (Elasticsearch/OpenSearch) backup.
 
 The `/actuator/backupRuntime` API then creates a consistent backup of each partition while processing continues. The “wait for backup to complete” steps in this guide only poll backup status and do not introduce any additional pause in processing beyond the initial soft export pause.
 

--- a/versioned_docs/version-8.7/self-managed/operational-guides/backup-restore/backup.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/backup-restore/backup.md
@@ -432,8 +432,8 @@ During a hot backup, the Zeebe cluster remains fully operational:
 
 - Zeebe continues to accept new client requests (for example, starting process instances) and to process existing workflow instances.
 - Job workers and other external workers continue to receive and complete jobs.
-- Exporters continue to export records. While soft pause is active, Zeebe temporarily does not advance the exporter position, which prevents log compaction and increases broker disk usage for the duration of the backup window. Ensure broker disks have enough free space.
-- If a broker restarts while soft pause is active, some already-exported records may be exported again after the restart. This is expected, because exporting always resumes from the last acknowledged exporter position.
+- Exporters continue to export records. While soft pause is active, Zeebe temporarily does not advance the exporter position, which prevents log compaction and increases broker disk usage for the duration of the backup window. Ensure broker disks have enough free space. Keep the backup window as short as possible and resume exporting promptly once the backup completes.
+- If a broker restarts while soft pause is active, some already-exported records may be exported again after the restart. This is expected, because exporting always resumes from the last acknowledged exporter position. The same behavior applies after a restore: exporters start from the last persisted position and re-export all records processed during the soft-pause window. This is the intended mechanism that bridges the Zeebe backup and the secondary storage (Elasticsearch/OpenSearch) backup.
 
 The `/actuator/backupRuntime` API then creates a consistent backup of each partition while processing continues. The “wait for backup to complete” steps in this guide only poll backup status and do not introduce any additional pause in processing beyond the initial soft export pause.
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/management-api.md
@@ -82,7 +82,7 @@ POST actuator/exporting/pause?soft=true
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
 :::warning
-Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+Broker disk usage grows throughout the soft-pause window because log compaction is blocked. Keep the window as short as possible and resume exporting promptly once the backup completes.
 
 Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/management-api.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/management-api.md
@@ -81,6 +81,14 @@ POST actuator/exporting/pause?soft=true
 
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
+:::warning
+Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+
+Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
+
+For a real-world example of disk growth and recovery, see the [full-disk chaos day report](https://camunda.github.io/zeebe-chaos/2026/06/18/Full-disk-due-to-soft-pause-exporters).
+:::
+
 ## Exporters API
 
 The Exporters API allows for enabling, disabling or deleting configured exporters. By default, all configured exporters are enabled.

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/resource-planning.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/resource-planning.md
@@ -142,7 +142,7 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
-During a [hot backup (soft-pause window)](/self-managed/zeebe-deployment/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+During a [hot backup (soft-pause window)](/self-managed/zeebe-deployment/operations/management-api.md#soft-pause-exports), log compaction is intentionally blocked for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
 
 ### Effect on exporters of node failure
 

--- a/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/resource-planning.md
+++ b/versioned_docs/version-8.7/self-managed/zeebe-deployment/operations/resource-planning.md
@@ -142,6 +142,8 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
+During a [hot backup (soft-pause window)](/self-managed/zeebe-deployment/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+
 ### Effect on exporters of node failure
 
 Only the leader of a partition exports events. Only committed events (events that have been replicated) are passed to exporters. The exporter then updates its read position. The exporter read position is only replicated between brokers in the snapshot. It is not itself written to the event log. This means _an exporter’s current position cannot be reconstructed from the replicated event log, only from a snapshot_.

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -94,7 +94,7 @@ POST actuator/exporting/pause?soft=true
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
 :::warning
-Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+Broker disk usage grows throughout the soft-pause window because log compaction is blocked. Keep the window as short as possible and resume exporting promptly once the backup completes.
 
 Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -93,6 +93,14 @@ POST actuator/exporting/pause?soft=true
 
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
+:::warning
+Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+
+Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
+
+For a real-world example of disk growth and recovery, see the [full-disk chaos day report](https://camunda.github.io/zeebe-chaos/2026/06/18/Full-disk-due-to-soft-pause-exporters).
+:::
+
 ## Exporters API
 
 The Exporters API allows for enabling, disabling or deleting configured exporters. By default, all configured exporters are enabled.

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
@@ -142,7 +142,7 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
-During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally blocked for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
 
 ### Effect on exporters of node failure
 

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
@@ -142,6 +142,8 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
+During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+
 ### Effect on exporters of node failure
 
 Only the leader of a partition exports events. Only committed events (events that have been replicated) are passed to exporters. The exporter then updates its read position. The exporter read position is only replicated between brokers in the snapshot. It is not itself written to the event log. This means _an exporter’s current position cannot be reconstructed from the replicated event log, only from a snapshot_.

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -94,7 +94,7 @@ POST actuator/exporting/pause?soft=true
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
 :::warning
-Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+Broker disk usage grows throughout the soft-pause window because log compaction is blocked. Keep the window as short as possible and resume exporting promptly once the backup completes.
 
 Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -93,6 +93,14 @@ POST actuator/exporting/pause?soft=true
 
 When all partitions soft pause exporting, the response contains `"status": 204`. If the request fails, some partitions may have soft paused exporting. Therefore, either retry until success or revert the partial soft pause by resuming the export.
 
+:::warning
+Broker disk usage grows throughout the soft-pause window because log compaction is disabled. Keep the window as short as possible and resume exporting promptly once the backup completes.
+
+Avoid restarting brokers while soft pause is active. After a restart, exporters resume from the last persisted position (before soft-pausing started) and re-export all records from the soft-pause window. Recovery time is proportional to how long soft pause was active.
+
+For a real-world example of disk growth and recovery, see the [full-disk chaos day report](https://camunda.github.io/zeebe-chaos/2026/06/18/Full-disk-due-to-soft-pause-exporters).
+:::
+
 ## Exporters API
 
 The Exporters API allows for enabling, disabling or deleting configured exporters. By default, all configured exporters are enabled.

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
@@ -142,7 +142,7 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
-During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally blocked for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
 
 ### Effect on exporters of node failure
 

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md
@@ -142,6 +142,8 @@ If an external system relied on by an exporter fails (for example, if you are ex
 
 To ensure your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
+During a [hot backup (soft-pause window)](/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md#soft-pause-exports), log compaction is intentionally disabled for the duration of the backup. This adds a predictable, temporary disk requirement: roughly `throughput × backup_window_duration` of additional log data per partition, replicated across all followers. Size broker disks with enough headroom to absorb at least one full backup window on top of the steady-state estimates above.
+
 ### Effect on exporters of node failure
 
 Only the leader of a partition exports events. Only committed events (events that have been replicated) are passed to exporters. The exporter then updates its read position. The exporter read position is only replicated between brokers in the snapshot. It is not itself written to the event log. This means _an exporter’s current position cannot be reconstructed from the replicated event log, only from a snapshot_.

--- a/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/elasticsearch/backup.md
+++ b/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/elasticsearch/backup.md
@@ -206,8 +206,8 @@ During a hot backup, the Zeebe cluster remains fully operational:
 
 - Zeebe continues to accept new client requests (for example, starting process instances) and to process existing workflow instances.
 - Job workers and other external workers continue to receive and complete jobs.
-- Exporters continue to export records. While soft pause is active, Zeebe temporarily does not advance the exporter position, which prevents log compaction and increases broker disk usage for the duration of the backup window. Ensure broker disks have enough free space.
-- If a broker restarts while soft pause is active, some already-exported records may be exported again after the restart. This is expected, because exporting always resumes from the last acknowledged exporter position.
+- Exporters continue to export records. While soft pause is active, Zeebe temporarily does not advance the exporter position, which prevents log compaction and increases broker disk usage for the duration of the backup window. Ensure broker disks have enough free space. Keep the backup window as short as possible and resume exporting promptly once the backup completes.
+- If a broker restarts while soft pause is active, some already-exported records may be exported again after the restart. This is expected, because exporting always resumes from the last acknowledged exporter position. The same behavior applies after a restore: exporters start from the last persisted position and re-export all records processed during the soft-pause window. This is the intended mechanism that bridges the Zeebe backup and the secondary storage (Elasticsearch/OpenSearch) backup.
 
 The `/actuator/backupRuntime` API then creates a consistent backup of each partition while processing continues. The “wait for backup to complete” steps in this guide only poll backup status and do not introduce any additional pause in processing beyond the initial soft export pause.
 


### PR DESCRIPTION
## Summary

- Adds a `:::warning` callout to the Management API soft-pause section documenting disk growth and the broker-restart re-export risk.
- Extends the "Behavior during a Zeebe hot backup" bullets in the Elasticsearch backup guide with a keep-window-short recommendation and a note on restore re-export behavior.
- Links the warning to the [full-disk chaos day report](https://camunda.github.io/zeebe-chaos/2026/06/18/Full-disk-due-to-soft-pause-exporters) for real-world evidence.

## Context



These risks were surfaced by recent L1 incidents we had and confirmed by a chaos day experiment (zeebe-chaos [PR #861](https://github.com/camunda/zeebe-chaos/pull/861)) that reproduced full-disk conditions caused by soft-paused exporters running too long. An earlier attempt to document this (camunda/camunda#47413) targeted Javadoc rather than the public docs.


This replaces an older PR https://github.com/camunda/camunda/pull/47413 which wrongly targeted internal docs based on discussions on slack https://camunda.slack.com/archives/C037RS2JHB8/p1756962597282979

## Test plan

- [ ] Preview renders `:::warning` block correctly in Docusaurus
- [ ] Links resolve: management-api doc → chaos day report, backup guide → no new external links

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)