### PR TITLE
docs(saas): remove incorrect note about manual update button availability

### DIFF
--- a/docs/components/hub/organization/manage-clusters/manage-cluster.md
+++ b/docs/components/hub/organization/manage-clusters/manage-cluster.md
@@ -69,10 +69,6 @@ Clusters must be healthy before an update can be performed.
 
 If an update is available, a **Review Update** button is shown.
 
-:::note
-This button is not available for clusters enrolled in [automatic updates](/components/saas/auto-updates.md).
-:::
-
 ### Automated cluster updates
 
 You can decide if you want to have [automated updates](/components/saas/auto-updates.md) to new versions of Camunda 8 activated. You can also toggle this feature anytime later in the **Settings** tab of your cluster.

--- a/versioned_docs/version-8.7/components/console/manage-clusters/manage-cluster.md
+++ b/versioned_docs/version-8.7/components/console/manage-clusters/manage-cluster.md
@@ -69,10 +69,6 @@ Clusters must be healthy before an update can be performed.
 
 If an update is available, a **Review Update** button is shown.
 
-:::note
-This button is not available for clusters enrolled in [automatic updates](/reference/auto-updates.md).
-:::
-
 ### Automated cluster updates
 
 You can decide if you want to have [automated updates](/reference/auto-updates.md) to new versions of Camunda 8 activated. You can also toggle this feature anytime later in the **Settings** tab of your cluster.

--- a/versioned_docs/version-8.8/components/console/manage-clusters/manage-cluster.md
+++ b/versioned_docs/version-8.8/components/console/manage-clusters/manage-cluster.md
@@ -69,10 +69,6 @@ Clusters must be healthy before an update can be performed.
 
 If an update is available, a **Review Update** button is shown.
 
-:::note
-This button is not available for clusters enrolled in [automatic updates](/components/saas/auto-updates.md).
-:::
-
 ### Automated cluster updates
 
 You can decide if you want to have [automated updates](/components/saas/auto-updates.md) to new versions of Camunda 8 activated. You can also toggle this feature anytime later in the **Settings** tab of your cluster.

--- a/versioned_docs/version-8.9/components/console/manage-clusters/manage-cluster.md
+++ b/versioned_docs/version-8.9/components/console/manage-clusters/manage-cluster.md
@@ -69,10 +69,6 @@ Clusters must be healthy before an update can be performed.
 
 If an update is available, a **Review Update** button is shown.
 
-:::note
-This button is not available for clusters enrolled in [automatic updates](/components/saas/auto-updates.md).
-:::
-
 ### Automated cluster updates
 
 You can decide if you want to have [automated updates](/components/saas/auto-updates.md) to new versions of Camunda 8 activated. You can also toggle this feature anytime later in the **Settings** tab of your cluster.


### PR DESCRIPTION
## Description

Removes an incorrect note from the "Update a cluster manually" section in `manage-cluster.md` that claimed the **Review Update** button is not available for clusters enrolled in automatic updates. Manual updates remain available even when auto-updates are enabled.

Change applied to next (`/docs/`) and versioned docs for 8.7, 8.8, and 8.9.

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
