### PR TITLE
Use camelCase for Elasticsearch/OpenSearch exporter configuration keys

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -51,7 +51,7 @@ camunda:
   data:
     exporters:
       elasticsearch:
-        class-name: io.camunda.zeebe.exporter.ElasticsearchExporter
+        className: io.camunda.zeebe.exporter.ElasticsearchExporter
         args:
         # Refer to the table below for the available args options
 ```
@@ -143,9 +143,9 @@ camunda:
       elasticsearch:
         args:
           index:
-            variable-name-inclusion-start-with:
+            variableNameInclusionStartWith:
               - business_
-            variable-name-exclusion-start-with:
+            variableNameExclusionStartWith:
               - business_debug
 ```
 
@@ -166,10 +166,10 @@ camunda:
       elasticsearch:
         args:
           index:
-            variable-value-type-inclusion:
+            variableValueTypeInclusion:
               - Object
               - String
-            variable-value-type-exclusion:
+            variableValueTypeExclusion:
               - Object
 ```
 
@@ -191,28 +191,28 @@ camunda:
       elasticsearch:
         args:
           index:
-            export-local-variables-enabled: true
+            exportLocalVariablesEnabled: true
 
             # Root variable name filters
-            root-variable-name-inclusion-exact: []
-            root-variable-name-inclusion-start-with: []
-            root-variable-name-inclusion-end-with: []
-            root-variable-name-exclusion-exact: []
-            root-variable-name-exclusion-start-with: []
-            root-variable-name-exclusion-end-with: []
+            rootVariableNameInclusionExact: []
+            rootVariableNameInclusionStartWith: []
+            rootVariableNameInclusionEndWith: []
+            rootVariableNameExclusionExact: []
+            rootVariableNameExclusionStartWith: []
+            rootVariableNameExclusionEndWith: []
             # Local variable name filters
-            local-variable-name-inclusion-exact: []
-            local-variable-name-inclusion-start-with: []
-            local-variable-name-inclusion-end-with: []
-            local-variable-name-exclusion-exact: []
-            local-variable-name-exclusion-start-with: []
-            local-variable-name-exclusion-end-with: []
+            localVariableNameInclusionExact: []
+            localVariableNameInclusionStartWith: []
+            localVariableNameInclusionEndWith: []
+            localVariableNameExclusionExact: []
+            localVariableNameExclusionStartWith: []
+            localVariableNameExclusionEndWith: []
             # Root variable type filters
-            root-variable-value-type-inclusion: []
-            root-variable-value-type-exclusion: []
+            rootVariableValueTypeInclusion: []
+            rootVariableValueTypeExclusion: []
             # Local variable type filters
-            local-variable-value-type-inclusion: []
-            local-variable-value-type-exclusion: []
+            localVariableValueTypeInclusion: []
+            localVariableValueTypeExclusion: []
 ```
 
 Behavior overview:
@@ -228,14 +228,14 @@ Export only selected root variables and exclude temporary local variables:
 
 ```yaml
 index:
-  export-local-variables-enabled: true
+  exportLocalVariablesEnabled: true
 
   # Include only specific root variables
-  root-variable-name-inclusion-exact: ["customerId", "orderId"]
+  rootVariableNameInclusionExact: ["customerId", "orderId"]
   # Exclude local variables used for temporary processing
-  local-variable-name-exclusion-start-with: ["tmp_", "debug_"]
+  localVariableNameExclusionStartWith: ["tmp_", "debug_"]
   # Export only simple root variable types
-  root-variable-value-type-inclusion: ["String", "Number"]
+  rootVariableValueTypeInclusion: ["String", "Number"]
 ```
 
 In this example:
@@ -257,9 +257,9 @@ camunda:
       elasticsearch:
         args:
           index:
-            bpmn-process-id-inclusion:
+            bpmnProcessIdInclusion:
               - orderProcess
-            bpmn-process-id-exclusion:
+            bpmnProcessIdExclusion:
               - debugProcess
 ```
 
@@ -280,7 +280,7 @@ camunda:
       elasticsearch:
         args:
           index:
-            optimize-mode-enabled: true
+            optimizeModeEnabled: true
 ```
 
 When enabled, the exporter emits only the value types and intents that Optimize imports. Other value types are dropped unless you explicitly opt in to the legacy behavior (for example, via `include-enabled-records`).
@@ -362,7 +362,7 @@ camunda:
         # These settings can also be overridden using environment variables "CAMUNDA_DATA_EXPORTERS_ELASTICSEARCH_..."
         #
 
-        class-name: io.camunda.zeebe.exporter.ElasticsearchExporter
+        className: io.camunda.zeebe.exporter.ElasticsearchExporter
         args:
           # A comma separated list of URLs pointing to the Elasticsearch instances you wish to export to.
           # For example, if you want to connect to multiple nodes for redundancy:
@@ -372,12 +372,12 @@ camunda:
           bulk:
             delay: 5
             size: 1000
-            memory-limit: 10485760
+            memoryLimit: 10485760
 
           retention:
             enabled: true
-            minimum-age: 30d
-            policy-name: zeebe-records-retention-policy
+            minimumAge: 30d
+            policyName: zeebe-records-retention-policy
 
           authentication:
             username: elastic
@@ -385,43 +385,43 @@ camunda:
 
           index:
             prefix: zeebe-record
-            create-template: true
+            createTemplate: true
 
-            index-suffix-date-pattern: "yyyy-MM-dd"
+            indexSuffixDatePattern: "yyyy-MM-dd"
 
             command: false
             event: true
             rejection: false
 
-            command-distribution: true
-            decision-requirements: true
+            commandDistribution: true
+            decisionRequirements: true
             decision: true
-            decision-evaluation: true
+            decisionEvaluation: true
             deployment: true
-            deployment-distribution: true
+            deploymentDistribution: true
             error: true
             escalation: true
             form: true
             incident: true
             job: true
-            job-batch: false
+            jobBatch: false
             message: true
-            message-start-subscription: true
-            message-subscription: true
+            messageStartSubscription: true
+            messageSubscription: true
             process: true
-            process-event: false
-            process-instance: true
-            process-instance-creation: true
-            process-instance-migration: true
-            process-instance-modification: true
-            process-message-subscription: true
-            resource-deletion: true
+            processEvent: false
+            processInstance: true
+            processInstanceCreation: true
+            processInstanceMigration: true
+            processInstanceModification: true
+            processMessageSubscription: true
+            resourceDeletion: true
             signal: true
-            signal-subscription: true
+            signalSubscription: true
             timer: true
-            user-task: true
+            userTask: true
             variable: true
-            variable-document: true
+            variableDocument: true
 ```
 
 ## Self-signed certificates

--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -50,7 +50,7 @@ camunda:
   data:
     exporters:
       opensearch:
-        class-name: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
+        className: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
         args:
         # Refer to the table below for the available args options
 ```
@@ -141,9 +141,9 @@ camunda:
       opensearch:
         args:
           index:
-            variable-name-inclusion-start-with:
+            variableNameInclusionStartWith:
               - business_
-            variable-name-exclusion-start-with:
+            variableNameExclusionStartWith:
               - business_debug
 ```
 
@@ -164,10 +164,10 @@ camunda:
       opensearch:
         args:
           index:
-            variable-value-type-inclusion:
+            variableValueTypeInclusion:
               - Object
               - String
-            variable-value-type-exclusion:
+            variableValueTypeExclusion:
               - Object
 ```
 
@@ -189,28 +189,28 @@ camunda:
       opensearch:
         args:
           index:
-            export-local-variables-enabled: true
+            exportLocalVariablesEnabled: true
 
             # Root variable name filters
-            root-variable-name-inclusion-exact: []
-            root-variable-name-inclusion-start-with: []
-            root-variable-name-inclusion-end-with: []
-            root-variable-name-exclusion-exact: []
-            root-variable-name-exclusion-start-with: []
-            root-variable-name-exclusion-end-with: []
+            rootVariableNameInclusionExact: []
+            rootVariableNameInclusionStartWith: []
+            rootVariableNameInclusionEndWith: []
+            rootVariableNameExclusionExact: []
+            rootVariableNameExclusionStartWith: []
+            rootVariableNameExclusionEndWith: []
             # Local variable name filters
-            local-variable-name-inclusion-exact: []
-            local-variable-name-inclusion-start-with: []
-            local-variable-name-inclusion-end-with: []
-            local-variable-name-exclusion-exact: []
-            local-variable-name-exclusion-start-with: []
-            local-variable-name-exclusion-end-with: []
+            localVariableNameInclusionExact: []
+            localVariableNameInclusionStartWith: []
+            localVariableNameInclusionEndWith: []
+            localVariableNameExclusionExact: []
+            localVariableNameExclusionStartWith: []
+            localVariableNameExclusionEndWith: []
             # Root variable type filters
-            root-variable-value-type-inclusion: []
-            root-variable-value-type-exclusion: []
+            rootVariableValueTypeInclusion: []
+            rootVariableValueTypeExclusion: []
             # Local variable type filters
-            local-variable-value-type-inclusion: []
-            local-variable-value-type-exclusion: []
+            localVariableValueTypeInclusion: []
+            localVariableValueTypeExclusion: []
 ```
 
 Behavior overview:
@@ -226,14 +226,14 @@ Export only selected root variables and exclude temporary local variables:
 
 ```yaml
 index:
-  export-local-variables-enabled: true
+  exportLocalVariablesEnabled: true
 
   # Include only specific root variables
-  root-variable-name-inclusion-exact: ["customerId", "orderId"]
+  rootVariableNameInclusionExact: ["customerId", "orderId"]
   # Exclude local variables used for temporary processing
-  local-variable-name-exclusion-start-with: ["tmp_", "debug_"]
+  localVariableNameExclusionStartWith: ["tmp_", "debug_"]
   # Export only simple root variable types
-  root-variable-value-type-inclusion: ["String", "Number"]
+  rootVariableValueTypeInclusion: ["String", "Number"]
 ```
 
 In this example:
@@ -253,9 +253,9 @@ camunda:
       opensearch:
         args:
           index:
-            bpmn-process-id-inclusion:
+            bpmnProcessIdInclusion:
               - orderProcess
-            bpmn-process-id-exclusion:
+            bpmnProcessIdExclusion:
               - debugProcess
 ```
 
@@ -274,7 +274,7 @@ camunda:
       opensearch:
         args:
           index:
-            optimize-mode-enabled: true
+            optimizeModeEnabled: true
 ```
 
 When enabled, the exporter emits only the value types and intents that Optimize imports. Other value types are dropped unless you explicitly opt in to the legacy behavior (for example, via `include-enabled-records`).
@@ -370,7 +370,7 @@ camunda:
         #
         # These settings can also be overridden using environment variables "CAMUNDA_DATA_EXPORTERS_OPENSEARCH_..."
 
-        class-name: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
+        className: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
         args:
           # A comma separated list of URLs pointing to the Opensearch instances you wish to export to.
           # For example, if you want to connect to multiple nodes for redundancy:
@@ -380,13 +380,13 @@ camunda:
           bulk:
             delay: 5
             size: 1000
-            memory-limit: 10485760
+            memoryLimit: 10485760
 
           retention:
             enabled: true
-            minimum-age: 30d
-            policy-name: zeebe-records-retention-policy
-            policy-description: Zeebe records retention policy
+            minimumAge: 30d
+            policyName: zeebe-records-retention-policy
+            policyDescription: Zeebe records retention policy
 
           authentication:
             username: opensearch
@@ -394,46 +394,46 @@ camunda:
 
           aws:
             enabled: true
-            service-name: es
+            serviceName: es
             region: eu-west-1
 
           index:
             prefix: zeebe-record
-            create-template: true
+            createTemplate: true
 
             command: false
             event: true
             rejection: false
 
-            command-distribution: true
-            decision-requirements: true
+            commandDistribution: true
+            decisionRequirements: true
             decision: true
-            decision-evaluation: true
+            decisionEvaluation: true
             deployment: true
-            deployment-distribution: true
+            deploymentDistribution: true
             error: true
             escalation: true
             form: true
             incident: true
             job: true
-            job-batch: false
+            jobBatch: false
             message: true
-            message-start-event-subscription: true
-            message-subscription: true
+            messageStartEventSubscription: true
+            messageSubscription: true
             process: true
-            process-event: false
-            process-instance: true
-            process-instance-creation: true
-            process-instance-migration: true
-            process-instance-modification: true
-            process-message-subscription: true
-            resource-deletion: true
+            processEvent: false
+            processInstance: true
+            processInstanceCreation: true
+            processInstanceMigration: true
+            processInstanceModification: true
+            processMessageSubscription: true
+            resourceDeletion: true
             signal: true
-            signal-subscription: true
+            signalSubscription: true
             timer: true
-            user-task: true
+            userTask: true
             variable: true
-            variable-document: true
+            variableDocument: true
 ```
 
 ## Self-signed certificates

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md
@@ -65,7 +65,7 @@ camunda:
   data:
     exporters:
       elasticsearch:
-        class-name: io.camunda.zeebe.exporter.ElasticsearchExporter
+        className: io.camunda.zeebe.exporter.ElasticsearchExporter
         args:
         # Refer to the table below for the available args options
 ```
@@ -160,9 +160,9 @@ camunda:
       elasticsearch:
         args:
           index:
-            variable-name-inclusion-start-with:
+            variableNameInclusionStartWith:
               - business_
-            variable-name-exclusion-start-with:
+            variableNameExclusionStartWith:
               - business_debug
 ```
 
@@ -184,10 +184,10 @@ camunda:
       elasticsearch:
         args:
           index:
-            variable-value-type-inclusion:
+            variableValueTypeInclusion:
               - Object
               - String
-            variable-value-type-exclusion:
+            variableValueTypeExclusion:
               - Object
 ```
 
@@ -207,9 +207,9 @@ camunda:
       elasticsearch:
         args:
           index:
-            bpmn-process-id-inclusion:
+            bpmnProcessIdInclusion:
               - orderProcess
-            bpmn-process-id-exclusion:
+            bpmnProcessIdExclusion:
               - debugProcess
 ```
 
@@ -230,7 +230,7 @@ camunda:
       elasticsearch:
         args:
           index:
-            optimize-mode-enabled: true
+            optimizeModeEnabled: true
 ```
 
 When enabled, the exporter emits only the value types and intents that Optimize imports. Other value types are dropped unless you explicitly opt in to the legacy behavior (for example, via `include-enabled-records`).
@@ -314,7 +314,7 @@ camunda:
         # These settings can also be overridden using environment variables "CAMUNDA_DATA_EXPORTERS_ELASTICSEARCH_..."
         #
 
-        class-name: io.camunda.zeebe.exporter.ElasticsearchExporter
+        className: io.camunda.zeebe.exporter.ElasticsearchExporter
         args:
           # A comma separated list of URLs pointing to the Elasticsearch instances you wish to export to.
           # For example, if you want to connect to multiple nodes for redundancy:
@@ -324,12 +324,12 @@ camunda:
           bulk:
             delay: 5
             size: 1000
-            memory-limit: 10485760
+            memoryLimit: 10485760
 
           retention:
             enabled: true
-            minimum-age: 30d
-            policy-name: zeebe-records-retention-policy
+            minimumAge: 30d
+            policyName: zeebe-records-retention-policy
 
           authentication:
             username: elastic
@@ -337,43 +337,43 @@ camunda:
 
           index:
             prefix: zeebe-record
-            create-template: true
+            createTemplate: true
 
-            index-suffix-date-pattern: "yyyy-MM-dd"
+            indexSuffixDatePattern: "yyyy-MM-dd"
 
             command: false
             event: true
             rejection: false
 
-            command-distribution: true
-            decision-requirements: true
+            commandDistribution: true
+            decisionRequirements: true
             decision: true
-            decision-evaluation: true
+            decisionEvaluation: true
             deployment: true
-            deployment-distribution: true
+            deploymentDistribution: true
             error: true
             escalation: true
             form: true
             incident: true
             job: true
-            job-batch: false
+            jobBatch: false
             message: true
-            message-start-subscription: true
-            message-subscription: true
+            messageStartSubscription: true
+            messageSubscription: true
             process: true
-            process-event: false
-            process-instance: true
-            process-instance-creation: true
-            process-instance-migration: true
-            process-instance-modification: true
-            process-message-subscription: true
-            resource-deletion: true
+            processEvent: false
+            processInstance: true
+            processInstanceCreation: true
+            processInstanceMigration: true
+            processInstanceModification: true
+            processMessageSubscription: true
+            resourceDeletion: true
             signal: true
-            signal-subscription: true
+            signalSubscription: true
             timer: true
-            user-task: true
+            userTask: true
             variable: true
-            variable-document: true
+            variableDocument: true
 ```
 
 ## Self-signed certificates

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/opensearch-exporter.md
@@ -58,7 +58,7 @@ camunda:
   data:
     exporters:
       opensearch:
-        class-name: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
+        className: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
         args:
         # Refer to the table below for the available args options
 ```
@@ -152,9 +152,9 @@ camunda:
       opensearch:
         args:
           index:
-            variable-name-inclusion-start-with:
+            variableNameInclusionStartWith:
               - business_
-            variable-name-exclusion-start-with:
+            variableNameExclusionStartWith:
               - business_debug
 ```
 
@@ -176,10 +176,10 @@ camunda:
       opensearch:
         args:
           index:
-            variable-value-type-inclusion:
+            variableValueTypeInclusion:
               - Object
               - String
-            variable-value-type-exclusion:
+            variableValueTypeExclusion:
               - Object
 ```
 
@@ -197,9 +197,9 @@ camunda:
       opensearch:
         args:
           index:
-            bpmn-process-id-inclusion:
+            bpmnProcessIdInclusion:
               - orderProcess
-            bpmn-process-id-exclusion:
+            bpmnProcessIdExclusion:
               - debugProcess
 ```
 
@@ -218,7 +218,7 @@ camunda:
       opensearch:
         args:
           index:
-            optimize-mode-enabled: true
+            optimizeModeEnabled: true
 ```
 
 When enabled, the exporter emits only the value types and intents that Optimize imports. Other value types are dropped unless you explicitly opt in to the legacy behavior (for example, via `include-enabled-records`).
@@ -322,7 +322,7 @@ camunda:
         #
         # These settings can also be overridden using environment variables "CAMUNDA_DATA_EXPORTERS_OPENSEARCH_..."
 
-        class-name: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
+        className: io.camunda.zeebe.exporter.opensearch.OpensearchExporter
         args:
           # A comma separated list of URLs pointing to the Opensearch instances you wish to export to.
           # For example, if you want to connect to multiple nodes for redundancy:
@@ -332,13 +332,13 @@ camunda:
           bulk:
             delay: 5
             size: 1000
-            memory-limit: 10485760
+            memoryLimit: 10485760
 
           retention:
             enabled: true
-            minimum-age: 30d
-            policy-name: zeebe-records-retention-policy
-            policy-description: Zeebe records retention policy
+            minimumAge: 30d
+            policyName: zeebe-records-retention-policy
+            policyDescription: Zeebe records retention policy
 
           authentication:
             username: opensearch
@@ -346,46 +346,46 @@ camunda:
 
           aws:
             enabled: true
-            service-name: es
+            serviceName: es
             region: eu-west-1
 
           index:
             prefix: zeebe-record
-            create-template: true
+            createTemplate: true
 
             command: false
             event: true
             rejection: false
 
-            command-distribution: true
-            decision-requirements: true
+            commandDistribution: true
+            decisionRequirements: true
             decision: true
-            decision-evaluation: true
+            decisionEvaluation: true
             deployment: true
-            deployment-distribution: true
+            deploymentDistribution: true
             error: true
             escalation: true
             form: true
             incident: true
             job: true
-            job-batch: false
+            jobBatch: false
             message: true
-            message-start-event-subscription: true
-            message-subscription: true
+            messageStartEventSubscription: true
+            messageSubscription: true
             process: true
-            process-event: false
-            process-instance: true
-            process-instance-creation: true
-            process-instance-migration: true
-            process-instance-modification: true
-            process-message-subscription: true
-            resource-deletion: true
+            processEvent: false
+            processInstance: true
+            processInstanceCreation: true
+            processInstanceMigration: true
+            processInstanceModification: true
+            processMessageSubscription: true
+            resourceDeletion: true
             signal: true
-            signal-subscription: true
+            signalSubscription: true
             timer: true
-            user-task: true
+            userTask: true
             variable: true
-            variable-document: true
+            variableDocument: true
 ```
 
 ## Self-signed certificates


### PR DESCRIPTION
## Description

The Elasticsearch and OpenSearch exporter pages show `args` configuration keys in **kebab-case**. Before Camunda 8.10, exporter `args.*` keys in kebab-case are **silently ignored** — the broker starts with no error and the setting has no effect (the key never matches the camelCase Java field). kebab-case was only made to work in 8.10 via camunda/camunda#51307.

This PR converts the YAML configuration **examples** on these pages to **camelCase**, which binds correctly on **all supported versions** (8.10 accepts both kebab and camelCase; pre-8.10 accepts only camelCase). Values are unchanged.

## Changes

Converted YAML example keys from kebab-case to camelCase in:

- `docs/.../zeebe/exporters/elasticsearch-exporter.md` (current / 8.10)
- `docs/.../zeebe/exporters/opensearch-exporter.md` (current / 8.10)
- `versioned_docs/version-8.9/.../zeebe/exporters/elasticsearch-exporter.md`
- `versioned_docs/version-8.9/.../zeebe/exporters/opensearch-exporter.md`

Examples were the functional copy-paste hazard for 8.9 users. The descriptive **reference tables** and prose still list the canonical kebab option names — happy to convert those too if reviewers prefer full consistency.

## Why this matters

Found on a live 8.9.9 cluster: kebab-cased `variable-name-inclusion-start-with` / `optimize-mode-enabled` silently did nothing, so the Optimize-oriented ES-exporter filters never applied. Switching to camelCase fixed it (verified via the broker's `Exporter configured with …` log).

## Refs

- Bug (8.9 silent-ignore): camunda/camunda#55795
- 8.10 fix that added kebab support: camunda/camunda#51307
