### PR TITLE
dx: move gh secrets to vault

### DIFF
--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -23,7 +23,7 @@ jobs:
       - id: slack
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          webhook: ${{ steps.secrets.outputs.SLACK_ASK_C8_DOCUMENTATION }}
+          webhook: ${{ steps.secrets.outputs.DOCS_RELEASE_BOT_WEBHOOK }}
           webhook-type: webhook-trigger
           payload-templated: true
           # This data can be any valid JSON from a previous step in the GitHub Action

--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -9,10 +9,21 @@ jobs:
     name: Send message to Slack
     runs-on: ubuntu-latest
     steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda-docs/ci/slack DOCS_RELEASE_BOT_WEBHOOK;
       - id: slack
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          webhook: ${{ secrets.SLACK_ASK_C8_DOCUMENTATION }}
+          webhook: ${{ steps.secrets.outputs.SLACK_ASK_C8_DOCUMENTATION }}
           webhook-type: webhook-trigger
           payload-templated: true
           # This data can be any valid JSON from a previous step in the GitHub Action


### PR DESCRIPTION
## Description

Migrate slack secrets to vault.

Closes: https://github.com/camunda/camunda-docs/issues/8949

## When should this change go live?

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
