### PR TITLE
docs(spring-boot-starter): clarify Spring Boot 3.5.x OSS support window vs Camunda support

### DIFF
--- a/docs/apis-tools/camunda-spring-boot-starter/getting-started.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/getting-started.md
@@ -53,12 +53,12 @@ Starting with Camunda 8.9, the default `camunda-spring-boot-starter` artifact is
 - **`camunda-spring-boot-3-starter`**: Bundled with Spring Boot 3.5.x. Use this if your application is not yet ready to upgrade to Spring Boot 4.0.
 
 :::caution Spring Boot 3.5.x OSS support window
-Spring's open source support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). This is a Spring framework lifecycle change and does not mean Camunda is dropping support for `camunda-spring-boot-3-starter`. Camunda will continue to maintain and patch this module with no announced end date.
+Spring's open source support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). Camunda will continue to support and maintain `camunda-spring-boot-3-starter` with no announced end date.
 
 What this means for your application:
 
 - **Camunda's starter:** Camunda continues to release patches for `camunda-spring-boot-3-starter`.
-- **Spring framework patches:** After June 2026, Spring will no longer provide security or bug-fix patches for Spring Boot 3.x. If your application requires Spring framework-level security patches after that date, consider obtaining commercial support from a third-party provider such as [HeroDevs](https://www.herodevs.com/support/spring-nes), or plan to migrate to Spring Boot 4.0.
+- **Spring framework patches:** After June 2026, Spring will no longer provide security or bug-fix patches for Spring Boot 3.x. If your application requires Spring framework-level security patches after that date, consider obtaining commercial support from a third-party provider, or plan to migrate to Spring Boot 4.0.
   :::
 
 To use the Spring Boot 3 module, replace the default dependency in your project:

--- a/docs/apis-tools/camunda-spring-boot-starter/getting-started.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/getting-started.md
@@ -52,9 +52,14 @@ Starting with Camunda 8.9, the default `camunda-spring-boot-starter` artifact is
 - **`camunda-spring-boot-4-starter`**: Identical to `camunda-spring-boot-starter`. Use this if you want to explicitly target Spring Boot 4.0.x.
 - **`camunda-spring-boot-3-starter`**: Bundled with Spring Boot 3.5.x. Use this if your application is not yet ready to upgrade to Spring Boot 4.0.
 
-:::caution Spring Boot 3.5.x support window
-OSS support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). We encourage you to migrate to Spring Boot 4.0 before the support window closes. If you need continued Spring Boot 3.x support after June 2026, consider obtaining enterprise support from a third-party provider.
-:::
+:::caution Spring Boot 3.5.x OSS support window
+Spring's open source support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). This is a Spring framework lifecycle change and does not mean Camunda is dropping support for `camunda-spring-boot-3-starter`. Camunda will continue to maintain and patch this module with no announced end date.
+
+What this means for your application:
+
+- **Camunda's starter:** Camunda continues to release patches for `camunda-spring-boot-3-starter`.
+- **Spring framework patches:** After June 2026, Spring will no longer provide security or bug-fix patches for Spring Boot 3.x. If your application requires Spring framework-level security patches after that date, consider obtaining commercial support from a third-party provider such as [HeroDevs](https://www.herodevs.com/support/spring-nes), or plan to migrate to Spring Boot 4.0.
+  :::
 
 To use the Spring Boot 3 module, replace the default dependency in your project:
 

--- a/docs/apis-tools/migration-manuals/migrate-to-89.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-89.md
@@ -344,7 +344,7 @@ Starting with 8.9.0, the default [Camunda Spring Boot Starter](/apis-tools/camun
 #### Action
 
 - Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`.
-- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Camunda will continue to maintain this module beyond June 2026 (when Spring's own OSS support for Spring Boot 3.x ends) — there is no announced end date. For Spring framework-level security patches after that date, consider commercial support from a third-party provider.
+- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Camunda will continue to maintain this module beyond June 2026 (when Spring's own OSS support for Spring Boot 3.x ends). For Spring framework-level security patches after that date, consider commercial support from a third-party provider.
 - See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for details.
 - See the [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules) documentation for more information.
 

--- a/docs/apis-tools/migration-manuals/migrate-to-89.md
+++ b/docs/apis-tools/migration-manuals/migrate-to-89.md
@@ -344,7 +344,7 @@ Starting with 8.9.0, the default [Camunda Spring Boot Starter](/apis-tools/camun
 #### Action
 
 - Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`.
-- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Note that OSS support for Spring Boot 3.5.x ends in June 2026, so plan your migration accordingly.
+- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Camunda will continue to maintain this module beyond June 2026 (when Spring's own OSS support for Spring Boot 3.x ends) — there is no announced end date. For Spring framework-level security patches after that date, consider commercial support from a third-party provider.
 - See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for details.
 - See the [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules) documentation for more information.
 

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -270,7 +270,7 @@ Starting with 8.9.0-alpha3, the default [Camunda Spring Boot Starter](../../../a
 **Action:** Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`. If you're not yet ready to upgrade, switch to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x and has no announced end date. See [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules).
 
 :::info Spring Boot support timeline
-OSS support for Spring Boot 3.x ends in June 2026 — this is a Spring framework lifecycle change. Camunda will continue to maintain `camunda-spring-boot-3-starter` beyond that date. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for context on Spring's support lifecycle.
+OSS support for Spring Boot 3.x ends in June 2026. This is a Spring framework lifecycle change. Camunda will continue to maintain `camunda-spring-boot-3-starter` beyond that date. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for context on Spring's support lifecycle.
 :::
 
 </div>

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -263,14 +263,14 @@ Previously, a shared `DocumentMetadata` schema was used for both creating and re
 </div>
 <div className="release-announcement-content">
 
-#### Camunda Spring Boot Starter now requires Spring Boot 4.0.x
+#### Camunda Spring Boot Starter default now requires Spring Boot 4.0.x
 
-Starting with 8.9.0-alpha3, the [Camunda Spring Boot Starter](../../../apis-tools/camunda-spring-boot-starter/getting-started.md) requires Spring Boot 4.0.x.
+Starting with 8.9.0-alpha3, the default [Camunda Spring Boot Starter](../../../apis-tools/camunda-spring-boot-starter/getting-started.md) (`camunda-spring-boot-starter`) is bundled with Spring Boot 4.0.x.
 
-**Action:** To remain compatible, migrate your application to Spring Boot 4.0.x.
+**Action:** Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`. If you're not yet ready to upgrade, switch to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x and has no announced end date. See [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules).
 
 :::info Spring Boot support timeline
-This change aligns with the Spring Boot support policy, as OSS support for Spring Boot 3.x ends in June 2026. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support).
+OSS support for Spring Boot 3.x ends in June 2026 — this is a Spring framework lifecycle change. Camunda will continue to maintain `camunda-spring-boot-3-starter` beyond that date. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for context on Spring's support lifecycle.
 :::
 
 </div>

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/getting-started.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/getting-started.md
@@ -53,12 +53,12 @@ Starting with Camunda 8.9, the default `camunda-spring-boot-starter` artifact is
 - **`camunda-spring-boot-3-starter`**: Bundled with Spring Boot 3.5.x. Use this if your application is not yet ready to upgrade to Spring Boot 4.0.
 
 :::caution Spring Boot 3.5.x OSS support window
-Spring's open source support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). This is a Spring framework lifecycle change and does not mean Camunda is dropping support for `camunda-spring-boot-3-starter`. Camunda will continue to maintain and patch this module with no announced end date.
+Spring's open source support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). Camunda will continue to support and maintain `camunda-spring-boot-3-starter` with no announced end date.
 
 What this means for your application:
 
 - **Camunda's starter:** Camunda continues to release patches for `camunda-spring-boot-3-starter`.
-- **Spring framework patches:** After June 2026, Spring will no longer provide security or bug-fix patches for Spring Boot 3.x. If your application requires Spring framework-level security patches after that date, consider obtaining commercial support from a third-party provider such as [HeroDevs](https://www.herodevs.com/support/spring-nes), or plan to migrate to Spring Boot 4.0.
+- **Spring framework patches:** After June 2026, Spring will no longer provide security or bug-fix patches for Spring Boot 3.x. If your application requires Spring framework-level security patches after that date, consider obtaining commercial support from a third-party provider, or plan to migrate to Spring Boot 4.0.
   :::
 
 To use the Spring Boot 3 module, replace the default dependency in your project:

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/getting-started.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/getting-started.md
@@ -52,9 +52,14 @@ Starting with Camunda 8.9, the default `camunda-spring-boot-starter` artifact is
 - **`camunda-spring-boot-4-starter`**: Identical to `camunda-spring-boot-starter`. Use this if you want to explicitly target Spring Boot 4.0.x.
 - **`camunda-spring-boot-3-starter`**: Bundled with Spring Boot 3.5.x. Use this if your application is not yet ready to upgrade to Spring Boot 4.0.
 
-:::caution Spring Boot 3.5.x support window
-OSS support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). We encourage you to migrate to Spring Boot 4.0 before the support window closes. If you need continued Spring Boot 3.x support after June 2026, consider obtaining enterprise support from a third-party provider.
-:::
+:::caution Spring Boot 3.5.x OSS support window
+Spring's open source support for Spring Boot 3.5.x ends in June 2026 (see [Spring Boot support timeline](https://spring.io/projects/spring-boot#support)). This is a Spring framework lifecycle change and does not mean Camunda is dropping support for `camunda-spring-boot-3-starter`. Camunda will continue to maintain and patch this module with no announced end date.
+
+What this means for your application:
+
+- **Camunda's starter:** Camunda continues to release patches for `camunda-spring-boot-3-starter`.
+- **Spring framework patches:** After June 2026, Spring will no longer provide security or bug-fix patches for Spring Boot 3.x. If your application requires Spring framework-level security patches after that date, consider obtaining commercial support from a third-party provider such as [HeroDevs](https://www.herodevs.com/support/spring-nes), or plan to migrate to Spring Boot 4.0.
+  :::
 
 To use the Spring Boot 3 module, replace the default dependency in your project:
 

--- a/versioned_docs/version-8.9/apis-tools/migration-manuals/migrate-to-89.md
+++ b/versioned_docs/version-8.9/apis-tools/migration-manuals/migrate-to-89.md
@@ -344,7 +344,7 @@ Starting with 8.9.0, the default [Camunda Spring Boot Starter](/apis-tools/camun
 #### Action
 
 - Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`.
-- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Camunda will continue to maintain this module beyond June 2026 (when Spring's own OSS support for Spring Boot 3.x ends) — there is no announced end date. For Spring framework-level security patches after that date, consider commercial support from a third-party provider.
+- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Camunda will continue to maintain this module beyond June 2026 (when Spring's own OSS support for Spring Boot 3.x ends). For Spring framework-level security patches after that date, consider commercial support from a third-party provider.
 - See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for details.
 - See the [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules) documentation for more information.
 

--- a/versioned_docs/version-8.9/apis-tools/migration-manuals/migrate-to-89.md
+++ b/versioned_docs/version-8.9/apis-tools/migration-manuals/migrate-to-89.md
@@ -344,7 +344,7 @@ Starting with 8.9.0, the default [Camunda Spring Boot Starter](/apis-tools/camun
 #### Action
 
 - Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`.
-- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Note that OSS support for Spring Boot 3.5.x ends in June 2026, so plan your migration accordingly.
+- If you cannot migrate yet, switch your dependency to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x. Camunda will continue to maintain this module beyond June 2026 (when Spring's own OSS support for Spring Boot 3.x ends) — there is no announced end date. For Spring framework-level security patches after that date, consider commercial support from a third-party provider.
 - See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for details.
 - See the [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules) documentation for more information.
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -270,7 +270,7 @@ Starting with 8.9.0-alpha3, the default [Camunda Spring Boot Starter](../../../a
 **Action:** Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`. If you're not yet ready to upgrade, switch to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x and has no announced end date. See [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules).
 
 :::info Spring Boot support timeline
-OSS support for Spring Boot 3.x ends in June 2026 — this is a Spring framework lifecycle change. Camunda will continue to maintain `camunda-spring-boot-3-starter` beyond that date. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for context on Spring's support lifecycle.
+OSS support for Spring Boot 3.x ends in June 2026. This is a Spring framework lifecycle change. Camunda will continue to maintain `camunda-spring-boot-3-starter` beyond that date. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for context on Spring's support lifecycle.
 :::
 
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -263,14 +263,14 @@ Previously, a shared `DocumentMetadata` schema was used for both creating and re
 </div>
 <div className="release-announcement-content">
 
-#### Camunda Spring Boot Starter now requires Spring Boot 4.0.x
+#### Camunda Spring Boot Starter default now requires Spring Boot 4.0.x
 
-Starting with 8.9.0-alpha3, the [Camunda Spring Boot Starter](../../../apis-tools/camunda-spring-boot-starter/getting-started.md) requires Spring Boot 4.0.x.
+Starting with 8.9.0-alpha3, the default [Camunda Spring Boot Starter](../../../apis-tools/camunda-spring-boot-starter/getting-started.md) (`camunda-spring-boot-starter`) is bundled with Spring Boot 4.0.x.
 
-**Action:** To remain compatible, migrate your application to Spring Boot 4.0.x.
+**Action:** Migrate your application to Spring Boot 4.0.x and continue using `camunda-spring-boot-starter`. If you're not yet ready to upgrade, switch to `camunda-spring-boot-3-starter`, which is bundled with Spring Boot 3.5.x and has no announced end date. See [dedicated Spring Boot 3 and 4 modules](/apis-tools/camunda-spring-boot-starter/getting-started.md#dedicated-spring-boot-3-and-4-modules).
 
 :::info Spring Boot support timeline
-This change aligns with the Spring Boot support policy, as OSS support for Spring Boot 3.x ends in June 2026. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support).
+OSS support for Spring Boot 3.x ends in June 2026 — this is a Spring framework lifecycle change. Camunda will continue to maintain `camunda-spring-boot-3-starter` beyond that date. See the [Spring Boot support timeline](https://spring.io/projects/spring-boot#support) for context on Spring's support lifecycle.
 :::
 
 </div>


### PR DESCRIPTION
## Description

Clarifies the wording around Spring Boot 3.5.x support in three places:

- `apis-tools/camunda-spring-boot-starter/getting-started.md`
- `reference/announcements-release-notes/890/890-announcements.md`
- `apis-tools/migration-manuals/migrate-to-89.md`

(Each edited in both `docs/` and `versioned_docs/version-8.9/`.)

**Problem:** The existing caution banner and breaking-change notes implied that Camunda is dropping support for Spring Boot 3.x in line with Spring's June 2026 OSS support end date. This led at least one customer (ČSOB) to believe they were blocked from upgrading to 8.10 because they couldn't move to Spring Boot 4.0. See internal discussion in #ask-product-management.

**Fix:** Reworded all three locations to make the distinction explicit:
- The June 2026 deadline is a **Spring framework lifecycle event** (no more OSS security patches from Spring for SB3.x).
- **Camunda will continue to maintain and patch `camunda-spring-boot-3-starter`** with no announced end date.
- Users who need Spring framework-level security patches after June 2026 need commercial Spring support (for example, HeroDevs) — that is a Spring-side decision, independent of Camunda.

The breaking-change section in the 8.9 announcements was also updated to surface `camunda-spring-boot-3-starter` as an explicit alternative for users who can't upgrade to Spring Boot 4.0 yet.

Related Slack thread: [#ask-product-management](https://camunda.slack.com/archives/C02AWA0RF8A/p1780501075619089)

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) — @Meggle (Sebastian B.) to confirm accuracy
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)