### PR TITLE
docs: add Amazon Aurora PostgreSQL 18, remove Aurora 14

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -44,11 +44,12 @@ Camunda 8.10 drops support for PostgreSQL 14. Supported versions are now 15, 16,
 </div>
 <div className="release-announcement-content">
 
-#### Amazon Aurora PostgreSQL 14 no longer supported
+#### Amazon Aurora PostgreSQL 14 removed, 18 added
 
-Camunda 8.10 drops support for Amazon Aurora PostgreSQL 14. Supported versions are now 15, 16, and 17.
+Camunda 8.10 drops support for Amazon Aurora PostgreSQL 14 and adds support for version 18. Supported versions are now 15, 16, 17, and 18.
 
 - Aurora PostgreSQL 14 has reached the end of standard support on AWS.
+- Aurora PostgreSQL 18 is explicitly tested by Camunda in CI.
 - Migrate your Aurora cluster to a supported version before moving to Camunda 8.10.
 
 <p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -49,7 +49,6 @@ Camunda 8.10 drops support for PostgreSQL 14. Supported versions are now 15, 16,
 Camunda 8.10 drops support for Amazon Aurora PostgreSQL 14 and adds support for version 18. Supported versions are now 15, 16, 17, and 18.
 
 - Aurora PostgreSQL 14 has reached the end of standard support on AWS.
-- Aurora PostgreSQL 18 is explicitly tested by Camunda in CI.
 - Migrate your Aurora cluster to a supported version before moving to Camunda 8.10.
 
 <p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>

--- a/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -28,7 +28,7 @@ The following relational databases are officially supported when used as an RDBM
 | Database                 | Supported versions |
 | ------------------------ | ------------------ |
 | PostgreSQL               | 15, 16, 17, 18     |
-| Amazon Aurora PostgreSQL | 15, 16, 17         |
+| Amazon Aurora PostgreSQL | 15, 16, 17, 18     |
 | MariaDB                  | 10.11, 11.4, 11.8  |
 | MySQL                    | 8.4                |
 | Microsoft SQL Server     | 2022, 2025         |


### PR DESCRIPTION
## Summary

Updates the RDBMS version support policy table and 8.10 release announcements to reflect Amazon Aurora PostgreSQL 18 support and the removal of Aurora PostgreSQL 14.

- Aurora PostgreSQL 14 reached end of standard support on AWS.
- Aurora PostgreSQL 18 is explicitly tested by Camunda in CI.
- Merges the two separate Aurora announcements into a single block following the pattern established in #9255.

## Related

https://github.com/camunda/camunda/issues/52148