### PR TITLE
docs: add MariaDB 12.3 LTS support

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -95,6 +95,25 @@ Oracle has rebranded Oracle Database 23ai as Oracle AI Database 26ai, effective 
 </div>
 <div className="release-announcement-content">
 
+#### MariaDB 11.8 replaced by 12.3
+
+Camunda 8.10 adds support for MariaDB 12.3 LTS and drops support for MariaDB 11.8. Supported versions are now 10.11, 11.4, and 12.3.
+
+- MariaDB 12.3 is the latest LTS release.
+- MariaDB 11.8 was a non-LTS development series release. Camunda supports MariaDB LTS releases only.
+- Upgrade your MariaDB 11.8 instance to 11.4 or 12.3 before moving to Camunda 8.10.
+
+<p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--change">Change</span>
+</div>
+<div className="release-announcement-content">
+
 #### H2 2.3 no longer supported
 
 Camunda 8.10 drops support for H2 2.3. Only H2 2.4 is now supported.
@@ -137,39 +156,6 @@ Camunda 8.10 raises the minimum supported OpenSearch 3.x version to 3.5. Support
 - Upgrade OpenSearch 3.4 clusters to 3.5 or later before moving to Camunda 8.10.
 
 <p className="link-arrow">[Supported environments](/reference/supported-environments.md)</p>
-
-</div>
-</div>
-
-<div className="release-announcement-row">
-<div className="release-announcement-badge">
-<span className="badge badge--new">New</span>
-</div>
-<div className="release-announcement-content">
-
-#### MariaDB 12.3 now supported
-
-Camunda 8.10 adds support for MariaDB 12.3, the latest LTS release of MariaDB.
-
-<p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
-
-</div>
-</div>
-
-<div className="release-announcement-row">
-<div className="release-announcement-badge">
-<span className="badge badge--change">Change</span>
-</div>
-<div className="release-announcement-content">
-
-#### MariaDB 11.8 no longer supported
-
-Camunda 8.10 drops support for MariaDB 11.8. Supported versions are now 10.11, 11.4, and 12.3.
-
-- MariaDB 11.8 was a non-LTS development series release. Camunda supports MariaDB LTS releases only.
-- Upgrade your MariaDB instance to a supported version before moving to Camunda 8.10.
-
-<p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -141,6 +141,39 @@ Camunda 8.10 raises the minimum supported OpenSearch 3.x version to 3.5. Support
 </div>
 </div>
 
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--new">New</span>
+</div>
+<div className="release-announcement-content">
+
+#### MariaDB 12.3 now supported
+
+Camunda 8.10 adds support for MariaDB 12.3, the latest LTS release of MariaDB.
+
+<p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--change">Change</span>
+</div>
+<div className="release-announcement-content">
+
+#### MariaDB 11.8 no longer supported
+
+Camunda 8.10 drops support for MariaDB 11.8. Supported versions are now 10.11, 11.4, and 12.3.
+
+- MariaDB 11.8 was a non-LTS development series release. Camunda supports MariaDB LTS releases only.
+- Upgrade your MariaDB instance to a supported version before moving to Camunda 8.10.
+
+<p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
+
+</div>
+</div>
+
 ## Agentic orchestration
 
 <div className="release-announcement-row">

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -91,17 +91,13 @@ Oracle has rebranded Oracle Database 23ai as Oracle AI Database 26ai, effective 
 
 <div className="release-announcement-row">
 <div className="release-announcement-badge">
-<span className="badge badge--change">Change</span>
+<span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
 
-#### MariaDB 11.8 replaced by 12.3
+#### MariaDB 12.3 now supported
 
-Camunda 8.10 adds support for MariaDB 12.3 LTS and drops support for MariaDB 11.8. Supported versions are now 10.11, 11.4, and 12.3.
-
-- MariaDB 12.3 is the latest LTS release.
-- MariaDB 11.8 was a non-LTS development series release. Camunda supports MariaDB LTS releases only.
-- Upgrade your MariaDB 11.8 instance to 11.4 or 12.3 before moving to Camunda 8.10.
+Camunda 8.10 adds support for MariaDB 12.3 LTS. Supported versions are now 10.11, 11.4, 11.8, and 12.3.
 
 <p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
 

--- a/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -29,7 +29,7 @@ The following relational databases are officially supported when used as an RDBM
 | ------------------------ | ------------------ |
 | PostgreSQL               | 15, 16, 17, 18     |
 | Amazon Aurora PostgreSQL | 15, 16, 17, 18     |
-| MariaDB                  | 10.11, 11.4, 12.3  |
+| MariaDB                  | 10.11, 11.4, 11.8, 12.3 |
 | MySQL                    | 8.4                |
 | Microsoft SQL Server     | 2022, 2025         |
 | Oracle                   | 19c, 26ai          |

--- a/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -29,7 +29,7 @@ The following relational databases are officially supported when used as an RDBM
 | ------------------------ | ------------------ |
 | PostgreSQL               | 15, 16, 17, 18     |
 | Amazon Aurora PostgreSQL | 15, 16, 17, 18     |
-| MariaDB                  | 10.11, 11.4, 11.8  |
+| MariaDB                  | 10.11, 11.4, 12.3  |
 | MySQL                    | 8.4                |
 | Microsoft SQL Server     | 2022, 2025         |
 | Oracle                   | 19c, 26ai          |


### PR DESCRIPTION
## Summary

Updates the RDBMS version support policy table and 8.10 release announcements to reflect MariaDB 12.3 LTS support and the removal of MariaDB 11.8 (non-LTS development series).

## Related

https://github.com/camunda/camunda/pull/56174