### PR TITLE
docs(tls): align 8.10 TLS guide with chart 15.x (javaOpts targets, NOTES.txt framing)

### DIFF
--- a/docs/self-managed/deployment/helm/configure/tls.md
+++ b/docs/self-managed/deployment/helm/configure/tls.md
@@ -239,11 +239,11 @@ Server certs for Elasticsearch, OpenSearch, and PostgreSQL must be issued separa
 
 ## Install-time guardrails
 
-After each `helm install` or `helm upgrade`, check the `NOTES.txt` output for these warnings (re-display it at any time with `helm status <release>`):
+The chart emits these as `[camunda][warning]` messages from its constraints template while rendering `helm install` / `helm upgrade`. They also appear in the `helm status <release>` NOTES output when `global.createReleaseInfo` is enabled. Keep them in mind — some are enforced as render-time errors, others are silent precedence rules you must account for in your values:
 
 - Per-component JKS overrides the bundle. If a component has a legacy `tls.secret` JKS configured, the JKS takes precedence and the bundle is ignored for that component. Remove `tls.secret` to use the bundle.
 - Bundle is trust, not encryption. `global.tls.caBundle` adds CA trust but does not enable TLS on a plaintext URL. Set the URL to `https://` (or set the JDBC `sslmode`).
-- `JAVA_TOOL_OPTIONS` in component `env` overrides the truststore flags. Set it via `javaOpts` (orchestration, optimize, Web Modeler restapi) instead, which the chart appends to.
+- `JAVA_TOOL_OPTIONS` in component `env` overrides the truststore flags. For Orchestration and Optimize, set it via `javaOpts` instead, which the chart appends its truststore flags to. Connectors, Identity, and Web Modeler restapi receive the truststore flags automatically through a dedicated `JAVA_TOOL_OPTIONS` env — do not put truststore flags in their `javaOpts` (Web Modeler restapi's `javaOpts` feeds `JAVA_OPTIONS`, a different variable, so it has no effect on trust).
 
 ## Verify no plaintext fallback
 


### PR DESCRIPTION
## Summary

Two technical-accuracy fixes to the 8.10 (\"Next\") Helm TLS guide, found while reviewing the TLS docs for alignment with the chart-15.x TLS work on the `6356-optimize-tls` branch.

1. **`javaOpts` targets corrected.** Only **Orchestration** and **Optimize** compose `<component>.javaOpts` into `JAVA_TOOL_OPTIONS` (`orchestration/statefulset.yaml:91`, `optimize/deployment.yaml:86,195`). Web Modeler restapi's `javaOpts` feeds `JAVA_OPTIONS` — a different variable — so listing it as a truststore-flag target was incorrect (`web-modeler/deployment-restapi.yaml:56`). restapi, Connectors, and Identity receive the truststore flags automatically via `caBundleJavaToolOptionsEnv` (`:103`).
2. **NOTES.txt framing corrected.** The three guardrails are `[camunda][warning]` render-time messages from the constraints template (`constraints.tpl:472-549`), surfacing in NOTES output only when `global.createReleaseInfo` is enabled (`NOTES.txt:237-243`) — they are not authored in `NOTES.txt`.

> The same incorrect `javaOpts` guidance exists chart-side (`constraints.tpl:543`, `values.yaml:303`); a corresponding helm issue tracks the fix there. The 8.9 backport already carries the corrected `javaOpts` wording; 8.8 uses generic wording.

## Test plan

- [ ] Page renders unchanged structurally; only the guardrails section wording changes
- [ ] `npm run format` clean