### PR TITLE
docs: document Zeebe record ILM retention requirement when running Optimize

### DIFF
--- a/docs/components/best-practices/architecture/sizing-your-environment.md
+++ b/docs/components/best-practices/architecture/sizing-your-environment.md
@@ -113,6 +113,23 @@ Optimize creates a dedicated index per deployed process definition, each using a
 Account for shard budget when sizing the Elasticsearch/OpenSearch cluster, not just CPU, memory, and disk. See [impact of high process deployments on Elasticsearch](https://camunda.github.io/zeebe-chaos/2026/05/28/Impact-of-High-Process-Deployments-on-Elasticsearch).
 :::
 
+#### Zeebe record ILM retention
+
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+
+**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+
+- Import lag that grows as the Optimize process instance index grows larger.
+- Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
+
+The default `minimum-age` of `30d` provides sufficient headroom. If you reduced it to limit disk usage, verify that the new value still exceeds your observed Optimize import lag before applying it to production.
+
+**Disk sizing:** A longer ILM retention window means Zeebe record indices are kept on disk longer before deletion. Factor the additional raw exporter index volume into your Elasticsearch disk budget when increasing `minimum-age` beyond the default.
+
+**Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
+
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+
 The sizing guidance for [Self-Managed](./sizing-self-managed.md#baseline-resource-configuration) provides configurations with and without Optimize to help you plan accordingly.
 
 ### Latency and cycle time

--- a/docs/components/best-practices/architecture/sizing-your-environment.md
+++ b/docs/components/best-practices/architecture/sizing-your-environment.md
@@ -115,9 +115,9 @@ Account for shard budget when sizing the Elasticsearch/OpenSearch cluster, not j
 
 #### Zeebe record ILM retention
 
-When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md#retention) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as `ACTIVE` with no `endDate`, and history cleanup can never remove it.
 
-**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+**Minimum recommended retention:** Set `minimum-age` to at least **3 days** when running Optimize; **7 or more days** is recommended. This provides headroom for:
 
 - Import lag that grows as the Optimize process instance index grows larger.
 - Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
@@ -128,7 +128,7 @@ The default `minimum-age` of `30d` provides sufficient headroom. If you reduced 
 
 **Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
 
-**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned `ACTIVE` documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
 
 The sizing guidance for [Self-Managed](./sizing-self-managed.md#baseline-resource-configuration) provides configurations with and without Optimize to help you plan accordingly.
 

--- a/docs/self-managed/components/optimize/configuration/history-cleanup.md
+++ b/docs/self-managed/components/optimize/configuration/history-cleanup.md
@@ -88,3 +88,13 @@ The above configuration results in the following setup:
 - The `cleanupMode` performed on all process instances that passed the `ttl` period is just clearing their variable data but keeping the overall instance data like activityInstances.
 - There is a process specific setup for the process definition key `'VeryConfidentProcess'` that has a special `ttl` of one month and those will be deleted completely due the specific `cleanupMode: 'all'` configuration for them.
 - There is another process specific setup for the process definition key `'KeepTwoMonthsProcess'` that has a special `ttl` of two months.
+
+## Diagnosing stalled cleanup
+
+If history cleanup runs on schedule but consistently completes in zero seconds, this is expected when all process instances are either still running or have not yet exceeded the configured TTL. No action is needed in that case.
+
+If you know that completed instances are past their TTL but cleanup still finishes in zero seconds, orphaned ACTIVE documents are likely accumulating. Cleanup only deletes process instances that have an `endDate` set. If Optimize never received the completion event for an instance, it has no `endDate` and cleanup cannot remove it regardless of how old it is.
+
+This happens when the Zeebe exporter's ILM retention window is shorter than Optimize's import lag: the exporter deletes Zeebe records before Optimize imports them, so Optimize writes an ACTIVE entry for the creation event but never sets an endDate. These orphaned documents grow the Optimize process instance index without a cleanup path.
+
+To prevent this, set the Zeebe exporter `retention.minimum-age` to at least 3-7 days when running Optimize. See [Zeebe record ILM retention](/components/best-practices/architecture/sizing-your-environment.md#zeebe-record-ilm-retention) in the sizing guide for details.

--- a/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
@@ -124,7 +124,7 @@ Using your throughput and retention settings, you can now calculate the required
 
 ### Zeebe record ILM retention
 
-When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+When the [Elasticsearch exporter retention policy](/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
 
 **Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
 

--- a/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
@@ -122,6 +122,23 @@ Using your throughput and retention settings, you can now calculate the required
 | Disk space                 |     \* 21 kib      |      72.10 GiB |                                                                                                    |
 | **Sum**                    |                    | **113.87 GiB** |                                                                                                    |
 
+### Zeebe record ILM retention
+
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+
+**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+
+- Import lag that grows as the Optimize process instance index grows larger.
+- Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
+
+The default `minimum-age` of `30d` provides sufficient headroom. If you reduced it to limit disk usage, verify that the new value still exceeds your observed Optimize import lag before applying it to production.
+
+**Disk sizing:** A longer ILM retention window means Zeebe record indices are kept on disk longer before deletion. Factor the additional raw exporter index volume into your Elasticsearch disk budget when increasing `minimum-age` beyond the default.
+
+**Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
+
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/optimize-deployment/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+
 ## Understanding sizing and scalability behavior
 
 Spinning up a Camunda 8 Cluster means you run multiple components that all need resources in the background, like the Zeebe Broker, Elasticsearch (as the database for Operate, Tasklist, and Optimize), Operate, Tasklist, and Optimize. All those components need to be equipped with resources.

--- a/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.7/components/best-practices/architecture/sizing-your-environment.md
@@ -124,9 +124,9 @@ Using your throughput and retention settings, you can now calculate the required
 
 ### Zeebe record ILM retention
 
-When the [Elasticsearch exporter retention policy](/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+When the [Elasticsearch exporter retention policy](/self-managed/zeebe-deployment/exporters/elasticsearch-exporter.md#retention) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as `ACTIVE` with no `endDate`, and history cleanup can never remove it.
 
-**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+**Minimum recommended retention:** Set `minimum-age` to at least **3 days** when running Optimize; **7 or more days** is recommended. This provides headroom for:
 
 - Import lag that grows as the Optimize process instance index grows larger.
 - Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
@@ -137,7 +137,7 @@ The default `minimum-age` of `30d` provides sufficient headroom. If you reduced 
 
 **Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
 
-**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/optimize-deployment/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned `ACTIVE` documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/optimize-deployment/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
 
 ## Understanding sizing and scalability behavior
 

--- a/versioned_docs/version-8.7/self-managed/optimize-deployment/configuration/history-cleanup.md
+++ b/versioned_docs/version-8.7/self-managed/optimize-deployment/configuration/history-cleanup.md
@@ -88,3 +88,13 @@ The above configuration results in the following setup:
 - The `cleanupMode` performed on all process instances that passed the `ttl` period is just clearing their variable data but keeping the overall instance data like activityInstances.
 - There is a process specific setup for the process definition key `'VeryConfidentProcess'` that has a special `ttl` of one month and those will be deleted completely due the specific `cleanupMode: 'all'` configuration for them.
 - There is another process specific setup for the process definition key `'KeepTwoMonthsProcess'` that has a special `ttl` of two months.
+
+## Diagnosing stalled cleanup
+
+If history cleanup runs on schedule but consistently completes in zero seconds, this is expected when all process instances are either still running or have not yet exceeded the configured TTL. No action is needed in that case.
+
+If you know that completed instances are past their TTL but cleanup still finishes in zero seconds, orphaned ACTIVE documents are likely accumulating. Cleanup only deletes process instances that have an `endDate` set. If Optimize never received the completion event for an instance, it has no `endDate` and cleanup cannot remove it regardless of how old it is.
+
+This happens when the Zeebe exporter's ILM retention window is shorter than Optimize's import lag: the exporter deletes Zeebe records before Optimize imports them, so Optimize writes an ACTIVE entry for the creation event but never sets an endDate. These orphaned documents grow the Optimize process instance index without a cleanup path.
+
+To prevent this, set the Zeebe exporter `retention.minimum-age` to at least 3-7 days when running Optimize. See [Zeebe record ILM retention](/components/best-practices/architecture/sizing-your-environment.md#zeebe-record-ilm-retention) in the sizing guide for details.

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-your-environment.md
@@ -112,6 +112,23 @@ Optimize creates a dedicated index per deployed process definition, each using a
 Account for shard budget when sizing the Elasticsearch/OpenSearch cluster, not just CPU, memory, and disk. See [impact of high process deployments on Elasticsearch](https://camunda.github.io/zeebe-chaos/2026/05/28/Impact-of-High-Process-Deployments-on-Elasticsearch).
 :::
 
+#### Zeebe record ILM retention
+
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+
+**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+
+- Import lag that grows as the Optimize process instance index grows larger.
+- Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
+
+The default `minimum-age` of `30d` provides sufficient headroom. If you reduced it to limit disk usage, verify that the new value still exceeds your observed Optimize import lag before applying it to production.
+
+**Disk sizing:** A longer ILM retention window means Zeebe record indices are kept on disk longer before deletion. Factor the additional raw exporter index volume into your Elasticsearch disk budget when increasing `minimum-age` beyond the default.
+
+**Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
+
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+
 The sizing guidance for [Self-Managed](./sizing-self-managed.md#baseline-resource-configuration) provides configurations with and without Optimize to help you plan accordingly.
 
 ### Latency and cycle time

--- a/versioned_docs/version-8.8/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.8/components/best-practices/architecture/sizing-your-environment.md
@@ -114,9 +114,9 @@ Account for shard budget when sizing the Elasticsearch/OpenSearch cluster, not j
 
 #### Zeebe record ILM retention
 
-When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md#retention) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as `ACTIVE` with no `endDate`, and history cleanup can never remove it.
 
-**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+**Minimum recommended retention:** Set `minimum-age` to at least **3 days** when running Optimize; **7 or more days** is recommended. This provides headroom for:
 
 - Import lag that grows as the Optimize process instance index grows larger.
 - Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
@@ -127,7 +127,7 @@ The default `minimum-age` of `30d` provides sufficient headroom. If you reduced 
 
 **Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
 
-**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned `ACTIVE` documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
 
 The sizing guidance for [Self-Managed](./sizing-self-managed.md#baseline-resource-configuration) provides configurations with and without Optimize to help you plan accordingly.
 

--- a/versioned_docs/version-8.8/self-managed/components/optimize/configuration/history-cleanup.md
+++ b/versioned_docs/version-8.8/self-managed/components/optimize/configuration/history-cleanup.md
@@ -88,3 +88,13 @@ The above configuration results in the following setup:
 - The `cleanupMode` performed on all process instances that passed the `ttl` period is just clearing their variable data but keeping the overall instance data like activityInstances.
 - There is a process specific setup for the process definition key `'VeryConfidentProcess'` that has a special `ttl` of one month and those will be deleted completely due the specific `cleanupMode: 'all'` configuration for them.
 - There is another process specific setup for the process definition key `'KeepTwoMonthsProcess'` that has a special `ttl` of two months.
+
+## Diagnosing stalled cleanup
+
+If history cleanup runs on schedule but consistently completes in zero seconds, this is expected when all process instances are either still running or have not yet exceeded the configured TTL. No action is needed in that case.
+
+If you know that completed instances are past their TTL but cleanup still finishes in zero seconds, orphaned ACTIVE documents are likely accumulating. Cleanup only deletes process instances that have an `endDate` set. If Optimize never received the completion event for an instance, it has no `endDate` and cleanup cannot remove it regardless of how old it is.
+
+This happens when the Zeebe exporter's ILM retention window is shorter than Optimize's import lag: the exporter deletes Zeebe records before Optimize imports them, so Optimize writes an ACTIVE entry for the creation event but never sets an endDate. These orphaned documents grow the Optimize process instance index without a cleanup path.
+
+To prevent this, set the Zeebe exporter `retention.minimum-age` to at least 3-7 days when running Optimize. See [Zeebe record ILM retention](/components/best-practices/architecture/sizing-your-environment.md#zeebe-record-ilm-retention) in the sizing guide for details.

--- a/versioned_docs/version-8.9/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.9/components/best-practices/architecture/sizing-your-environment.md
@@ -113,6 +113,23 @@ Optimize creates a dedicated index per deployed process definition, each using a
 Account for shard budget when sizing the Elasticsearch/OpenSearch cluster, not just CPU, memory, and disk. See [impact of high process deployments on Elasticsearch](https://camunda.github.io/zeebe-chaos/2026/05/28/Impact-of-High-Process-Deployments-on-Elasticsearch).
 :::
 
+#### Zeebe record ILM retention
+
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+
+**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+
+- Import lag that grows as the Optimize process instance index grows larger.
+- Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
+
+The default `minimum-age` of `30d` provides sufficient headroom. If you reduced it to limit disk usage, verify that the new value still exceeds your observed Optimize import lag before applying it to production.
+
+**Disk sizing:** A longer ILM retention window means Zeebe record indices are kept on disk longer before deletion. Factor the additional raw exporter index volume into your Elasticsearch disk budget when increasing `minimum-age` beyond the default.
+
+**Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
+
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+
 The sizing guidance for [Self-Managed](./sizing-self-managed.md#baseline-resource-configuration) provides configurations with and without Optimize to help you plan accordingly.
 
 ### Latency and cycle time

--- a/versioned_docs/version-8.9/components/best-practices/architecture/sizing-your-environment.md
+++ b/versioned_docs/version-8.9/components/best-practices/architecture/sizing-your-environment.md
@@ -115,9 +115,9 @@ Account for shard budget when sizing the Elasticsearch/OpenSearch cluster, not j
 
 #### Zeebe record ILM retention
 
-When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as ACTIVE with no endDate, and history cleanup can never remove it.
+When the [Elasticsearch exporter retention policy](/self-managed/components/orchestration-cluster/zeebe/exporters/elasticsearch-exporter.md#retention) is enabled, Zeebe record indices are deleted after the configured `minimum-age`. Optimize reads from these same indices, so the retention window must be long enough to cover Optimize's worst-case import lag. If the exporter deletes records before Optimize imports them, process instance completion events are permanently lost: Optimize records the instance as `ACTIVE` with no `endDate`, and history cleanup can never remove it.
 
-**Minimum recommended retention:** Set `minimum-age` to at least **3-7 days** when running Optimize. This provides headroom for:
+**Minimum recommended retention:** Set `minimum-age` to at least **3 days** when running Optimize; **7 or more days** is recommended. This provides headroom for:
 
 - Import lag that grows as the Optimize process instance index grows larger.
 - Recovery time after Elasticsearch cluster events such as node restarts, rolling upgrades, and shard rebalancing.
@@ -128,7 +128,7 @@ The default `minimum-age` of `30d` provides sufficient headroom. If you reduced 
 
 **Self-reinforcing failure mode:** As Optimize's process instance index grows, Elasticsearch write latency increases, which raises per-batch import lag. Higher import lag increases the probability of an ILM race on the next cluster event. This cycle compounds on long-lived clusters running at sustained load. To break it, increase ILM retention and reduce the Optimize index size through history cleanup or variable filtering.
 
-**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned ACTIVE documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
+**Symptom:** If Optimize history cleanup runs on schedule but consistently completes in zero seconds against a large dataset, orphaned `ACTIVE` documents are likely accumulating. See [diagnosing stalled cleanup](/self-managed/components/optimize/configuration/history-cleanup.md#diagnosing-stalled-cleanup).
 
 The sizing guidance for [Self-Managed](./sizing-self-managed.md#baseline-resource-configuration) provides configurations with and without Optimize to help you plan accordingly.
 

--- a/versioned_docs/version-8.9/self-managed/components/optimize/configuration/history-cleanup.md
+++ b/versioned_docs/version-8.9/self-managed/components/optimize/configuration/history-cleanup.md
@@ -88,3 +88,13 @@ The above configuration results in the following setup:
 - The `cleanupMode` performed on all process instances that passed the `ttl` period is just clearing their variable data but keeping the overall instance data like activityInstances.
 - There is a process specific setup for the process definition key `'VeryConfidentProcess'` that has a special `ttl` of one month and those will be deleted completely due the specific `cleanupMode: 'all'` configuration for them.
 - There is another process specific setup for the process definition key `'KeepTwoMonthsProcess'` that has a special `ttl` of two months.
+
+## Diagnosing stalled cleanup
+
+If history cleanup runs on schedule but consistently completes in zero seconds, this is expected when all process instances are either still running or have not yet exceeded the configured TTL. No action is needed in that case.
+
+If you know that completed instances are past their TTL but cleanup still finishes in zero seconds, orphaned ACTIVE documents are likely accumulating. Cleanup only deletes process instances that have an `endDate` set. If Optimize never received the completion event for an instance, it has no `endDate` and cleanup cannot remove it regardless of how old it is.
+
+This happens when the Zeebe exporter's ILM retention window is shorter than Optimize's import lag: the exporter deletes Zeebe records before Optimize imports them, so Optimize writes an ACTIVE entry for the creation event but never sets an endDate. These orphaned documents grow the Optimize process instance index without a cleanup path.
+
+To prevent this, set the Zeebe exporter `retention.minimum-age` to at least 3-7 days when running Optimize. See [Zeebe record ILM retention](/components/best-practices/architecture/sizing-your-environment.md#zeebe-record-ilm-retention) in the sizing guide for details.


### PR DESCRIPTION
## Description

Documents the Zeebe record ILM retention requirement when running Optimize, covering the minimum recommended retention window, disk sizing implications, the self-reinforcing failure mode, and how to diagnose stalled history cleanup.

Relates to [camunda/camunda#56446](https://github.com/camunda/camunda/issues/56446) and [camunda/camunda#56443](https://github.com/camunda/camunda/issues/56443) (incident writeup).

Closes https://github.com/camunda/camunda/issues/56446

Changes:
- `sizing-your-environment.md` (docs + 8.7 + 8.8 + 8.9): new `#### Zeebe record ILM retention` section under Impact of Optimize, covering the minimum-age recommendation (at least 3 days; 7 or more recommended), disk sizing impact of longer retention, and the self-reinforcing failure mode
- `history-cleanup.md` (docs + 8.7 + 8.8 + 8.9): new `## Diagnosing stalled cleanup` section explaining when zero-second runs are normal (long-running or unexpired instances) vs. a symptom of orphaned `ACTIVE` documents from an ILM race

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available &amp; undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.