### PR TITLE
dx: fix sync rest api

### DIFF
--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -230,6 +230,7 @@ jobs:
           # To mitigate this, we stage the changes _before_ we check if there are any.
           # Then, we run lint-staged manually. Finally, we check if there are changes.
           # This should get rid of the whitespace-only changes and avoid an empty commit.
+          npm ci
           git add .
           npx lint-staged --allow-empty
 

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -1,6 +1,9 @@
 name: Sync Camunda Hub REST API
 
 on:
+  push:
+    branches:
+      - "fix-sync-rest-api"
   schedule:
     - cron: "0 15 * * *"
   workflow_dispatch:
@@ -218,6 +221,18 @@ jobs:
         id: check_changes
         run: |
           cd docs
+
+          # We run lint-staged as a pre-commit hook. One of the format changes it performs
+          # is to remove whitespace-only changes. Therefore, if the REST API spec changes only
+          # include whitespace changes, lint-staged removes them and results in an error:
+          # "[FAILED] Prevented an empty git commit!"
+          # 
+          # To mitigate this, we stage the changes _before_ we check if there are any.
+          # Then, we run lint-staged manually. Finally, we check if there are changes.
+          # This should get rid of the whitespace-only changes and avoid an empty commit.
+          git add .
+          npx lint-staged --allow-empty
+
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -1,9 +1,6 @@
 name: Sync Camunda Hub REST API
 
 on:
-  push:
-    branches:
-      - "fix-sync-rest-api"
   schedule:
     - cron: "0 15 * * *"
   workflow_dispatch:

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -1,9 +1,6 @@
 name: Sync Camunda REST API
 
 on:
-  push:
-    branches:
-      - "fix-sync-rest-api"
   schedule:
     - cron: "0 15 * * 4" # Runs every Thursday at 3 PM UTC
   workflow_dispatch:

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -150,6 +150,18 @@ jobs:
         id: check_changes
         run: |
           cd docs
+
+          # We run lint-staged as a pre-commit hook. One of the format changes it performs
+          # is to remove whitespace-only changes. Therefore, if the REST API spec changes only
+          # include whitespace changes, lint-staged removes them and results in an error:
+          # "[FAILED] Prevented an empty git commit!"
+          # 
+          # To mitigate this, we stage the changes _before_ we check if there are any.
+          # Then, we run lint-staged manually. Finally, we check if there are changes.
+          # This should get rid of the whitespace-only changes and avoid an empty commit.
+          git add .
+          npx lint-staged --allow-empty
+
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -1,6 +1,9 @@
 name: Sync Camunda REST API
 
 on:
+  push:
+    branches:
+      - "fix-sync-rest-api"
   schedule:
     - cron: "0 15 * * 4" # Runs every Thursday at 3 PM UTC
   workflow_dispatch:


### PR DESCRIPTION
## Description

The sync rest API job has the following (simplified) steps:

1. Pull the latest REST API spec
2. Check if there are changes. If yes...
3. Commit the changes
4. Create a PR with the changes

The problem we're facing here is during (2), it sees changes, but those changes are only whitespace changes. In (3), the lint-staged pre-commit hook rejects them, which results in an empty commit and the error message we see in the logs:

```
[FAILED] Prevented an empty git commit!
```

This ultimately fails the job.

This PR changes the workflow to run lint_staged before we check for changes (2).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
