### PR TITLE
fix(agentic-ai): update element-template download URLs after multi-module restructure

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the **MCP Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
+2. In a Self-Managed environment, install the **MCP Client** element template. Refer to the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) to find the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
+2. In a Self-Managed environment, install the **MCP Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
+2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
+2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
+2. In a Self-Managed environment, install the **MCP Remote Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the **MCP Remote Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
+2. In a Self-Managed environment, install the **MCP Client** element template. Refer to the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) to find the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md
+++ b/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](../../../connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the **MCP Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
+2. In a Self-Managed environment, install the **MCP Client** element template. Refer to the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) to find the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md
+++ b/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](../../../connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
+2. In a Self-Managed environment, install the **MCP Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md
+++ b/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](../../../connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
+2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md
+++ b/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](../../../connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
+2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md
+++ b/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](../../../connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
+2. In a Self-Managed environment, install the **MCP Remote Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md
+++ b/versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](../../../connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the **MCP Remote Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
+2. In a Self-Managed environment, install the **MCP Client** element template. Refer to the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) to find the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the **MCP Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
+2. In a Self-Managed environment, install the **MCP Client** element template. Refer to the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) to find the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
+2. In a Self-Managed environment, install the **MCP Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md
@@ -172,7 +172,7 @@ this for your specific use case varies on the connector runtime you are using.
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
+2. In a Self-Managed environment, install the [MCP Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json).
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Client** element template.
 4. In the **MCP Client** section of the properties panel, configure the **Client ID** to match the value of the MCP client you used in the runtime configuration (example: `filesystem`).
 5. Execute your process. You should see tool discovery calls being routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
+2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the [MCP Remote Client element template](https://raw.githubusercontent.com/camunda/connectors/refs/heads/main/connectors/agentic-ai/connector-agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json).
+2. In a Self-Managed environment, install the **MCP Remote Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md
@@ -22,7 +22,7 @@ Due to this overhead, the MCP Remote Client connector is primarily intended for 
 ## Modeling
 
 1. Configure an AI agent ad-hoc sub-process as described in the [example integration](./agentic-ai-aiagent-subprocess-example.md). Do not configure any tools within the ad-hoc sub-process yet.
-2. In a Self-Managed environment, install the **MCP Remote Client** element template — consult the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) for the correct version for your Camunda release.
+2. In a Self-Managed environment, install the **MCP Client** element template. Refer to the [element template index](https://github.com/camunda/connectors/blob/main/connectors/agentic-ai/connector-agentic-ai/element-templates/README.md#mcp-client-connectors) to find the correct version for your Camunda release.
 3. Create a service task within the ad-hoc sub-process and apply the **MCP Remote Client** element template.
 4. Configure the transport type and connection settings as described in [Transport type](#transport-type).
 5. Execute your process. You should see tool discovery calls routed to the MCP Client service task, and tool definitions provided by the MCP server listed in the agent context variable. As a result, the agent should be able to call the tools provided by the MCP server.


### PR DESCRIPTION
## Description

PR [camunda/connectors#7684](https://github.com/camunda/connectors/pull/7684) restructured the agentic-ai module into a multi-module Maven layout. As part of that change, element templates moved from:

```
connectors/agentic-ai/element-templates/
```

to:

```
connectors/agentic-ai/connector-agentic-ai/element-templates/
```

The `raw.githubusercontent.com` download links in the MCP Client and MCP Remote Client connector docs still pointed to the old path and returned 404s. This PR fixes all six affected files and points to the element template index (containing version information) instead of the raw JSON files.

**Files updated:**
- `docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md`
- `docs/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md`
- `versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-client-connector.md`
- `versioned_docs/version-8.8/components/early-access/alpha/mcp-client/mcp-remote-client-connector.md`
- `versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector.md`
- `versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector.md`

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.