### PR TITLE
docs: clarify rollover interval semantics and retention interaction

### DIFF
--- a/versioned_docs/version-8.7/self-managed/operate-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/data-retention.md
@@ -27,16 +27,16 @@ All Operate data present in Elasticsearch (from both **main** and **dated** indi
 
 The default time between a process instance finishing and being moved to a dated index is one hour. This can be modified by setting the [waitPeriodBeforeArchiving](importer-and-archiver.md#archive-period) configuration parameter.
 
-## Rollover Interval
+## Rollover interval
 
 Process instances are archived into historical indices based on a rollover interval. By default, this value is `1d`, so a process instance that completed on `yyyy-mm-dd` is archived into an index with that date as a suffix, meaning there is one historical index per day. Increasing this interval reduces the number of historical indices, which reduces shard consumption.
 
 This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter.
 
 :::warning
-With a `1w` or `1M` rollover interval, effective retention can be shorter than the configured retention value. Retention is applied per index, counted from the start of that index's calendar bucket (the Monday of the ISO week for `1w`, or the 1st of the month for `1M`), not from the date the process instance actually finished.
+With a `1w` or `1M` rollover interval, effective retention can be shorter than the configured retention value. Retention is applied per index, counted from the start of that index's calendar bucket (the Monday of the ISO week for `1w`, or the 1st of the month for `1M`) — not from the date the process instance actually finished.
 
-For example, with `rolloverInterval: 1w` and a retention period of `30d`: a process instance that finishes on Sunday, 14 June 2026 is archived into the weekly index starting Monday, 8 June 2026 (suffix `2026-06-08`). Retention counts from 8 June, so the index becomes eligible for deletion after 8 July 2026, only 24 days after the instance actually finished.
+For example, with `rolloverInterval: 1w` and a retention period of `30d`: a process instance that finishes on Sunday, 14 June 2026 is archived into the weekly index starting Monday, 8 June 2026 (suffix `2026-06-08`). Retention counts from 8 June, so the index becomes eligible for deletion after 8 July 2026 — only 24 days after the instance actually finished, instead of the full 30 days.
 :::
 
 ## Data cleanup

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/data-retention.md
@@ -33,7 +33,13 @@ Process instances are archived into historical indices based on some rollover in
 at yyyy-mm-dd would be archived into an index which that date as a suffix, meaning there would be one historical index per day. By increasing this interval, the number
 of historical indices will reduce which will reduce shard consumption.
 
-This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter
+This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter.
+
+:::warning
+With a `1w` or `1M` rollover interval, effective retention can be shorter than the configured retention value. Retention is applied per index, counted from the start of that index's calendar bucket (the Monday of the ISO week for `1w`, or the 1st of the month for `1M`), not from the date the process instance actually finished.
+
+For example, with `rolloverInterval: 1w` and a retention period of `30d`: a process instance that finishes on Sunday, 14 June 2026 is archived into the weekly index starting Monday, 8 June 2026 (suffix `2026-06-08`). Retention counts from 8 June, so the index becomes eligible for deletion after 8 July 2026, only 24 days after the instance actually finished.
+:::
 
 ## Data cleanup
 

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/data-retention.md
@@ -29,9 +29,7 @@ The default time between a process instance finishing and being moved to a dated
 
 ## Rollover Interval
 
-Process instances are archived into historical indices based on some rollover interval, by default this value is `1d` therefore a process instance which completed
-at yyyy-mm-dd would be archived into an index which that date as a suffix, meaning there would be one historical index per day. By increasing this interval, the number
-of historical indices will reduce which will reduce shard consumption.
+Process instances are archived into historical indices based on a rollover interval. By default, this value is `1d`, so a process instance that completed on `yyyy-mm-dd` is archived into an index with that date as a suffix, meaning there is one historical index per day. Increasing this interval reduces the number of historical indices, which reduces shard consumption.
 
 This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter.
 

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
@@ -132,5 +132,5 @@ Camunda supports the same set of rollover interval values on both Elasticsearch 
 See [data retention](data-retention.md#rollover-interval) for how the rollover interval affects effective retention.
 
 :::note
-This feature is officially supported from version >= 8.7.15.
+This feature is officially supported from version 8.7.15 onward.
 :::

--- a/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/operate-deployment/importer-and-archiver.md
@@ -117,17 +117,19 @@ The syntax for the parameter uses Elasticsearch date math. See the table below f
 
 ## Rollover interval
 
-The size of the historical indices from which process instances are archived into. By default this value is set to `1d` (1 day), as an example a
-value of `1w` would archive based on weekly intervals so a process instance which completed on the 10th of a month would fall into the 7th-14th bucket
-therefore it would be archived into a historical index with a suffix of `yyyy-mm-07`
+The size of the historical indices into which process instances are archived, based on a **calendar interval**, a fixed calendar boundary (start of a day or start of an ISO week).
+
+Only single-unit values are supported, using the same units as [archive period](#archive-period), for example `1d` (the default) or `1w`. Multi-quantity values such as `2d` or `2w` are not supported.
 
 | Configuration parameter                   | Description                            | Default value |
 | ----------------------------------------- | -------------------------------------- | ------------- |
 | camunda.operate.archiver.rolloverInterval | Interval for size of archived indices. | 1d            |
 
-Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
-or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
-for more information on possible values and their effects.
+With `1w`, indices are split into weekly buckets aligned to **ISO week boundaries (Monday to Sunday)**. Each bucket's index suffix is the date of the Monday that starts that ISO week. For example, a process instance that completes on Wednesday, 10 June 2026 falls into the ISO week starting Monday, 8 June 2026, so it is archived into a historical index with the suffix `2026-06-08`.
+
+Camunda supports the same set of rollover interval values on both Elasticsearch and OpenSearch.
+
+See [data retention](data-retention.md#rollover-interval) for how the rollover interval affects effective retention.
 
 :::note
 This feature is officially supported from version >= 8.7.15.

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
@@ -33,7 +33,13 @@ Process instances are archived into historical indices based on some rollover in
 at yyyy-mm-dd would be archived into an index which that date as a suffix, meaning there would be one historical index per day. By increasing this interval, the number
 of historical indices will reduce which will reduce shard consumption.
 
-This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter
+This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter.
+
+:::warning
+With a `1w` or `1M` rollover interval, effective retention can be shorter than the configured retention value. Retention is applied per index, counted from the start of that index's calendar bucket (the Monday of the ISO week for `1w`, or the 1st of the month for `1M`) — not from the date the process instance actually finished.
+
+For example, with `rolloverInterval: 1w` and a retention period of `30d`: a process instance that finishes on Sunday, 14 June 2026 is archived into the weekly index starting Monday, 8 June 2026 (suffix `2026-06-08`). Retention counts from 8 June, so the index becomes eligible for deletion after 8 July 2026 — only 24 days after the instance actually finished, instead of the full 30 days.
+:::
 
 ## Data cleanup
 

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
@@ -27,7 +27,7 @@ All Tasklist data present in Elasticsearch (from both **main** and **dated** ind
 
 The default time between a process instance finishing and being moved to a dated index is one hour. This can be modified by setting the [waitPeriodBeforeArchiving](importer-and-archiver.md#archive-period) configuration parameter.
 
-## Rollover Interval
+## Rollover interval
 
 Process instances are archived into historical indices based on a rollover interval. By default, this value is `1d`, so a process instance that completed on `yyyy-mm-dd` is archived into an index with that date as a suffix, meaning there is one historical index per day. Increasing this interval reduces the number of historical indices, which reduces shard consumption.
 

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/data-retention.md
@@ -29,9 +29,7 @@ The default time between a process instance finishing and being moved to a dated
 
 ## Rollover Interval
 
-Process instances are archived into historical indices based on some rollover interval, by default this value is `1d` therefore a process instance which completed
-at yyyy-mm-dd would be archived into an index which that date as a suffix, meaning there would be one historical index per day. By increasing this interval, the number
-of historical indices will reduce which will reduce shard consumption.
+Process instances are archived into historical indices based on a rollover interval. By default, this value is `1d`, so a process instance that completed on `yyyy-mm-dd` is archived into an index with that date as a suffix, meaning there is one historical index per day. Increasing this interval reduces the number of historical indices, which reduces shard consumption.
 
 This value can be modified by setting the [rolloverInterval](importer-and-archiver.md#rollover-interval) configuration parameter.
 

--- a/versioned_docs/version-8.7/self-managed/tasklist-deployment/importer-and-archiver.md
+++ b/versioned_docs/version-8.7/self-managed/tasklist-deployment/importer-and-archiver.md
@@ -117,18 +117,20 @@ The syntax for the parameter uses Elasticsearch date math. See the table below f
 
 ## Rollover interval
 
-The size of the historical indices from which process instances are archived into. By default this value is set to `1d` (1 day), as an example a
-value of `1w` would archive based on weekly intervals so a process instance which completed on the 10th of a month would fall into the 7th-14th bucket
-therefore it would be archived into a historical index with a suffix of `yyyy-mm-07`
+The size of the historical indices into which process instances are archived, based on a **calendar interval**, a fixed calendar boundary (start of a day or start of an ISO week).
+
+Only single-unit values are supported, using the same units as [archive period](#archive-period), for example `1d` (the default) or `1w`. Multi-quantity values such as `2d` or `2w` are not supported.
 
 | Configuration parameter                    | Description                            | Default value |
 | ------------------------------------------ | -------------------------------------- | ------------- |
 | camunda.tasklist.archiver.rolloverInterval | Interval for size of archived indices. | 1d            |
 
-Refer to [Elasticsearch calendar intervals](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-datehistogram-aggregation#calendar_intervals)
-or [OpenSearch Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
-for more information on possible values and their effects.
+With `1w`, indices are split into weekly buckets aligned to **ISO week boundaries (Monday to Sunday)**. Each bucket's index suffix is the date of the Monday that starts that ISO week. For example, a process instance that completes on Wednesday, 10 June 2026 falls into the ISO week starting Monday, 8 June 2026, so it is archived into a historical index with the suffix `2026-06-08`.
+
+Camunda supports the same set of rollover interval values on both Elasticsearch and OpenSearch.
+
+See [data retention](data-retention.md#rollover-interval) for how the rollover interval affects effective retention.
 
 :::note
-This feature is officially supported from version >= 8.7.15.
+This feature is officially supported from version 8.7.15 onward. On OpenSearch, versions before 8.7.15 require the value `Week` (capitalized) instead of `1w` for weekly rollover to take effect; from 8.7.15 onward, use `1w`.
 :::


### PR DESCRIPTION
## Description

Clarifies rollover configuration for Operate and Tasklist archiver (8.7 docs) to reduce misconfiguration and unexpected retention outcomes, per support ticket SUPPORT-29608.

- Explains `rolloverInterval` uses calendar intervals (fixed calendar boundaries), not a rolling duration from completion time.
- States only single-unit values are supported, using the same units as the archive period table (`y`, `M`, `w`, `d`, `h`, `m`, `s`) — multi-quantity values like `2d` are not supported.
- Fixes an incorrect `1w` example (previously said a process finishing "on the 10th" falls into a "7th-14th bucket" suffixed `yyyy-mm-07`) with a correct ISO week (Monday-Sunday) example.
- Removes external ES/OS calendar-interval doc links in favor of stating Camunda supports the same values on both.
- Adds a Tasklist-specific note: before 8.7.15, Tasklist on OpenSearch requires `Week` (capitalized) instead of `1w`.
- Adds a warning in both `data-retention.md` pages with a worked example showing effective retention can be shorter than configured retention when using `1w`/`1M` rollover, since retention is applied from the start of the calendar bucket, not the actual completion date.

Closes #7116

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
