### PR TITLE
docs(dx): use vault secrets for staging and prod deployments

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -40,16 +40,29 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           DOCS_SITE_URL: https://docs.camunda.io
           DOCS_SITE_BASE_URL: /
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda-docs/ci/publish PROD_PATH;
+            secret/data/products/camunda-docs/ci/publish HOST;
+            secret/data/products/camunda-docs/ci/publish USER;
+            secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
         uses: burnett01/rsync-deployments@v9
         with:
           switches: -avzr --delete
           path: build/
-          remote_path: ${{ secrets.AWS_PROD_PUBLISH_PATH }}
-          remote_host: ${{ secrets.AWS_PROD_PUBLISH_HOST }}
-          remote_user: ${{ secrets.AWS_PROD_PUBLISH_USER }}
-          # vvvvv Intentionally missing the AWS_ prefix vvvvv
-          remote_key: ${{ secrets.PUBLISH_PROD_KEY }}
+          remote_path: ${{ steps.secrets.outputs.PROD_PATH }}
+          remote_host: ${{ steps.secrets.outputs.HOST }}
+          remote_user: ${{ steps.secrets.outputs.USER }}
+          remote_key: ${{ steps.secrets.outputs.PRIVATE_KEY }}
   trigger-crawl:
     runs-on: ubuntu-latest
     needs: publish

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "vault-secrets-pt-2"
     tags-ignore:
       - "*"
 
@@ -31,13 +32,26 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           DOCS_SITE_URL: https://stage.docs.camunda.io
           DOCS_SITE_BASE_URL: /
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda-docs/ci/publish STAGE_PATH;
+            secret/data/products/camunda-docs/ci/publish HOST;
+            secret/data/products/camunda-docs/ci/publish USER;
+            secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
         uses: burnett01/rsync-deployments@v9
         with:
           switches: -avzr --delete
           path: build/
-          remote_path: ${{ secrets.AWS_STAGE_PUBLISH_PATH }}
-          remote_host: ${{ secrets.AWS_STAGE_PUBLISH_HOST }}
-          remote_user: ${{ secrets.AWS_STAGE_PUBLISH_USER }}
-          # vvvvv Intentionally missing the AWS_ prefix vvvvv
-          remote_key: ${{ secrets.PUBLISH_STAGE_KEY }}
+          remote_path: ${{ steps.secrets.outputs.STAGE_PATH }}
+          remote_host: ${{ steps.secrets.outputs.HOST }}
+          remote_user: ${{ steps.secrets.outputs.USER }}
+          remote_key: ${{ steps.secrets.outputs.PRIVATE_KEY }}

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "vault-secrets-pt-2"
     tags-ignore:
       - "*"
 

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -46,7 +46,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-prod.yaml
   sed -i '' "s/remote_path: \${{ steps.secrets.outputs.PROD_PATH }}/remote_path: \${{ steps.secrets.outputs.PROD_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 else
-  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-prod.yaml
+  sed -i "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-prod.yaml
   sed -i "s/remote_path: \${{ steps.secrets.outputs.PROD_PATH }}/remote_path: \${{ steps.secrets.outputs.PROD_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 fi
 
@@ -78,7 +78,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
   sed -i '' "s/remote_path: \${{ steps.secrets.outputs.STAGE_PATH }}/remote_path: \${{ steps.secrets.outputs.STAGE_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
 else
-  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i "s/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
   sed -i "s/remote_path: \${{ steps.secrets.outputs.STAGE_PATH }}/remote_path: \${{ steps.secrets.outputs.STAGE_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
 fi
 

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -43,10 +43,10 @@ fi
 
 #   e. replace the main docs remote_path with this isolated version's remote_path.
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-prod.yaml
   sed -i '' "s/remote_path: \${{ steps.secrets.outputs.PROD_PATH }}/remote_path: \${{ steps.secrets.outputs.PROD_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 else
-  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-prod.yaml
   sed -i "s/remote_path: \${{ steps.secrets.outputs.PROD_PATH }}/remote_path: \${{ steps.secrets.outputs.PROD_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 fi
 

--- a/hacks/isolateVersion/6-updateCIWorkflows.sh
+++ b/hacks/isolateVersion/6-updateCIWorkflows.sh
@@ -43,9 +43,11 @@ fi
 
 #   e. replace the main docs remote_path with this isolated version's remote_path.
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
+  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i '' "s/remote_path: \${{ steps.secrets.outputs.PROD_PATH }}/remote_path: \${{ steps.secrets.outputs.PROD_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 else
-  sed -i "s/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_PROD_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
+  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish PROD_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish PROD_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i "s/remote_path: \${{ steps.secrets.outputs.PROD_PATH }}/remote_path: \${{ steps.secrets.outputs.PROD_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-prod.yaml
 fi
 
 #   f. update `DOCS_SITE_BASE_URL` to specify isolated version
@@ -71,11 +73,13 @@ else
   sed -i 's/https:\/\/stage.docs.camunda.io/https:\/\/stage.unsupported.docs.camunda.io/' .github/workflows/publish-stage.yaml
 fi
 
-#   c. replace `${{ secrets.AWS_STAGE_PUBLISH_PATH }}` with `${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}/{version}`
+#   c. replace `${{ steps.secrets.outputs.STAGE_PATH }}` with `${{ steps.secrets.outputs.STAGE_UNSUPPORTED_PATH }}/{version}`
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
+  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i '' "s/remote_path: \${{ steps.secrets.outputs.STAGE_PATH }}/remote_path: \${{ steps.secrets.outputs.STAGE_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
 else
-  sed -i "s/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH }}/remote_path: \${{ secrets.AWS_STAGE_PUBLISH_PATH_UNSUPPORTED }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
+  sed -i '' "s/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_PATH;/secret\/data\/products\/camunda-docs\/ci\/publish STAGE_UNSUPPORTED_PATH;/g" .github/workflows/publish-stage.yaml
+  sed -i "s/remote_path: \${{ steps.secrets.outputs.STAGE_PATH }}/remote_path: \${{ steps.secrets.outputs.STAGE_UNSUPPORTED_PATH }}\/$ARCHIVED_VERSION/g" .github/workflows/publish-stage.yaml
 fi
 
 #   d. update `DOCS_SITE_BASE_URL` to specify isolated version


### PR DESCRIPTION
## Description

Use existing vault credentials instead of GH credentials (part 2). This PR addresses the prod and staging pipelines for both docs.camunda.io and the unsupported site.

Refs: https://github.com/camunda/camunda-docs/issues/8949

## When should this change go live?

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
