### PR TITLE
docs(self-managed): Helm TLS modes guide for Orchestration, Connectors, Optimize

### DIFF
--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -207,12 +207,12 @@ Note that `proxyVerify` covers only the NGINX → Orchestration leg. In-cluster 
 
 ## Supported modes
 
-| Mode | `global.tls.orchestration.rest.enabled` | `global.tls.orchestration.grpc.enabled` | `/orchestration` ingress backend | gRPC ingress backend-protocol | Web Modeler gRPC | Connectors gRPC | REST clients |
-| ---- | --------------------------------------- | --------------------------------------- | -------------------------------- | ----------------------------- | ---------------- | --------------- | ------------ |
-| Plaintext (default) | `false` | `false` | HTTP                             | `GRPC`                        | `grpc://`        | `http://`       | `http://`    |
-| REST TLS only       | `true`  | `false` | HTTPS                            | `GRPC`                        | `grpc://`        | `http://`       | `https://`   |
-| gRPC TLS only       | `false` | `true`  | HTTP                             | `GRPCS`                       | `grpcs://`       | `https://`      | `http://`    |
-| Both TLS            | `true`  | `true`  | HTTPS                            | `GRPCS`                       | `grpcs://`       | `https://`      | `https://`   |
+| Mode                | `global.tls.orchestration.rest.enabled` | `global.tls.orchestration.grpc.enabled` | `/orchestration` ingress backend | gRPC ingress backend-protocol | Web Modeler gRPC | Connectors gRPC | REST clients |
+| ------------------- | --------------------------------------- | --------------------------------------- | -------------------------------- | ----------------------------- | ---------------- | --------------- | ------------ |
+| Plaintext (default) | `false`                                 | `false`                                 | HTTP                             | `GRPC`                        | `grpc://`        | `http://`       | `http://`    |
+| REST TLS only       | `true`                                  | `false`                                 | HTTPS                            | `GRPC`                        | `grpc://`        | `http://`       | `https://`   |
+| gRPC TLS only       | `false`                                 | `true`                                  | HTTP                             | `GRPCS`                       | `grpcs://`       | `https://`      | `http://`    |
+| Both TLS            | `true`                                  | `true`                                  | HTTPS                            | `GRPCS`                       | `grpcs://`       | `https://`      | `https://`   |
 
 The chart derives Web Modeler and Connectors endpoints automatically. Explicit `webModeler.restapi.clusters` and `connectors.configuration` blocks remain authoritative — set them only if you need an endpoint shape the helpers do not produce.
 
@@ -352,4 +352,126 @@ kubectl -n <namespace> get deployment <release>-connectors \
 
 kubectl -n <namespace> get deployment <release>-connectors \
   -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.scheme}{"\n"}'
+```
+
+## Optimize TLS
+
+Optimize in 8.10 runs its own Spring Boot HTTP server and is exposed through a Gateway API `HTTPRoute` (not via an NGINX ingress). `global.tls.optimize` mirrors the Orchestration REST surface and configures TLS termination at the Optimize pod.
+
+This server-side TLS is independent of the existing client-side `optimize.database.elasticsearch.tls` / `optimize.database.opensearch.tls` (and legacy `global.elasticsearch.tls.existingSecret` / `global.opensearch.tls.existingSecret`) truststore wiring, which secures the Optimize → ES/OS connection direction. Both can be configured together; the chart mounts the server-side keystore as a separate `optimize-server-tls` volume that coexists with the existing client-side `keystore` truststore mount.
+
+### Modes
+
+- **PKCS12 (default)** — `secret.type: pkcs12`. The chart sets `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, and `SERVER_SSL_KEY_STORE_PASSWORD` (from a `secretKeyRef`) on the Optimize main container. Use when you manage keystores out-of-band (Java PKI, internal CA).
+- **PEM (cert-manager compatible)** — `secret.type: pem`. The chart sets `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` on the Optimize main container. Compatible with cert-manager `kubernetes.io/tls` Secrets out of the box.
+
+In both modes the chart:
+
+- Sets `SERVER_SSL_ENABLED=true` on the Optimize main container (and only the main container — the optional `migration` init container is untouched, since it does not serve HTTP).
+- Mounts the referenced Secret at `/usr/local/camunda/certificates/optimize/` as a `optimize-server-tls` projected Secret volume with mode `0440`.
+- Switches the container probes (`startupProbe` / `readinessProbe` / `livenessProbe`) to `HTTPS` when the user has left the probe `scheme` at its default `HTTP`.
+- Stamps a `checksum/optimize-tls` pod annotation when `global.tls.optimize.autoRollout: true`, so the next `helm upgrade` rolls Optimize on cert rotation.
+
+### Server-side vs client-side TLS in Optimize
+
+The two surfaces are deliberately orthogonal:
+
+| Direction                     | Values key                                                                                  | Volume name           | Purpose                                                                               |
+| ----------------------------- | ------------------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------- |
+| Inbound (clients → Optimize)  | `global.tls.optimize.secret.existingSecret`                                                 | `optimize-server-tls` | Server identity cert + key for the Optimize HTTP listener (this guide).               |
+| Outbound (Optimize → ES / OS) | `optimize.database.elasticsearch.tls.secret.existingSecret` (or `…opensearch.tls.secret.…`) | `keystore`            | Truststore so Optimize trusts the ES / OS server cert when calling secondary storage. |
+
+Operators commonly need both at once (mTLS-style hardening across the whole data plane). The chart supports both simultaneously; the regression test suite asserts that the `optimize-server-tls` and `keystore` volumes coexist with their respective mounts on the Optimize main container.
+
+### PKCS12 example
+
+```yaml
+global:
+  tls:
+    optimize:
+      enabled: true
+      secret:
+        existingSecret: optimize-tls-keystore
+        existingSecretKey: keystore.p12
+        existingSecretPasswordKey: keystore-password
+        keyAlias: optimize-rest
+    caBundle:
+      secret:
+        existingSecret: camunda-internal-ca
+        existingSecretKey: ca.crt
+```
+
+Create the Secret out-of-band:
+
+```shell
+openssl pkcs12 -export \
+  -in ./tls.crt -inkey ./tls.key \
+  -out ./keystore.p12 \
+  -password pass:changeit \
+  -name optimize-rest
+
+kubectl create secret generic optimize-tls-keystore \
+  --from-file=keystore.p12=./keystore.p12 \
+  --from-literal=keystore-password=changeit
+```
+
+### PEM example (cert-manager)
+
+```yaml
+global:
+  tls:
+    optimize:
+      enabled: true
+      secret:
+        existingSecret: optimize-cert
+        type: pem
+    caBundle:
+      secret:
+        existingSecret: camunda-internal-ca
+        existingSecretKey: ca.crt
+```
+
+With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (the PKCS12 default `existingSecretKey: keystore.p12` is auto-substituted to `tls.crt` in PEM mode).
+
+### Combined server + client TLS example
+
+```yaml
+global:
+  tls:
+    optimize:
+      enabled: true
+      secret:
+        existingSecret: optimize-tls-keystore
+    caBundle:
+      secret:
+        existingSecret: camunda-internal-ca
+        existingSecretKey: ca.crt
+optimize:
+  enabled: true
+  database:
+    elasticsearch:
+      tls:
+        enabled: true
+        secret:
+          existingSecret: elasticsearch-ca
+          existingSecretKey: ca.crt
+```
+
+The chart wires the inbound `optimize-server-tls` keystore for the Optimize HTTP listener AND the outbound `keystore` truststore that Optimize uses when calling Elasticsearch over HTTPS. Both paths are independent and may be enabled together.
+
+### Gateway API caveat
+
+In 8.10, Optimize is exposed via the Gateway API `HTTPRoute`, not via an NGINX `Ingress`. Backend HTTPS for Gateway API is configured at the listener / Service level on the gateway implementation — not via NGINX `backend-protocol` annotations. The `global.tls.optimize.proxyVerify` block is reserved for parity with the Orchestration surface and has no effect on the Gateway API path today. Intra-cluster TLS terminates at the Optimize pod with this configuration; backend-protocol selection for the gateway listener is a separate concern.
+
+### Verification
+
+```shell
+kubectl -n <namespace> get deployment <release>-optimize \
+  -o jsonpath='{.spec.template.spec.containers[0].env}' | jq '.[] | select(.name|startswith("SERVER_SSL_"))'
+
+kubectl -n <namespace> get deployment <release>-optimize \
+  -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.scheme}{"\n"}'
+
+kubectl -n <namespace> get deployment <release>-optimize \
+  -o jsonpath='{range .spec.template.spec.volumes[*]}{.name}{"\n"}{end}' | grep -E 'optimize-server-tls|keystore'
 ```

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -120,8 +120,11 @@ spec:
 # IMPORTANT: dnsNames must match the actual Kubernetes Service name
 # that fronts the Orchestration gRPC port (26500). Confirm with:
 #   kubectl -n camunda get svc -l app.kubernetes.io/component=zeebe-gateway
-# In the chart 8.10 default layout this is `<release>-zeebe-gateway`
-# (kept for backward compatibility through the Orchestration rebrand).
+# The Service name derives from orchestration.serviceName; in the chart 8.10
+# default layout it is typically `<release>-zeebe-gateway` (the
+# zeebe-gateway component label is kept for backward compatibility through
+# the Orchestration rebrand). Always confirm the actual name with the
+# command above rather than assuming it.
 # Substitute your actual release name for `my-release` below.
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -318,10 +321,10 @@ After deploying, confirm the in-cluster endpoints match the chosen mode:
 kubectl -n <namespace> get ingress <release>-grpc \
   -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/backend-protocol}{"\n"}'
 
-kubectl -n <namespace> get configmap <release>-connectors \
+kubectl -n <namespace> get configmap <release>-connectors-configuration \
   -o jsonpath='{.data.application\.yaml}' | grep -E 'grpc-address|rest-address'
 
-kubectl -n <namespace> get configmap <release>-web-modeler-restapi \
+kubectl -n <namespace> get configmap <release>-web-modeler-restapi-configuration \
   -o jsonpath='{.data.application\.yaml}' | grep -E '^\s+(grpc|rest):'
 ```
 

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -302,7 +302,7 @@ With this configuration the chart:
 - Renders the Web Modeler REST API ConfigMap with `grpc: grpcs://<orchestration-grpc-service>:26500`.
 - Renders the Connectors ConfigMap with `grpc-address: https://<orchestration-grpc-service>:26500`.
 
-Trust material for in-cluster Java components flows through [`global.tls.caBundle`](./secret-management.md). The CA bundle is mounted as a Java truststore into Orchestration, Web Modeler, Connectors, and any other Java components in the release.
+Trust material for in-cluster Java components flows through [`global.tls.caBundle`](#recipe-cert-manager--lets-encrypt-or-internal-issuer). The CA bundle is mounted as a Java truststore into Orchestration, Web Modeler, Connectors, and any other Java components in the release.
 
 ## Verification
 

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -54,13 +54,19 @@ The gRPC server only accepts PEM, so the gRPC `secret` block has no `type` field
 
 ### Cert rotation
 
-`global.tls.orchestration.autoRollout` mirrors `global.tls.caBundle.autoRollout`. When `true`, the chart stamps a `checksum/orchestration-tls-{rest,grpc}` pod annotation derived from **only the public cert content** of the configured Secret, so a `helm upgrade` rolls the Orchestration pods whenever the cert content changes. Hashing only the cert (not the keystore password or private key) means the annotation reveals nothing an attacker couldn't already learn from the TLS handshake — it cannot be replayed against candidate passwords. This uses Helm's `lookup`, which **requires the upgrading identity to have `get` on Secrets** in the release namespace and is **inert under GitOps tools that render with `helm template`**. Leave it off in those environments and rotate manually with `kubectl rollout restart statefulset/<release>-orchestration`.
+`global.tls.orchestration.autoRollout` mirrors `global.tls.caBundle.autoRollout`. When `true`, the chart stamps a `checksum/orchestration-tls-{rest,grpc}` pod annotation derived from the public cert content of the configured Secret. A `helm upgrade` then rolls the Orchestration pods whenever the cert content changes.
+
+The hash covers only the cert, not the keystore password or private key. That means the annotation reveals nothing an attacker could not already learn from the TLS handshake, and it cannot be replayed against candidate passwords.
+
+This uses Helm's `lookup`, which requires the upgrading identity to have `get` on Secrets in the release namespace. It is inert under GitOps tools that render with `helm template`. Leave `autoRollout` off in those environments and rotate manually with `kubectl rollout restart statefulset/<release>-orchestration`.
 
 One edge case: rotating **only the keystore password** without changing the cert content does not flip the hash, so autoRollout will not pick it up. In practice every modern rotation tool (cert-manager `Certificate` renewal, manual `openssl pkcs12 -export` cycles) writes a fresh keystore on each renewal, so the cert content changes too. For password-only rotation, use `kubectl rollout restart statefulset/<release>-orchestration`.
 
 ### Recipe: cert-manager + Let's Encrypt or internal Issuer
 
 cert-manager produces `kubernetes.io/tls` Secrets with `tls.crt` + `tls.key`. The chart consumes those directly — PEM for REST (via `type: pem`) and PEM for gRPC.
+
+This recipe assumes cert-manager v1.x is already installed in the cluster. If it is not, install it first per the [cert-manager installation guide](https://cert-manager.io/docs/installation/) (typically `helm install cert-manager jetstack/cert-manager --set crds.enabled=true`).
 
 If you are issuing certificates from a public ACME provider (Let's Encrypt, ZeroSSL, Buypass) skip directly to step 4 — your CA is already in the JVM default truststore and no `caBundle` is needed. The four-step block below covers the in-cluster CA flow that most Self-Managed installs use.
 
@@ -246,7 +252,7 @@ This adds the following annotations to the `/orchestration` and gRPC ingresses r
 - `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.existingSecret>`
 - `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost>` and `proxy-ssl-server-name: on` (only when `sniHost` is set)
 
-`proxyVerify` is opt-in independently per protocol — you can verify gRPC traffic only, REST only, or both. The CA Secret **must live in the same namespace as the Ingress resource** (an NGINX Ingress requirement). The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.existingSecret` is empty.
+`proxyVerify` is opt-in independently per protocol — you can verify gRPC traffic only, REST only, or both. By default the chart expects the CA Secret to live in the same namespace as the Ingress resource (an NGINX requirement). To reference a CA Secret in a different namespace (centralised cert-management namespace), set `caSecret.namespace`; the NGINX Ingress controller must be configured with `--watch-namespace` covering that namespace for the cross-namespace reference to resolve. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.existingSecret` is empty.
 
 Note that `proxyVerify` covers only the NGINX → Orchestration leg. In-cluster Java clients (Web Modeler, Connectors) trust upstream certs through `global.tls.caBundle`, which is independent.
 

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -9,7 +9,7 @@ Orchestration exposes a REST API (`SERVER_SSL_ENABLED`) and a gRPC API (`CAMUNDA
 
 :::caution Trust bundle is required for self-signed and private-PKI certificates
 
-The settings on this page configure the Orchestration **server** and the **NGINX ingress** legs. They do **not** by themselves teach in-cluster Java clients (Web Modeler, Connectors) to trust the cert. If the Orchestration server certificate is self-signed or issued by a private/internal CA, you **must also** set [`global.tls.caBundle.secret.existingSecret`](./secret-management.md) to a Secret holding the trust bundle. Without it, the JVM default truststore is used and gRPC/REST handshakes will fail.
+The settings on this page configure the Orchestration **server** and the **NGINX ingress** legs. They do **not** by themselves teach in-cluster Java clients (Web Modeler, Connectors) to trust the cert. If the Orchestration server certificate is self-signed or issued by a private/internal CA, you **must also** set `global.tls.caBundle.secret.existingSecret` to a Secret holding the CA bundle that signed it. Without it, the JVM default truststore is used and gRPC/REST handshakes from Web Modeler and Connectors will fail with `PKIX path building failed`. The minimal caBundle configuration is shown in the [cert-manager recipe](#recipe-cert-manager--lets-encrypt-or-internal-issuer) below.
 
 Certificates issued by a public CA already present in the JVM truststore (Let's Encrypt, DigiCert, etc.) do not require this.
 
@@ -62,29 +62,72 @@ One edge case: rotating **only the keystore password** without changing the cert
 
 cert-manager produces `kubernetes.io/tls` Secrets with `tls.crt` + `tls.key`. The chart consumes those directly — PEM for REST (via `type: pem`) and PEM for gRPC.
 
+If you are issuing certificates from a public ACME provider (Let's Encrypt, ZeroSSL, Buypass) skip directly to step 4 — your CA is already in the JVM default truststore and no `caBundle` is needed. The four-step block below covers the in-cluster CA flow that most Self-Managed installs use.
+
 ```yaml
-# 1. Issuer (or ClusterIssuer): in this example a self-signed in-cluster CA.
-#    For a public CA, use the cert-manager ACME / Let's Encrypt Issuer instead.
+# 1. Bootstrap Issuer. A bare selfSigned Issuer cannot issue a CA bundle on
+#    its own — it only signs each Certificate with that Certificate's own
+#    private key. It exists solely to sign step 2 (the actual CA Certificate).
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: camunda-ca
+  name: camunda-selfsigned-bootstrap
   namespace: camunda
 spec:
   selfSigned: {}
 ---
-# 2. Certificate request. SAN must match the in-cluster service hostname.
+# 2. The actual CA Certificate. isCA: true makes this a CA cert whose
+#    private key signs subsequent leaf certs. The resulting Secret
+#    (camunda-ca-bundle) is what global.tls.caBundle.secret.existingSecret
+#    points at — Web Modeler and Connectors load it into the JVM truststore.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: camunda-ca
+  namespace: camunda
+spec:
+  isCA: true
+  commonName: camunda-ca
+  secretName: camunda-ca-bundle
+  duration: 87600h # 10 years — pick a CA lifetime longer than any leaf
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: camunda-selfsigned-bootstrap
+    kind: Issuer
+---
+# 3. The CA Issuer. Uses the CA cert+key from step 2 to sign leaf
+#    Certificates. This is the Issuer your server Certificates reference.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: camunda-ca-issuer
+  namespace: camunda
+spec:
+  ca:
+    secretName: camunda-ca-bundle
+---
+# 4. Server Certificate (gRPC shown; REST is identical with its own
+#    secretName + dnsNames matching the REST service).
+#
+# IMPORTANT: dnsNames must match the actual Kubernetes Service name
+# that fronts the Orchestration gRPC port (26500). Confirm with:
+#   kubectl -n camunda get svc -l app.kubernetes.io/component=zeebe-gateway
+# In the chart 8.10 default layout this is `<release>-zeebe-gateway`
+# (kept for backward compatibility through the Orchestration rebrand).
+# Substitute your actual release name for `my-release` below.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: orchestration-grpc-cert
   namespace: camunda
 spec:
-  secretName: orchestration-grpc-cert # → matches existingSecret below
+  secretName: orchestration-grpc-cert # → matches existingSecret in values
   duration: 8760h
   renewBefore: 720h
   issuerRef:
-    name: camunda-ca
+    name: camunda-ca-issuer # step 3, NOT the bootstrap
     kind: Issuer
   dnsNames:
     - my-release-zeebe-gateway
@@ -102,7 +145,7 @@ global:
       rest:
         enabled: true
         secret:
-          existingSecret: orchestration-rest-cert # also a cert-manager Certificate
+          existingSecret: orchestration-rest-cert # a step-4 Certificate for the REST service
           type: pem
           # existingSecretKey defaults to tls.crt when type=pem (auto-substituted)
           # existingSecretPrivateKeyKey defaults to tls.key
@@ -114,9 +157,11 @@ global:
           # existingSecretPrivateKeyKey defaults to tls.key
     caBundle:
       secret:
-        # For an internal CA Issuer, expose the CA cert as a Secret and reference it
-        # here so Web Modeler and Connectors trust it. Skip this if the cert is from
-        # a public CA already in the JVM truststore.
+        # The CA cert Secret from step 2 above. Web Modeler and Connectors
+        # load this into the JVM truststore so their handshakes to the
+        # Orchestration REST and gRPC servers succeed. Skip this whole
+        # block if your server certs are from a public CA already in the
+        # JVM default truststore (Let's Encrypt, DigiCert, etc.).
         existingSecret: camunda-ca-bundle
         existingSecretKey: ca.crt
       autoRollout: true

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -1,0 +1,355 @@
+---
+id: orchestration-tls-modes
+sidebar_label: Orchestration TLS modes
+title: Configure Orchestration REST and gRPC TLS modes
+description: Enable REST TLS and gRPC TLS independently on the Orchestration component with first-class Helm values.
+---
+
+Orchestration exposes a REST API (`SERVER_SSL_ENABLED`) and a gRPC API (`CAMUNDA_API_GRPC_SSL_ENABLED`) as independent server settings. The Camunda 8 Helm chart provides a first-class values surface that configures both server flags, the public NGINX ingress backend protocol, and the in-cluster client schemes used by Web Modeler and Connectors. Customers no longer need to duplicate `webModeler.restapi.clusters` or `connectors.configuration` blocks just to enable Orchestration TLS.
+
+:::caution Trust bundle is required for self-signed and private-PKI certificates
+
+The settings on this page configure the Orchestration **server** and the **NGINX ingress** legs. They do **not** by themselves teach in-cluster Java clients (Web Modeler, Connectors) to trust the cert. If the Orchestration server certificate is self-signed or issued by a private/internal CA, you **must also** set [`global.tls.caBundle.secret.existingSecret`](./secret-management.md) to a Secret holding the trust bundle. Without it, the JVM default truststore is used and gRPC/REST handshakes will fail.
+
+Certificates issued by a public CA already present in the JVM truststore (Let's Encrypt, DigiCert, etc.) do not require this.
+
+:::
+
+## First-class values
+
+```yaml
+global:
+  tls:
+    orchestration:
+      autoRollout: false # opt-in: roll Orchestration pods on Secret rotation (requires Secret read RBAC)
+      rest:
+        enabled: false # REST TLS — sets SERVER_SSL_ENABLED on Orchestration
+        secret:
+          existingSecret: "" # Kubernetes secret holding the REST server cert material
+          type: pkcs12 # one of: pkcs12, pem
+          existingSecretKey: keystore.p12 # pkcs12: keystore file; pem: certificate file (e.g. tls.crt)
+          existingSecretPrivateKeyKey: tls.key # pem only — private-key file
+          existingSecretPasswordKey: keystore-password # pkcs12 only — keystore password key
+          keyAlias: "" # pkcs12 only — optional cert alias inside the keystore
+      grpc:
+        enabled: false # gRPC TLS — sets CAMUNDA_API_GRPC_SSL_ENABLED on Orchestration
+        secret:
+          existingSecret: "" # Kubernetes secret with PEM cert + key for the gRPC server
+          existingSecretKey: tls.crt
+          existingSecretPrivateKeyKey: tls.key
+```
+
+Both flags default to `false`. Set either independently to enable that protocol's TLS. Explicit `orchestration.env` entries with the same name override these flags (Kubernetes last-wins on duplicate env names).
+
+When `enabled: true`, the chart fails template rendering unless the cert material is configured either via the `secret` sub-block (recommended) or via explicit env vars (`SERVER_SSL_KEY_STORE` / `SERVER_SSL_CERTIFICATE` for REST, `CAMUNDA_API_GRPC_SSL_CERTIFICATE` for gRPC). This prevents the silent Spring Boot / gRPC startup crash that would otherwise occur.
+
+### REST TLS: PKCS12 vs PEM
+
+The REST `secret.type` field selects which Spring Boot SSL property family the chart emits:
+
+- **`pkcs12` (default)** — emits `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, `SERVER_SSL_KEY_STORE_PASSWORD` (via `secretKeyRef`), and optionally `SERVER_SSL_KEY_ALIAS`.
+- **`pem`** — emits `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` (Spring Boot 2.7+). Use this for cert-manager `kubernetes.io/tls` Secrets (`tls.crt` + `tls.key`) and Let's Encrypt-issued certificates — no manual PKCS12 conversion needed.
+
+The gRPC server only accepts PEM, so the gRPC `secret` block has no `type` field.
+
+### Cert rotation
+
+`global.tls.orchestration.autoRollout` mirrors `global.tls.caBundle.autoRollout`. When `true`, the chart stamps a `checksum/orchestration-tls-{rest,grpc}` pod annotation derived from **only the public cert content** of the configured Secret, so a `helm upgrade` rolls the Orchestration pods whenever the cert content changes. Hashing only the cert (not the keystore password or private key) means the annotation reveals nothing an attacker couldn't already learn from the TLS handshake — it cannot be replayed against candidate passwords. This uses Helm's `lookup`, which **requires the upgrading identity to have `get` on Secrets** in the release namespace and is **inert under GitOps tools that render with `helm template`**. Leave it off in those environments and rotate manually with `kubectl rollout restart statefulset/<release>-orchestration`.
+
+One edge case: rotating **only the keystore password** without changing the cert content does not flip the hash, so autoRollout will not pick it up. In practice every modern rotation tool (cert-manager `Certificate` renewal, manual `openssl pkcs12 -export` cycles) writes a fresh keystore on each renewal, so the cert content changes too. For password-only rotation, use `kubectl rollout restart statefulset/<release>-orchestration`.
+
+### Recipe: cert-manager + Let's Encrypt or internal Issuer
+
+cert-manager produces `kubernetes.io/tls` Secrets with `tls.crt` + `tls.key`. The chart consumes those directly — PEM for REST (via `type: pem`) and PEM for gRPC.
+
+```yaml
+# 1. Issuer (or ClusterIssuer): in this example a self-signed in-cluster CA.
+#    For a public CA, use the cert-manager ACME / Let's Encrypt Issuer instead.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: camunda-ca
+  namespace: camunda
+spec:
+  selfSigned: {}
+---
+# 2. Certificate request. SAN must match the in-cluster service hostname.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: orchestration-grpc-cert
+  namespace: camunda
+spec:
+  secretName: orchestration-grpc-cert # → matches existingSecret below
+  duration: 8760h
+  renewBefore: 720h
+  issuerRef:
+    name: camunda-ca
+    kind: Issuer
+  dnsNames:
+    - my-release-zeebe-gateway
+    - my-release-zeebe-gateway.camunda.svc
+    - my-release-zeebe-gateway.camunda.svc.cluster.local
+```
+
+Then in the chart values:
+
+```yaml
+global:
+  tls:
+    orchestration:
+      autoRollout: true # cert-manager renews on schedule; this rolls Orchestration on renewal
+      rest:
+        enabled: true
+        secret:
+          existingSecret: orchestration-rest-cert # also a cert-manager Certificate
+          type: pem
+          # existingSecretKey defaults to tls.crt when type=pem (auto-substituted)
+          # existingSecretPrivateKeyKey defaults to tls.key
+      grpc:
+        enabled: true
+        secret:
+          existingSecret: orchestration-grpc-cert
+          # existingSecretKey defaults to tls.crt
+          # existingSecretPrivateKeyKey defaults to tls.key
+    caBundle:
+      secret:
+        # For an internal CA Issuer, expose the CA cert as a Secret and reference it
+        # here so Web Modeler and Connectors trust it. Skip this if the cert is from
+        # a public CA already in the JVM truststore.
+        existingSecret: camunda-ca-bundle
+        existingSecretKey: ca.crt
+      autoRollout: true
+```
+
+### Migrating from a hand-wired Orchestration TLS setup
+
+Before this guide existed, customers enabled Orchestration TLS by hand-wiring everything in `orchestration.env` plus `extraVolumes`/`extraVolumeMounts`. The legacy shape still works (the helpers OR-merge the new flag with the env vars), so an upgrade is non-breaking by default. To migrate to the first-class surface:
+
+**Before** (legacy):
+
+```yaml
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+  extraVolumes:
+    - name: orchestration-tls
+      secret:
+        secretName: orchestration-grpc-cert
+  extraVolumeMounts:
+    - name: orchestration-tls
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true
+```
+
+**After** (first-class):
+
+```yaml
+global:
+  tls:
+    orchestration:
+      grpc:
+        enabled: true
+        secret:
+          existingSecret: orchestration-grpc-cert
+```
+
+The `helm upgrade` will roll the Orchestration StatefulSet because the rendered env vars and volume names change. Expect a brief outage during the rolling restart (no data loss — PVCs are unchanged). Existing hand-written `webModeler.restapi.clusters` or `connectors.configuration` blocks remain authoritative; if their `grpc-address` / `rest-address` matches what the chart would derive (visible via `helm template`), you can delete them too.
+
+### Verifying the backend cert at the ingress (NGINX)
+
+By default NGINX Ingress talks TLS to the upstream when `backend-protocol: HTTPS`/`GRPCS` is set, but **does not verify the upstream cert** — any cert is accepted. For Zero-Trust networks where this would leave a sidecar-interception gap, opt in via the `proxyVerify` sub-block on each protocol:
+
+```yaml
+global:
+  tls:
+    orchestration:
+      rest:
+        enabled: true
+        secret:
+          existingSecret: orchestration-rest-cert
+          type: pem
+          existingSecretKey: tls.crt
+          existingSecretPrivateKeyKey: tls.key
+        proxyVerify:
+          enabled: true
+          caSecret:
+            existingSecret: orchestration-upstream-ca # PEM CA bundle
+            existingSecretKey: ca.crt
+          sniHost: "" # set when the cert SAN does not match the in-cluster service name
+      grpc:
+        enabled: true
+        secret:
+          existingSecret: orchestration-grpc-cert
+          existingSecretKey: tls.crt
+          existingSecretPrivateKeyKey: tls.key
+        proxyVerify:
+          enabled: true
+          caSecret:
+            existingSecret: orchestration-upstream-ca
+            existingSecretKey: ca.crt
+```
+
+This adds the following annotations to the `/orchestration` and gRPC ingresses respectively:
+
+- `nginx.ingress.kubernetes.io/proxy-ssl-verify: on`
+- `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.existingSecret>`
+- `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost>` and `proxy-ssl-server-name: on` (only when `sniHost` is set)
+
+`proxyVerify` is opt-in independently per protocol — you can verify gRPC traffic only, REST only, or both. The CA Secret **must live in the same namespace as the Ingress resource** (an NGINX Ingress requirement). The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.existingSecret` is empty.
+
+Note that `proxyVerify` covers only the NGINX → Orchestration leg. In-cluster Java clients (Web Modeler, Connectors) trust upstream certs through `global.tls.caBundle`, which is independent.
+
+## Supported modes
+
+| Mode | `global.tls.orchestration.rest.enabled` | `global.tls.orchestration.grpc.enabled` | `/orchestration` ingress backend | gRPC ingress backend-protocol | Web Modeler gRPC | Connectors gRPC | REST clients |
+| ---- | --------------------------------------- | --------------------------------------- | -------------------------------- | ----------------------------- | ---------------- | --------------- | ------------ |
+| Plaintext (default) | `false` | `false` | HTTP                             | `GRPC`                        | `grpc://`        | `http://`       | `http://`    |
+| REST TLS only       | `true`  | `false` | HTTPS                            | `GRPC`                        | `grpc://`        | `http://`       | `https://`   |
+| gRPC TLS only       | `false` | `true`  | HTTP                             | `GRPCS`                       | `grpcs://`       | `https://`      | `http://`    |
+| Both TLS            | `true`  | `true`  | HTTPS                            | `GRPCS`                       | `grpcs://`       | `https://`      | `https://`   |
+
+The chart derives Web Modeler and Connectors endpoints automatically. Explicit `webModeler.restapi.clusters` and `connectors.configuration` blocks remain authoritative — set them only if you need an endpoint shape the helpers do not produce.
+
+## Example: REST plaintext + gRPC TLS
+
+This is the SUPPORT-33090 customer shape: an internal Zero-Trust network where the gRPC API must be TLS-protected but the REST API stays on plaintext behind the cluster ingress.
+
+```yaml
+global:
+  host: camunda.example.com
+  ingress:
+    enabled: true
+    tls:
+      enabled: true
+      secretName: camunda-platform-tls
+  tls:
+    orchestration:
+      grpc:
+        enabled: true
+        secret:
+          existingSecret: orchestration-grpc-cert
+          existingSecretKey: tls.crt
+          existingSecretPrivateKeyKey: tls.key
+    caBundle:
+      secret:
+        existingSecret: camunda-internal-ca
+        existingSecretKey: ca.crt
+```
+
+The chart mounts `orchestration-grpc-cert` into the Orchestration pod and sets `CAMUNDA_API_GRPC_SSL_CERTIFICATE` / `CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY` to the mounted paths automatically. Create the secret out-of-band, for example:
+
+```shell
+kubectl create secret generic orchestration-grpc-cert \
+  --from-file=tls.crt=./tls.crt \
+  --from-file=tls.key=./tls.key
+```
+
+With this configuration the chart:
+
+- Sets `CAMUNDA_API_GRPC_SSL_ENABLED=true` on the Orchestration container.
+- Annotates the public gRPC ingress with `nginx.ingress.kubernetes.io/backend-protocol: GRPCS`.
+- Renders the Web Modeler REST API ConfigMap with `grpc: grpcs://<orchestration-grpc-service>:26500`.
+- Renders the Connectors ConfigMap with `grpc-address: https://<orchestration-grpc-service>:26500`.
+
+Trust material for in-cluster Java components flows through [`global.tls.caBundle`](./secret-management.md). The CA bundle is mounted as a Java truststore into Orchestration, Web Modeler, Connectors, and any other Java components in the release.
+
+## Verification
+
+After deploying, confirm the in-cluster endpoints match the chosen mode:
+
+```shell
+kubectl -n <namespace> get ingress <release>-grpc \
+  -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/backend-protocol}{"\n"}'
+
+kubectl -n <namespace> get configmap <release>-connectors \
+  -o jsonpath='{.data.application\.yaml}' | grep -E 'grpc-address|rest-address'
+
+kubectl -n <namespace> get configmap <release>-web-modeler-restapi \
+  -o jsonpath='{.data.application\.yaml}' | grep -E '^\s+(grpc|rest):'
+```
+
+## Connectors TLS
+
+Connectors in 8.10 runs its own Spring Boot HTTP server and is exposed through a Gateway API `HTTPRoute` (not via an NGINX ingress). `global.tls.connectors` mirrors the Orchestration REST surface and configures TLS termination at the Connectors pod.
+
+### Modes
+
+- **PKCS12 (default)** — `secret.type: pkcs12`. The chart sets `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, and `SERVER_SSL_KEY_STORE_PASSWORD` (from a `secretKeyRef`) on the Connectors container. Use when you manage keystores out-of-band (Java PKI, internal CA).
+- **PEM (cert-manager compatible)** — `secret.type: pem`. The chart sets `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` on the Connectors container. Compatible with cert-manager `kubernetes.io/tls` Secrets out of the box.
+
+In both modes the chart:
+
+- Sets `SERVER_SSL_ENABLED=true` on the Connectors container.
+- Mounts the referenced Secret at `/usr/local/camunda/certificates/connectors/`.
+- Switches the container probes (`startupProbe` / `readinessProbe` / `livenessProbe`) to `HTTPS`.
+- Stamps a `checksum/connectors-tls` pod annotation when `global.tls.connectors.autoRollout: true`, so the next `helm upgrade` rolls Connectors on cert rotation.
+
+### PKCS12 example
+
+```yaml
+global:
+  tls:
+    connectors:
+      enabled: true
+      secret:
+        existingSecret: connectors-tls-keystore
+        existingSecretKey: keystore.p12
+        existingSecretPasswordKey: keystore-password
+        keyAlias: connectors-rest
+    caBundle:
+      secret:
+        existingSecret: camunda-internal-ca
+        existingSecretKey: ca.crt
+```
+
+Create the Secret out-of-band:
+
+```shell
+openssl pkcs12 -export \
+  -in ./tls.crt -inkey ./tls.key \
+  -out ./keystore.p12 \
+  -password pass:changeit \
+  -name connectors-rest
+
+kubectl create secret generic connectors-tls-keystore \
+  --from-file=keystore.p12=./keystore.p12 \
+  --from-literal=keystore-password=changeit
+```
+
+### PEM example (cert-manager)
+
+```yaml
+global:
+  tls:
+    connectors:
+      enabled: true
+      secret:
+        existingSecret: connectors-cert
+        type: pem
+    caBundle:
+      secret:
+        existingSecret: camunda-internal-ca
+        existingSecretKey: ca.crt
+```
+
+With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (the PKCS12 default `existingSecretKey: keystore.p12` is auto-substituted to `tls.crt` in PEM mode).
+
+### Gateway API caveat
+
+In 8.10, Connectors is exposed via the Gateway API `HTTPRoute`, not via an NGINX `Ingress`. Backend HTTPS for Gateway API is configured at the listener / Service level on the gateway implementation — not via NGINX `backend-protocol` annotations. The `global.tls.connectors.proxyVerify` block is reserved for parity with the Orchestration surface and has no effect on the Gateway API path today. Intra-cluster TLS terminates at the Connectors pod with this configuration; backend-protocol selection for the gateway listener is a separate concern.
+
+### Verification
+
+```shell
+kubectl -n <namespace> get deployment <release>-connectors \
+  -o jsonpath='{.spec.template.spec.containers[0].env}' | jq '.[] | select(.name|startswith("SERVER_SSL_"))'
+
+kubectl -n <namespace> get deployment <release>-connectors \
+  -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.scheme}{"\n"}'
+```

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -24,19 +24,34 @@ global:
       autoRollout: false # opt-in: roll Orchestration pods on Secret rotation (requires Secret read RBAC)
       rest:
         enabled: false # REST TLS — sets SERVER_SSL_ENABLED on Orchestration
-        secret:
-          existingSecret: "" # Kubernetes secret holding the REST server cert material
-          type: pkcs12 # one of: pkcs12, pem
-          existingSecretKey: keystore.p12 # pkcs12: keystore file; pem: certificate file (e.g. tls.crt)
-          existingSecretPrivateKeyKey: tls.key # pem only — private-key file
-          existingSecretPasswordKey: keystore-password # pkcs12 only — keystore password key
-          keyAlias: "" # pkcs12 only — optional cert alias inside the keystore
+        type: pkcs12 # one of: pkcs12, pem
+        keyAlias: "" # pkcs12 only — optional cert alias inside the keystore
+        cert:
+          secret:
+            existingSecret: "" # Kubernetes Secret holding the REST server cert (or PKCS12 keystore)
+            existingSecretKey: "" # pkcs12: keystore file key (default keystore.p12); pem: cert key (default tls.crt)
+        privateKey:
+          secret:
+            existingSecretKey: tls.key # pem only — private-key key inside the Secret
+        keystorePassword:
+          secret:
+            existingSecretKey: keystore-password # pkcs12 only — keystore password key inside the Secret
+        proxyVerify:
+          enabled: false
+          caSecret:
+            secret:
+              existingSecret: "" # Secret holding the CA bundle for NGINX upstream verification
+              existingSecretKey: ca.crt
+            namespace: "" # optional: CA Secret namespace (defaults to release namespace)
       grpc:
         enabled: false # gRPC TLS — sets CAMUNDA_API_GRPC_SSL_ENABLED on Orchestration
-        secret:
-          existingSecret: "" # Kubernetes secret with PEM cert + key for the gRPC server
-          existingSecretKey: tls.crt
-          existingSecretPrivateKeyKey: tls.key
+        cert:
+          secret:
+            existingSecret: "" # Kubernetes Secret with PEM cert for the gRPC server
+            existingSecretKey: "" # defaults to tls.crt
+        privateKey:
+          secret:
+            existingSecretKey: tls.key
 ```
 
 Both flags default to `false`. Set either independently to enable that protocol's TLS. Explicit `orchestration.env` entries with the same name override these flags (Kubernetes last-wins on duplicate env names).
@@ -45,7 +60,7 @@ When `enabled: true`, the chart fails template rendering unless the cert materia
 
 ### REST TLS: PKCS12 vs PEM
 
-The REST `secret.type` field selects which Spring Boot SSL property family the chart emits:
+The REST `type` field selects which Spring Boot SSL property family the chart emits:
 
 - **`pkcs12` (default)** — emits `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, `SERVER_SSL_KEY_STORE_PASSWORD` (via `secretKeyRef`), and optionally `SERVER_SSL_KEY_ALIAS`.
 - **`pem`** — emits `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` (Spring Boot 2.7+). Use this for cert-manager `kubernetes.io/tls` Secrets (`tls.crt` + `tls.key`) and Let's Encrypt-issued certificates — no manual PKCS12 conversion needed.
@@ -153,17 +168,19 @@ global:
       autoRollout: true # cert-manager renews on schedule; this rolls Orchestration on renewal
       rest:
         enabled: true
-        secret:
-          existingSecret: orchestration-rest-cert # a step-4 Certificate for the REST service
-          type: pem
-          # existingSecretKey defaults to tls.crt when type=pem (auto-substituted)
-          # existingSecretPrivateKeyKey defaults to tls.key
+        type: pem
+        cert:
+          secret:
+            existingSecret: orchestration-rest-cert # a step-4 Certificate for the REST service
+            # existingSecretKey defaults to tls.crt when type=pem (auto-substituted)
+        # privateKey.secret.existingSecretKey defaults to tls.key
       grpc:
         enabled: true
-        secret:
-          existingSecret: orchestration-grpc-cert
-          # existingSecretKey defaults to tls.crt
-          # existingSecretPrivateKeyKey defaults to tls.key
+        cert:
+          secret:
+            existingSecret: orchestration-grpc-cert
+            # existingSecretKey defaults to tls.crt
+        # privateKey.secret.existingSecretKey defaults to tls.key
     caBundle:
       secret:
         # The CA cert Secret from step 2 above. Web Modeler and Connectors
@@ -209,8 +226,9 @@ global:
     orchestration:
       grpc:
         enabled: true
-        secret:
-          existingSecret: orchestration-grpc-cert
+        cert:
+          secret:
+            existingSecret: orchestration-grpc-cert
 ```
 
 The `helm upgrade` will roll the Orchestration StatefulSet because the rendered env vars and volume names change. Expect a brief outage during the rolling restart (no data loss — PVCs are unchanged). Existing hand-written `webModeler.restapi.clusters` or `connectors.configuration` blocks remain authoritative; if their `grpc-address` / `rest-address` matches what the chart would derive (visible via `helm template`), you can delete them too.
@@ -225,37 +243,45 @@ global:
     orchestration:
       rest:
         enabled: true
-        secret:
-          existingSecret: orchestration-rest-cert
-          type: pem
-          existingSecretKey: tls.crt
-          existingSecretPrivateKeyKey: tls.key
+        type: pem
+        cert:
+          secret:
+            existingSecret: orchestration-rest-cert
+            existingSecretKey: tls.crt
+        privateKey:
+          secret:
+            existingSecretKey: tls.key
         proxyVerify:
           enabled: true
           caSecret:
-            existingSecret: orchestration-upstream-ca # PEM CA bundle
-            existingSecretKey: ca.crt
+            secret:
+              existingSecret: orchestration-upstream-ca # PEM CA bundle
+              existingSecretKey: ca.crt
           sniHost: "" # set when the cert SAN does not match the in-cluster service name
       grpc:
         enabled: true
-        secret:
-          existingSecret: orchestration-grpc-cert
-          existingSecretKey: tls.crt
-          existingSecretPrivateKeyKey: tls.key
+        cert:
+          secret:
+            existingSecret: orchestration-grpc-cert
+            existingSecretKey: tls.crt
+        privateKey:
+          secret:
+            existingSecretKey: tls.key
         proxyVerify:
           enabled: true
           caSecret:
-            existingSecret: orchestration-upstream-ca
-            existingSecretKey: ca.crt
+            secret:
+              existingSecret: orchestration-upstream-ca
+              existingSecretKey: ca.crt
 ```
 
 This adds the following annotations to the `/orchestration` and gRPC ingresses respectively:
 
 - `nginx.ingress.kubernetes.io/proxy-ssl-verify: on`
-- `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.existingSecret>`
+- `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.secret.existingSecret>`
 - `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost>` and `proxy-ssl-server-name: on` (only when `sniHost` is set)
 
-`proxyVerify` is opt-in independently per protocol — you can verify gRPC traffic only, REST only, or both. By default the chart expects the CA Secret to live in the same namespace as the Ingress resource (an NGINX requirement). To reference a CA Secret in a different namespace (centralised cert-management namespace), set `caSecret.namespace`; the NGINX Ingress controller must be configured with `--watch-namespace` covering that namespace for the cross-namespace reference to resolve. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.existingSecret` is empty.
+`proxyVerify` is opt-in independently per protocol — you can verify gRPC traffic only, REST only, or both. By default the chart expects the CA Secret to live in the same namespace as the Ingress resource (an NGINX requirement). To reference a CA Secret in a different namespace (centralised cert-management namespace), set `caSecret.namespace`; the NGINX Ingress controller must be configured with `--watch-namespace` covering that namespace for the cross-namespace reference to resolve. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.secret.existingSecret` is empty.
 
 Note that `proxyVerify` covers only the NGINX → Orchestration leg. In-cluster Java clients (Web Modeler, Connectors) trust upstream certs through `global.tls.caBundle`, which is independent.
 
@@ -286,10 +312,13 @@ global:
     orchestration:
       grpc:
         enabled: true
-        secret:
-          existingSecret: orchestration-grpc-cert
-          existingSecretKey: tls.crt
-          existingSecretPrivateKeyKey: tls.key
+        cert:
+          secret:
+            existingSecret: orchestration-grpc-cert
+            existingSecretKey: tls.crt
+        privateKey:
+          secret:
+            existingSecretKey: tls.key
     caBundle:
       secret:
         existingSecret: camunda-internal-ca
@@ -334,8 +363,8 @@ Connectors in 8.10 runs its own Spring Boot HTTP server and is exposed through a
 
 ### Modes
 
-- **PKCS12 (default)** — `secret.type: pkcs12`. The chart sets `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, and `SERVER_SSL_KEY_STORE_PASSWORD` (from a `secretKeyRef`) on the Connectors container. Use when you manage keystores out-of-band (Java PKI, internal CA).
-- **PEM (cert-manager compatible)** — `secret.type: pem`. The chart sets `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` on the Connectors container. Compatible with cert-manager `kubernetes.io/tls` Secrets out of the box.
+- **PKCS12 (default)** — `type: pkcs12`. The chart sets `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, and `SERVER_SSL_KEY_STORE_PASSWORD` (from a `secretKeyRef`) on the Connectors container. Use when you manage keystores out-of-band (Java PKI, internal CA).
+- **PEM (cert-manager compatible)** — `type: pem`. The chart sets `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` on the Connectors container. Compatible with cert-manager `kubernetes.io/tls` Secrets out of the box.
 
 In both modes the chart:
 
@@ -351,11 +380,15 @@ global:
   tls:
     connectors:
       enabled: true
-      secret:
-        existingSecret: connectors-tls-keystore
-        existingSecretKey: keystore.p12
-        existingSecretPasswordKey: keystore-password
-        keyAlias: connectors-rest
+      type: pkcs12
+      keyAlias: connectors-rest
+      cert:
+        secret:
+          existingSecret: connectors-tls-keystore
+          existingSecretKey: keystore.p12
+      keystorePassword:
+        secret:
+          existingSecretKey: keystore-password
     caBundle:
       secret:
         existingSecret: camunda-internal-ca
@@ -383,16 +416,18 @@ global:
   tls:
     connectors:
       enabled: true
-      secret:
-        existingSecret: connectors-cert
-        type: pem
+      type: pem
+      cert:
+        secret:
+          existingSecret: connectors-cert
+          # existingSecretKey defaults to tls.crt when type=pem (auto-substituted)
     caBundle:
       secret:
         existingSecret: camunda-internal-ca
         existingSecretKey: ca.crt
 ```
 
-With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (the PKCS12 default `existingSecretKey: keystore.p12` is auto-substituted to `tls.crt` in PEM mode).
+With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (when `cert.secret.existingSecretKey` is left empty in PEM mode, `tls.crt` is substituted automatically).
 
 ### Gateway API caveat
 
@@ -416,8 +451,8 @@ This server-side TLS is independent of the existing client-side `optimize.databa
 
 ### Modes
 
-- **PKCS12 (default)** — `secret.type: pkcs12`. The chart sets `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, and `SERVER_SSL_KEY_STORE_PASSWORD` (from a `secretKeyRef`) on the Optimize main container. Use when you manage keystores out-of-band (Java PKI, internal CA).
-- **PEM (cert-manager compatible)** — `secret.type: pem`. The chart sets `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` on the Optimize main container. Compatible with cert-manager `kubernetes.io/tls` Secrets out of the box.
+- **PKCS12 (default)** — `type: pkcs12`. The chart sets `SERVER_SSL_KEY_STORE`, `SERVER_SSL_KEY_STORE_TYPE=PKCS12`, and `SERVER_SSL_KEY_STORE_PASSWORD` (from a `secretKeyRef`) on the Optimize main container. Use when you manage keystores out-of-band (Java PKI, internal CA).
+- **PEM (cert-manager compatible)** — `type: pem`. The chart sets `SERVER_SSL_CERTIFICATE` and `SERVER_SSL_CERTIFICATE_PRIVATE_KEY` on the Optimize main container. Compatible with cert-manager `kubernetes.io/tls` Secrets out of the box.
 
 In both modes the chart:
 
@@ -432,7 +467,7 @@ The two surfaces are deliberately orthogonal:
 
 | Direction                     | Values key                                                                                  | Volume name           | Purpose                                                                               |
 | ----------------------------- | ------------------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------- |
-| Inbound (clients → Optimize)  | `global.tls.optimize.secret.existingSecret`                                                 | `optimize-server-tls` | Server identity cert + key for the Optimize HTTP listener (this guide).               |
+| Inbound (clients → Optimize)  | `global.tls.optimize.cert.secret.existingSecret`                                            | `optimize-server-tls` | Server identity cert + key for the Optimize HTTP listener (this guide).               |
 | Outbound (Optimize → ES / OS) | `optimize.database.elasticsearch.tls.secret.existingSecret` (or `…opensearch.tls.secret.…`) | `keystore`            | Truststore so Optimize trusts the ES / OS server cert when calling secondary storage. |
 
 Operators commonly need both at once (mTLS-style hardening across the whole data plane). The chart supports both simultaneously; the regression test suite asserts that the `optimize-server-tls` and `keystore` volumes coexist with their respective mounts on the Optimize main container.
@@ -444,11 +479,15 @@ global:
   tls:
     optimize:
       enabled: true
-      secret:
-        existingSecret: optimize-tls-keystore
-        existingSecretKey: keystore.p12
-        existingSecretPasswordKey: keystore-password
-        keyAlias: optimize-rest
+      type: pkcs12
+      keyAlias: optimize-rest
+      cert:
+        secret:
+          existingSecret: optimize-tls-keystore
+          existingSecretKey: keystore.p12
+      keystorePassword:
+        secret:
+          existingSecretKey: keystore-password
     caBundle:
       secret:
         existingSecret: camunda-internal-ca
@@ -476,16 +515,18 @@ global:
   tls:
     optimize:
       enabled: true
-      secret:
-        existingSecret: optimize-cert
-        type: pem
+      type: pem
+      cert:
+        secret:
+          existingSecret: optimize-cert
+          # existingSecretKey defaults to tls.crt when type=pem (auto-substituted)
     caBundle:
       secret:
         existingSecret: camunda-internal-ca
         existingSecretKey: ca.crt
 ```
 
-With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (the PKCS12 default `existingSecretKey: keystore.p12` is auto-substituted to `tls.crt` in PEM mode).
+With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (when `cert.secret.existingSecretKey` is left empty in PEM mode, `tls.crt` is substituted automatically).
 
 ### Combined server + client TLS example
 
@@ -494,8 +535,9 @@ global:
   tls:
     optimize:
       enabled: true
-      secret:
-        existingSecret: optimize-tls-keystore
+      cert:
+        secret:
+          existingSecret: optimize-tls-keystore
     caBundle:
       secret:
         existingSecret: camunda-internal-ca

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -233,7 +233,7 @@ The `helm upgrade` will roll the Orchestration StatefulSet because the rendered 
 
 ### Verify the REST backend certificate at the Ingress (NGINX)
 
-By default, NGINX Ingress uses TLS for the REST upstream when `backend-protocol: HTTPS` is set, but it doesn't verify the upstream certificate. Enable `proxyVerify` under `global.tls.orchestration.rest` to verify the REST certificate. The chart doesn't support `proxyVerify` for gRPC because ingress-nginx applies its `proxy-ssl-*` annotations to `proxy_pass`, not the `grpc_pass` used by a GRPCS backend.
+By default, NGINX Ingress uses TLS for the REST upstream when `backend-protocol: HTTPS` is set, but it doesn't verify the upstream certificate. Enable `proxyVerify` under `global.tls.orchestration.rest` to verify the REST certificate. The chart doesn't support `proxyVerify` for gRPC because the Ingress-NGINX controller applies its `proxy-ssl-*` annotations to `proxy_pass`, not the `grpc_pass` used by a GRPCS backend.
 
 ```yaml
 global:
@@ -264,7 +264,7 @@ This adds the following annotations to the `/orchestration` Ingress:
 - `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.secret.existingSecret>`
 - `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost>` and `proxy-ssl-server-name: on` (only when `sniHost` is set)
 
-The CA Secret must contain the CA bundle under the fixed `ca.crt` key. By default, the chart expects the Secret in the same namespace as the Ingress resource. To reference a Secret in a different namespace, set `caSecret.namespace` and configure the ingress-nginx controller with `allow-cross-namespace-resources=true`. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.secret.existingSecret` is empty.
+The CA Secret must contain the CA bundle under the fixed `ca.crt` key. By default, the chart expects the Secret in the same namespace as the Ingress resource. To reference a Secret in a different namespace, set `caSecret.namespace` and configure the Ingress-NGINX controller with `allow-cross-namespace-resources=true`. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.secret.existingSecret` is empty.
 
 Note that `proxyVerify` covers only the NGINX → Orchestration leg. In-cluster Java clients (Web Modeler, Connectors) trust upstream certs through `global.tls.caBundle`, which is independent.
 

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -262,7 +262,10 @@ This adds the following annotations to the `/orchestration` Ingress:
 
 - `nginx.ingress.kubernetes.io/proxy-ssl-verify: on`
 - `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.secret.existingSecret>`
-- `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost>` and `proxy-ssl-server-name: on` (only when `sniHost` is set)
+- `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost-or-orchestration-service-name>`
+- `nginx.ingress.kubernetes.io/proxy-ssl-server-name: on`
+
+The chart defaults `proxy-ssl-name` to the Orchestration Service name. Set `sniHost` only when the certificate subject alternative name requires a different hostname.
 
 The CA Secret must contain the CA bundle under the fixed `ca.crt` key. By default, the chart expects the Secret in the same namespace as the Ingress resource. To reference a Secret in a different namespace, set `caSecret.namespace` and configure the Ingress-NGINX controller with `allow-cross-namespace-resources=true`. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.secret.existingSecret` is empty.
 
@@ -430,7 +433,7 @@ kubectl -n <namespace> get deployment <release>-connectors \
 
 Optimize in 8.10 runs its own Spring Boot HTTP server. The chart can expose it through an NGINX Ingress or a Gateway API `HTTPRoute`. `global.tls.optimize` mirrors the Orchestration REST configuration and enables TLS at the Optimize pod.
 
-This server-side TLS is independent of the existing client-side `optimize.database.elasticsearch.tls` / `optimize.database.opensearch.tls` configuration. The legacy `global.elasticsearch.tls.secret.existingSecret` and `global.opensearch.tls.secret.existingSecret` paths also configure the client truststore. Both directions can use TLS together. The chart mounts the server certificate from a regular Secret volume named `optimize-server-tls`, alongside the client-side `keystore` truststore mount.
+This server-side TLS is independent of the existing client-side `optimize.database.elasticsearch.tls` / `optimize.database.opensearch.tls` configuration. Both directions can use TLS together. The chart mounts the server certificate from a regular Secret volume named `optimize-server-tls`, alongside the client-side `keystore` truststore mount when configured.
 
 ### Modes
 
@@ -453,7 +456,7 @@ The two surfaces are deliberately orthogonal:
 | Inbound (clients → Optimize)  | `global.tls.optimize.cert.secret.existingSecret`                                            | `optimize-server-tls` | Server identity cert + key for the Optimize HTTP listener (this guide).               |
 | Outbound (Optimize → ES / OS) | `optimize.database.elasticsearch.tls.secret.existingSecret` (or `…opensearch.tls.secret.…`) | `keystore`            | Truststore so Optimize trusts the ES / OS server cert when calling secondary storage. |
 
-Operators commonly need both at once (mTLS-style hardening across the whole data plane). The chart supports both simultaneously; the regression test suite asserts that the `optimize-server-tls` and `keystore` volumes coexist with their respective mounts on the Optimize main container.
+Operators commonly need TLS for both inbound and outbound connections. These are independent one-way TLS connections; neither side requires a client certificate. The chart supports both simultaneously, and the `optimize-server-tls` and `keystore` volumes can coexist with their respective mounts on the Optimize main container.
 
 ### PKCS12 example
 
@@ -529,14 +532,11 @@ optimize:
   enabled: true
   database:
     elasticsearch:
-      tls:
-        enabled: true
-        secret:
-          existingSecret: elasticsearch-ca
-          existingSecretKey: ca.crt
+      url:
+        protocol: https
 ```
 
-The chart wires the inbound `optimize-server-tls` keystore for the Optimize HTTP listener AND the outbound `keystore` truststore that Optimize uses when calling Elasticsearch over HTTPS. Both paths are independent and may be enabled together.
+The chart wires the inbound `optimize-server-tls` keystore for the Optimize HTTP listener. For the outbound connection, `url.protocol: https` enables HTTPS and `global.tls.caBundle` supplies the PEM CA that Optimize uses to trust Elasticsearch. Both paths are independent and may be enabled together.
 
 ### Configure inbound routing
 

--- a/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
+++ b/docs/self-managed/deployment/helm/configure/orchestration-tls-modes.md
@@ -5,11 +5,11 @@ title: Configure Orchestration REST and gRPC TLS modes
 description: Enable REST TLS and gRPC TLS independently on the Orchestration component with first-class Helm values.
 ---
 
-Orchestration exposes a REST API (`SERVER_SSL_ENABLED`) and a gRPC API (`CAMUNDA_API_GRPC_SSL_ENABLED`) as independent server settings. The Camunda 8 Helm chart provides a first-class values surface that configures both server flags, the public NGINX ingress backend protocol, and the in-cluster client schemes used by Web Modeler and Connectors. Customers no longer need to duplicate `webModeler.restapi.clusters` or `connectors.configuration` blocks just to enable Orchestration TLS.
+Orchestration exposes a REST API (`SERVER_SSL_ENABLED`) and a gRPC API (`CAMUNDA_API_GRPC_SSL_ENABLED`) as independent server settings. The Camunda 8 Helm chart provides a first-class values surface that configures both server flags, the public NGINX Ingress backend protocol, and the in-cluster client schemes used by Web Modeler and Connectors. Customers no longer need to duplicate `webModeler.restapi.clusters` or `connectors.configuration` blocks just to enable Orchestration TLS.
 
 :::caution Trust bundle is required for self-signed and private-PKI certificates
 
-The settings on this page configure the Orchestration **server** and the **NGINX ingress** legs. They do **not** by themselves teach in-cluster Java clients (Web Modeler, Connectors) to trust the cert. If the Orchestration server certificate is self-signed or issued by a private/internal CA, you **must also** set `global.tls.caBundle.secret.existingSecret` to a Secret holding the CA bundle that signed it. Without it, the JVM default truststore is used and gRPC/REST handshakes from Web Modeler and Connectors will fail with `PKIX path building failed`. The minimal caBundle configuration is shown in the [cert-manager recipe](#recipe-cert-manager--lets-encrypt-or-internal-issuer) below.
+The settings on this page configure the Orchestration **server** and the **NGINX Ingress** legs. They do **not** by themselves teach in-cluster Java clients (Web Modeler, Connectors) to trust the cert. If the Orchestration server certificate is self-signed or issued by a private/internal CA, you **must also** set `global.tls.caBundle.secret.existingSecret` to a Secret holding the CA bundle that signed it. Without it, the JVM default truststore is used and gRPC/REST handshakes from Web Modeler and Connectors will fail with `PKIX path building failed`. The minimal caBundle configuration is shown in the [cert-manager recipe](#recipe-cert-manager--lets-encrypt-or-internal-issuer) below.
 
 Certificates issued by a public CA already present in the JVM truststore (Let's Encrypt, DigiCert, etc.) do not require this.
 
@@ -69,13 +69,11 @@ The gRPC server only accepts PEM, so the gRPC `secret` block has no `type` field
 
 ### Cert rotation
 
-`global.tls.orchestration.autoRollout` mirrors `global.tls.caBundle.autoRollout`. When `true`, the chart stamps a `checksum/orchestration-tls-{rest,grpc}` pod annotation derived from the public cert content of the configured Secret. A `helm upgrade` then rolls the Orchestration pods whenever the cert content changes.
+`global.tls.orchestration.autoRollout` mirrors `global.tls.caBundle.autoRollout`. When `true`, the chart stamps `checksum/orchestration-tls-{rest,grpc}` pod annotations derived from the configured Secret. For PEM REST and gRPC certificates, the hash covers both the certificate and private key. For PKCS12, it covers the keystore. A `helm upgrade` then rolls the Orchestration pods when this material changes.
 
-The hash covers only the cert, not the keystore password or private key. That means the annotation reveals nothing an attacker could not already learn from the TLS handshake, and it cannot be replayed against candidate passwords.
+The hash deliberately excludes the keystore password. Rotate the password with the keystore material or restart the StatefulSet manually after a password-only change.
 
 This uses Helm's `lookup`, which requires the upgrading identity to have `get` on Secrets in the release namespace. It is inert under GitOps tools that render with `helm template`. Leave `autoRollout` off in those environments and rotate manually with `kubectl rollout restart statefulset/<release>-orchestration`.
-
-One edge case: rotating **only the keystore password** without changing the cert content does not flip the hash, so autoRollout will not pick it up. In practice every modern rotation tool (cert-manager `Certificate` renewal, manual `openssl pkcs12 -export` cycles) writes a fresh keystore on each renewal, so the cert content changes too. For password-only rotation, use `kubectl rollout restart statefulset/<release>-orchestration`.
 
 ### Recipe: cert-manager + Let's Encrypt or internal Issuer
 
@@ -83,7 +81,7 @@ cert-manager produces `kubernetes.io/tls` Secrets with `tls.crt` + `tls.key`. Th
 
 This recipe assumes cert-manager v1.x is already installed in the cluster. If it is not, install it first per the [cert-manager installation guide](https://cert-manager.io/docs/installation/) (typically `helm install cert-manager jetstack/cert-manager --set crds.enabled=true`).
 
-If you are issuing certificates from a public ACME provider (Let's Encrypt, ZeroSSL, Buypass) skip directly to step 4 — your CA is already in the JVM default truststore and no `caBundle` is needed. The four-step block below covers the in-cluster CA flow that most Self-Managed installs use.
+The four-step example below creates and uses an internal CA. For a public ACME provider such as Let's Encrypt, don't apply steps one through three. In the server `Certificate` from step four, replace `issuerRef.name` and `issuerRef.kind` with the name and kind of your existing ACME `Issuer` or `ClusterIssuer`. Public CA certificates already present in the JVM default truststore don't need `global.tls.caBundle`.
 
 ```yaml
 # 1. Bootstrap Issuer. A bare selfSigned Issuer cannot issue a CA bundle on
@@ -233,9 +231,9 @@ global:
 
 The `helm upgrade` will roll the Orchestration StatefulSet because the rendered env vars and volume names change. Expect a brief outage during the rolling restart (no data loss — PVCs are unchanged). Existing hand-written `webModeler.restapi.clusters` or `connectors.configuration` blocks remain authoritative; if their `grpc-address` / `rest-address` matches what the chart would derive (visible via `helm template`), you can delete them too.
 
-### Verifying the backend cert at the ingress (NGINX)
+### Verify the REST backend certificate at the Ingress (NGINX)
 
-By default NGINX Ingress talks TLS to the upstream when `backend-protocol: HTTPS`/`GRPCS` is set, but **does not verify the upstream cert** — any cert is accepted. For Zero-Trust networks where this would leave a sidecar-interception gap, opt in via the `proxyVerify` sub-block on each protocol:
+By default, NGINX Ingress uses TLS for the REST upstream when `backend-protocol: HTTPS` is set, but it doesn't verify the upstream certificate. Enable `proxyVerify` under `global.tls.orchestration.rest` to verify the REST certificate. The chart doesn't support `proxyVerify` for gRPC because ingress-nginx applies its `proxy-ssl-*` annotations to `proxy_pass`, not the `grpc_pass` used by a GRPCS backend.
 
 ```yaml
 global:
@@ -258,36 +256,21 @@ global:
               existingSecret: orchestration-upstream-ca # PEM CA bundle
               existingSecretKey: ca.crt
           sniHost: "" # set when the cert SAN does not match the in-cluster service name
-      grpc:
-        enabled: true
-        cert:
-          secret:
-            existingSecret: orchestration-grpc-cert
-            existingSecretKey: tls.crt
-        privateKey:
-          secret:
-            existingSecretKey: tls.key
-        proxyVerify:
-          enabled: true
-          caSecret:
-            secret:
-              existingSecret: orchestration-upstream-ca
-              existingSecretKey: ca.crt
 ```
 
-This adds the following annotations to the `/orchestration` and gRPC ingresses respectively:
+This adds the following annotations to the `/orchestration` Ingress:
 
 - `nginx.ingress.kubernetes.io/proxy-ssl-verify: on`
 - `nginx.ingress.kubernetes.io/proxy-ssl-secret: <namespace>/<caSecret.secret.existingSecret>`
 - `nginx.ingress.kubernetes.io/proxy-ssl-name: <sniHost>` and `proxy-ssl-server-name: on` (only when `sniHost` is set)
 
-`proxyVerify` is opt-in independently per protocol — you can verify gRPC traffic only, REST only, or both. By default the chart expects the CA Secret to live in the same namespace as the Ingress resource (an NGINX requirement). To reference a CA Secret in a different namespace (centralised cert-management namespace), set `caSecret.namespace`; the NGINX Ingress controller must be configured with `--watch-namespace` covering that namespace for the cross-namespace reference to resolve. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.secret.existingSecret` is empty.
+The CA Secret must contain the CA bundle under the fixed `ca.crt` key. By default, the chart expects the Secret in the same namespace as the Ingress resource. To reference a Secret in a different namespace, set `caSecret.namespace` and configure the ingress-nginx controller with `allow-cross-namespace-resources=true`. The chart fails template rendering if `proxyVerify.enabled: true` and `caSecret.secret.existingSecret` is empty.
 
 Note that `proxyVerify` covers only the NGINX → Orchestration leg. In-cluster Java clients (Web Modeler, Connectors) trust upstream certs through `global.tls.caBundle`, which is independent.
 
 ## Supported modes
 
-| Mode                | `global.tls.orchestration.rest.enabled` | `global.tls.orchestration.grpc.enabled` | `/orchestration` ingress backend | gRPC ingress backend-protocol | Web Modeler gRPC | Connectors gRPC | REST clients |
+| Mode                | `global.tls.orchestration.rest.enabled` | `global.tls.orchestration.grpc.enabled` | `/orchestration` Ingress backend | gRPC Ingress backend-protocol | Web Modeler gRPC | Connectors gRPC | REST clients |
 | ------------------- | --------------------------------------- | --------------------------------------- | -------------------------------- | ----------------------------- | ---------------- | --------------- | ------------ |
 | Plaintext (default) | `false`                                 | `false`                                 | HTTP                             | `GRPC`                        | `grpc://`        | `http://`       | `http://`    |
 | REST TLS only       | `true`                                  | `false`                                 | HTTPS                            | `GRPC`                        | `grpc://`        | `http://`       | `https://`   |
@@ -298,7 +281,7 @@ The chart derives Web Modeler and Connectors endpoints automatically. Explicit `
 
 ## Example: REST plaintext + gRPC TLS
 
-This is the SUPPORT-33090 customer shape: an internal Zero-Trust network where the gRPC API must be TLS-protected but the REST API stays on plaintext behind the cluster ingress.
+This is the SUPPORT-33090 customer shape: an internal Zero-Trust network where the gRPC API must be TLS-protected but the REST API stays on plaintext behind the cluster Ingress.
 
 ```yaml
 global:
@@ -336,7 +319,7 @@ kubectl create secret generic orchestration-grpc-cert \
 With this configuration the chart:
 
 - Sets `CAMUNDA_API_GRPC_SSL_ENABLED=true` on the Orchestration container.
-- Annotates the public gRPC ingress with `nginx.ingress.kubernetes.io/backend-protocol: GRPCS`.
+- Annotates the public gRPC Ingress with `nginx.ingress.kubernetes.io/backend-protocol: GRPCS`.
 - Renders the Web Modeler REST API ConfigMap with `grpc: grpcs://<orchestration-grpc-service>:26500`.
 - Renders the Connectors ConfigMap with `grpc-address: https://<orchestration-grpc-service>:26500`.
 
@@ -359,7 +342,7 @@ kubectl -n <namespace> get configmap <release>-web-modeler-restapi-configuration
 
 ## Connectors TLS
 
-Connectors in 8.10 runs its own Spring Boot HTTP server and is exposed through a Gateway API `HTTPRoute` (not via an NGINX ingress). `global.tls.connectors` mirrors the Orchestration REST surface and configures TLS termination at the Connectors pod.
+Connectors in 8.10 runs its own Spring Boot HTTP server. The chart can expose it through an NGINX Ingress or a Gateway API `HTTPRoute`. `global.tls.connectors` mirrors the Orchestration REST configuration and enables TLS at the Connectors pod.
 
 ### Modes
 
@@ -429,9 +412,9 @@ global:
 
 With a cert-manager `Certificate` that issues into the same namespace, the resulting `kubernetes.io/tls` Secret already carries `tls.crt` and `tls.key` — the chart picks them up automatically (when `cert.secret.existingSecretKey` is left empty in PEM mode, `tls.crt` is substituted automatically).
 
-### Gateway API caveat
+### Configure inbound routing
 
-In 8.10, Connectors is exposed via the Gateway API `HTTPRoute`, not via an NGINX `Ingress`. Backend HTTPS for Gateway API is configured at the listener / Service level on the gateway implementation — not via NGINX `backend-protocol` annotations. The `global.tls.connectors.proxyVerify` block is reserved for parity with the Orchestration surface and has no effect on the Gateway API path today. Intra-cluster TLS terminates at the Connectors pod with this configuration; backend-protocol selection for the gateway listener is a separate concern.
+The dedicated NGINX Ingress template sets its backend protocol to HTTPS when Connectors TLS is enabled. The Gateway API `HTTPRoute` still forwards plaintext unless a `BackendTLSPolicy` targets the Connectors Service. Create that policy according to your Gateway implementation and configure its certificate validation before enabling pod TLS. Without the policy, inbound Connectors traffic through the generated `HTTPRoute` fails.
 
 ### Verification
 
@@ -445,9 +428,9 @@ kubectl -n <namespace> get deployment <release>-connectors \
 
 ## Optimize TLS
 
-Optimize in 8.10 runs its own Spring Boot HTTP server and is exposed through a Gateway API `HTTPRoute` (not via an NGINX ingress). `global.tls.optimize` mirrors the Orchestration REST surface and configures TLS termination at the Optimize pod.
+Optimize in 8.10 runs its own Spring Boot HTTP server. The chart can expose it through an NGINX Ingress or a Gateway API `HTTPRoute`. `global.tls.optimize` mirrors the Orchestration REST configuration and enables TLS at the Optimize pod.
 
-This server-side TLS is independent of the existing client-side `optimize.database.elasticsearch.tls` / `optimize.database.opensearch.tls` (and legacy `global.elasticsearch.tls.existingSecret` / `global.opensearch.tls.existingSecret`) truststore wiring, which secures the Optimize → ES/OS connection direction. Both can be configured together; the chart mounts the server-side keystore as a separate `optimize-server-tls` volume that coexists with the existing client-side `keystore` truststore mount.
+This server-side TLS is independent of the existing client-side `optimize.database.elasticsearch.tls` / `optimize.database.opensearch.tls` configuration. The legacy `global.elasticsearch.tls.secret.existingSecret` and `global.opensearch.tls.secret.existingSecret` paths also configure the client truststore. Both directions can use TLS together. The chart mounts the server certificate from a regular Secret volume named `optimize-server-tls`, alongside the client-side `keystore` truststore mount.
 
 ### Modes
 
@@ -457,8 +440,8 @@ This server-side TLS is independent of the existing client-side `optimize.databa
 In both modes the chart:
 
 - Sets `SERVER_SSL_ENABLED=true` on the Optimize main container (and only the main container — the optional `migration` init container is untouched, since it does not serve HTTP).
-- Mounts the referenced Secret at `/usr/local/camunda/certificates/optimize/` as a `optimize-server-tls` projected Secret volume with mode `0440`.
-- Switches the container probes (`startupProbe` / `readinessProbe` / `livenessProbe`) to `HTTPS` when the user has left the probe `scheme` at its default `HTTP`.
+- Mounts the referenced Secret at `/usr/local/camunda/certificates/optimize/` as a regular Secret volume named `optimize-server-tls`.
+- Uses HTTPS for `startupProbe`, `readinessProbe`, and `livenessProbe` when their `scheme` values are empty, which is the default. An explicit scheme remains authoritative, including `HTTP`.
 - Stamps a `checksum/optimize-tls` pod annotation when `global.tls.optimize.autoRollout: true`, so the next `helm upgrade` rolls Optimize on cert rotation.
 
 ### Server-side vs client-side TLS in Optimize
@@ -555,9 +538,9 @@ optimize:
 
 The chart wires the inbound `optimize-server-tls` keystore for the Optimize HTTP listener AND the outbound `keystore` truststore that Optimize uses when calling Elasticsearch over HTTPS. Both paths are independent and may be enabled together.
 
-### Gateway API caveat
+### Configure inbound routing
 
-In 8.10, Optimize is exposed via the Gateway API `HTTPRoute`, not via an NGINX `Ingress`. Backend HTTPS for Gateway API is configured at the listener / Service level on the gateway implementation — not via NGINX `backend-protocol` annotations. The `global.tls.optimize.proxyVerify` block is reserved for parity with the Orchestration surface and has no effect on the Gateway API path today. Intra-cluster TLS terminates at the Optimize pod with this configuration; backend-protocol selection for the gateway listener is a separate concern.
+The dedicated NGINX Ingress template sets its backend protocol to HTTPS when Optimize TLS is enabled. The Gateway API `HTTPRoute` still forwards plaintext unless a `BackendTLSPolicy` targets the Optimize Service. Create that policy according to your Gateway implementation and configure its certificate validation before enabling pod TLS. Without the policy, inbound Optimize traffic through the generated `HTTPRoute` fails.
 
 ### Verification
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1750,6 +1750,7 @@ module.exports = {
                 //   ],
                 // },
                 "self-managed/deployment/helm/configure/application-configs",
+                "self-managed/deployment/helm/configure/orchestration-tls-modes",
                 "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/operator-based-infrastructure",
                 "self-managed/deployment/helm/configure/enable-additional-components",

--- a/sidebars.js
+++ b/sidebars.js
@@ -1797,6 +1797,7 @@ module.exports = {
                 //   ],
                 // },
                 "self-managed/deployment/helm/configure/application-configs",
+                "self-managed/deployment/helm/configure/orchestration-tls-modes",
                 "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/pod-scheduling",
                 "self-managed/deployment/helm/configure/operator-based-infrastructure",


### PR DESCRIPTION
## Description

Adds a new Self-Managed configuration guide documenting the first-class TLS values introduced by the `global.tls.<component>.*` surface in chart 8.10. Covers three components today:

- **Orchestration** — REST (`SERVER_SSL_*`) and gRPC (`CAMUNDA_API_GRPC_SSL_*`)
- **Connectors** — Spring Boot `SERVER_SSL_*`
- **Optimize** — Spring Boot `SERVER_SSL_*` (distinct from existing Optimize-as-client ES/OS truststore)

Each section covers the PKCS12 and PEM modes, a cert-manager recipe, the `caBundle` requirement for self-signed certs, and the autoRollout edge case for password-only rotations. Page also adds the sidebar nav entry.

Related Helm PRs (stack):

> | PR | What |
> |---|---|
> | [helm#6423](https://github.com/camunda/camunda-platform-helm/pull/6423) | first-class TLS for Orchestration |
> | [helm#6425](https://github.com/camunda/camunda-platform-helm/pull/6425) | first-class TLS for Connectors (stacked on #6423) |
> | [helm#6426](https://github.com/camunda/camunda-platform-helm/pull/6426) | first-class TLS for Optimize (stacked on #6425) |
> | **docs#new** | **← you are here** — guide covering all three |

Web Modeler TLS is deferred — upstream \`hub-websockets\` (Laravel/PHP) does not appear to support pod-level TLS today; it expects ingress-level termination. A follow-up docs section will be added if/when the upstream image gains TLS support.

Closes part of camunda/camunda-platform-helm#6356.

## When should this change go live?

- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using \`{type}(scope): {description}\` commit message(s)

- [x] My changes are for **an upcoming minor release** and are in the \`/docs\` directory.
- [ ] My changes are for an **already released minor** and are in a \`/versioned_docs\` directory.

- [x] I included my new page in the sidebar file(s).

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via \`@camunda/tech-writers\` unless working with an embedded writer.


Fixes https://github.com/camunda/camunda-platform-helm/issues/6356