### PR TITLE
docs(ai-agent): clarify toolCallResult placement in multi-element tool flows

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
@@ -186,6 +186,9 @@ Depending on the used task, setting the variable content can be achieved in mult
   to a part of the `toolCallResult` variable (for example, an output mapping could be set to `toolCallResult.statusCode`)
 - A [script task](../../modeler/bpmn/script-tasks/script-tasks.md) that sets the `toolCallResult` variable
 
+If a tool consists of multiple elements (for example, a sequence of tasks with a gateway), `toolCallResult` can be set at
+any point in the flow. The variable is [read from the tool's scope when the flow completes](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md#collect-output).
+
 Tool call results can be either primitive values (for example, a string) or complex ones, such as
 a [FEEL context](../../modeler/feel/language-guide/feel-context-expressions.md) that is serialized to a JSON
 string before passing it to the LLM.

--- a/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
+++ b/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
@@ -186,6 +186,9 @@ Depending on the used task, setting the variable content can be achieved in mult
   to a part of the `toolCallResult` variable (for example, an output mapping could be set to `toolCallResult.statusCode`)
 - A [script task](../../modeler/bpmn/script-tasks/script-tasks.md) that sets the `toolCallResult` variable
 
+If a tool consists of multiple elements (for example, a sequence of tasks with a gateway), `toolCallResult` can be set at
+any point in the flow. The variable is [read from the tool's scope when the flow completes](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md#collect-output).
+
 Tool call results can be either primitive values (for example, a string) or complex ones, such as
 a [FEEL context](../../modeler/feel/language-guide/feel-context-expressions.md) that is serialized to a JSON
 string before passing it to the LLM.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
@@ -186,6 +186,9 @@ Depending on the used task, setting the variable content can be achieved in mult
   to a part of the `toolCallResult` variable (for example, an output mapping could be set to `toolCallResult.statusCode`)
 - A [script task](../../modeler/bpmn/script-tasks/script-tasks.md) that sets the `toolCallResult` variable
 
+If a tool consists of multiple elements (for example, a sequence of tasks with a gateway), `toolCallResult` can be set at
+any point in the flow. The variable is [read from the tool's scope when the flow completes](/components/modeler/bpmn/ad-hoc-subprocesses/ad-hoc-subprocesses.md#collect-output).
+
 Tool call results can be either primitive values (for example, a string) or complex ones, such as
 a [FEEL context](../../modeler/feel/language-guide/feel-context-expressions.md) that is serialized to a JSON
 string before passing it to the LLM.


### PR DESCRIPTION
## Description

Adds a short paragraph to the **Tool call responses** section of the AI Agent tool definitions docs clarifying that `toolCallResult` can be set at any point in a multi-element tool flow (for example, a sequence of tasks followed by a gateway) — not only at the final element. Links to the [ad-hoc sub-process collect output docs](https://docs.camunda.io/docs/components/modeler/bpmn/ad-hoc-subprocesses/#collect-output) for the underlying mechanism.

Applied to `docs/` and `versioned_docs/` (8.8, 8.9).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
