### PR TITLE
docs(spring-boot-starter): document completing jobs with a result function

### DIFF
--- a/docs/apis-tools/camunda-spring-boot-starter/configuration.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/configuration.md
@@ -605,6 +605,43 @@ public DocumentResult sendDocumentAsResult() {
 }
 ```
 
+##### Completing ad-hoc sub-process jobs with a result
+
+When your job worker handles an [ad-hoc sub-process](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md) job, you can return an `AdHocSubProcessResultFunction` to specify which element to activate within the sub-process. The starter automatically applies the result when completing the job.
+
+Return a lambda that calls `activateElement` with the target element ID:
+
+```java
+@JobWorker(type = "myAdHocSubprocessJob")
+public AdHocSubProcessResultFunction handleAdHocSubprocess() {
+  return r -> r.activateElement("myElementId");
+}
+```
+
+To also submit process variables with the result, use the `AdHocSubProcessResultFunction.withVariables` factory method:
+
+```java
+@JobWorker(type = "myAdHocSubprocessJob")
+public AdHocSubProcessResultFunction handleAdHocSubprocess() {
+  Map<String, Object> variables = Map.of("decision", "approved");
+  return AdHocSubProcessResultFunction.withVariables(variables,
+      r -> r.activateElement("approvalTask"));
+}
+```
+
+##### Completing user task listener jobs with a result
+
+When your job worker handles a user task listener job, you can return a `UserTaskResultFunction` to control the outcome of the listener. The starter automatically applies the result when completing the job.
+
+Return a lambda that configures the result, for example to correct the assignee:
+
+```java
+@JobWorker(type = "io.camunda:userTaskListener:complete")
+public UserTaskResultFunction handleUserTaskListener() {
+  return r -> r.correctAssignee("newAssignee");
+}
+```
+
 #### Programmatically completing jobs
 
 Your job worker code can also complete the job itself. This gives you more control over when exactly you want to complete the job (for example, allowing the completion to be moved to reactive callbacks):

--- a/docs/apis-tools/camunda-spring-boot-starter/configuration.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/configuration.md
@@ -74,7 +74,7 @@ This applies the following defaults:
 https://github.com/camunda/camunda/blob/main/clients/camunda-spring-boot-starter/src/main/resources/modes/self-managed.yaml
 ```
 
-For some specific OIDC setups (e.g [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity)), you might need to define additional properties like `camunda.client.auth.scope` in addition to the defaults provided by the mode, see the [`camunda.client.auth`-Properties reference](./properties-reference.md) for a full overview.
+For some specific OIDC setups (for example, [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity)), you might need to define additional properties like `camunda.client.auth.scope` in addition to the defaults provided by the mode, see the [`camunda.client.auth`-Properties reference](./properties-reference.md) for a full overview.
 
 ## Connectivity
 
@@ -607,7 +607,7 @@ public DocumentResult sendDocumentAsResult() {
 
 ##### Completing ad-hoc sub-process jobs with a result
 
-When your job worker handles an [ad-hoc sub-process](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md) job, you can return an `AdHocSubProcessResultFunction` to specify which element to activate within the sub-process. The starter automatically applies the result when completing the job.
+When your job worker handles an [ad-hoc sub-process](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md) job, you can return an `AdHocSubProcessResultFunction` to specify which element to activate within the sub-process. The starter automatically applies the result when you complete the job.
 
 Return a lambda that calls `activateElement` with the target element ID:
 
@@ -631,7 +631,7 @@ public AdHocSubProcessResultFunction handleAdHocSubprocess() {
 
 ##### Completing user task listener jobs with a result
 
-When your job worker handles a user task listener job, you can return a `UserTaskResultFunction` to control the outcome of the listener. The starter automatically applies the result when completing the job.
+When your job worker handles a user task listener job, you can return a `UserTaskResultFunction` to control the outcome of the listener. The starter automatically applies the result when you complete the job.
 
 Return a lambda that configures the result, for example to correct the assignee:
 
@@ -644,7 +644,7 @@ public UserTaskResultFunction handleUserTaskListener() {
 
 #### Programmatically completing jobs
 
-Your job worker code can also complete the job itself. This gives you more control over when exactly you want to complete the job (for example, allowing the completion to be moved to reactive callbacks):
+Your job worker code can also complete the job itself. This gives you more control over when you want to complete the job (for example, allowing you to move the completion to reactive callbacks):
 
 ```java
 @JobWorker(type = "foo", autoComplete = false)

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/configuration.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/configuration.md
@@ -603,6 +603,43 @@ public DocumentResult sendDocumentAsResult() {
 }
 ```
 
+##### Completing ad-hoc sub-process jobs with a result
+
+When your job worker handles an [ad-hoc sub-process](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md) job, you can return an `AdHocSubProcessResultFunction` to specify which element to activate within the sub-process. The starter automatically applies the result when completing the job.
+
+Return a lambda that calls `activateElement` with the target element ID:
+
+```java
+@JobWorker(type = "myAdHocSubprocessJob")
+public AdHocSubProcessResultFunction handleAdHocSubprocess() {
+  return r -> r.activateElement("myElementId");
+}
+```
+
+To also submit process variables with the result, use the `AdHocSubProcessResultFunction.withVariables` factory method:
+
+```java
+@JobWorker(type = "myAdHocSubprocessJob")
+public AdHocSubProcessResultFunction handleAdHocSubprocess() {
+  Map<String, Object> variables = Map.of("decision", "approved");
+  return AdHocSubProcessResultFunction.withVariables(variables,
+      r -> r.activateElement("approvalTask"));
+}
+```
+
+##### Completing user task listener jobs with a result
+
+When your job worker handles a user task listener job, you can return a `UserTaskResultFunction` to control the outcome of the listener. The starter automatically applies the result when completing the job.
+
+Return a lambda that configures the result, for example to correct the assignee:
+
+```java
+@JobWorker(type = "io.camunda:userTaskListener:complete")
+public UserTaskResultFunction handleUserTaskListener() {
+  return r -> r.correctAssignee("newAssignee");
+}
+```
+
 #### Programmatically completing jobs
 
 Your job worker code can also complete the job itself. This gives you more control over when exactly you want to complete the job (for example, allowing the completion to be moved to reactive callbacks):

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/configuration.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/configuration.md
@@ -74,7 +74,7 @@ This applies the following defaults:
 https://github.com/camunda/camunda/blob/main/clients/camunda-spring-boot-starter/src/main/resources/modes/self-managed.yaml
 ```
 
-For some specific OIDC setups (e.g [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity)), you might need to define additional properties like `camunda.client.auth.scope` in addition to the defaults provided by the mode, see the [`camunda.client.auth`-Properties reference](./properties-reference.md) for a full overview.
+For some specific OIDC setups (for example, [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity)), you might need to define additional properties like `camunda.client.auth.scope` in addition to the defaults provided by the mode, see the [`camunda.client.auth`-Properties reference](./properties-reference.md) for a full overview.
 
 ## Connectivity
 
@@ -605,7 +605,7 @@ public DocumentResult sendDocumentAsResult() {
 
 ##### Completing ad-hoc sub-process jobs with a result
 
-When your job worker handles an [ad-hoc sub-process](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md) job, you can return an `AdHocSubProcessResultFunction` to specify which element to activate within the sub-process. The starter automatically applies the result when completing the job.
+When your job worker handles an [ad-hoc sub-process](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md) job, you can return an `AdHocSubProcessResultFunction` to specify which element to activate within the sub-process. The starter automatically applies the result when you complete the job.
 
 Return a lambda that calls `activateElement` with the target element ID:
 
@@ -629,7 +629,7 @@ public AdHocSubProcessResultFunction handleAdHocSubprocess() {
 
 ##### Completing user task listener jobs with a result
 
-When your job worker handles a user task listener job, you can return a `UserTaskResultFunction` to control the outcome of the listener. The starter automatically applies the result when completing the job.
+When your job worker handles a user task listener job, you can return a `UserTaskResultFunction` to control the outcome of the listener. The starter automatically applies the result when you complete the job.
 
 Return a lambda that configures the result, for example to correct the assignee:
 
@@ -642,7 +642,7 @@ public UserTaskResultFunction handleUserTaskListener() {
 
 #### Programmatically completing jobs
 
-Your job worker code can also complete the job itself. This gives you more control over when exactly you want to complete the job (for example, allowing the completion to be moved to reactive callbacks):
+Your job worker code can also complete the job itself. This gives you more control over when you want to complete the job (for example, allowing you to move the completion to reactive callbacks):
 
 ```java
 @JobWorker(type = "foo", autoComplete = false)


### PR DESCRIPTION
## Description

Documents two result-function return types for `@JobWorker` methods in the Camunda Spring Boot Starter:

- **`AdHocSubProcessResultFunction`** — new in [camunda/camunda#44741](https://github.com/camunda/camunda/pull/44741). When a job worker handles an ad-hoc sub-process job, returning this function lets it specify which element to activate within the sub-process, with optional variables via `AdHocSubProcessResultFunction.withVariables`.
- **`UserTaskResultFunction`** — previously undocumented. When a job worker handles a user task listener job, returning this function lets it control the listener outcome (for example, correcting the assignee).

Both the `next` and `8.9` versions of `configuration.md` are updated.

Closes Asana task: https://app.asana.com/1/384886434863350/task/1213108735244687

## Review checklist

_If you're a Camunda team member, check the following before merging:_

- [ ] All links on the staging site work as expected.
- [ ] The new sections are listed in the correct heading hierarchy (`##### ` under `#### Auto-completing jobs`).
- [ ] The `8.9` versioned file matches the `next` file for these sections.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)