### PR TITLE
fix(docs): update AWS document store credential keys to nested structure (8.8–8.10)

### DIFF
--- a/docs/self-managed/concepts/document-handling/configuration/helm.md
+++ b/docs/self-managed/concepts/document-handling/configuration/helm.md
@@ -47,12 +47,20 @@ global:
                 bucketTtl: 0
                 ## @param global.documentStore.type.aws.class Fully qualified class name for the AWS document store provider.
                 class: "io.camunda.document.store.aws.AwsDocumentStoreProvider"
-                ## @param global.documentStore.type.aws.existingSecret Reference to an existing Kubernetes secret containing AWS credentials.
-                existingSecret: "aws-credentials"
-                ## @param global.documentStore.type.aws.accessKeyIdKey Key within the AWS credentials secret for AWS_ACCESS_KEY_ID.
-                accessKeyIdKey: "awsAccessKeyId"
-                ## @param global.documentStore.type.aws.secretAccessKeyKey Key within the AWS credentials secret for AWS_SECRET_ACCESS_KEY.
-                secretAccessKeyKey: "awsSecretAccessKey"
+                ## @extra global.documentStore.type.aws.accessKeyId configuration to provide the AWS access key ID.
+                accessKeyId:
+                  ## @param global.documentStore.type.aws.accessKeyId.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the access key ID.
+                  ## @param global.documentStore.type.aws.accessKeyId.secret.existingSecretKey defines the key within the existing secret object.
+                  secret:
+                    existingSecret: ""
+                    existingSecretKey: "access-key-id"
+                ## @extra global.documentStore.type.aws.secretAccessKey configuration to provide the AWS secret access key.
+                secretAccessKey:
+                  ## @param global.documentStore.type.aws.secretAccessKey.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the secret access key.
+                  ## @param global.documentStore.type.aws.secretAccessKey.secret.existingSecretKey defines the key within the existing secret object.
+                  secret:
+                    existingSecret: ""
+                    existingSecretKey: "secret-access-key"
             gcp:
                 ## @param global.documentStore.type.gcp.enabled Enable GCP document store configuration.
                 enabled: false

--- a/versioned_docs/version-8.8/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/document-handling/configuration/helm.md
@@ -42,12 +42,23 @@ global:
                 bucketTtl: 0
                 ## @param global.documentStore.type.aws.class Fully qualified class name for the AWS document store provider.
                 class: "io.camunda.document.store.aws.AwsDocumentStoreProvider"
-                ## @param global.documentStore.type.aws.existingSecret Reference to an existing Kubernetes secret containing AWS credentials.
-                existingSecret: "aws-credentials"
-                ## @param global.documentStore.type.aws.accessKeyIdKey Key within the AWS credentials secret for AWS_ACCESS_KEY_ID.
-                accessKeyIdKey: "awsAccessKeyId"
-                ## @param global.documentStore.type.aws.secretAccessKeyKey Key within the AWS credentials secret for AWS_SECRET_ACCESS_KEY.
-                secretAccessKeyKey: "awsSecretAccessKey"
+                ## @extra global.documentStore.type.aws.accessKeyId configuration to provide the AWS access key ID.
+                accessKeyId:
+                  ## @param global.documentStore.type.aws.accessKeyId.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the access key ID.
+                  ## @param global.documentStore.type.aws.accessKeyId.secret.existingSecretKey defines the key within the existing secret object.
+                  secret:
+                    existingSecret: ""
+                    existingSecretKey: "access-key-id"
+                ## @extra global.documentStore.type.aws.secretAccessKey configuration to provide the AWS secret access key.
+                secretAccessKey:
+                  ## @param global.documentStore.type.aws.secretAccessKey.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the secret access key.
+                  ## @param global.documentStore.type.aws.secretAccessKey.secret.existingSecretKey defines the key within the existing secret object.
+                  secret:
+                    existingSecret: ""
+                    existingSecretKey: "secret-access-key"
+                ## @param global.documentStore.type.aws.existingSecret (Deprecated) Use accessKeyId.secret and secretAccessKey.secret instead.
+                ## @param global.documentStore.type.aws.accessKeyIdKey (Deprecated) Use accessKeyId.secret instead.
+                ## @param global.documentStore.type.aws.secretAccessKeyKey (Deprecated) Use secretAccessKey.secret instead.
             gcp:
                 ## @param global.documentStore.type.gcp.enabled Enable GCP document store configuration.
                 enabled: false

--- a/versioned_docs/version-8.9/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/document-handling/configuration/helm.md
@@ -47,12 +47,20 @@ global:
                 bucketTtl: 0
                 ## @param global.documentStore.type.aws.class Fully qualified class name for the AWS document store provider.
                 class: "io.camunda.document.store.aws.AwsDocumentStoreProvider"
-                ## @param global.documentStore.type.aws.existingSecret Reference to an existing Kubernetes secret containing AWS credentials.
-                existingSecret: "aws-credentials"
-                ## @param global.documentStore.type.aws.accessKeyIdKey Key within the AWS credentials secret for AWS_ACCESS_KEY_ID.
-                accessKeyIdKey: "awsAccessKeyId"
-                ## @param global.documentStore.type.aws.secretAccessKeyKey Key within the AWS credentials secret for AWS_SECRET_ACCESS_KEY.
-                secretAccessKeyKey: "awsSecretAccessKey"
+                ## @extra global.documentStore.type.aws.accessKeyId configuration to provide the AWS access key ID.
+                accessKeyId:
+                  ## @param global.documentStore.type.aws.accessKeyId.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the access key ID.
+                  ## @param global.documentStore.type.aws.accessKeyId.secret.existingSecretKey defines the key within the existing secret object.
+                  secret:
+                    existingSecret: ""
+                    existingSecretKey: "access-key-id"
+                ## @extra global.documentStore.type.aws.secretAccessKey configuration to provide the AWS secret access key.
+                secretAccessKey:
+                  ## @param global.documentStore.type.aws.secretAccessKey.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the secret access key.
+                  ## @param global.documentStore.type.aws.secretAccessKey.secret.existingSecretKey defines the key within the existing secret object.
+                  secret:
+                    existingSecret: ""
+                    existingSecretKey: "secret-access-key"
             gcp:
                 ## @param global.documentStore.type.gcp.enabled Enable GCP document store configuration.
                 enabled: false


### PR DESCRIPTION
## Description

The AWS document store values example on the **Document handling configuration in Helm** page showed stale flat credential keys (`existingSecret`, `accessKeyIdKey`, `secretAccessKeyKey`) that no longer exist in the chart for 8.9+. The chart moved to a nested `accessKeyId.secret.*` / `secretAccessKey.secret.*` structure in Camunda 8.8 (where the flat keys became deprecated) and removed them in 8.9.

**Changes:**
- `docs/` (8.10): Replace flat keys with new nested structure
- `versioned_docs/version-8.9`: Replace flat keys with new nested structure
- `versioned_docs/version-8.8`: Replace flat keys with new nested structure as primary; retain deprecated flat keys as comments for reference
- `versioned_docs/version-8.7`: No change — flat keys are still correct for 8.7

Spotted during review of camunda/camunda-docs#9131.

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.