### PR TITLE
ci: speed up deploy by using gcloud instead of gsutil

### DIFF
--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -118,7 +118,7 @@ jobs:
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         run: |
-          gsutil -m rsync -d -r build gs://$BUCKET_NAME/pr-${{ github.event.number }}
+          gcloud storage rsync --gzip-in-flight-all --delete-unmatched-destination-objects --recursive build gs://$BUCKET_NAME/pr-${{ github.event.number }}
 
       - uses: bobheadxi/deployments@v1
         with:


### PR DESCRIPTION
Reduces upload times significantly. Before:
- [9 minutes](https://github.com/camunda/camunda-docs/actions/runs/28033187530/job/82982442873?pr=9176) 
- [8 minutes](https://github.com/camunda/camunda-docs/actions/runs/28030935759/job/82973919300)

With these changes, we are under two minutes: https://github.com/camunda/camunda-docs/actions/runs/28035168806/job/82988894261?pr=9177