### PR TITLE
docs(self-managed): add Keycloak HTTP/2 cleartext (h2c) crash troubleshooting to operator-based guide [ready]

### DIFF
--- a/docs/self-managed/deployment/helm/configure/operator-based-infrastructure.md
+++ b/docs/self-managed/deployment/helm/configure/operator-based-infrastructure.md
@@ -691,6 +691,30 @@ kubectl get keycloak keycloak -n $CAMUNDA_NAMESPACE -o jsonpath='{.status.condit
 
 **Reference:** [Keycloak Operator Documentation](https://www.keycloak.org/operator/basic-deployment)
 
+#### Keycloak pod crashes on HTTP/2 cleartext (h2c) requests
+
+**Symptoms:** The Keycloak pod exits or enters `CrashLoopBackOff` when it receives an HTTP/2 cleartext (h2c) request, such as a client sending an `Upgrade: h2c` header over a plain-HTTP port-forward. Clients receive an empty reply, and the Keycloak logs show a `java.lang.NoSuchMethodError` originating from Vert.x and Netty.
+
+**Cause:** `camunda/keycloak:quay-optimized-*` image tags older than `quay-optimized-26.6.4` bundle a conflicting Netty HTTP/2 codec under `/opt/keycloak/providers`, pulled in transitively by the AWS Advanced JDBC Wrapper. It shadows the Netty version shipped with Keycloak and breaks h2c handling.
+
+**Solutions:**
+
+- Upgrade the Keycloak image to `camunda/keycloak:quay-optimized-26.6.4` or later, where the conflicting Netty libraries are removed. Update the `image` field in your Keycloak custom resource (`keycloak-instance-*.yml`). This is the recommended fix.
+- If you cannot upgrade, disable HTTP/2 so Keycloak falls back to HTTP/1.1. Set the `QUARKUS_HTTP_HTTP2` environment variable to `false` in the Keycloak custom resource:
+
+  ```yaml
+  spec:
+    unsupported:
+      podTemplate:
+        spec:
+          containers:
+            - env:
+                - name: QUARKUS_HTTP_HTTP2
+                  value: "false"
+  ```
+
+**Reference:** [camunda/keycloak HTTP/2 cleartext crash issue](https://github.com/camunda/camunda-deployment-references/issues/2809)
+
 ## Production considerations
 
 ### Security

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/operator-based-infrastructure.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/operator-based-infrastructure.md
@@ -700,6 +700,30 @@ kubectl get keycloak keycloak -n $CAMUNDA_NAMESPACE -o jsonpath='{.status.condit
 
 **Reference:** [Keycloak Operator Documentation](https://www.keycloak.org/operator/basic-deployment)
 
+#### Keycloak pod crashes on HTTP/2 cleartext (h2c) requests
+
+**Symptoms:** The Keycloak pod exits or enters `CrashLoopBackOff` when it receives an HTTP/2 cleartext (h2c) request, such as a client sending an `Upgrade: h2c` header over a plain-HTTP port-forward. Clients receive an empty reply, and the Keycloak logs show a `java.lang.NoSuchMethodError` originating from Vert.x and Netty.
+
+**Cause:** `camunda/keycloak:quay-optimized-*` image tags older than `quay-optimized-26.6.4` bundle a conflicting Netty HTTP/2 codec under `/opt/keycloak/providers`, pulled in transitively by the AWS Advanced JDBC Wrapper. It shadows the Netty version shipped with Keycloak and breaks h2c handling.
+
+**Solutions:**
+
+- Upgrade the Keycloak image to `camunda/keycloak:quay-optimized-26.6.4` or later, where the conflicting Netty libraries are removed. Update the `image` field in your Keycloak custom resource (`keycloak-instance-*.yml`). This is the recommended fix.
+- If you cannot upgrade, disable HTTP/2 so Keycloak falls back to HTTP/1.1. Set the `QUARKUS_HTTP_HTTP2` environment variable to `false` in the Keycloak custom resource:
+
+  ```yaml
+  spec:
+    unsupported:
+      podTemplate:
+        spec:
+          containers:
+            - env:
+                - name: QUARKUS_HTTP_HTTP2
+                  value: "false"
+  ```
+
+**Reference:** [camunda/keycloak HTTP/2 cleartext crash issue](https://github.com/camunda/camunda-deployment-references/issues/2809)
+
 ## Production considerations
 
 ### Security

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/operator-based-infrastructure.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/operator-based-infrastructure.md
@@ -691,6 +691,30 @@ kubectl get keycloak keycloak -n $CAMUNDA_NAMESPACE -o jsonpath='{.status.condit
 
 **Reference:** [Keycloak Operator Documentation](https://www.keycloak.org/operator/basic-deployment)
 
+#### Keycloak pod crashes on HTTP/2 cleartext (h2c) requests
+
+**Symptoms:** The Keycloak pod exits or enters `CrashLoopBackOff` when it receives an HTTP/2 cleartext (h2c) request, such as a client sending an `Upgrade: h2c` header over a plain-HTTP port-forward. Clients receive an empty reply, and the Keycloak logs show a `java.lang.NoSuchMethodError` originating from Vert.x and Netty.
+
+**Cause:** `camunda/keycloak:quay-optimized-*` image tags older than `quay-optimized-26.6.4` bundle a conflicting Netty HTTP/2 codec under `/opt/keycloak/providers`, pulled in transitively by the AWS Advanced JDBC Wrapper. It shadows the Netty version shipped with Keycloak and breaks h2c handling.
+
+**Solutions:**
+
+- Upgrade the Keycloak image to `camunda/keycloak:quay-optimized-26.6.4` or later, where the conflicting Netty libraries are removed. Update the `image` field in your Keycloak custom resource (`keycloak-instance-*.yml`). This is the recommended fix.
+- If you cannot upgrade, disable HTTP/2 so Keycloak falls back to HTTP/1.1. Set the `QUARKUS_HTTP_HTTP2` environment variable to `false` in the Keycloak custom resource:
+
+  ```yaml
+  spec:
+    unsupported:
+      podTemplate:
+        spec:
+          containers:
+            - env:
+                - name: QUARKUS_HTTP_HTTP2
+                  value: "false"
+  ```
+
+**Reference:** [camunda/keycloak HTTP/2 cleartext crash issue](https://github.com/camunda/camunda-deployment-references/issues/2809)
+
 ## Production considerations
 
 ### Security


### PR DESCRIPTION
## Description

Adds a troubleshooting entry to the operator-based (Kubernetes operator) deployment guide for a Keycloak pod crash on HTTP/2 cleartext (h2c) requests, covering both the recommended fix and an interim workaround.

**Problem:** `camunda/keycloak:quay-optimized-*` image tags older than `quay-optimized-26.6.4` bundle a conflicting Netty HTTP/2 codec under `/opt/keycloak/providers` (pulled in transitively by the AWS Advanced JDBC Wrapper). It shadows the Netty version shipped with Keycloak, so an h2c request crashes the Keycloak pod with a `java.lang.NoSuchMethodError`.

**Guidance added** (under _Verification and troubleshooting → Common issues and solutions_):

- **Recommended fix:** upgrade the Keycloak image to `quay-optimized-26.6.4` or later, where the conflicting Netty libraries are removed.
- **Workaround for older images:** set `QUARKUS_HTTP_HTTP2=false` on the Keycloak custom resource so it falls back to HTTP/1.1.

The image fix ships in [`camunda/keycloak`](https://github.com/camunda/keycloak); the reference deployment was updated in camunda/camunda-deployment-references#2809.

Applied to `/docs` (8.10) and backported to `/versioned_docs/version-8.9` and `/versioned_docs/version-8.8`. Version 8.7 does not ship the operator-based guide, so it is not affected.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
