### PR TITLE
docs: add Kubernetes version support policy to supported environments

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -55,6 +55,8 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
 
+Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 
 - [Stock Kubernetes](/self-managed/deployment/helm/install/quick-install.md)

--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -53,9 +53,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
-
-Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -175,7 +175,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -175,7 +175,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.7/reference/supported-environments.md
+++ b/versioned_docs/version-8.7/reference/supported-environments.md
@@ -47,9 +47,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the right configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
-
-Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+With the right configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/versioned_docs/version-8.7/reference/supported-environments.md
+++ b/versioned_docs/version-8.7/reference/supported-environments.md
@@ -49,6 +49,8 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 With the right configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
 
+Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 
 - [Stock Kubernetes](/self-managed/setup/install.md)

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -124,7 +124,7 @@ For more details on multi-region configurations, especially dual-region setups, 
 
 We recommend using an officially [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/setup/install.md) for easy installation on Kubernetes. The latest Helm chart is typically compatible with Kubernetes' [official support cycle](https://kubernetes.io/releases/).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/setup/install.md) for easy installation on Kubernetes. The latest Helm chart is typically compatible with Kubernetes' [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -124,7 +124,7 @@ For more details on multi-region configurations, especially dual-region setups, 
 
 We recommend using an officially [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/setup/install.md) for easy installation on Kubernetes. The latest Helm chart is typically compatible with Kubernetes' [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/setup/install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.8/reference/supported-environments.md
+++ b/versioned_docs/version-8.8/reference/supported-environments.md
@@ -56,6 +56,8 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
 
+Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 
 - [Stock Kubernetes](/self-managed/deployment/helm/install/quick-install.md)

--- a/versioned_docs/version-8.8/reference/supported-environments.md
+++ b/versioned_docs/version-8.8/reference/supported-environments.md
@@ -54,9 +54,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
-
-Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -169,7 +169,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -169,7 +169,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.9/reference/supported-environments.md
+++ b/versioned_docs/version-8.9/reference/supported-environments.md
@@ -55,6 +55,8 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
 
+Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 
 - [Stock Kubernetes](/self-managed/deployment/helm/install/quick-install.md)

--- a/versioned_docs/version-8.9/reference/supported-environments.md
+++ b/versioned_docs/version-8.9/reference/supported-environments.md
@@ -53,9 +53,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises). However, we officially test and support a specific list of platforms.
-
-Camunda 8 is not tied to a specific Kubernetes version. The Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -175,7 +175,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -175,7 +175,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). For the full list of tested and supported environments, see [supported environments](/reference/supported-environments.md).
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
 
 #### Minimum cluster requirements
 


### PR DESCRIPTION
## Summary

Two doc changes to align and cross-link our Kubernetes version support policy.

**Context:** A question came up in a Helm chart PR ([camunda/camunda-platform-helm#6027](https://github.com/camunda/camunda-platform-helm/pull/6027)) about whether a change requiring Kubernetes 1.23 features would break customers on older versions. Our answer: no — we follow the Kubernetes official support cycle and 1.23 is already EOL within it. However, that policy was only stated in `reference-architecture/kubernetes.md`, not in `supported-environments.md` where customers and support engineers look first.

**Changes (all versions 8.7–8.10/current):**

1. **`reference/supported-environments.md`:** Merged the Kubernetes version support policy into the existing Deployment options paragraph — no new block, just tighter wording that makes the policy discoverable in the right place.

2. **`self-managed/reference-architecture/kubernetes.md`:** Simplified the `#infrastructure` version statement and replaced the external `kubernetes.io/releases` link with a link to `supported-environments.md` as the single authoritative reference.