### PR TITLE
docs(hub): rename cluster config types webModelerWebApp→hub, orchestrationIdentity→admin

### DIFF
--- a/docs/self-managed/components/hub/configuration/properties.md
+++ b/docs/self-managed/components/hub/configuration/properties.md
@@ -221,8 +221,8 @@ Available component types and requirements:
 | `zeebe`             | Zeebe Broker          | Cluster version < 8.8, gRPC URL, and REST URL  |
 | `zeebeGateway`      | Zeebe Gateway         | Cluster version < 8.8                          |
 
-:::note Backwards compatibility
-The old values `webModelerWebApp` (replaced by `hub`) and `orchestrationIdentity` (replaced by `admin`) are still accepted for backwards compatibility.
+:::note Backward compatibility
+The old values `webModelerWebApp` (replaced by `hub`) and `orchestrationIdentity` (replaced by `admin`) are still accepted for backward compatibility.
 :::
 
 Example configuration:

--- a/docs/self-managed/components/hub/configuration/properties.md
+++ b/docs/self-managed/components/hub/configuration/properties.md
@@ -208,18 +208,22 @@ Use `CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS` to set up components in the cluster:
 
 Available component types and requirements:
 
-| Configuration value     | Component             | Requirements                                   |
-| :---------------------- | :-------------------- | :--------------------------------------------- |
-| `connectors`            | Connectors            | REST URL                                       |
-| `identity`              | Management Identity   | -                                              |
-| `webModelerWebApp`      | Camunda Hub           | -                                              |
-| `operate`               | Operate               | -                                              |
-| `optimize`              | Optimize              | -                                              |
-| `orchestration`         | Orchestration Cluster | Cluster version >= 8.8, gRPC URL, and REST URL |
-| `orchestrationIdentity` | Admin                 | -                                              |
-| `tasklist`              | Tasklist              | -                                              |
-| `zeebe`                 | Zeebe Broker          | Cluster version < 8.8, gRPC URL, and REST URL  |
-| `zeebeGateway`          | Zeebe Gateway         | Cluster version < 8.8                          |
+| Configuration value | Component             | Requirements                                   |
+| :------------------ | :-------------------- | :--------------------------------------------- |
+| `connectors`        | Connectors            | REST URL                                       |
+| `identity`          | Management Identity   | -                                              |
+| `hub`               | Camunda Hub           | -                                              |
+| `operate`           | Operate               | -                                              |
+| `optimize`          | Optimize              | -                                              |
+| `orchestration`     | Orchestration Cluster | Cluster version >= 8.8, gRPC URL, and REST URL |
+| `admin`             | Admin                 | -                                              |
+| `tasklist`          | Tasklist              | -                                              |
+| `zeebe`             | Zeebe Broker          | Cluster version < 8.8, gRPC URL, and REST URL  |
+| `zeebeGateway`      | Zeebe Gateway         | Cluster version < 8.8                          |
+
+:::note Backwards compatibility
+The old values `webModelerWebApp` (replaced by `hub`) and `orchestrationIdentity` (replaced by `admin`) are still accepted for backwards compatibility.
+:::
 
 Example configuration:
 
@@ -241,7 +245,7 @@ camunda:
               rest: "https://camunda.example.com"
               readiness: "https://camunda.example.com:9600/core/actuator/health/readiness"
           - name: "Orchestration Admin"
-            type: "orchestrationIdentity"
+            type: "admin"
             version: "8.10-SNAPSHOT"
             urls:
               webapp: "https://camunda.example.com"
@@ -260,7 +264,7 @@ CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_URLS_REST=https://camunda.example.com
 CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_URLS_READINESS=https://camunda.example.com:9600/core/actuator/health/readiness
 
 CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_NAME='Orchestration Admin'
-CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_TYPE=orchestrationIdentity
+CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_TYPE=admin
 CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_VERSION=8.10-SNAPSHOT
 CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_URLS_WEBAPP=https://camunda.example.com
 CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_URLS_READINESS=https://camunda.example.com:9600/core/actuator/health/readiness

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -180,8 +180,8 @@ camunda:
             urls:
               webapp: "https://qa.ci.distro.ultrawombat.com/identity"
               readiness: "http://camunda-platform-identity.qa-camunda-platform:82/actuator/health"
-          - name: "WebModeler"
-            type: "webModelerWebApp"
+          - name: "Camunda Hub"
+            type: "hub"
             version: "8.10-SNAPSHOT"
             urls:
               webapp: "https://qa.ci.distro.ultrawombat.com/modeler"
@@ -211,7 +211,7 @@ camunda:
               webapp: "https://qa.ci.distro.ultrawombat.com/core/tasklist"
               readiness: "http://camunda-platform-zeebe.qa-camunda-platform:9600/core/actuator/health/readiness"
           - name: "Orchestration Admin"
-            type: "orchestrationIdentity"
+            type: "admin"
             version: "8.10-SNAPSHOT"
             urls:
               webapp: "https://qa.ci.distro.ultrawombat.com/core/admin"
@@ -228,6 +228,13 @@ camunda:
 ### Component types
 
 `console` and `keycloak` are no longer valid component types. The application will fail on startup if you've configured a `console` or `keycloak` component:
+
+Additionally, the following component types have been renamed:
+
+- `webModelerWebApp` → `hub`
+- `orchestrationIdentity` → `admin`
+
+The old values are still accepted for backwards compatibility, but you should update your configuration to use the new values.
 
 ```yaml
 camunda:

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -227,14 +227,14 @@ camunda:
 
 ### Component types
 
-`console` and `keycloak` are no longer valid component types. The application will fail on startup if you've configured a `console` or `keycloak` component:
+`console` and `keycloak` are no longer valid component types. The application will fail on startup if you've configured a `console` or `keycloak` component.
 
 Additionally, the following component types have been renamed:
 
 - `webModelerWebApp` → `hub`
 - `orchestrationIdentity` → `admin`
 
-The old values are still accepted for backwards compatibility, but you should update your configuration to use the new values.
+The old values are still accepted for backward compatibility, but you should update your configuration to use the new values.
 
 ```yaml
 camunda:


### PR DESCRIPTION
## Summary

Updates the component type reference table and examples in the Hub Self-Managed property docs to reflect the renamed configuration values introduced in camunda/camunda-hub#25769:

- `webModelerWebApp` → `hub`
- `orchestrationIdentity` → `admin`

A backwards-compatibility note is added to the table explaining that old values are still accepted.

## Changes

- Updated component type table with new values
- Added backwards-compat note for old values
- Updated YAML and env var examples to use `admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)