### PR TITLE
docs: simplify Kubernetes version support wording (follow-up to #9190)

### DIFF
--- a/docs/reference/supported-environments.md
+++ b/docs/reference/supported-environments.md
@@ -53,7 +53,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
+With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/docs/self-managed/reference-architecture/kubernetes.md
+++ b/docs/self-managed/reference-architecture/kubernetes.md
@@ -175,7 +175,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows our [Kubernetes support statement](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.7/reference/supported-environments.md
+++ b/versioned_docs/version-8.7/reference/supported-environments.md
@@ -47,7 +47,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the right configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
+With the right configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.7/self-managed/reference-architecture/kubernetes.md
@@ -124,7 +124,7 @@ For more details on multi-region configurations, especially dual-region setups, 
 
 We recommend using an officially [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/setup/install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/setup/install.md) that follows our [Kubernetes support statement](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.8/reference/supported-environments.md
+++ b/versioned_docs/version-8.8/reference/supported-environments.md
@@ -54,7 +54,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
+With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.8/self-managed/reference-architecture/kubernetes.md
@@ -169,7 +169,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows our [Kubernetes support statement](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 

--- a/versioned_docs/version-8.9/reference/supported-environments.md
+++ b/versioned_docs/version-8.9/reference/supported-environments.md
@@ -53,7 +53,7 @@ We recommend running Camunda 8 Self-Managed in a Kubernetes environment. We prov
 
 ### Deployment options
 
-With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/). However, we officially test and support a specific list of platforms.
+With the correct configuration, Camunda 8 Self-Managed can be deployed on any [Certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution (cloud or on-premises), and is not tied to a specific Kubernetes version — the Helm chart supports the Kubernetes [official support cycle](https://kubernetes.io/releases/).
 
 The following are tested and supported deployment options for Kubernetes, Docker, and manual installation:
 

--- a/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
+++ b/versioned_docs/version-8.9/self-managed/reference-architecture/kubernetes.md
@@ -175,7 +175,7 @@ For details on multi-region configurations, especially dual-region setups, refer
 
 We recommend using a [certified Kubernetes](https://www.cncf.io/training/certification/software-conformance/#benefits) distribution.
 
-Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows the Kubernetes official support cycle. See [supported environments](/reference/supported-environments.md) for tested and supported platforms.
+Camunda 8 is not tied to a specific Kubernetes version. To simplify deployment, we provide a [Helm chart](/self-managed/deployment/helm/install/quick-install.md) that follows our [Kubernetes support statement](/reference/supported-environments.md).
 
 #### Minimum cluster requirements
 


### PR DESCRIPTION
## Description

Follow-up to #9190 addressing @leiicamundi's review comments that landed after the PR was already merged.

Two wording refinements, applied consistently across current (`/docs`) and versioned 8.7–8.9:

1. **`reference/supported-environments.md`:** Removed the sentence _"However, we officially test and support a specific list of platforms."_ — it no longer adds value, since the tested and supported deployment options are listed immediately below.

2. **`self-managed/reference-architecture/kubernetes.md`:** Avoided repeating the Kubernetes support cycle and instead point to the [Kubernetes support statement](/reference/supported-environments.md) in supported environments as the single authoritative reference:

   > ...that follows our [Kubernetes support statement](/reference/supported-environments.md).

> [!NOTE]
> @leiicamundi also raised a question in review on the 8.7 file: does a customer who installed 8.7 with a Kubernetes version that is no longer in the official support cycle today lose support? That is a policy question, not a wording fix, so it is intentionally left out of this PR. Flagging it here for a separate decision.

## When should this change go live?

- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style.
