### PR TITLE
docs: add output mapping composite variable behavior change announcement for 8.7, 8.8, 8.9

### DIFF
--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -102,7 +102,7 @@ Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -53,7 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -90,11 +90,11 @@ Under these conditions:
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
 
-### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
 
-Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to object variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -53,6 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -88,6 +89,28 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
+
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -100,7 +100,7 @@ Patches 8.7.28–8.7.32 changed how output mappings behave when writing to compo
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -109,8 +109,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -96,8 +96,6 @@ Under these conditions:
 
 Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -107,10 +105,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -79,7 +79,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [8.8.29](https://github.com/camunda/camunda/releases/tag/8.8.29) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                                          |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
-| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                                                             |
+| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                                                |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
@@ -1039,11 +1039,11 @@ Under these conditions:
 </div>
 <div className="release-announcement-content">
 
-#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+#### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.8.23–8.8.27. Fixed in 8.8.28.
 
-Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.8.23–8.8.27 changed how output mappings behave when writing to object variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -1049,7 +1049,7 @@ Patches 8.8.23–8.8.27 changed how output mappings behave when writing to compo
 
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.8.23 and from 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -1058,8 +1058,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.8.23–8.8.27:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.8.28+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.8.23–8.8.27:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -29,8 +29,9 @@ Supported environment changes and breaking changes or deprecations for the Camun
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Elasticsearch and OpenSearch minimal supported versions
+
 Elasticsearch 8.16+ and OpenSearch 2.17+ are now supported as minimal versions to ensure you can benefit from the latest, most stable database releases. Older versions are no longer supported.
 
 </div>
@@ -41,8 +42,9 @@ Elasticsearch 8.16+ and OpenSearch 2.17+ are now supported as minimal versions t
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### PostgreSQL, Oracle and Microsoft SQL Server supported versions
+
 Management Identity now supports PostgreSQL and Amazon Aurora PostgreSQL versions 16.x and 17.x.
 
 Web Modeler now supports PostgreSQL version 18.x, Amazon Aurora PostgreSQL version 17.x, Oracle versions 19c and 23ai and Microsoft SQL Server versions 2019 and 2022.
@@ -55,8 +57,9 @@ Web Modeler now supports PostgreSQL version 18.x, Amazon Aurora PostgreSQL versi
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Zeebe, Operate, Tasklist, and Identity must run on same minor and patch levels
+
 From version `8.8.0` onwards, the Zeebe, Operate, Tasklist, and Identity [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) components must run on the exact same `minor`and `patch` level to ensure compatibility.
 
 :::info
@@ -76,6 +79,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [8.8.29](https://github.com/camunda/camunda/releases/tag/8.8.29) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                                          |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
+| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                                                             |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
@@ -119,7 +123,7 @@ The [Get decision instance](/apis-tools/orchestration-cluster-api-rest/specifica
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Orchestration Cluster: Zeebe Java Client &lt;=8.7.15 with REST API enabled
 
 The Zeebe Java Client &lt;=8.7.15 with REST API enabled is incompatible with Camunda 8.8 if you are running:
@@ -223,7 +227,7 @@ What to do:
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Tasklist GraphQL API
 
 With the Camunda 8.8 release, the deprecated Tasklist GraphQL API is removed.
@@ -236,7 +240,7 @@ With the Camunda 8.8 release, the deprecated Tasklist GraphQL API is removed.
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Deprecated OpenAPI objects
 
 With the Camunda 8.8 release, deprecated API objects containing number keys are removed, including the
@@ -259,7 +263,7 @@ To learn more about the key attribute type change, see [8.7 API key attributes o
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Optimize Index Rollover
 
 Prior to the Camunda 8.8 release, Optimize used the following configuration properties to apply index rollover to its External Variable Indices:
@@ -277,7 +281,7 @@ These properties are deleted in Camunda 8.8, with External Variables now stored 
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Web Modeler API milestone endpoints
 
 With the Camunda 8.8 release, the [Web Modeler API](/apis-tools/web-modeler-api/index.md) endpoints under `/api/v1/milestones` are deprecated and scheduled for removal in 8.9. You can use the corresponding endpoints under `/api/v1/versions` instead.
@@ -290,7 +294,7 @@ With the Camunda 8.8 release, the [Web Modeler API](/apis-tools/web-modeler-api/
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Operate and Tasklist v1 REST APIs
 
 With the Camunda 8.8 release, the deprecation process for the [Operate](/versioned_docs/version-8.9/apis-tools/operate-api/overview.md) and [Tasklist](/versioned_docs/version-8.9/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md) REST APIs begins.
@@ -319,7 +323,7 @@ To learn more about the differences between Tasklist v1 and v2 UI modes, see [Ta
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Job-based user tasks querying
 
 With the Camunda 8.8 release, the deprecation process for job-based user tasks begins.
@@ -340,7 +344,7 @@ With the Camunda 8.8 release, the deprecation process for job-based user tasks b
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe Client job worker metrics
 
 With the Camunda 8.8 release, the deprecation of Zeebe client job worker metrics is announced.
@@ -359,7 +363,7 @@ To learn more, see [Zeebe client job worker](/apis-tools/java-client/job-worker.
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe gRPC DeployProcess endpoint
 
 The `DeployProcess` endpoint was deprecated with 8.0, replaced with `DeployResource` RPC.
@@ -374,7 +378,7 @@ This endpoint is scheduled for removal in the Camunda 8.10 release.
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: File type `connector_template` in Web Modeler API
 
 With the Camunda 8.8 release, the `connector_template` file type in the [Web Modeler API](/apis-tools/web-modeler-api/index.md) endpoint for file creation (`POST /api/v1/files`) is deprecated.
@@ -391,7 +395,7 @@ You should use `element_template` instead, which provides equivalent functionali
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe Process Test
 
 With the Camunda 8.8 release, the deprecation of Zeebe Process Test is announced.
@@ -411,7 +415,7 @@ To learn more, see [migrate to Camunda Process Test](../../../apis-tools/migrati
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Operate & Tasklist usage metrics endpoints
 
 With the Camunda 8.8 release, the deprecation of usage metrics endpoints in Operate and Tasklist is announced.
@@ -450,7 +454,7 @@ With the Camunda 8.8 release, the deprecation of the start public process via fo
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-   
+
 #### Public API definition for greater platform stability
 
 To enhance predictability and offer a more stable experience for developers, Camunda introduced the official [public API definition for Camunda 8](/reference/public-api.md).
@@ -467,7 +471,7 @@ To enhance predictability and offer a more stable experience for developers, Cam
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Camunda Java client and Camunda Spring Boot Starter
 
 With the Camunda 8.8 release, Camunda Java Client and Camunda Spring Boot Starter replace the Zeebe Java client and Spring Zeebe SDK. This allows you to use a single consolidated client to interact with Camunda orchestration clusters.
@@ -544,7 +548,7 @@ To learn more, see the [TypeScript SDK](/apis-tools/typescript/typescript-sdk.md
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Connector SDK: Core SDK restructuring
 
 The internal structure of the Connector SDK has been updated to make the Core SDK more lightweight, with **no dependency on the Camunda client**.
@@ -576,7 +580,7 @@ DocumentReference
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Connector SDK: Changes to activity logging in inbound connectors
 
 The Connector SDK 8.8 introduces a new way to [log activities](/components/hub/organization/manage-clusters/manage-connectors.md#activity-log) in inbound connectors.
@@ -614,7 +618,7 @@ The new `ActivityBuilder` interface provides a more flexible and fluent API for 
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Harmonized Error Contexts for jobError and bpmnError in Connectors
 
 With the Camunda 8.8 release, Camunda has harmonized the error context structures returned by the `jobError` and `bpmnError` functions in connectors to align with the corresponding error handling in Camunda core.
@@ -664,7 +668,7 @@ For configuration examples and details, see [Helm chart Elasticsearch/OpenSearch
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Elasticsearch and OpenSearch: Single instance
 
 With the Camunda 8.8 release, the use of more than one isolated Elasticsearch/OpenSearch instance for exported Zeebe, Operate, and Tasklist data is no longer supported.
@@ -747,7 +751,7 @@ The existing data schema in the secondary storage has been harmonized, to be use
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Separated Ingress deprecation
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed was deprecated in Camunda 8.6 and is removed from the Helm chart in Camunda 8.8.
@@ -769,7 +773,7 @@ Additional upgrade considerations are necessary for deployments that use custom 
 <span className="badge badge--breaking-change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Custom users and clients for Management Identity
 
 You can now configure custom users and OAuth2 clients for Management Identity during Helm installation.
@@ -788,7 +792,7 @@ Additional upgrade considerations are required for deployments that use custom e
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Orchestration Cluster: Unified component configuration
 
 With the Camunda 8.8 release, the new unified configuration is introduced.
@@ -830,7 +834,7 @@ As a result, the following Docker images are deprecated as of Camunda 8.8:
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Secret management improvements and deprecations
 
 With the Camunda 8.8 release, a consistent secret pattern for Helm charts is introduced. The legacy secret configuration is deprecated and will be removed with 8.9, but remains functional during the transition period.
@@ -847,7 +851,7 @@ See the [secret management guide](/self-managed/deployment/helm/configure/secret
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: External database for Web Modeler REST API
 
 With the Camunda 8.8 release, the configuration for the external database used by the Web Modeler REST API is updated to align with the Identity component's database configuration.
@@ -863,7 +867,7 @@ With the Camunda 8.8 release, the configuration for the external database used b
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Default username claim in Web Modeler
 
 With the Camunda 8.8 release, the default ID token claim that Web Modeler uses to assign usernames has changed from `name` to `preferred_username`.
@@ -896,7 +900,7 @@ See [Bitnami Docker repository migration](/self-managed/upgrade/helm/index.md#bi
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Bitnami: Alternative container images
 
 <!-- https://github.com/camunda/product-hub/issues/2826 -->
@@ -921,7 +925,7 @@ Full setup instructions are available in the [installation guide](/self-managed/
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Alternative infrastructure methods
 
 For production environments, use managed or external services first. If not available, prefer [Kubernetes operators](/self-managed/deployment/helm/configure/operator-based-infrastructure.md) for PostgreSQL, Elasticsearch/OpenSearch, and Keycloak over Bitnami subcharts. Bitnami subcharts remain available for evaluation or proof-of-concept use.
@@ -949,7 +953,7 @@ This change reduces the risk of unexpected breaking changes from upstream Bitnam
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: EC2
 
 New EC2 manual and VM blueprint for high availability (HA) multi-AZ clusters. Includes managed OpenSearch, optional Aurora PostgreSQL, dual load balancer pattern, VPN/bastion access, and modular Terraform setup. See [Amazon EC2](/self-managed/deployment/manual/cloud-providers/amazon/aws-ec2.md).
@@ -962,7 +966,7 @@ New EC2 manual and VM blueprint for high availability (HA) multi-AZ clusters. In
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: Azure AKS
 
 New Azure AKS architecture with a zonal AKS baseline, managed or operator-based data services, unified Ingress and Identity patterns, private networking, and a modular Terraform and Helm workflow.  
@@ -976,7 +980,7 @@ See [Microsoft AKS](/self-managed/deployment/helm/cloud-providers/azure/microsof
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: General updates
 
 - Managed search (EKS single-region & EC2): OpenSearch upgraded 2.15 → 2.19 (aligns with [supported environments](/reference/supported-environments.md)).
@@ -1025,6 +1029,37 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Regression</span>
+</div>
+<div className="release-announcement-content">
+
+#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.8.23–8.8.27. Fixed in 8.8.28.
+
+Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.8.23 and 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.8.23–8.8.27:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.8.28+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 </div>
 </div>
@@ -1083,7 +1118,7 @@ You must transition to use [OIDC or Basic authentication](/self-managed/concepts
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### AWS Marketplace offering for Self-Managed
 
 As of October 2025, the Self-Managed AWS Marketplace offering is deprecated and no longer publicly available.  
@@ -1132,7 +1167,7 @@ For more information on how to modify your existing configuration, see the [upgr
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Play job-based user tasks
 
 With the Camunda 8.8 release, user tasks with a job worker implementation are deprecated and no longer supported in Play from cluster versions 8.8 and above.
@@ -1152,7 +1187,7 @@ You should consider migrating to [Camunda user tasks](/components/modeler/bpmn/u
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Starter plan
 
 The Camunda SaaS Starter plan is no longer available.

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -1051,7 +1051,7 @@ Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.8.23 and 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.8.23 and from 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -1045,8 +1045,6 @@ Under these conditions:
 
 Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -1056,10 +1054,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.8.23–8.8.27:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -137,6 +137,7 @@ The following key changes were also released as part of an 8.9.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                     |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ## Agentic orchestration
@@ -1436,6 +1437,37 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Regression</span>
+</div>
+<div className="release-announcement-content">
+
+#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.9.1–8.9.8. Fixed in 8.9.9.
+
+Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.9.1 and 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.9.1–8.9.8): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.9.1–8.9.8:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.9.9+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -1453,8 +1453,6 @@ Under these conditions:
 
 Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -1464,10 +1462,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.9.1–8.9.8:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.9.9+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.9.9+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -1457,7 +1457,7 @@ Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composi
 
 Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.9.1 and from 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.9.1–8.9.8): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -1466,8 +1466,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.9.1–8.9.8:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.9.9+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.9.1–8.9.8:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.9.9+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -1459,7 +1459,7 @@ Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.9.1 and 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.9.1 and from 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.9.1–8.9.8): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -137,7 +137,7 @@ The following key changes were also released as part of an 8.9.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                     |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ## Agentic orchestration
@@ -1447,11 +1447,11 @@ Under these conditions:
 </div>
 <div className="release-announcement-content">
 
-#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+#### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.9.1–8.9.8. Fixed in 8.9.9.
 
-Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.9.1–8.9.8 changed how output mappings behave when writing to object variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
@@ -100,7 +100,7 @@ Patches 8.7.28–8.7.32 changed how output mappings behave when writing to compo
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -109,8 +109,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 ### Deploy diagram change <span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span> {#web-modeler-deploy-diagram-change}
 

--- a/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
@@ -102,7 +102,7 @@ Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
@@ -53,7 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -90,11 +90,11 @@ Under these conditions:
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
 
-### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
 
-Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to object variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
@@ -53,6 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -88,6 +89,28 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
+
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 ### Deploy diagram change <span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span> {#web-modeler-deploy-diagram-change}
 

--- a/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-announcements.md
@@ -96,8 +96,6 @@ Under these conditions:
 
 Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -107,10 +105,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 ### Deploy diagram change <span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span> {#web-modeler-deploy-diagram-change}
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
@@ -102,7 +102,7 @@ Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
@@ -53,7 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -90,11 +90,11 @@ Under these conditions:
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
 
-### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
 
-Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to object variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
@@ -53,6 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -88,6 +89,28 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
+
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
@@ -100,7 +100,7 @@ Patches 8.7.28–8.7.32 changed how output mappings behave when writing to compo
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -109,8 +109,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-announcements.md
@@ -96,8 +96,6 @@ Under these conditions:
 
 Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -107,10 +105,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
@@ -29,8 +29,9 @@ Supported environment changes and breaking changes or deprecations for the Camun
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Elasticsearch and OpenSearch minimal supported versions
+
 Elasticsearch 8.16+ and OpenSearch 2.17+ are now supported as minimal versions to ensure you can benefit from the latest, most stable database releases. Older versions are no longer supported.
 
 </div>
@@ -41,8 +42,9 @@ Elasticsearch 8.16+ and OpenSearch 2.17+ are now supported as minimal versions t
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### PostgreSQL, Oracle and Microsoft SQL Server supported versions
+
 Management Identity now supports PostgreSQL and Amazon Aurora PostgreSQL versions 16.x and 17.x.
 
 Web Modeler now supports PostgreSQL version 18.x, Amazon Aurora PostgreSQL version 17.x, Oracle versions 19c and 23ai and Microsoft SQL Server versions 2019 and 2022.
@@ -55,8 +57,9 @@ Web Modeler now supports PostgreSQL version 18.x, Amazon Aurora PostgreSQL versi
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Zeebe, Operate, Tasklist, and Identity must run on same minor and patch levels
+
 From version `8.8.0` onwards, the Zeebe, Operate, Tasklist, and Identity [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) components must run on the exact same `minor`and `patch` level to ensure compatibility.
 
 :::info
@@ -76,6 +79,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [8.8.29](https://github.com/camunda/camunda/releases/tag/8.8.29) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                                          |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
+| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                                                             |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
@@ -119,7 +123,7 @@ The [Get decision instance](/apis-tools/orchestration-cluster-api-rest/specifica
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Orchestration Cluster: Zeebe Java Client &lt;=8.7.15 with REST API enabled
 
 The Zeebe Java Client &lt;=8.7.15 with REST API enabled is incompatible with Camunda 8.8 if you are running:
@@ -223,7 +227,7 @@ What to do:
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Tasklist GraphQL API
 
 With the Camunda 8.8 release, the deprecated Tasklist GraphQL API is removed.
@@ -236,7 +240,7 @@ With the Camunda 8.8 release, the deprecated Tasklist GraphQL API is removed.
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Deprecated OpenAPI objects
 
 With the Camunda 8.8 release, deprecated API objects containing number keys are removed, including the
@@ -259,7 +263,7 @@ To learn more about the key attribute type change, see [8.7 API key attributes o
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Optimize Index Rollover
 
 Prior to the Camunda 8.8 release, Optimize used the following configuration properties to apply index rollover to its External Variable Indices:
@@ -277,7 +281,7 @@ These properties are deleted in Camunda 8.8, with External Variables now stored 
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Web Modeler API milestone endpoints
 
 With the Camunda 8.8 release, the [Web Modeler API](/apis-tools/web-modeler-api/index.md) endpoints under `/api/v1/milestones` are deprecated and scheduled for removal in 8.9. You can use the corresponding endpoints under `/api/v1/versions` instead.
@@ -290,7 +294,7 @@ With the Camunda 8.8 release, the [Web Modeler API](/apis-tools/web-modeler-api/
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Operate and Tasklist v1 REST APIs
 
 With the Camunda 8.8 release, the deprecation process for the [Operate](/apis-tools/operate-api/overview.md) and [Tasklist](/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md) REST APIs begins.
@@ -319,7 +323,7 @@ To learn more about the differences between Tasklist v1 and v2 UI modes, see [Ta
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Job-based user tasks querying
 
 With the Camunda 8.8 release, the deprecation process for job-based user tasks begins.
@@ -340,7 +344,7 @@ With the Camunda 8.8 release, the deprecation process for job-based user tasks b
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe Client job worker metrics
 
 With the Camunda 8.8 release, the deprecation of Zeebe client job worker metrics is announced.
@@ -359,7 +363,7 @@ To learn more, see [Zeebe client job worker](/apis-tools/java-client/job-worker.
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe gRPC DeployProcess endpoint
 
 The `DeployProcess` endpoint was deprecated with 8.0, replaced with `DeployResource` RPC.
@@ -374,7 +378,7 @@ This endpoint is scheduled for removal in the Camunda 8.10 release.
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: File type `connector_template` in Web Modeler API
 
 With the Camunda 8.8 release, the `connector_template` file type in the [Web Modeler API](/apis-tools/web-modeler-api/index.md) endpoint for file creation (`POST /api/v1/files`) is deprecated.
@@ -391,7 +395,7 @@ You should use `element_template` instead, which provides equivalent functionali
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe Process Test
 
 With the Camunda 8.8 release, the deprecation of [Zeebe Process Test](../../../apis-tools/testing/zeebe-process-test.md) is announced.
@@ -411,7 +415,7 @@ To learn more, see [migrate to Camunda Process Test](../../../apis-tools/migrati
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Operate & Tasklist usage metrics endpoints
 
 With the Camunda 8.8 release, the deprecation of usage metrics endpoints in Operate and Tasklist is announced.
@@ -450,7 +454,7 @@ With the Camunda 8.8 release, the deprecation of the [start public process via f
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-   
+
 #### Public API definition for greater platform stability
 
 To enhance predictability and offer a more stable experience for developers, Camunda introduced the official [public API definition for Camunda 8](/reference/public-api.md).
@@ -467,7 +471,7 @@ To enhance predictability and offer a more stable experience for developers, Cam
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Camunda Java client and Camunda Spring Boot Starter
 
 With the Camunda 8.8 release, Camunda Java Client and Camunda Spring Boot Starter replace the Zeebe Java client and Spring Zeebe SDK. This allows you to use a single consolidated client to interact with Camunda orchestration clusters.
@@ -543,7 +547,7 @@ To learn more, see the [TypeScript SDK](/apis-tools/typescript/typescript-sdk.md
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Connector SDK: Core SDK restructuring
 
 The internal structure of the Connector SDK has been updated to make the Core SDK more lightweight, with **no dependency on the Camunda client**.
@@ -575,7 +579,7 @@ DocumentReference
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Connector SDK: Changes to activity logging in inbound connectors
 
 The Connector SDK 8.8 introduces a new way to [log activities](/components/console/manage-clusters/manage-connectors.md#activity-log) in inbound connectors.
@@ -613,7 +617,7 @@ The new `ActivityBuilder` interface provides a more flexible and fluent API for 
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Harmonized Error Contexts for jobError and bpmnError in Connectors
 
 With the Camunda 8.8 release, Camunda has harmonized the error context structures returned by the `jobError` and `bpmnError` functions in connectors to align with the corresponding error handling in Camunda core.
@@ -663,7 +667,7 @@ For configuration examples and details, see [Helm chart Elasticsearch/OpenSearch
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Elasticsearch and OpenSearch: Single instance
 
 With the Camunda 8.8 release, the use of more than one isolated Elasticsearch/OpenSearch instance for exported Zeebe, Operate, and Tasklist data is no longer supported.
@@ -746,7 +750,7 @@ The existing data schema in the secondary storage has been harmonized, to be use
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Separated Ingress deprecation
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed was deprecated in Camunda 8.6 and is removed from the Helm chart in Camunda 8.8.
@@ -768,7 +772,7 @@ Additional upgrade considerations are necessary for deployments that use custom 
 <span className="badge badge--breaking-change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Custom users and clients for Management Identity
 
 You can now configure custom users and OAuth2 clients for Management Identity during Helm installation.
@@ -787,7 +791,7 @@ Additional upgrade considerations are required for deployments that use custom e
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Orchestration Cluster: Unified component configuration
 
 With the Camunda 8.8 release, the new unified configuration is introduced.
@@ -829,7 +833,7 @@ As a result, the following Docker images are deprecated as of Camunda 8.8:
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Secret management improvements and deprecations
 
 With the Camunda 8.8 release, a consistent secret pattern for Helm charts is introduced. The legacy secret configuration is deprecated and will be removed with 8.9, but remains functional during the transition period.
@@ -846,7 +850,7 @@ See the [secret management guide](/self-managed/deployment/helm/configure/secret
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: External database for Web Modeler REST API
 
 With the Camunda 8.8 release, the configuration for the external database used by the Web Modeler REST API is updated to align with the Identity component's database configuration.
@@ -862,7 +866,7 @@ With the Camunda 8.8 release, the configuration for the external database used b
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Default username claim in Web Modeler
 
 With the Camunda 8.8 release, the default ID token claim that Web Modeler uses to assign usernames has changed from `name` to `preferred_username`.
@@ -895,7 +899,7 @@ See [Bitnami Docker repository migration](/self-managed/upgrade/helm/index.md#bi
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Bitnami: Alternative container images
 
 <!-- https://github.com/camunda/product-hub/issues/2826 -->
@@ -920,7 +924,7 @@ Full setup instructions are available in the [installation guide](/self-managed/
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Alternative infrastructure methods
 
 For production environments, use managed or external services first. If not available, prefer [Kubernetes operators](/self-managed/deployment/helm/configure/operator-based-infrastructure.md) for PostgreSQL, Elasticsearch/OpenSearch, and Keycloak over Bitnami subcharts. Bitnami subcharts remain supported for existing deployments. For new deployments, they should be used only for evaluation or proof-of-concept scenarios.
@@ -948,7 +952,7 @@ This change reduces the risk of unexpected breaking changes from upstream Bitnam
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: EC2
 
 New EC2 manual and VM blueprint for high availability (HA) multi-AZ clusters. Includes managed OpenSearch, optional Aurora PostgreSQL, dual load balancer pattern, VPN/bastion access, and modular Terraform setup. See [Amazon EC2](/self-managed/deployment/manual/cloud-providers/amazon/aws-ec2.md).
@@ -961,7 +965,7 @@ New EC2 manual and VM blueprint for high availability (HA) multi-AZ clusters. In
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: Azure AKS
 
 New Azure AKS architecture with a zonal AKS baseline, managed or operator-based data services, unified Ingress and Identity patterns, private networking, and a modular Terraform and Helm workflow.  
@@ -975,7 +979,7 @@ See [Microsoft AKS](/self-managed/deployment/helm/cloud-providers/azure/microsof
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: General updates
 
 - Managed search (EKS single-region & EC2): OpenSearch upgraded 2.15 → 2.19 (aligns with [supported environments](/reference/supported-environments.md)).
@@ -1024,6 +1028,37 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Regression</span>
+</div>
+<div className="release-announcement-content">
+
+#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.8.23–8.8.27. Fixed in 8.8.28.
+
+Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.8.23 and 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.8.23–8.8.27:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.8.28+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 </div>
 </div>
@@ -1082,7 +1117,7 @@ You must transition to use [OIDC or Basic authentication](/self-managed/concepts
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### AWS Marketplace offering for Self-Managed
 
 As of October 2025, the Self-Managed AWS Marketplace offering is deprecated and no longer publicly available.  
@@ -1131,7 +1166,7 @@ For more information on how to modify your existing configuration, see the [upgr
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Play job-based user tasks
 
 With the Camunda 8.8 release, user tasks with a job worker implementation are deprecated and no longer supported in Play from cluster versions 8.8 and above.
@@ -1151,7 +1186,7 @@ You should consider migrating to [Camunda user tasks](/components/modeler/bpmn/u
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Starter plan
 
 The Camunda SaaS Starter plan is no longer available.

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
@@ -79,7 +79,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [8.8.29](https://github.com/camunda/camunda/releases/tag/8.8.29) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                                          |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
-| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                                                             |
+| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                                                |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
@@ -1038,11 +1038,11 @@ Under these conditions:
 </div>
 <div className="release-announcement-content">
 
-#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+#### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.8.23–8.8.27. Fixed in 8.8.28.
 
-Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.8.23–8.8.27 changed how output mappings behave when writing to object variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
@@ -1048,7 +1048,7 @@ Patches 8.8.23–8.8.27 changed how output mappings behave when writing to compo
 
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.8.23 and from 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -1057,8 +1057,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.8.23–8.8.27:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.8.28+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.8.23–8.8.27:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 </div>
 </div>

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
@@ -1050,7 +1050,7 @@ Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.8.23 and 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.8.23 and from 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/880/880-announcements.md
@@ -1044,8 +1044,6 @@ Under these conditions:
 
 Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -1055,10 +1053,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.8.23–8.8.27:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
@@ -102,7 +102,7 @@ Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
@@ -53,7 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -90,11 +90,11 @@ Under these conditions:
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
 
-### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
 
-Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to object variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
@@ -53,6 +53,7 @@ The following key changes were also released as part of an 8.7.x patch release.
 | Patch release                                                    | Type            | Key change                                                                                                       |
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
+| [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
@@ -88,6 +89,28 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.7.28–8.7.32. Fixed in 8.7.33.
+
+Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.7.28 and 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
@@ -100,7 +100,7 @@ Patches 8.7.28–8.7.32 changed how output mappings behave when writing to compo
 
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.7.28 and from 8.7.33+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.7.28–8.7.32): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -109,8 +109,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.7.28–8.7.32:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.7.33+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-announcements.md
@@ -96,8 +96,6 @@ Under these conditions:
 
 Patches 8.7.28–8.7.32 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.7.33+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.7.28 and from 8.7.33+, assigning an object literal to a variable replaces the variable entirely. In 8.7.28–8.7.32, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -107,10 +105,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.7.28–8.7.32:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.7.33+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 ### Deprecation of Self-Managed AWS Marketplace offering
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
@@ -1036,7 +1036,7 @@ Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replac
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.8.23 and 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.8.23 and from 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
@@ -79,7 +79,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [8.8.29](https://github.com/camunda/camunda/releases/tag/8.8.29) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                                          |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
-| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                                                             |
+| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                                                |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
@@ -1024,11 +1024,11 @@ Under these conditions:
 </div>
 <div className="release-announcement-content">
 
-#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+#### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.8.23–8.8.27. Fixed in 8.8.28.
 
-Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.8.23–8.8.27 changed how output mappings behave when writing to object variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
@@ -29,8 +29,9 @@ Supported environment changes and breaking changes or deprecations for the Camun
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Elasticsearch and OpenSearch minimal supported versions
+
 Elasticsearch 8.16+ and OpenSearch 2.17+ are now supported as minimal versions to ensure you can benefit from the latest, most stable database releases. Older versions are no longer supported.
 
 </div>
@@ -41,8 +42,9 @@ Elasticsearch 8.16+ and OpenSearch 2.17+ are now supported as minimal versions t
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### PostgreSQL, Oracle and Microsoft SQL Server supported versions
+
 Management Identity now supports PostgreSQL and Amazon Aurora PostgreSQL versions 16.x and 17.x.
 
 Web Modeler now supports PostgreSQL version 18.x, Amazon Aurora PostgreSQL version 17.x, Oracle versions 19c and 23ai and Microsoft SQL Server versions 2019 and 2022.
@@ -55,8 +57,9 @@ Web Modeler now supports PostgreSQL version 18.x, Amazon Aurora PostgreSQL versi
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Zeebe, Operate, Tasklist, and Identity must run on same minor and patch levels
+
 From version `8.8.0` onwards, the Zeebe, Operate, Tasklist, and Identity [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) components must run on the exact same `minor`and `patch` level to ensure compatibility.
 
 :::info
@@ -76,6 +79,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [8.8.29](https://github.com/camunda/camunda/releases/tag/8.8.29) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                                          |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
+| [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                                                             |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
@@ -104,7 +108,7 @@ A fix that restores the method (now deprecated, returning an empty list for reco
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Orchestration Cluster: Zeebe Java Client &lt;=8.7.15 with REST API enabled
 
 The Zeebe Java Client &lt;=8.7.15 with REST API enabled is incompatible with Camunda 8.8 if you are running:
@@ -208,7 +212,7 @@ What to do:
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Tasklist GraphQL API
 
 With the Camunda 8.8 release, the deprecated Tasklist GraphQL API is removed.
@@ -221,7 +225,7 @@ With the Camunda 8.8 release, the deprecated Tasklist GraphQL API is removed.
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Deprecated OpenAPI objects
 
 With the Camunda 8.8 release, deprecated API objects containing number keys are removed, including the
@@ -244,7 +248,7 @@ To learn more about the key attribute type change, see [8.7 API key attributes o
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Optimize Index Rollover
 
 Prior to the Camunda 8.8 release, Optimize used the following configuration properties to apply index rollover to its External Variable Indices:
@@ -262,7 +266,7 @@ These properties are deleted in Camunda 8.8, with External Variables now stored 
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Web Modeler API milestone endpoints
 
 With the Camunda 8.8 release, the [Web Modeler API](/apis-tools/web-modeler-api/index.md) endpoints under `/api/v1/milestones` are deprecated and scheduled for removal in 8.9. You can use the corresponding endpoints under `/api/v1/versions` instead.
@@ -275,7 +279,7 @@ With the Camunda 8.8 release, the [Web Modeler API](/apis-tools/web-modeler-api/
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Operate and Tasklist v1 REST APIs
 
 With the Camunda 8.8 release, the deprecation process for the [Operate](/apis-tools/operate-api/overview.md) and [Tasklist](/apis-tools/tasklist-api-rest/tasklist-api-rest-overview.md) REST APIs begins.
@@ -304,7 +308,7 @@ To learn more about the differences between Tasklist v1 and v2 UI modes, see [Ta
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Job-based user tasks querying
 
 With the Camunda 8.8 release, the deprecation process for job-based user tasks begins.
@@ -325,7 +329,7 @@ With the Camunda 8.8 release, the deprecation process for job-based user tasks b
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe Client job worker metrics
 
 With the Camunda 8.8 release, the deprecation of Zeebe client job worker metrics is announced.
@@ -344,7 +348,7 @@ To learn more, see [Zeebe client job worker](/apis-tools/java-client/job-worker.
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe gRPC DeployProcess endpoint
 
 The `DeployProcess` endpoint was deprecated with 8.0, replaced with `DeployResource` RPC.
@@ -359,7 +363,7 @@ This endpoint is scheduled for removal in the Camunda 8.10 release.
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: File type `connector_template` in Web Modeler API
 
 With the Camunda 8.8 release, the `connector_template` file type in the [Web Modeler API](/apis-tools/web-modeler-api/index.md) endpoint for file creation (`POST /api/v1/files`) is deprecated.
@@ -376,7 +380,7 @@ You should use `element_template` instead, which provides equivalent functionali
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Zeebe Process Test
 
 With the Camunda 8.8 release, the deprecation of [Zeebe Process Test](../../../apis-tools/testing/zeebe-process-test.md) is announced.
@@ -396,7 +400,7 @@ To learn more, see [migrate to Camunda Process Test](../../../apis-tools/migrati
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Deprecated: Operate & Tasklist usage metrics endpoints
 
 With the Camunda 8.8 release, the deprecation of usage metrics endpoints in Operate and Tasklist is announced.
@@ -435,7 +439,7 @@ With the Camunda 8.8 release, the deprecation of the [start public process via f
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-   
+
 #### Public API definition for greater platform stability
 
 To enhance predictability and offer a more stable experience for developers, Camunda introduced the official [public API definition for Camunda 8](/reference/public-api.md).
@@ -452,7 +456,7 @@ To enhance predictability and offer a more stable experience for developers, Cam
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Camunda Java client and Camunda Spring Boot Starter
 
 With the Camunda 8.8 release, Camunda Java Client and Camunda Spring Boot Starter replace the Zeebe Java client and Spring Zeebe SDK. This allows you to use a single consolidated client to interact with Camunda orchestration clusters.
@@ -529,7 +533,7 @@ To learn more, see the [TypeScript SDK](/apis-tools/typescript/typescript-sdk.md
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Connector SDK: Core SDK restructuring
 
 The internal structure of the Connector SDK has been updated to make the Core SDK more lightweight, with **no dependency on the Camunda client**.
@@ -561,7 +565,7 @@ DocumentReference
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Connector SDK: Changes to activity logging in inbound connectors
 
 The Connector SDK 8.8 introduces a new way to [log activities](/components/console/manage-clusters/manage-connectors.md#activity-log) in inbound connectors.
@@ -599,7 +603,7 @@ The new `ActivityBuilder` interface provides a more flexible and fluent API for 
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Harmonized Error Contexts for jobError and bpmnError in Connectors
 
 With the Camunda 8.8 release, Camunda has harmonized the error context structures returned by the `jobError` and `bpmnError` functions in connectors to align with the corresponding error handling in Camunda core.
@@ -649,7 +653,7 @@ For configuration examples and details, see [Helm chart Elasticsearch/OpenSearch
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Elasticsearch and OpenSearch: Single instance
 
 With the Camunda 8.8 release, the use of more than one isolated Elasticsearch/OpenSearch instance for exported Zeebe, Operate, and Tasklist data is no longer supported.
@@ -732,7 +736,7 @@ The existing data schema in the secondary storage has been harmonized, to be use
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Separated Ingress deprecation
 
 The separated Ingress Helm configuration for Camunda 8 Self-Managed was deprecated in Camunda 8.6 and is removed from the Helm chart in Camunda 8.8.
@@ -754,7 +758,7 @@ Additional upgrade considerations are necessary for deployments that use custom 
 <span className="badge badge--breaking-change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Custom users and clients for Management Identity
 
 You can now configure custom users and OAuth2 clients for Management Identity during Helm installation.
@@ -773,7 +777,7 @@ Additional upgrade considerations are required for deployments that use custom e
 <span className="badge badge--breaking-change">Breaking change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Orchestration Cluster: Unified component configuration
 
 With the Camunda 8.8 release, the new unified configuration is introduced.
@@ -815,7 +819,7 @@ As a result, the following Docker images are deprecated as of Camunda 8.8:
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Secret management improvements and deprecations
 
 With the Camunda 8.8 release, a consistent secret pattern for Helm charts is introduced. The legacy secret configuration is deprecated and will be removed with 8.9, but remains functional during the transition period.
@@ -832,7 +836,7 @@ See the [secret management guide](/self-managed/deployment/helm/configure/secret
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: External database for Web Modeler REST API
 
 With the Camunda 8.8 release, the configuration for the external database used by the Web Modeler REST API is updated to align with the Identity component's database configuration.
@@ -848,7 +852,7 @@ With the Camunda 8.8 release, the configuration for the external database used b
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Default username claim in Web Modeler
 
 With the Camunda 8.8 release, the default ID token claim that Web Modeler uses to assign usernames has changed from `name` to `preferred_username`.
@@ -881,7 +885,7 @@ See [Bitnami Docker repository migration](/self-managed/upgrade/helm/index.md#bi
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Bitnami: Alternative container images
 
 <!-- https://github.com/camunda/product-hub/issues/2826 -->
@@ -906,7 +910,7 @@ Full setup instructions are available in the [installation guide](/self-managed/
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Helm chart: Alternative infrastructure methods
 
 For production environments, use managed or external services first. If not available, prefer [Kubernetes operators](/self-managed/deployment/helm/configure/operator-based-infrastructure.md) for PostgreSQL, Elasticsearch/OpenSearch, and Keycloak over Bitnami subcharts. Bitnami subcharts remain available for evaluation or proof-of-concept use.
@@ -934,7 +938,7 @@ This change reduces the risk of unexpected breaking changes from upstream Bitnam
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: EC2
 
 New EC2 manual and VM blueprint for high availability (HA) multi-AZ clusters. Includes managed OpenSearch, optional Aurora PostgreSQL, dual load balancer pattern, VPN/bastion access, and modular Terraform setup. See [Amazon EC2](/self-managed/deployment/manual/cloud-providers/amazon/aws-ec2.md).
@@ -947,7 +951,7 @@ New EC2 manual and VM blueprint for high availability (HA) multi-AZ clusters. In
 <span className="badge badge--new">New</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: Azure AKS
 
 New Azure AKS architecture with a zonal AKS baseline, managed or operator-based data services, unified Ingress and Identity patterns, private networking, and a modular Terraform and Helm workflow.  
@@ -961,7 +965,7 @@ See [Microsoft AKS](/self-managed/deployment/helm/cloud-providers/azure/microsof
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Reference architecture: General updates
 
 - Managed search (EKS single-region & EC2): OpenSearch upgraded 2.15 → 2.19 (aligns with [supported environments](/reference/supported-environments.md)).
@@ -1010,6 +1014,37 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Regression</span>
+</div>
+<div className="release-announcement-content">
+
+#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.8.23–8.8.27. Fixed in 8.8.28.
+
+Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.8.23 and 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.8.23–8.8.27:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.8.28+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 </div>
 </div>
@@ -1068,7 +1103,7 @@ You must transition to use [OIDC or Basic authentication](/self-managed/concepts
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### AWS Marketplace offering for Self-Managed
 
 As of October 2025, the Self-Managed AWS Marketplace offering is deprecated and no longer publicly available.  
@@ -1117,7 +1152,7 @@ For more information on how to modify your existing configuration, see the [upgr
 <span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Play job-based user tasks
 
 With the Camunda 8.8 release, user tasks with a job worker implementation are deprecated and no longer supported in Play from cluster versions 8.8 and above.
@@ -1137,7 +1172,7 @@ You should consider migrating to [Camunda user tasks](/components/modeler/bpmn/u
 <span className="badge badge--breaking-change">Removed</span>
 </div>
 <div className="release-announcement-content">
-  
+
 #### Removed: Starter plan
 
 The Camunda SaaS Starter plan is no longer available.

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
@@ -1030,8 +1030,6 @@ Under these conditions:
 
 Patches 8.8.23–8.8.27 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.8.28+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -1041,10 +1039,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.8.23–8.8.27:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/880/880-announcements.md
@@ -1034,7 +1034,7 @@ Patches 8.8.23–8.8.27 changed how output mappings behave when writing to compo
 
 Before 8.8.23 and from 8.8.28+, assigning an object literal to a variable replaces the variable entirely. In 8.8.23–8.8.27, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.8.23 and from 8.8.28+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.8.23–8.8.27): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -1043,8 +1043,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.8.23–8.8.27:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.8.28+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.8.23–8.8.27:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.8.28+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -137,6 +137,7 @@ The following key changes were also released as part of an 8.9.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                     |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ## Agentic orchestration
@@ -1436,6 +1437,37 @@ Under these conditions:
 
 - Before the fix is available: ensure all variable names inside the multi-instance sub-process are unique and do not reuse names that exist on the parent scope.
 - After upgrading to the fixed patch: bugs #11789 and #35251 are reintroduced by the fix. If you previously had adaptations in place to work around these bugs and removed them, reapply those adaptations.
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Regression</span>
+</div>
+<div className="release-announcement-content">
+
+#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+
+**Affected versions:** 8.9.1–8.9.8. Fixed in 8.9.9.
+
+Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
+
+**What changed**
+
+Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
+
+Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+
+- _Replace_ (before 8.9.1 and 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
+- _Merge_ (8.9.1–8.9.8): `result = {"a": 1, "b": 2}` — task A's value is preserved.
+
+Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
+
+**Action**
+
+- **Running 8.9.1–8.9.8:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
+- **Upgrading to 8.9.9+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -1453,8 +1453,6 @@ Under these conditions:
 
 Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
 
-**What changed**
-
 Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
 Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
@@ -1464,10 +1462,10 @@ Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.
 
-**Action**
+**Action:**
 
 - **Running 8.9.1–8.9.8:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
-- **Upgrading to 8.9.9+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
+- **Upgrading to 8.9.9+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`.
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -1457,7 +1457,7 @@ Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composi
 
 Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 
-Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
+Example: task A sets `result = {a: 1}`, then task B sets `result = {b: 2}`:
 
 - _Replace_ (before 8.9.1 and from 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.9.1–8.9.8): `result = {"a": 1, "b": 2}` — task A's value is preserved.
@@ -1466,8 +1466,8 @@ Replace is the intended long-term behavior. The merge behavior in the affected p
 
 **Action**
 
-- **Running 8.9.1–8.9.8:** your processes use merge behavior. Review any process that writes to composite variables from multiple tasks.
-- **Upgrading to 8.9.9+:** output mappings revert to replace behavior. Test affected processes before upgrading to production.
+- **Running 8.9.1–8.9.8:** your processes use merge behavior. Identify any process where one task writes to a sub-key of a variable and a later task assigns an object literal to the same parent. If found, either switch the later task to path notation `result.b = 2` or include all required keys explicitly in its object literal.
+- **Upgrading to 8.9.9+:** replace behavior is restored. The same processes identified above will behave differently after upgrading. If your process was relying on earlier tasks' values being kept, you need to fix it before upgrading: instead of assigning a whole object `result = {a: 1, b: 2}`, make sure it includes all the keys it needs explicitly — or write each key separately `result.a = 1, result.b = 2`
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -1459,7 +1459,7 @@ Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces
 
 Example: task A sets `result.a = 1`, then task B sets `result = {b: 2}`:
 
-- _Replace_ (before 8.9.1 and 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
+- _Replace_ (before 8.9.1 and from 8.9.9+): `result = {"b": 2}` — task A's value is overwritten.
 - _Merge_ (8.9.1–8.9.8): `result = {"a": 1, "b": 2}` — task A's value is preserved.
 
 Replace is the intended long-term behavior. The merge behavior in the affected patches was an unintended regression.

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -137,7 +137,7 @@ The following key changes were also released as part of an 8.9.x patch release.
 | :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
 | [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                     |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for composite variables](#output-mapping-behavior-change)                        |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
 ## Agentic orchestration
@@ -1447,11 +1447,11 @@ Under these conditions:
 </div>
 <div className="release-announcement-content">
 
-#### Output mapping behavior change for composite variables {#output-mapping-behavior-change}
+#### Output mapping behavior change for object variables {#output-mapping-behavior-change}
 
 **Affected versions:** 8.9.1–8.9.8. Fixed in 8.9.9.
 
-Patches 8.9.1–8.9.8 changed how output mappings behave when writing to composite (object) variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
+Patches 8.9.1–8.9.8 changed how output mappings behave when writing to object variables. Upgrading to 8.9.9+ reverts this change, which can alter the behavior of your running processes.
 
 Before 8.9.1 and from 8.9.9+, assigning an object literal to a variable replaces the variable entirely. In 8.9.1–8.9.8, the behavior changed to _merge_: existing keys in the variable are preserved and new keys are added.
 


### PR DESCRIPTION
## Description

Adds a new announcement entry — "Output mapping behavior change for composite variables" — to the 8.7, 8.8, and 8.9 release announcements, alongside the existing multi-instance sub-process regression entry.

Patches 8.7.28–8.7.32, 8.8.23–8.8.27, and 8.9.1–8.9.8 changed output mapping behavior for composite (object) variables from replace to merge. The fix patches (8.7.33, 8.8.28, 8.9.9) reverted this change. Neither the introduction nor the reversion was documented, leaving users who upgraded into or out of the affected range without an explanation for silent behavioral changes in their processes.

The new entry explains the merge-vs-replace distinction, identifies the affected version ranges, clarifies that replace is the intended long-term behavior, and gives users concrete action items for both the affected patches and the upgrade to the fix.

Relates to [camunda/camunda#56133](https://github.com/camunda/camunda/issues/56133).

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
