### PR TITLE
docs: collect Elasticsearch/OpenSearch _cat/indices in the diagnostics script

### DIFF
--- a/docs/self-managed/deployment/helm/operational-tasks/diagnostics.md
+++ b/docs/self-managed/deployment/helm/operational-tasks/diagnostics.md
@@ -24,6 +24,7 @@ The script outputs the following data from your namespace and creates a zip file
 - **Network Resources**: Services, endpoints, and ingresses.
 - **Configuration**: Config map information.
 - **Actuator endpoints**: Read-only Zeebe and Spring Boot actuator outputs from Camunda pods (partition status, cluster topology, exporters, flow control, job streams, backup state, Prometheus metrics, and configuration properties).
+- **Database indices**: The Elasticsearch/OpenSearch index list (`_cat/indices`), when the datastore is deployed in the same namespace and reachable without TLS/authentication.
 
 ### Usage
 
@@ -257,6 +258,37 @@ else
       done
       if [[ -n "$collected" ]]; then
         echo "    - Collected actuators from pod ${pod}:${collected}"
+      fi
+      cleanup_port_forward
+    fi
+  done
+
+  # Collect the Elasticsearch/OpenSearch index list. It is cluster-wide, so the first reachable
+  # node is enough. Secured datastores (TLS/auth) are skipped here and must be collected manually.
+  es_port=9200
+  es_pods=$(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | grep -iE 'elasticsearch|opensearch' || true)
+  for pod in $es_pods; do
+    local_port=""
+    attempt=0
+    while [[ -z "$local_port" && "$attempt" -lt 3 ]]; do
+      attempt=$((attempt + 1))
+      pf_log=$(mktemp 2>/dev/null || mktemp -t camunda-diag 2>/dev/null || echo "./.es-pf.$$.${attempt}")
+      kubectl port-forward -n "$namespace" "$pod" ":${es_port}" > "$pf_log" 2>&1 &
+      pf_pid=$!
+      for _ in $(seq 1 10); do
+        local_port=$(sed -n 's/.*Forwarding from 127.0.0.1:\([0-9]*\) ->.*/\1/p' "$pf_log" | head -1)
+        [[ -n "$local_port" ]] && break
+        kill -0 "$pf_pid" 2>/dev/null || break
+        sleep 1
+      done
+      [[ -z "$local_port" ]] && cleanup_port_forward
+    done
+
+    if [[ -n "$local_port" ]]; then
+      if curl -sf -m 10 "http://localhost:${local_port}/_cat/indices?v" -o "${pod}-cat-indices.txt" 2>/dev/null; then
+        echo "    - Collected _cat/indices from pod ${pod}"
+        cleanup_port_forward
+        break
       fi
       cleanup_port_forward
     fi

--- a/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/troubleshooting/diagnostics.md
@@ -24,6 +24,7 @@ The script outputs the following data from your namespace and creates a zip file
 - **Network Resources**: Services, endpoints, and ingresses.
 - **Configuration**: Config map information.
 - **Actuator endpoints**: Read-only Zeebe and Spring Boot actuator outputs from Camunda pods (partition status, cluster topology, exporters, flow control, job streams, backup state, Prometheus metrics, and configuration properties).
+- **Database indices**: The Elasticsearch/OpenSearch index list (`_cat/indices`), when the datastore is deployed in the same namespace and reachable without TLS/authentication.
 
 ### Usage
 
@@ -257,6 +258,37 @@ else
       done
       if [[ -n "$collected" ]]; then
         echo "    - Collected actuators from pod ${pod}:${collected}"
+      fi
+      cleanup_port_forward
+    fi
+  done
+
+  # Collect the Elasticsearch/OpenSearch index list. It is cluster-wide, so the first reachable
+  # node is enough. Secured datastores (TLS/auth) are skipped here and must be collected manually.
+  es_port=9200
+  es_pods=$(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | grep -iE 'elasticsearch|opensearch' || true)
+  for pod in $es_pods; do
+    local_port=""
+    attempt=0
+    while [[ -z "$local_port" && "$attempt" -lt 3 ]]; do
+      attempt=$((attempt + 1))
+      pf_log=$(mktemp 2>/dev/null || mktemp -t camunda-diag 2>/dev/null || echo "./.es-pf.$$.${attempt}")
+      kubectl port-forward -n "$namespace" "$pod" ":${es_port}" > "$pf_log" 2>&1 &
+      pf_pid=$!
+      for _ in $(seq 1 10); do
+        local_port=$(sed -n 's/.*Forwarding from 127.0.0.1:\([0-9]*\) ->.*/\1/p' "$pf_log" | head -1)
+        [[ -n "$local_port" ]] && break
+        kill -0 "$pf_pid" 2>/dev/null || break
+        sleep 1
+      done
+      [[ -z "$local_port" ]] && cleanup_port_forward
+    done
+
+    if [[ -n "$local_port" ]]; then
+      if curl -sf -m 10 "http://localhost:${local_port}/_cat/indices?v" -o "${pod}-cat-indices.txt" 2>/dev/null; then
+        echo "    - Collected _cat/indices from pod ${pod}"
+        cleanup_port_forward
+        break
       fi
       cleanup_port_forward
     fi

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/diagnostics.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/diagnostics.md
@@ -24,6 +24,7 @@ The script outputs the following data from your namespace and creates a zip file
 - **Network Resources**: Services, endpoints, and ingresses.
 - **Configuration**: Config map information.
 - **Actuator endpoints**: Read-only Zeebe and Spring Boot actuator outputs from Camunda pods (partition status, cluster topology, exporters, flow control, job streams, backup state, Prometheus metrics, and configuration properties).
+- **Database indices**: The Elasticsearch/OpenSearch index list (`_cat/indices`), when the datastore is deployed in the same namespace and reachable without TLS/authentication.
 
 ### Usage
 
@@ -257,6 +258,37 @@ else
       done
       if [[ -n "$collected" ]]; then
         echo "    - Collected actuators from pod ${pod}:${collected}"
+      fi
+      cleanup_port_forward
+    fi
+  done
+
+  # Collect the Elasticsearch/OpenSearch index list. It is cluster-wide, so the first reachable
+  # node is enough. Secured datastores (TLS/auth) are skipped here and must be collected manually.
+  es_port=9200
+  es_pods=$(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | grep -iE 'elasticsearch|opensearch' || true)
+  for pod in $es_pods; do
+    local_port=""
+    attempt=0
+    while [[ -z "$local_port" && "$attempt" -lt 3 ]]; do
+      attempt=$((attempt + 1))
+      pf_log=$(mktemp 2>/dev/null || mktemp -t camunda-diag 2>/dev/null || echo "./.es-pf.$$.${attempt}")
+      kubectl port-forward -n "$namespace" "$pod" ":${es_port}" > "$pf_log" 2>&1 &
+      pf_pid=$!
+      for _ in $(seq 1 10); do
+        local_port=$(sed -n 's/.*Forwarding from 127.0.0.1:\([0-9]*\) ->.*/\1/p' "$pf_log" | head -1)
+        [[ -n "$local_port" ]] && break
+        kill -0 "$pf_pid" 2>/dev/null || break
+        sleep 1
+      done
+      [[ -z "$local_port" ]] && cleanup_port_forward
+    done
+
+    if [[ -n "$local_port" ]]; then
+      if curl -sf -m 10 "http://localhost:${local_port}/_cat/indices?v" -o "${pod}-cat-indices.txt" 2>/dev/null; then
+        echo "    - Collected _cat/indices from pod ${pod}"
+        cleanup_port_forward
+        break
       fi
       cleanup_port_forward
     fi

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/diagnostics.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/diagnostics.md
@@ -24,6 +24,7 @@ The script outputs the following data from your namespace and creates a zip file
 - **Network Resources**: Services, endpoints, and ingresses.
 - **Configuration**: Config map information.
 - **Actuator endpoints**: Read-only Zeebe and Spring Boot actuator outputs from Camunda pods (partition status, cluster topology, exporters, flow control, job streams, backup state, Prometheus metrics, and configuration properties).
+- **Database indices**: The Elasticsearch/OpenSearch index list (`_cat/indices`), when the datastore is deployed in the same namespace and reachable without TLS/authentication.
 
 ### Usage
 
@@ -257,6 +258,37 @@ else
       done
       if [[ -n "$collected" ]]; then
         echo "    - Collected actuators from pod ${pod}:${collected}"
+      fi
+      cleanup_port_forward
+    fi
+  done
+
+  # Collect the Elasticsearch/OpenSearch index list. It is cluster-wide, so the first reachable
+  # node is enough. Secured datastores (TLS/auth) are skipped here and must be collected manually.
+  es_port=9200
+  es_pods=$(kubectl get pod -n "$namespace" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | grep -iE 'elasticsearch|opensearch' || true)
+  for pod in $es_pods; do
+    local_port=""
+    attempt=0
+    while [[ -z "$local_port" && "$attempt" -lt 3 ]]; do
+      attempt=$((attempt + 1))
+      pf_log=$(mktemp 2>/dev/null || mktemp -t camunda-diag 2>/dev/null || echo "./.es-pf.$$.${attempt}")
+      kubectl port-forward -n "$namespace" "$pod" ":${es_port}" > "$pf_log" 2>&1 &
+      pf_pid=$!
+      for _ in $(seq 1 10); do
+        local_port=$(sed -n 's/.*Forwarding from 127.0.0.1:\([0-9]*\) ->.*/\1/p' "$pf_log" | head -1)
+        [[ -n "$local_port" ]] && break
+        kill -0 "$pf_pid" 2>/dev/null || break
+        sleep 1
+      done
+      [[ -z "$local_port" ]] && cleanup_port_forward
+    done
+
+    if [[ -n "$local_port" ]]; then
+      if curl -sf -m 10 "http://localhost:${local_port}/_cat/indices?v" -o "${pod}-cat-indices.txt" 2>/dev/null; then
+        echo "    - Collected _cat/indices from pod ${pod}"
+        cleanup_port_forward
+        break
       fi
       cleanup_port_forward
     fi


### PR DESCRIPTION
## Description

Follow-up to the actuator collection added in #9210. @epollum asked that the diagnostics bundle also include the secondary-storage index list, which is useful when investigating storage growth or exporter issues.

Adds a step that port-forwards the datastore HTTP port (`9200`) and saves `_cat/indices?v` from the first reachable Elasticsearch/OpenSearch node into `<pod>-cat-indices.txt`. The listing is cluster-wide, so it stops after the first node that answers. It reuses the same ephemeral-port + bounded-retry + trap-based cleanup machinery as the actuator step.

Secured datastores (TLS/auth) are skipped — we have no credentials in this context — and the docs note they must be collected manually.

Also adds a matching "Database indices" entry to the "What the script collects" list.

Applied consistently to all four copies of the page (current, 8.9, 8.8, 8.7).
