### PR TITLE
docs: add OpenSearch 3.7 support to 8.10 release announcements

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -141,6 +141,21 @@ Camunda 8.10 raises the minimum supported OpenSearch 3.x version to 3.5. Support
 </div>
 </div>
 
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--change">Change</span>
+</div>
+<div className="release-announcement-content">
+
+#### OpenSearch 3.7 now supported
+
+Camunda 8.10 adds support for OpenSearch 3.7. Supported OpenSearch 3.x versions are now 3.5, 3.6, and 3.7.
+
+<p className="link-arrow">[Supported environments](/reference/supported-environments.md)</p>
+
+</div>
+</div>
+
 ## Agentic orchestration
 
 <div className="release-announcement-row">


### PR DESCRIPTION
## Summary

Adds a release announcement entry for OpenSearch 3.7 support in the Camunda 8.10 announcements page. OpenSearch 3.7.0 has been released and is now tested in CI alongside 3.5 and 3.6 (minimum supported version remains 3.5).

The `supported-environments.md` table (`OpenSearch 3.5+`) is unchanged — the existing language already covers 3.7.

## Related

https://github.com/camunda/camunda/pull/56067

## Checklist

- [x] Prose follows the [technical writing style guide](https://github.com/camunda/camunda-docs/blob/main/howtos/technical-writing-styleguide.md)
- [x] All internal links include `.md` extension
- [x] New pages are added to `sidebars.js`
- [x] Images have alt text