### PR TITLE
docs: document ES/OS index replica disk space impact in sizing and management guides

### DIFF
--- a/docs/components/best-practices/architecture/sizing-self-managed.md
+++ b/docs/components/best-practices/architecture/sizing-self-managed.md
@@ -146,6 +146,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Memory:** Increase Elasticsearch memory to store more historical data without performance degradation.
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
+- **Index replicas:** The disk estimates in the baseline tables above do not account for index-level replicas. In multi-node clusters, configure at least one replica per index for fault tolerance — each replica stores a full copy of the primary shard data, approximately doubling total disk usage. From Camunda 8.10 onwards, the Elasticsearch/OpenSearch Exporter defaults to one replica. For earlier versions, configure this explicitly. See [managing replicas](/self-managed/concepts/secondary-storage/managing-secondary-storage.md#replicas).
 
 ## Secondary storage considerations
 

--- a/docs/self-managed/concepts/secondary-storage/managing-secondary-storage.md
+++ b/docs/self-managed/concepts/secondary-storage/managing-secondary-storage.md
@@ -61,6 +61,10 @@ Define shard count according to your data size and expected growth.
 
 - **Multi-node clusters:** Configure at least **one replica per index**. Replicas ensure fault tolerance by keeping data available if one node fails.
 
+:::note
+Each replica stores a full copy of the primary shard data, so one replica per index approximately doubles the total disk required for those indices. Account for replica storage when [sizing your Elasticsearch/OpenSearch cluster](/components/best-practices/architecture/sizing-self-managed.md#elasticsearch-scaling).
+:::
+
 ## Backups
 
 Regular backups of your secondary storage are critical for disaster recovery and business continuity.

--- a/versioned_docs/version-8.7/self-managed/concepts/secondary-storage-management.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/secondary-storage-management.md
@@ -52,6 +52,10 @@ The number of primary shards should be determined based on your data size and an
 
 - **Multiple Node Cluster**: In a multi-node cluster, it is advisable to configure at least one replica for each index. This ensures that if one node fails, the data remains accessible from another node, enhancing fault tolerance and availability.
 
+:::note
+Each replica stores a full copy of the primary shard data, so one replica per index approximately doubles the total disk required for those indices. Account for replica storage when sizing your Elasticsearch/OpenSearch cluster.
+:::
+
 ## Backups
 
 Regular backups of your secondary storage data are crucial for disaster recovery and data integrity:

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
@@ -146,7 +146,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Memory:** Increase Elasticsearch memory to store more historical data without performance degradation.
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
-- **Index replicas:** The disk estimates in the baseline tables above do not account for index-level replicas. In multi-node clusters, configure at least one replica per index for fault tolerance — each replica stores a full copy of the primary shard data, approximately doubling total disk usage. From Camunda 8.10 onwards, the Elasticsearch/OpenSearch Exporter defaults to one replica. For earlier versions, configure this explicitly. See [managing replicas](/self-managed/concepts/secondary-storage/managing-secondary-storage.md#replicas).
+- **Index replicas:** The disk estimates in the baseline tables above do not account for index-level replicas. In multi-node clusters, configure at least one replica per index for fault tolerance — each replica stores a full copy of the primary shard data, approximately doubling total disk usage. From Camunda 8.10 onwards, the Elasticsearch/OpenSearch Exporter defaults to one replica. For earlier versions, configure this explicitly. See [managing replicas](/self-managed/concepts/secondary-storage-management.md#replicas).
 
 ## Secondary storage considerations
 

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-self-managed.md
@@ -146,6 +146,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Memory:** Increase Elasticsearch memory to store more historical data without performance degradation.
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
+- **Index replicas:** The disk estimates in the baseline tables above do not account for index-level replicas. In multi-node clusters, configure at least one replica per index for fault tolerance — each replica stores a full copy of the primary shard data, approximately doubling total disk usage. From Camunda 8.10 onwards, the Elasticsearch/OpenSearch Exporter defaults to one replica. For earlier versions, configure this explicitly. See [managing replicas](/self-managed/concepts/secondary-storage/managing-secondary-storage.md#replicas).
 
 ## Secondary storage considerations
 

--- a/versioned_docs/version-8.8/self-managed/concepts/secondary-storage-management.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/secondary-storage-management.md
@@ -52,6 +52,10 @@ The number of primary shards should be determined based on your data size and an
 
 - **Multiple Node Cluster**: In a multi-node cluster, it is advisable to configure at least one replica for each index. This ensures that if one node fails, the data remains accessible from another node, enhancing fault tolerance and availability.
 
+:::note
+Each replica stores a full copy of the primary shard data, so one replica per index approximately doubles the total disk required for those indices. Account for replica storage when [sizing your Elasticsearch/OpenSearch cluster](/components/best-practices/architecture/sizing-self-managed.md#elasticsearch-scaling).
+:::
+
 ## Backups
 
 Regular backups of your secondary storage data are crucial for disaster recovery and data integrity:

--- a/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
+++ b/versioned_docs/version-8.9/components/best-practices/architecture/sizing-self-managed.md
@@ -146,6 +146,7 @@ Increase CPU and memory per broker. Note that there are **diminishing returns** 
 - **Memory:** Increase Elasticsearch memory to store more historical data without performance degradation.
 - **Nodes:** Add Elasticsearch statefulset replicas for more IOPS and query throughput.
 - **Disk:** Increase disk size based on your data retention requirements. With Optimize enabled and a realistic payload (~11 KB), Elasticsearch disk can fill rapidly (for example, 128 Gi in under 12 hours at 1 PI/s with 30-day retention).
+- **Index replicas:** The disk estimates in the baseline tables above do not account for index-level replicas. In multi-node clusters, configure at least one replica per index for fault tolerance — each replica stores a full copy of the primary shard data, approximately doubling total disk usage. From Camunda 8.10 onwards, the Elasticsearch/OpenSearch Exporter defaults to one replica. For earlier versions, configure this explicitly. See [managing replicas](/self-managed/concepts/secondary-storage/managing-secondary-storage.md#replicas).
 
 ## Secondary storage considerations
 

--- a/versioned_docs/version-8.9/self-managed/concepts/secondary-storage/managing-secondary-storage.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/secondary-storage/managing-secondary-storage.md
@@ -61,6 +61,10 @@ Define shard count according to your data size and expected growth.
 
 - **Multi-node clusters:** Configure at least **one replica per index**. Replicas ensure fault tolerance by keeping data available if one node fails.
 
+:::note
+Each replica stores a full copy of the primary shard data, so one replica per index approximately doubles the total disk required for those indices. Account for replica storage when [sizing your Elasticsearch/OpenSearch cluster](/components/best-practices/architecture/sizing-self-managed.md#elasticsearch-scaling).
+:::
+
 ## Backups
 
 Regular backups of your secondary storage are critical for disaster recovery and business continuity.


### PR DESCRIPTION
## Summary

- Adds a note to the **Manage secondary storage** replicas section explaining that each index replica stores a full copy of primary shard data, approximately doubling total disk usage, with a link to the sizing guide.
- Adds an **Index replicas** bullet to the Elasticsearch scaling section in the self-managed sizing guide, noting that baseline disk estimates do not account for replicas, that ≥1 replica is recommended for fault tolerance, and that Camunda 8.10+ defaults to 1 replica.

## Motivation

Load test failures surfaced in [camunda/camunda#55504](https://github.com/camunda/camunda/pull/55504) revealed that the ES/OS Exporter defaults to 0 replicas before 8.10, making node restarts briefly disrupt reads/writes and turning cluster health red. The sizing docs did not reflect the disk cost of enabling replicas, and the management docs did not mention the storage trade-off.

Tracks part of [camunda/camunda#55366](https://github.com/camunda/camunda/issues/55366).

## Test plan

- [ ] Preview rendered pages for both files
- [ ] Verify cross-links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)