### PR TITLE
docs(tls): remove version info callout from TLS guide

### DIFF
--- a/docs/self-managed/deployment/helm/configure/tls.md
+++ b/docs/self-managed/deployment/helm/configure/tls.md
@@ -5,12 +5,6 @@ title: Configure TLS
 description: "Enable TLS for Camunda 8 Self-Managed component connections to datastores using the Helm chart's values-tls.yaml overlay."
 ---
 
-:::info Applies to Camunda 8.10+ (Helm chart 15.x+)
-
-The `global.tls.caBundle` key and the `values-tls.yaml` overlay are introduced in chart 15.x.
-
-:::
-
 ## What's covered
 
 | Connection                                                                                 | Mechanism                                                                                                                                                                                     |


### PR DESCRIPTION
## Summary

Removes the `:::info Applies to Camunda 8.10+` callout from `docs/self-managed/deployment/helm/configure/tls.md`. Version context is implicit — readers know which version they're on from the docs version selector.

Companion cleanup to #9187 and #9188 (backports already updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)