### PR TITLE
docs: explain why primary storage requires low-latency SSDs

### DIFF
--- a/docs/components/best-practices/architecture/sizing-self-managed.md
+++ b/docs/components/best-practices/architecture/sizing-self-managed.md
@@ -149,9 +149,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 
 ## Primary storage considerations
 
-The Orchestration Cluster is highly IO-intensive: every command is written to the Raft log and flushed to disk before it can be processed. A partition leader must replicate and commit a record before processing and responding to it, and each follower must write and flush the record before acknowledging replication. Disk write and flush **latency** therefore sits directly on the critical path of request processing.
-
-For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
+Primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk **latency** — not throughput — is the critical metric: cloud providers often report similar throughput figures for HDD and SSD volumes, but the latency difference is what matters for Camunda. In testing, HDD-backed primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
 
 See [Command processing path](data-flow.md#command-processing-path) for the architectural context on why disk latency sits on the critical path, the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
 

--- a/docs/components/best-practices/architecture/sizing-self-managed.md
+++ b/docs/components/best-practices/architecture/sizing-self-managed.md
@@ -153,7 +153,7 @@ The Orchestration Cluster is highly IO-intensive: every command is written to th
 
 For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
 
-See the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+See [Command processing path](data-flow.md#command-processing-path) for the architectural context on why disk latency sits on the critical path, the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
 
 ## Secondary storage considerations
 

--- a/docs/components/best-practices/architecture/sizing-self-managed.md
+++ b/docs/components/best-practices/architecture/sizing-self-managed.md
@@ -147,6 +147,14 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
 
+## Primary storage considerations
+
+The Orchestration Cluster is highly IO-intensive: every command is written to the Raft log and flushed to disk before it can be processed. A partition leader must replicate and commit a record before processing and responding to it, and each follower must write and flush the record before acknowledging replication. Disk write and flush **latency** therefore sits directly on the critical path of request processing.
+
+For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
+
+See the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+
 ## Secondary storage considerations
 
 The resource tables above assume Elasticsearch as the secondary storage backend. If you are using a different backend:

--- a/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
@@ -93,6 +93,10 @@ Furthermore, data is also sent from Operate and Optimize, which store data in El
 Elasticsearch needs enough memory available to load a large amount of this data into memory.
 :::
 
+:::note Use SSDs for Zeebe (primary storage)
+Use SSD-backed storage for Zeebe (your primary storage). Every command is written and flushed to the Zeebe Raft log before it is processed: the leader must persist the entry and followers must flush it before acknowledging, so disk write and flush **latency** sits directly on the processing critical path. As with Elasticsearch, the critical factor is latency, not throughput — cloud-provider throughput figures often look similar for HDD and SSD, which is misleading. In testing, HDD-backed primary storage degraded throughput by roughly 50%, raised commit latency, and triggered additional Raft snapshot replication. Provision performant, low-latency (single-digit-millisecond write latency) disks for Zeebe. See the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+:::
+
 Assuming a [typical payload of 15 process variables (simple strings, numbers or booleans)](https://github.com/camunda/camunda/blob/main/load-tests/load-tester/src/main/resources/bpmn/typical_payload.json), Camunda measured the following approximate disk space requirements using Camunda 8 SaaS 1.2.4. These are not exact numbers, but they can help you estimate what to expect:
 
 - Zeebe: 75 kb / PI

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
@@ -149,9 +149,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 
 ## Primary storage considerations
 
-The Orchestration Cluster is highly IO-intensive: every command is written to the Raft log and flushed to disk before it can be processed. A partition leader must replicate and commit a record before processing and responding to it, and each follower must write and flush the record before acknowledging replication. Disk write and flush **latency** therefore sits directly on the critical path of request processing.
-
-For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
+Primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk **latency** — not throughput — is the critical metric: cloud providers often report similar throughput figures for HDD and SSD volumes, but the latency difference is what matters for Camunda. In testing, HDD-backed primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
 
 See [Command processing path](data-flow.md#command-processing-path) for the architectural context on why disk latency sits on the critical path, the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
 

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
@@ -153,7 +153,7 @@ The Orchestration Cluster is highly IO-intensive: every command is written to th
 
 For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
 
-See the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+See [Command processing path](data-flow.md#command-processing-path) for the architectural context on why disk latency sits on the critical path, the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
 
 ## Secondary storage considerations
 

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
@@ -147,6 +147,14 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
 
+## Primary storage considerations
+
+The Orchestration Cluster is highly IO-intensive: every command is written to the Raft log and flushed to disk before it can be processed. A partition leader must replicate and commit a record before processing and responding to it, and each follower must write and flush the record before acknowledging replication. Disk write and flush **latency** therefore sits directly on the critical path of request processing.
+
+For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
+
+See the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+
 ## Secondary storage considerations
 
 The resource tables above assume Elasticsearch as the secondary storage backend. If you are using a different backend:

--- a/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
@@ -149,9 +149,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 
 ## Primary storage considerations
 
-The Orchestration Cluster is highly IO-intensive: every command is written to the Raft log and flushed to disk before it can be processed. A partition leader must replicate and commit a record before processing and responding to it, and each follower must write and flush the record before acknowledging replication. Disk write and flush **latency** therefore sits directly on the critical path of request processing.
-
-For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
+Primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk **latency** — not throughput — is the critical metric: cloud providers often report similar throughput figures for HDD and SSD volumes, but the latency difference is what matters for Camunda. In testing, HDD-backed primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
 
 See [Command processing path](data-flow.md#command-processing-path) for the architectural context on why disk latency sits on the critical path, the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
 

--- a/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
@@ -153,7 +153,7 @@ The Orchestration Cluster is highly IO-intensive: every command is written to th
 
 For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
 
-See the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+See [Command processing path](data-flow.md#command-processing-path) for the architectural context on why disk latency sits on the critical path, the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
 
 ## Secondary storage considerations
 

--- a/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
@@ -147,6 +147,14 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
 
+## Primary storage considerations
+
+The Orchestration Cluster is highly IO-intensive: every command is written to the Raft log and flushed to disk before it can be processed. A partition leader must replicate and commit a record before processing and responding to it, and each follower must write and flush the record before acknowledging replication. Disk write and flush **latency** therefore sits directly on the critical path of request processing.
+
+For this reason, primary storage must use low-latency **SSDs**; HDD-backed volumes are not supported. Disk _throughput_ alone is not a reliable indicator — cloud providers often report similar throughput for HDD and SSD volumes, but the latency difference is large and is what matters for Camunda. In testing, using high-latency (HDD) disks for primary storage degraded throughput by around 50% compared to SSDs, increased commit latencies, and triggered additional Raft snapshot replication between brokers.
+
+See the [reference architecture minimum cluster requirements](/self-managed/reference-architecture/kubernetes.md#minimum-cluster-requirements) for concrete per-platform disk recommendations, and the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda) for the detailed findings.
+
 ## Secondary storage considerations
 
 The resource tables above assume Elasticsearch as the secondary storage backend. If you are using a different backend:


### PR DESCRIPTION
## Description

The reference architecture (`kubernetes.md`) states that primary storage must use SSDs and points readers to the sizing guide "for production sizing" — but the sizing guide never explained **why**. This adds a `## Primary storage considerations` section covering the mechanism: the Orchestration Cluster writes and flushes every command to the Raft log before processing, so disk write/flush **latency** sits directly on the critical path (leaders must commit, followers must flush before acknowledging). Disk *throughput* looks similar for HDD and SSD on cloud providers, which is misleading — latency is what matters.

This complements the secondary-storage (Elasticsearch) guidance in [#9150](https://github.com/camunda/camunda-docs/pull/9150).

## Source

Findings from a chaos-day load test: HDD-backed primary storage degraded throughput by ~50%, raised commit latency, and triggered additional Raft snapshot replication. See the [slow disk chaos day experiment](https://camunda.github.io/zeebe-chaos/2026/06/19/Using-slow-disk-with-Camunda).

## Changes

- **`sizing-self-managed.md`** (`next`, 8.8, 8.9): new `## Primary storage considerations` section, linking the reference architecture minimum requirements and the chaos day post.
- **`sizing-your-environment.md`** (8.7): 8.7 has no `sizing-self-managed.md`, so a "Use SSDs for Zeebe (primary storage)" note was added to the `Disk space` section instead, matching the version's existing voice.

## Review

- [ ] Content is technically accurate (validated by chaos day load test, 2026-06-19)
- [ ] Links resolve correctly across versions
- [ ] Fits existing page style and admonition conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)