### PR TITLE
docs(ecs-dual-region): reframe scope, remove experimental label and cost table

### DIFF
--- a/docs/self-managed/deployment/containers/cloud-providers/amazon/aws-ecs-dual-region.md
+++ b/docs/self-managed/deployment/containers/cloud-providers/amazon/aws-ecs-dual-region.md
@@ -8,9 +8,7 @@ sidebar_position: 2
 This reference architecture deploys Camunda 8 Self-Managed across two AWS regions on ECS Fargate in an active-active configuration, with Aurora Global Database as secondary storage and Camunda 8.10 unified `/v2/*` REST API.
 
 :::note Reference architecture
-This guide covers the **Orchestration Cluster** (Zeebe, Operate, Tasklist, Connectors). Optimize, Web Modeler, and Console are out of scope — see [Scope and what's not included](#scope-and-whats-not-included).
-
-Do not run production workloads without your own hardening, monitoring, and operational testing.
+This guide covers the **Orchestration Cluster** and Connectors.
 :::
 
 ## What you get
@@ -69,7 +67,7 @@ architecture-beta
 ```
 
 :::note
-This reference architecture is not a turnkey module. Clone the repository and adapt it to your environment — you are responsible for operating and maintaining the resulting infrastructure. Check the [changelog](https://github.com/camunda/camunda-deployment-references/releases) before upgrading to incorporate Camunda updates into your customized copy.
+This reference architecture is not a turnkey module. Clone the repository and adapt it to your environment — you are responsible for operating and maintaining the resulting infrastructure.
 :::
 
 ## Prerequisites
@@ -171,7 +169,7 @@ Wall-clock time for a greenfield deploy to a first healthy `/v2/topology` respon
 
 `terraform destroy` is faster: about 15–20 minutes end-to-end, with Aurora teardown again the bottleneck.
 
-Actual costs depend on region, instance sizing, commit discounts, and cross-region data egress. Use the [AWS Pricing Calculator](https://calculator.aws/#/) to estimate for your configuration. Always run `terraform destroy` when you are done with a demo to avoid ongoing charges.
+Actual costs depend on region, instance sizing, commit discounts, and cross-region data egress. Use the [AWS Pricing Calculator](https://calculator.aws/#/) to estimate for your configuration.
 
 ## Architecture decisions
 
@@ -600,15 +598,7 @@ aws ecs execute-command \
 
 For general troubleshooting, see the [operational guides troubleshooting documentation](/self-managed/operational-guides/troubleshooting.md).
 
-## Scope and what's not included
-
-This reference covers the **Orchestration Cluster**: Zeebe, Operate, Tasklist, and Connectors. The following are out of scope by design, not gaps in the architecture:
-
-- **Optimize** requires Elasticsearch or OpenSearch as secondary storage. RDBMS-based deployments (Aurora) do not support Optimize. Deploy Optimize separately against an independent search cluster if needed.
-- **Web Modeler and Console** are SaaS-only components and are not part of any Self-Managed reference architecture.
-- **SSO / external identity provider.** Basic authentication is configured out of the box. Connecting an external IDP directly to the Orchestration Cluster is supported — see [Connect to an identity provider](/self-managed/components/orchestration-cluster/admin/connect-external-identity-provider.md) in Next steps.
-
-The following are known operational constraints of this reference:
+## Known limitations
 
 - **Node ID assignment.** Even/odd broker ID assignment per region is pending follow-up work.
 - **Manual failover only.** No automated health-check-driven failover is included.

--- a/docs/self-managed/deployment/containers/cloud-providers/amazon/aws-ecs-dual-region.md
+++ b/docs/self-managed/deployment/containers/cloud-providers/amazon/aws-ecs-dual-region.md
@@ -7,8 +7,10 @@ sidebar_position: 2
 
 This reference architecture deploys Camunda 8 Self-Managed across two AWS regions on ECS Fargate in an active-active configuration, with Aurora Global Database as secondary storage and Camunda 8.10 unified `/v2/*` REST API.
 
-:::warning Experimental — reference only
-This reference architecture is experimental. RDBMS-based dual-region for Camunda 8 is uncharted territory and known limitations apply (see [Known limitations](#known-limitations)). Use it for learning, evaluation, and validation. Do not run production workloads through it without your own hardening, monitoring, and operational testing.
+:::note Reference architecture
+This guide covers the **Orchestration Cluster** (Zeebe, Operate, Tasklist, Connectors). Optimize, Web Modeler, and Console are out of scope — see [Scope and what's not included](#scope-and-whats-not-included).
+
+Do not run production workloads without your own hardening, monitoring, and operational testing.
 :::
 
 ## What you get
@@ -66,8 +68,8 @@ architecture-beta
     tasks1:L -- R:peer1
 ```
 
-:::warning
-Reference architectures provided in this guide are not turnkey modules. Camunda recommends cloning the repository and modifying it locally. You're responsible for operating and maintaining the infrastructure. Camunda updates the reference architecture over time, and changes may not be backward compatible.
+:::note
+This reference architecture is not a turnkey module. Clone the repository and adapt it to your environment — you are responsible for operating and maintaining the resulting infrastructure. Check the [changelog](https://github.com/camunda/camunda-deployment-references/releases) before upgrading to incorporate Camunda updates into your customized copy.
 :::
 
 ## Prerequisites
@@ -169,19 +171,7 @@ Wall-clock time for a greenfield deploy to a first healthy `/v2/topology` respon
 
 `terraform destroy` is faster: about 15–20 minutes end-to-end, with Aurora teardown again the bottleneck.
 
-Rough running cost for the default sizing (four brokers per region, one Connectors task per region, Aurora `db.r6g.large` × 2 instances per region, one NAT gateway per region, two ALBs, four NLBs):
-
-| Component                                               | Approximate cost per day |
-| ------------------------------------------------------- | ------------------------ |
-| Fargate orchestration cluster (4 vCPU / 8 GB × 8 tasks) | ~$38                     |
-| Fargate Connectors (2 vCPU / 4 GB × 2 tasks)            | ~$5                      |
-| Aurora Global (`db.r6g.large` × 4 instances)            | ~$28                     |
-| 2 × ALB + 4 × NLB                                       | ~$5                      |
-| 2 × NAT Gateway (data transfer extra)                   | ~$2                      |
-| EFS, S3, Secrets Manager, KMS                           | ~$1                      |
-| **Total**                                               | **~$80 per day**         |
-
-These are list-price ballparks for `us-east-1`. Commit discounts, region, idle time, and cross-region data egress all shift the number. Always run `terraform destroy` when you're done with a demo.
+Actual costs depend on region, instance sizing, commit discounts, and cross-region data egress. Use the [AWS Pricing Calculator](https://calculator.aws/#/) to estimate for your configuration. Always run `terraform destroy` when you are done with a demo to avoid ongoing charges.
 
 ## Architecture decisions
 
@@ -418,7 +408,6 @@ Without these additions, traffic is transmitted in cleartext and is therefore in
    ```
 
    Both ALBs expose the Orchestration Cluster and Connectors through the same port and use listener rules to determine the path they're on:
-
    - ALB:80
      - `/*` routes to the Orchestration Cluster UI and REST API.
      - `/connectors*` routes to the Connectors.
@@ -611,11 +600,16 @@ aws ecs execute-command \
 
 For general troubleshooting, see the [operational guides troubleshooting documentation](/self-managed/operational-guides/troubleshooting.md).
 
-## Known limitations
+## Scope and what's not included
 
-- **No Identity / Keycloak.** Authentication is Basic authentication only. There is no Single Sign-On integration in this reference.
-- **No Optimize.** RDBMS secondary storage does not yet support Optimize.
-- **No Web Modeler or Console.** Neither is included in the reference architecture.
+This reference covers the **Orchestration Cluster**: Zeebe, Operate, Tasklist, and Connectors. The following are out of scope by design, not gaps in the architecture:
+
+- **Optimize** requires Elasticsearch or OpenSearch as secondary storage. RDBMS-based deployments (Aurora) do not support Optimize. Deploy Optimize separately against an independent search cluster if needed.
+- **Web Modeler and Console** are SaaS-only components and are not part of any Self-Managed reference architecture.
+- **SSO / external identity provider.** Basic authentication is configured out of the box. Connecting an external IDP directly to the Orchestration Cluster is supported — see [Connect to an identity provider](/self-managed/components/orchestration-cluster/admin/connect-external-identity-provider.md) in Next steps.
+
+The following are known operational constraints of this reference:
+
 - **Node ID assignment.** Even/odd broker ID assignment per region is pending follow-up work.
 - **Manual failover only.** No automated health-check-driven failover is included.
 


### PR DESCRIPTION
## Description

Addresses reviewer feedback on the ECS Fargate dual-region reference page.

- **Remove "Experimental" label** — the page is 8.10 docs, not a preview feature. Replaced with a `:::note Reference architecture` admonition stating this guide covers the Orchestration Cluster and Connectors.
- **Remove advisory callouts** — removed prescriptive warnings about production hardening, changelog checks before upgrading, and the `terraform destroy` reminder from the cost section. These are operational judgement calls, not docs guidance.
- **Remove AWS cost table** — list-price figures are misleading (commit discounts, region variance, cross-region egress). Replaced with a pointer to the AWS Pricing Calculator.
- **Restore "Known limitations" heading** — reverts the section back to its original heading and removes the out-of-scope bullets for Optimize, Web Modeler/Console, and SSO. Keeps only the two genuine operational constraints (node ID assignment, manual failover only).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
