### PR TITLE
docs(upgrade): update Web Modeler restapi persistence upgrade note for ephemeral volume change

### DIFF
--- a/docs/self-managed/upgrade/helm/index.md
+++ b/docs/self-managed/upgrade/helm/index.md
@@ -51,19 +51,25 @@ See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issu
 
 ### Web Modeler restapi ephemeral volume
 
-Patched 8.10 charts replace the chart-managed shared persistent volume claim (PVC) for the Web Modeler `restapi` component with a per-pod ephemeral volume. The shared PVC (`<release>-webmodeler-data`) is removed from the chart. Kubernetes creates a dedicated PVC for each `restapi` pod when it starts and removes it when the pod terminates. The `/tmp` directory backed by this volume holds only scratch and cache data — Web Modeler content is stored in PostgreSQL, the document store, and Elasticsearch.
+Patched 8.10 charts replace the chart-managed shared persistent volume claim (PVC) for the Web Modeler `restapi` component with a per-pod ephemeral volume. The shared PVC (`<release>-webmodeler-data`) is removed from the chart. Kubernetes creates a dedicated PVC for each `restapi` pod when it starts and removes it when the pod terminates.
 
-For most deployments, no action is required. The following table shows what to expect based on your `webModeler.persistence` configuration:
+The `/tmp` directory backed by this ephemeral volume holds only scratch and cache data — Web Modeler content is stored in PostgreSQL, the document store, and Elasticsearch. **This is a safe change with no data loss risk.**
 
-| Setting | Upgrade behavior |
-| :--- | :--- |
-| `enabled: false` (default) | No change. Your pod continues using `emptyDir`. No action required. |
-| `enabled: true`, no `existingClaim` | `helm upgrade` succeeds. Each pod now uses a per-pod ephemeral PVC. The old `<release>-webmodeler-data` PVC is no longer managed by Helm and becomes an orphan. Clean it up after upgrading (see [Clean up the orphaned PVC](#clean-up-the-orphaned-pvc)). |
-| `enabled: true`, `existingClaim` set | No change. Your pod continues mounting your existing PVC. No action required. |
+For most deployments, no action is required on upgrade. The following table shows what to expect based on your `webModeler.persistence` configuration:
+
+| Setting                              | Upgrade behavior                                                                                                                                                                                                                       |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled: false` (default)           | No change. Your pod continues using `emptyDir`. No action required.                                                                                                                                                                    |
+| `enabled: true`, no `existingClaim`  | `helm upgrade` succeeds. Each pod now uses a per-pod ephemeral PVC. The old `<release>-webmodeler-data` PVC is no longer managed by Helm and becomes orphaned. [Clean it up after upgrading](#clean-up-the-orphaned-pvc) if it exists. |
+| `enabled: true`, `existingClaim` set | No change. Your pod continues mounting your existing PVC. No action required.                                                                                                                                                          |
 
 #### Clean up the orphaned PVC
 
-If you previously set `webModeler.persistence.enabled: true` without `existingClaim`, a `<release>-webmodeler-data` PVC may exist in your namespace after upgrading. This PVC is no longer referenced by the chart and will not be deleted automatically.
+If you previously set `webModeler.persistence.enabled: true` without `existingClaim`, an orphaned `<release>-webmodeler-data` PVC may exist in your namespace after upgrading. This PVC is no longer referenced by the chart and will not be deleted automatically.
+
+**On cloud providers (GKE, EKS, AKS):** The old PVC was most likely in `Pending` state because the default `WaitForFirstConsumer` storage class defers disk provisioning until a pod is scheduled. If the `restapi` pod never reached a `Running` state, no disk was ever provisioned. The PVC can be safely deleted with no data loss.
+
+**On on-premises clusters with `Immediate` binding:** A physical disk may have been provisioned when the PVC was created. Deleting the PVC releases the underlying disk. Since the volume only backed `/tmp` scratch content, no data is lost.
 
 1. Confirm the `restapi` pod is running and ready before proceeding:
 
@@ -71,23 +77,17 @@ If you previously set `webModeler.persistence.enabled: true` without `existingCl
    kubectl get pods -n <namespace> | grep restapi
    ```
 
-1. Check whether the orphaned PVC exists:
+2. Check whether the orphaned PVC exists:
 
    ```bash
    kubectl get pvc -n <namespace> | grep webmodeler-data
    ```
 
-1. If the PVC exists, delete it:
+3. If the PVC exists, delete it:
 
    ```bash
    kubectl delete pvc <release>-webmodeler-data -n <namespace>
    ```
-
-No data migration is needed. The PVC backed only `/tmp` scratch content.
-
-On GKE, EKS, and AKS, the old PVC was most likely in `Pending` state with no backing disk. The default `WaitForFirstConsumer` storage class defers disk provisioning until a pod is scheduled, so if `restapi` never reached a `Running` state, no disk was ever provisioned.
-
-On clusters using an `Immediate` binding storage class, a physical disk may have been provisioned when the PVC was created. Deleting the PVC releases the underlying disk. No data is at risk.
 
 ## Related resources
 

--- a/docs/self-managed/upgrade/helm/index.md
+++ b/docs/self-managed/upgrade/helm/index.md
@@ -49,16 +49,45 @@ If you are still using a Camunda Helm chart that references the old repository, 
 
 See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issues/83267) for details.
 
-### Web Modeler persistence PVC name
+### Web Modeler restapi ephemeral volume
 
-In some 8.10 chart versions, the Web Modeler `restapi` deployment referenced a persistent volume claim named `<release>-webModeler-data` (camelCase), which did not match the chart-managed PVC `<release>-webmodeler-data` (lowercase). This name mismatch prevented the Web Modeler persistence volume from mounting. A patched 8.10 chart corrects the `claimName` so the `restapi` pod mounts the existing `<release>-webmodeler-data` PVC.
+Patched 8.10 charts replace the chart-managed shared persistent volume claim (PVC) for the Web Modeler `restapi` component with a per-pod ephemeral volume. The shared PVC (`<release>-webmodeler-data`) is removed from the chart. Kubernetes creates a dedicated PVC for each `restapi` pod when it starts and removes it when the pod terminates. The `/tmp` directory backed by this volume holds only scratch and cache data — Web Modeler content is stored in PostgreSQL, the document store, and Elasticsearch.
 
-**No action is required for most deployments.** The fix only corrects the deployment's claim reference; it does not rename the PVC. On upgrade, the `restapi` pod mounts the already-existing `<release>-webmodeler-data` PVC and no data migration is needed. The persisted volume holds only `/tmp` scratch and cache data — Web Modeler content is stored in PostgreSQL.
+For most deployments, no action is required. The following table shows what to expect based on your `webModeler.persistence` configuration:
 
-If you manually created a `<release>-webModeler-data` (capital `M`) PVC as a workaround for the broken mount, the `restapi` pod stops using it after you upgrade to a patched chart. The manual PVC is not deleted; it remains orphaned and continues to consume storage until you act. Choose one of the following:
+| Setting | Upgrade behavior |
+| :--- | :--- |
+| `enabled: false` (default) | No change. Your pod continues using `emptyDir`. No action required. |
+| `enabled: true`, no `existingClaim` | `helm upgrade` succeeds. Each pod now uses a per-pod ephemeral PVC. The old `<release>-webmodeler-data` PVC is no longer managed by Helm and becomes an orphan. Clean it up after upgrading (see [Clean up the orphaned PVC](#clean-up-the-orphaned-pvc)). |
+| `enabled: true`, `existingClaim` set | No change. Your pod continues mounting your existing PVC. No action required. |
 
-- Set `webModeler.persistence.existingClaim` to your manually created PVC to keep using it, or
-- Delete the orphaned PVC after confirming the `restapi` pod successfully mounts `<release>-webmodeler-data`.
+#### Clean up the orphaned PVC
+
+If you previously set `webModeler.persistence.enabled: true` without `existingClaim`, a `<release>-webmodeler-data` PVC may exist in your namespace after upgrading. This PVC is no longer referenced by the chart and will not be deleted automatically.
+
+1. Confirm the `restapi` pod is running and ready before proceeding:
+
+   ```bash
+   kubectl get pods -n <namespace> | grep restapi
+   ```
+
+1. Check whether the orphaned PVC exists:
+
+   ```bash
+   kubectl get pvc -n <namespace> | grep webmodeler-data
+   ```
+
+1. If the PVC exists, delete it:
+
+   ```bash
+   kubectl delete pvc <release>-webmodeler-data -n <namespace>
+   ```
+
+No data migration is needed. The PVC backed only `/tmp` scratch content.
+
+On GKE, EKS, and AKS, the old PVC was most likely in `Pending` state with no backing disk. The default `WaitForFirstConsumer` storage class defers disk provisioning until a pod is scheduled, so if `restapi` never reached a `Running` state, no disk was ever provisioned.
+
+On clusters using an `Immediate` binding storage class, a physical disk may have been provisioned when the PVC was created. Deleting the PVC releases the underlying disk. No data is at risk.
 
 ## Related resources
 

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
@@ -51,19 +51,25 @@ See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issu
 
 ### Web Modeler restapi ephemeral volume
 
-Patched 8.9 charts replace the chart-managed shared persistent volume claim (PVC) for the Web Modeler `restapi` component with a per-pod ephemeral volume. The shared PVC (`<release>-webmodeler-data`) is removed from the chart. Kubernetes creates a dedicated PVC for each `restapi` pod when it starts and removes it when the pod terminates. The `/tmp` directory backed by this volume holds only scratch and cache data — Web Modeler content is stored in PostgreSQL, the document store, and Elasticsearch.
+Patched 8.9 charts replace the chart-managed shared persistent volume claim (PVC) for the Web Modeler `restapi` component with a per-pod ephemeral volume. The shared PVC (`<release>-webmodeler-data`) is removed from the chart. Kubernetes creates a dedicated PVC for each `restapi` pod when it starts and removes it when the pod terminates.
 
-For most deployments, no action is required. The following table shows what to expect based on your `webModeler.persistence` configuration:
+The `/tmp` directory backed by this ephemeral volume holds only scratch and cache data — Web Modeler content is stored in PostgreSQL, the document store, and Elasticsearch. **This is a safe change with no data loss risk.**
 
-| Setting | Upgrade behavior |
-| :--- | :--- |
-| `enabled: false` (default) | No change. Your pod continues using `emptyDir`. No action required. |
-| `enabled: true`, no `existingClaim` | `helm upgrade` succeeds. Each pod now uses a per-pod ephemeral PVC. The old `<release>-webmodeler-data` PVC is no longer managed by Helm and becomes an orphan. Clean it up after upgrading (see [Clean up the orphaned PVC](#clean-up-the-orphaned-pvc)). |
-| `enabled: true`, `existingClaim` set | No change. Your pod continues mounting your existing PVC. No action required. |
+For most deployments, no action is required on upgrade. The following table shows what to expect based on your `webModeler.persistence` configuration:
+
+| Setting                              | Upgrade behavior                                                                                                                                                                                                                       |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled: false` (default)           | No change. Your pod continues using `emptyDir`. No action required.                                                                                                                                                                    |
+| `enabled: true`, no `existingClaim`  | `helm upgrade` succeeds. Each pod now uses a per-pod ephemeral PVC. The old `<release>-webmodeler-data` PVC is no longer managed by Helm and becomes orphaned. [Clean it up after upgrading](#clean-up-the-orphaned-pvc) if it exists. |
+| `enabled: true`, `existingClaim` set | No change. Your pod continues mounting your existing PVC. No action required.                                                                                                                                                          |
 
 #### Clean up the orphaned PVC
 
-If you previously set `webModeler.persistence.enabled: true` without `existingClaim`, a `<release>-webmodeler-data` PVC may exist in your namespace after upgrading. This PVC is no longer referenced by the chart and will not be deleted automatically.
+If you previously set `webModeler.persistence.enabled: true` without `existingClaim`, an orphaned `<release>-webmodeler-data` PVC may exist in your namespace after upgrading. This PVC is no longer referenced by the chart and will not be deleted automatically.
+
+**On cloud providers (GKE, EKS, AKS):** The old PVC was most likely in `Pending` state because the default `WaitForFirstConsumer` storage class defers disk provisioning until a pod is scheduled. If the `restapi` pod never reached a `Running` state, no disk was ever provisioned. The PVC can be safely deleted with no data loss.
+
+**On on-premises clusters with `Immediate` binding:** A physical disk may have been provisioned when the PVC was created. Deleting the PVC releases the underlying disk. Since the volume only backed `/tmp` scratch content, no data is lost.
 
 1. Confirm the `restapi` pod is running and ready before proceeding:
 
@@ -71,23 +77,17 @@ If you previously set `webModeler.persistence.enabled: true` without `existingCl
    kubectl get pods -n <namespace> | grep restapi
    ```
 
-1. Check whether the orphaned PVC exists:
+2. Check whether the orphaned PVC exists:
 
    ```bash
    kubectl get pvc -n <namespace> | grep webmodeler-data
    ```
 
-1. If the PVC exists, delete it:
+3. If the PVC exists, delete it:
 
    ```bash
    kubectl delete pvc <release>-webmodeler-data -n <namespace>
    ```
-
-No data migration is needed. The PVC backed only `/tmp` scratch content.
-
-On GKE, EKS, and AKS, the old PVC was most likely in `Pending` state with no backing disk. The default `WaitForFirstConsumer` storage class defers disk provisioning until a pod is scheduled, so if `restapi` never reached a `Running` state, no disk was ever provisioned.
-
-On clusters using an `Immediate` binding storage class, a physical disk may have been provisioned when the PVC was created. Deleting the PVC releases the underlying disk. No data is at risk.
 
 ## Related resources
 

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
@@ -49,16 +49,45 @@ If you are still using a Camunda Helm chart that references the old repository, 
 
 See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issues/83267) for details.
 
-### Web Modeler persistence PVC name
+### Web Modeler restapi ephemeral volume
 
-In some 8.9 chart versions, the Web Modeler `restapi` deployment referenced a persistent volume claim named `<release>-webModeler-data` (camelCase), which did not match the chart-managed PVC `<release>-webmodeler-data` (lowercase). This name mismatch prevented the Web Modeler persistence volume from mounting. A patched 8.9 chart corrects the `claimName` so the `restapi` pod mounts the existing `<release>-webmodeler-data` PVC.
+Patched 8.9 charts replace the chart-managed shared persistent volume claim (PVC) for the Web Modeler `restapi` component with a per-pod ephemeral volume. The shared PVC (`<release>-webmodeler-data`) is removed from the chart. Kubernetes creates a dedicated PVC for each `restapi` pod when it starts and removes it when the pod terminates. The `/tmp` directory backed by this volume holds only scratch and cache data — Web Modeler content is stored in PostgreSQL, the document store, and Elasticsearch.
 
-**No action is required for most deployments.** The fix only corrects the deployment's claim reference; it does not rename the PVC. On upgrade, the `restapi` pod mounts the already-existing `<release>-webmodeler-data` PVC and no data migration is needed. The persisted volume holds only `/tmp` scratch and cache data — Web Modeler content is stored in PostgreSQL.
+For most deployments, no action is required. The following table shows what to expect based on your `webModeler.persistence` configuration:
 
-If you manually created a `<release>-webModeler-data` (capital `M`) PVC as a workaround for the broken mount, the `restapi` pod stops using it after you upgrade to a patched chart. The manual PVC is not deleted; it remains orphaned and continues to consume storage until you act. Choose one of the following:
+| Setting | Upgrade behavior |
+| :--- | :--- |
+| `enabled: false` (default) | No change. Your pod continues using `emptyDir`. No action required. |
+| `enabled: true`, no `existingClaim` | `helm upgrade` succeeds. Each pod now uses a per-pod ephemeral PVC. The old `<release>-webmodeler-data` PVC is no longer managed by Helm and becomes an orphan. Clean it up after upgrading (see [Clean up the orphaned PVC](#clean-up-the-orphaned-pvc)). |
+| `enabled: true`, `existingClaim` set | No change. Your pod continues mounting your existing PVC. No action required. |
 
-- Set `webModeler.persistence.existingClaim` to your manually created PVC to keep using it, or
-- Delete the orphaned PVC after confirming the `restapi` pod successfully mounts `<release>-webmodeler-data`.
+#### Clean up the orphaned PVC
+
+If you previously set `webModeler.persistence.enabled: true` without `existingClaim`, a `<release>-webmodeler-data` PVC may exist in your namespace after upgrading. This PVC is no longer referenced by the chart and will not be deleted automatically.
+
+1. Confirm the `restapi` pod is running and ready before proceeding:
+
+   ```bash
+   kubectl get pods -n <namespace> | grep restapi
+   ```
+
+1. Check whether the orphaned PVC exists:
+
+   ```bash
+   kubectl get pvc -n <namespace> | grep webmodeler-data
+   ```
+
+1. If the PVC exists, delete it:
+
+   ```bash
+   kubectl delete pvc <release>-webmodeler-data -n <namespace>
+   ```
+
+No data migration is needed. The PVC backed only `/tmp` scratch content.
+
+On GKE, EKS, and AKS, the old PVC was most likely in `Pending` state with no backing disk. The default `WaitForFirstConsumer` storage class defers disk provisioning until a pod is scheduled, so if `restapi` never reached a `Running` state, no disk was ever provisioned.
+
+On clusters using an `Immediate` binding storage class, a physical disk may have been provisioned when the PVC was created. Deleting the PVC releases the underlying disk. No data is at risk.
 
 ## Related resources
 


### PR DESCRIPTION
## Description

Updates the Web Modeler restapi persistence upgrade note in the Helm upgrade notes for both 8.9 (`versioned_docs/version-8.9`) and Next/8.10 (`docs/`).

The existing note documented a PVC name casing fix. It is now superseded by camunda/camunda-platform-helm#6027 (8.9) and camunda/camunda-platform-helm#6406 (8.10), which replace the chart-managed shared RWO PVC entirely with a per-pod ephemeral volume. The old note described behavior that no longer applies after those Helm PRs land.

**What changed in the Helm chart:**
- `persistentvolumeclaim-restapi.yaml` deleted — no more shared `<release>-webmodeler-data` PVC
- `deployment-restapi.yaml` updated — chart-managed path now renders an `ephemeral.volumeClaimTemplate` (per-pod PVC, auto-created and auto-deleted with the pod)
- `emptyDir` default and `existingClaim` paths are unchanged

**What the new docs section covers:**
- What the change is and why (scratch-only `/tmp`, ephemeral is correct primitive)
- Config-table showing zero-touch upgrade for default users and `existingClaim` users
- Orphaned PVC cleanup steps for users who had `enabled: true` without `existingClaim`
- Cloud provider context (WaitForFirstConsumer = no disk was provisioned on GKE/EKS/AKS) and on-prem note (Immediate binding = disk may exist, safe to delete)

Relates to: camunda/camunda-platform-helm#6027, camunda/camunda-platform-helm#6406

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.