### PR TITLE
add or example to data fetching

### DIFF
--- a/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md
+++ b/docs/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md
@@ -211,6 +211,27 @@ The top-level filters `assignee`, `processInstanceKey`, and `candidateGroups` ar
 
 </details>
 
+<details>
+<summary>Example: $or</summary>
+
+```
+POST /v2/user-tasks/search
+
+{
+  "filter": {
+    "state": "CREATED",
+    "$or": [
+      { "assignee": "demo" },
+      { "assignee": { "$exists": false } }
+    ]
+  }
+}
+```
+
+This returns created user tasks that are either assigned to `demo` or have no assignee. The top-level `state` filter applies to both branches of the `$or` condition via an implicit AND.
+
+</details>
+
 #### Variables
 
 Search endpoints can support filtering by variable values. This allows querying for process-related resources based on the values of specific variables that exist in their respective scope. For example, user task search supports filtering using the `localVariables` array and defining filter criteria for specific variables.

--- a/versioned_docs/version-8.8/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md
+++ b/versioned_docs/version-8.8/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md
@@ -211,6 +211,27 @@ The top-level filters `assignee`, `processInstanceKey`, and `candidateGroups` ar
 
 </details>
 
+<details>
+<summary>Example: $or</summary>
+
+```
+POST /v2/user-tasks/search
+
+{
+  "filter": {
+    "state": "CREATED",
+    "$or": [
+      { "assignee": "demo" },
+      { "assignee": { "$exists": false } }
+    ]
+  }
+}
+```
+
+This returns created user tasks that are either assigned to `demo` or have no assignee. The top-level `state` filter applies to both branches of the `$or` condition via an implicit AND.
+
+</details>
+
 #### Variables
 
 Search endpoints can support filtering by variable values. This allows querying for process-related resources based on the values of specific variables that exist in their respective scope. For example, user task search supports filtering using the `localVariables` array and defining filter criteria for specific variables.

--- a/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md
+++ b/versioned_docs/version-8.9/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md
@@ -211,6 +211,27 @@ The top-level filters `assignee`, `processInstanceKey`, and `candidateGroups` ar
 
 </details>
 
+<details>
+<summary>Example: $or</summary>
+
+```
+POST /v2/user-tasks/search
+
+{
+  "filter": {
+    "state": "CREATED",
+    "$or": [
+      { "assignee": "demo" },
+      { "assignee": { "$exists": false } }
+    ]
+  }
+}
+```
+
+This returns created user tasks that are either assigned to `demo` or have no assignee. The top-level `state` filter applies to both branches of the `$or` condition via an implicit AND.
+
+</details>
+
 #### Variables
 
 Search endpoints can support filtering by variable values. This allows querying for process-related resources based on the values of specific variables that exist in their respective scope. For example, user task search supports filtering using the `localVariables` array and defining filter criteria for specific variables.


### PR DESCRIPTION
## Description

PushFeedback from a user. Adds a `$or` example to the Logical Operators section of the data fetching reference page. Previously, the section documented `$or` in the operator table but only included an AND example, leaving users without a concrete `$or` usage pattern.

The new example shows filtering user tasks by `state` (AND) combined with an `$or` condition across two `assignee` values, demonstrating how `$or` composes with top-level filters.

Applied to `docs/`, `version-8.8`, and `version-8.9`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
