### PR TITLE
docs(agents): extend PR/issue workflow instructions with label and project guidance

### DIFF
--- a/.github/instructions/repo.instructions.md
+++ b/.github/instructions/repo.instructions.md
@@ -35,7 +35,7 @@ To determine the exact Docusaurus version used by this site, check the `@docusau
 ## 3. PR and issue workflow
 
 - Keep the PR in **draft** while actively working on it. Removing draft status signals it is ready for review.
-- Use **labels** to communicate the component, version, and priority. Both PRs and issues without labels may be triaged slowly.
+- Add **labels** to communicate the component, version, and priority. Both PRs and issues without labels may be triaged slowly.
 - Add the **`deploy` label** to trigger a preview site deployment. Recommended for large or complex changes. Preview deployments are published at `https://preview.docs.camunda.cloud/pr-<N>/`, where `<N>` is the PR number.
 - Use the PR template at `.github/pull_request_template.md` when opening a PR. When updating an existing PR description, preserve the full template structure and edit content inside the `## Description` section only, unless explicitly asked to change other sections.
 - Add both PRs and issues to the **Documentation Team** GitHub Project so they appear in the team's board and backlog.

--- a/.github/instructions/repo.instructions.md
+++ b/.github/instructions/repo.instructions.md
@@ -32,12 +32,13 @@ To determine the exact Docusaurus version used by this site, check the `@docusau
 - **Moving a page**: update the sidebar file(s) to reflect the new location, then add a redirect rule to the **top** of `static/.htaccess`.
 - **Removing a page**: remove it from the sidebar file(s) and add a redirect rule to the top of `static/.htaccess` pointing users to relevant content.
 
-## 3. PR workflow
+## 3. PR and issue workflow
 
 - Keep the PR in **draft** while actively working on it. Removing draft status signals it is ready for review.
-- Use **labels** to communicate the component, version, and priority. PRs without labels may be triaged slowly.
+- Use **labels** to communicate the component, version, and priority. Both PRs and issues without labels may be triaged slowly.
 - Add the **`deploy` label** to trigger a preview site deployment. Recommended for large or complex changes. Preview deployments are published at `https://preview.docs.camunda.cloud/pr-<N>/`, where `<N>` is the PR number.
 - Use the PR template at `.github/pull_request_template.md` when opening a PR. When updating an existing PR description, preserve the full template structure and edit content inside the `## Description` section only, unless explicitly asked to change other sections.
+- Add both PRs and issues to the **Documentation Team** GitHub Project so they appear in the team's board and backlog.
 
 ## 4. Code formatting and commits
 


### PR DESCRIPTION
## Description

Extends the agent instructions in `.github/instructions/repo.instructions.md` to cover two previously undocumented workflow steps:

1. **Labels apply to issues too** — the existing guidance said labels were for PRs; this clarifies they should be used on issues as well, since both may be triaged slowly without them.
2. **Add PRs and issues to the Documentation Team GitHub Project** — agents had no instruction to assign work to the team's project board; this adds an explicit step to do so.

## When should this change go live?

- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.