### PR TITLE
add SaaS multi-tenancy documentation

### DIFF
--- a/docs/components/admin/admin-introduction.md
+++ b/docs/components/admin/admin-introduction.md
@@ -37,7 +37,7 @@ Depending on your setup, Admin allows you to manage Orchestration Cluster access
 | [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
 | [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
 | [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
-| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | All deployments |
+| [Tenants](tenant.md)               | Logically isolate data within a single cluster. This is useful for multi-tenancy applications.                                      | All deployments |
 
 :::info Admin in Self-Managed
 For documentation on deploying Admin as part of Camunda 8 Self-Managed, see [Admin in Self-Managed](/self-managed/components/orchestration-cluster/admin/overview.md).

--- a/docs/components/admin/admin-introduction.md
+++ b/docs/components/admin/admin-introduction.md
@@ -31,13 +31,13 @@ For details about authorization concepts, resources, and configuration, see
 
 Depending on your setup, Admin allows you to manage Orchestration Cluster access as follows:
 
-| Entity                             | Description                                                                                                                         | Availability      |
-| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :---------------- |
-| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments   |
-| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments   |
-| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments   |
-| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments   |
-| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | Self-Managed only |
+| Entity                             | Description                                                                                                                         | Availability    |
+| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :-------------- |
+| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments |
+| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
+| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
+| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
+| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | All deployments |
 
 :::info Admin in Self-Managed
 For documentation on deploying Admin as part of Camunda 8 Self-Managed, see [Admin in Self-Managed](/self-managed/components/orchestration-cluster/admin/overview.md).

--- a/docs/components/admin/tenant.md
+++ b/docs/components/admin/tenant.md
@@ -133,10 +133,8 @@ You can manage these assignments by selecting the relevant tab on the tenant det
 
 ### Assign mapping rules to a tenant
 
-<!-- TODO: Confirm with eng whether the "OIDC in Self-Managed only" restriction on mapping rule assignment also applies to SaaS. On SaaS, Console manages the identity provider integration, so mapping rules may behave differently... -->
-
 :::note
-Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed).
+Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed). On SaaS, identity is managed by Camunda, so mapping rules cannot map claims from a customer identity provider.
 :::
 
 1. Select the **Mapping rules** tab.

--- a/docs/components/admin/tenant.md
+++ b/docs/components/admin/tenant.md
@@ -8,7 +8,7 @@ description: "Manage tenants within the Orchestration Cluster Admin to logically
 Use Admin to manage Orchestration Cluster tenants and isolate data within a single cluster. Tenant management is available on both Camunda 8 SaaS and Self-Managed.
 
 :::note
-On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks. Before enabling checks, confirm your tenant assignments so users retain the access they need.
 :::
 
 ## About tenants

--- a/docs/components/admin/tenant.md
+++ b/docs/components/admin/tenant.md
@@ -5,9 +5,11 @@ sidebar_label: "Tenants"
 description: "Manage tenants within the Orchestration Cluster Admin to logically separate your infrastructure."
 ---
 
-<span class="badge badge--platform">Self-Managed only</span>
+Use Admin to manage Orchestration Cluster tenants and isolate data within a single cluster. Tenant management is available on both Camunda 8 SaaS and Self-Managed.
 
-Use Admin to manage Orchestration Cluster tenants and isolate data within a single cluster.
+:::note
+On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+:::
 
 ## About tenants
 
@@ -26,7 +28,14 @@ You can manage your Orchestration Cluster tenants directly in [Admin](admin-intr
 
 This allows administrators to set up tenants and assignments before enforcing tenancy checks.
 
-To enable multi-tenancy checks, see [Self-Managed configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+How you enable multi-tenancy checks depends on your deployment model:
+
+- **SaaS**: Enable the **Multi-tenancy** toggle per cluster in [Camunda Hub cluster settings](/components/hub/organization/manage-clusters/settings.md#multi-tenancy).
+- **Self-Managed**: Configure multi-tenancy through [Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
+:::
 
 ## Create a tenant
 
@@ -123,6 +132,8 @@ You can manage these assignments by selecting the relevant tab on the tenant det
    ![tenant-management-assigned-roles](./img/tenant-management-assigned-roles.png)
 
 ### Assign mapping rules to a tenant
+
+<!-- TODO: Confirm with eng whether the "OIDC in Self-Managed only" restriction on mapping rule assignment also applies to SaaS. On SaaS, Console manages the identity provider integration, so mapping rules may behave differently... -->
 
 :::note
 Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed).

--- a/docs/components/admin/tenant.md
+++ b/docs/components/admin/tenant.md
@@ -23,10 +23,10 @@ To learn more about tenants, see [multi-tenancy](../concepts/multi-tenancy.md).
 
 You can manage your Orchestration Cluster tenants directly in [Admin](admin-introduction.md).
 
-- **Tenancy** is enabled by default.
-- **Tenancy checks** are disabled by default. All data maps to the `<default>` tenant.
+- **Multi-tenancy** is enabled by default.
+- **Multi-tenancy checks** are disabled by default. All data maps to the `<default>` tenant.
 
-This allows administrators to set up tenants and assignments before enforcing tenancy checks.
+This allows administrators to set up tenants and assignments before enforcing multi-tenancy checks.
 
 How you enable multi-tenancy checks depends on your deployment model:
 

--- a/docs/components/concepts/multi-tenancy.md
+++ b/docs/components/concepts/multi-tenancy.md
@@ -50,14 +50,14 @@ Tenant ownership in Camunda 8 is hierarchical. A user can only deploy resources 
 
 When a user deploys a process model or starts a process instance, the system validates the user's tenant assignments.
 
-For example, assume a user belongs to `Tenant A` but not `Tenant B`:
+For example, assume a user belongs to `tenant-a` but not `tenant-b`:
 
 1. **Deploying a process model**
-   - If the user deploys to `Tenant A`, the Orchestration Cluster verifies the assignment. If valid, the model is deployed and all related process instances belong to `Tenant A`.
-   - If the user deploys to `Tenant B`, the deployment fails because the user lacks access to that tenant.
+   - If the user deploys to `tenant-a`, the Orchestration Cluster verifies the assignment. If valid, the model is deployed and all related process instances belong to `tenant-a`.
+   - If the user deploys to `tenant-b`, the deployment fails because the user lacks access to that tenant.
 
 2. **Running process instances**
-   - When querying process instances, the user only sees instances belonging to `Tenant A`.
+   - When querying process instances, the user only sees instances belonging to `tenant-a`.
 
 This mechanism ensures proper isolation and access control across tenants.
 

--- a/docs/components/concepts/multi-tenancy.md
+++ b/docs/components/concepts/multi-tenancy.md
@@ -2,7 +2,7 @@
 id: multi-tenancy
 title: "Multi-tenancy"
 sidebar_label: "Multi-tenancy"
-description: "Multi-tenancy lets you host multiple isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
+description: "Multi-tenancy lets you host multiple logically isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
 ---
 
 [Multi-tenancy](/reference/glossary.md#multi-tenancy) in Camunda 8 enables a single installation to serve multiple [tenants](/reference/glossary.md#tenant) such as departments, teams, or external clients, while keeping each tenant's data and processes logically isolated.
@@ -74,8 +74,6 @@ On SaaS, enable multi-tenancy checks per cluster using the **Multi-tenancy** tog
 3. Enable the **Multi-tenancy** setting.
 
 For details on the toggle, its default state, and who can change it, see [cluster settings](/components/hub/organization/manage-clusters/settings.md#multi-tenancy).
-
-<!-- TODO: Confirm the exact minimum cluster generation with eng. The Console toggle is shown on clusters that ship MultiTenancyConfiguration (Zeebe 8.8.0-alpha7+)... the docs issue states "generation 8.8+". Confirm the customer-facing wording? -->
 
 The **Multi-tenancy** toggle is available for clusters running generation 8.8 and later. It is disabled by default, and only organization admins can change it. Disabling the toggle restores the implicit `<default>`-tenant behavior.
 

--- a/docs/components/concepts/multi-tenancy.md
+++ b/docs/components/concepts/multi-tenancy.md
@@ -2,21 +2,97 @@
 id: multi-tenancy
 title: "Multi-tenancy"
 sidebar_label: "Multi-tenancy"
-description: "Multi-tenancy allows you to host multiple tenants within a single Camunda installation."
+description: "Multi-tenancy lets you host multiple isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
 ---
 
-:::info
-Multi-tenancy is only supported in Camunda 8 Self-Managed. It is not available in Camunda 8 SaaS.
-:::
+[Multi-tenancy](/reference/glossary.md#multi-tenancy) in Camunda 8 enables a single installation to serve multiple [tenants](/reference/glossary.md#tenant) such as departments, teams, or external clients, while keeping each tenant's data and processes logically isolated.
+
+This page describes **logical multi-tenancy**: tenant-ID based isolation within a single cluster. Logical multi-tenancy is available on both **Camunda 8 SaaS** and **Camunda 8 Self-Managed**.
 
 :::note
-This page provides a conceptual overview of multi-tenancy. For detailed configuration and implementation in Self-Managed deployments, see [multi-tenancy in Self-Managed](/self-managed/concepts/multi-tenancy/index.md).
+Self-Managed also supports stronger isolation models. For a comparison of logical tenants, Physical Tenants, and multi-cluster deployments, see the [Self-Managed multi-tenancy overview](/self-managed/concepts/multi-tenancy/index.md).
 :::
 
-[Multi-tenancy](/reference/glossary.md#multi-tenancy) in Camunda 8 enables a single installation to serve multiple [tenants](/reference/glossary.md#tenant) such as departments, teams, or external clients, while keeping each tenant's data and processes isolated.
+## How multi-tenancy works
 
-Camunda 8 supports three distinct multi-tenancy models: **logical tenants** (lightweight, tenant-ID based), **Physical Tenants** (strong physical isolation within a cluster), and **multi-cluster** (full isolation with separate infrastructure).
+Camunda 8 implements multi-tenancy using tenant identifiers within a single installation. All tenant data is stored in the same database, with isolation enforced by appending a tenant identifier to each data object, such as process definitions, process instances, and jobs.
 
-If you need physical isolation within a single orchestration cluster, see [Physical Tenant isolation model](/self-managed/concepts/physical-tenants/index.md).
+### Tenant identifier
 
-For details on configuring and using multi-tenancy in your Self-Managed deployment, see [multi-tenancy](/self-managed/concepts/multi-tenancy/index.md).
+The tenant identifier is added to all data created in Camunda 8. By default, all data is assigned to the `<default>` tenant identifier.
+
+:::note
+The `<default>` tenant identifier is reserved and cannot be changed by users.
+:::
+
+Organizations can create additional tenants. Tenant identifiers must meet the following requirements:
+
+- Use only alphanumeric characters, dashes (`-`), underscores (`_`), or dots (`.`).
+- Be no longer than 31 characters.
+
+### Multi-tenancy checks
+
+Multi-tenancy checks enforce tenant-based access control.
+
+By default, multi-tenancy checks are **disabled**. This means that although tenants can be created and assigned, the system does not restrict access based on those assignments. All data is associated with the `<default>` tenant.
+
+When **enabled**, the system verifies that users can only access resources associated with their assigned tenants. Users, groups, and roles not assigned to a tenant lose access to resources scoped to that tenant.
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants **and** to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
+:::
+
+### Inherited tenant ownership
+
+Tenant ownership in Camunda 8 is hierarchical. A user can only deploy resources to authorized tenants. Any data created by those resources inherits the same tenant identifier.
+
+## Example: tenant membership in action
+
+When a user deploys a process model or starts a process instance, the system validates the user's tenant assignments.
+
+For example, assume a user belongs to `Tenant A` but not `Tenant B`:
+
+1. **Deploying a process model**
+   - If the user deploys to `Tenant A`, the Orchestration Cluster verifies the assignment. If valid, the model is deployed and all related process instances belong to `Tenant A`.
+   - If the user deploys to `Tenant B`, the deployment fails because the user lacks access to that tenant.
+
+2. **Running process instances**
+   - When querying process instances, the user only sees instances belonging to `Tenant A`.
+
+This mechanism ensures proper isolation and access control across tenants.
+
+## Enable multi-tenancy checks
+
+Tenants can be created and principals assigned regardless of whether checks are enabled. Enabling checks enforces the assignments. How you enable checks depends on your deployment model.
+
+### SaaS
+
+On SaaS, enable multi-tenancy checks per cluster using the **Multi-tenancy** toggle in Camunda Hub:
+
+1. Navigate to **Camunda Hub**, and select the **Clusters** tab.
+2. Select the cluster you want to manage, and select the **Settings** tab.
+3. Enable the **Multi-tenancy** setting.
+
+For details on the toggle, its default state, and who can change it, see [cluster settings](/components/hub/organization/manage-clusters/settings.md#multi-tenancy).
+
+<!-- TODO: Confirm the exact minimum cluster generation with eng. The Console toggle is shown on clusters that ship MultiTenancyConfiguration (Zeebe 8.8.0-alpha7+)... the docs issue states "generation 8.8+". Confirm the customer-facing wording? -->
+
+The **Multi-tenancy** toggle is available for clusters running generation 8.8 and later. It is disabled by default, and only organization admins can change it. Disabling the toggle restores the implicit `<default>`-tenant behavior.
+
+### Self-Managed
+
+On Self-Managed, operators enable multi-tenancy checks through configuration properties. See [Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+
+## Manage tenants
+
+Administrators can manage all tenants centrally in [Admin](/components/admin/tenant.md). This unified management interface simplifies monitoring, configuration, and maintenance tasks across tenant environments.
+
+The **Tenants** tab in Admin is available to organization admins on SaaS clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+
+## Optimize and multi-tenancy
+
+Optimize multi-tenancy is available in **Self-Managed only**.
+
+On SaaS, Optimize can only access data from the `<default>` tenant. Data scoped to other tenants is not available in Optimize on SaaS.
+
+In Self-Managed, [Management Identity](/self-managed/components/management-identity/overview.md) is used for identity and access management of components outside the [Orchestration Cluster](/self-managed/components/orchestration-cluster/overview.md). Of those, only [Optimize](/self-managed/components/optimize/overview.md) is tenant aware and can make use of multi-tenancy. To use it with the same tenants as an Orchestration Cluster, you must manually synchronize the tenants in both the Orchestration Cluster and Management Identity. This means manually creating them, and updating them whenever they change. Two tenants are considered the same if they have the same ID.

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -31,6 +31,10 @@ Learn more about [resource-based authorizations](/components/concepts/access-con
 
 You can enable multi-tenancy checks on a per-cluster basis to enforce tenant-level authorization for Orchestration Cluster resources.
 
+:::note
+This setting applies to Camunda 8 SaaS. In Self-Managed, multi-tenancy checks are not configured through this UI — set them using [configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy) at startup.
+:::
+
 - Enable this setting to enforce tenant-level authorization checks. Users, groups, and roles not assigned to a tenant lose access to any resources scoped to that tenant.
 - Disable this setting to allow tenants to be created and principals assigned without enforcing checks. All data maps to the `<default>` tenant.
 

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -24,7 +24,24 @@ You can enable authorizations on a per-cluster basis to control the level of acc
 - Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Admin, but they are only applied to cluster when you enable this setting.
 
 :::tip
-For more information, see [authorizations](/components/concepts/access-control/authorizations.md).
+Learn more about [resource-based authorizations](/components/concepts/access-control/authorizations.md).
+:::
+
+## Multi-tenancy
+
+You can enable multi-tenancy checks on a per-cluster basis to enforce tenant-level authorization for the cluster's Orchestration Cluster resources.
+
+- Enable this setting to enforce tenant-level authorization checks. Users, groups, and roles not assigned to a tenant lose access to any resources scoped to that tenant.
+- Disable this setting to allow tenants to be created and principals assigned without enforcing checks. All data maps to the `<default>` tenant.
+
+This setting is disabled by default. Only organization admins can change it, and it is available for clusters running generation 8.8 and later. The setting is reversible: disabling it restores the implicit `<default>`-tenant behavior.
+
+For details on creating tenants and managing assignments, see [tenant management](/components/admin/tenant.md).
+
+<!-- TODO: Confirm the exact minimum cluster generation and the final in-UI toggle label ("Multi-tenancy" vs "Multi-Tenancy") with eng. The Console toggle is shown on clusters that ship MultiTenancyConfiguration (Zeebe 8.8.0-alpha7+)... -->
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
 ## Automatic cluster updates

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -42,8 +42,6 @@ This setting is disabled by default. Only organization admins can change it, and
 
 For details on creating tenants and managing assignments, see [tenant management](/components/admin/tenant.md).
 
-<!-- TODO: Confirm the exact minimum cluster generation and the final in-UI toggle label ("Multi-tenancy" vs "Multi-Tenancy") with eng. The Console toggle is shown on clusters that ship MultiTenancyConfiguration (Zeebe 8.8.0-alpha7+)... -->
-
 :::warning
 Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -21,7 +21,7 @@ To manage your cluster settings:
 You can enable authorizations on a per-cluster basis to control the level of access users and clients have over Orchestration Cluster resources.
 
 - Enable this setting to use [authorizations](/components/concepts/access-control/authorizations.md) in the cluster.
-- Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Admin, but they are only applied to cluster when you enable this setting.
+- Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Admin, but they are only applied to the cluster when you enable this setting.
 
 :::tip
 Learn more about [resource-based authorizations](/components/concepts/access-control/authorizations.md).
@@ -29,7 +29,7 @@ Learn more about [resource-based authorizations](/components/concepts/access-con
 
 ## Multi-tenancy
 
-You can enable multi-tenancy checks on a per-cluster basis to enforce tenant-level authorization for the cluster's Orchestration Cluster resources.
+You can enable multi-tenancy checks on a per-cluster basis to enforce tenant-level authorization for Orchestration Cluster resources.
 
 - Enable this setting to enforce tenant-level authorization checks. Users, groups, and roles not assigned to a tenant lose access to any resources scoped to that tenant.
 - Disable this setting to allow tenants to be created and principals assigned without enforcing checks. All data maps to the `<default>` tenant.

--- a/versioned_docs/version-8.8/components/concepts/multi-tenancy.md
+++ b/versioned_docs/version-8.8/components/concepts/multi-tenancy.md
@@ -2,7 +2,7 @@
 id: multi-tenancy
 title: "Multi-tenancy"
 sidebar_label: "Multi-tenancy"
-description: "Multi-tenancy lets you host multiple isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
+description: "Multi-tenancy lets you host multiple logically isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
 ---
 
 Multi-tenancy in Camunda 8 enables a single installation to serve multiple tenants—such as departments, teams, or external clients—while keeping each tenant's data and processes logically isolated.

--- a/versioned_docs/version-8.8/components/concepts/multi-tenancy.md
+++ b/versioned_docs/version-8.8/components/concepts/multi-tenancy.md
@@ -2,14 +2,12 @@
 id: multi-tenancy
 title: "Multi-tenancy"
 sidebar_label: "Multi-tenancy"
-description: "Multi-tenancy allows you to host multiple tenants within a single Camunda installation."
+description: "Multi-tenancy lets you host multiple isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
 ---
 
-:::info
-Multi-tenancy is only supported in Camunda 8 Self-Managed. It is not available in Camunda 8 SaaS.
-:::
-
 Multi-tenancy in Camunda 8 enables a single installation to serve multiple tenants—such as departments, teams, or external clients—while keeping each tenant's data and processes logically isolated.
+
+Multi-tenancy (logical tenancy) is available on both **Camunda 8 SaaS** and **Camunda 8 Self-Managed**.
 
 The following sections explain how multi-tenancy works in Camunda 8.
 
@@ -76,7 +74,11 @@ Multi-tenancy checks enforce tenant-based access control.
 
 By default, multi-tenancy checks are **disabled**. This means that although tenants can be created and assigned, the system does not restrict access based on those assignments. All data is associated with the `<default>` tenant.
 
-When **enabled**, the system verifies that users can only access resources associated with their assigned tenants.
+When **enabled**, the system verifies that users can only access resources associated with their assigned tenants. Users, groups, and roles not assigned to a tenant lose access to resources scoped to that tenant.
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
+:::
 
 ### Inherited tenant ownership
 
@@ -86,6 +88,28 @@ A user can only deploy resources to authorized tenants. Any data created by thos
 The following diagram illustrates tenant ownership inheritance:
 
 ![Tenant ownership inheritance diagram](img/multi-tenancy.png)
+
+## Enable multi-tenancy checks
+
+Tenants can be created and principals assigned regardless of whether checks are enabled. Enabling checks enforces the assignments. How you enable checks depends on your deployment model.
+
+### SaaS
+
+On SaaS, enable multi-tenancy checks per cluster using the **Multi-tenancy** toggle in Console:
+
+1. Navigate to **Console**, and select the **Clusters** tab.
+2. Select the cluster you want to manage, and select the **Settings** tab.
+3. Enable the **Multi-tenancy** setting.
+
+For details on the toggle, see [cluster settings](/components/console/manage-clusters/settings.md#multi-tenancy). The toggle is available for clusters running generation 8.8 and later, is disabled by default, and can be changed only by organization admins.
+
+### Self-Managed
+
+On Self-Managed, operators enable multi-tenancy checks through configuration properties. See [Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+
+## Optimize and multi-tenancy
+
+Optimize multi-tenancy is available in **Self-Managed only**. On SaaS, Optimize can only access data from the `<default>` tenant.
 
 ## Management Identity
 

--- a/versioned_docs/version-8.8/components/console/manage-clusters/settings.md
+++ b/versioned_docs/version-8.8/components/console/manage-clusters/settings.md
@@ -21,10 +21,25 @@ To manage your cluster settings:
 You can enable authorizations on a per-cluster basis to control the level of access users and clients have over Orchestration Cluster resources.
 
 - Enable this setting to use [authorizations](/components/concepts/access-control/authorizations.md) in the cluster.
-- Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Identity, but they are only applied to cluster when you enable this setting.
+- Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Identity, but they are only applied to the cluster when you enable this setting.
 
 :::tip
-For more information, see [authorizations](/components/concepts/access-control/authorizations.md).
+Learn more about [resource-based authorizations](/components/concepts/access-control/authorizations.md).
+:::
+
+## Multi-tenancy
+
+You can enable multi-tenancy checks on a per-cluster basis to enforce tenant-level authorization for Orchestration Cluster resources.
+
+- Enable this setting to enforce tenant-level authorization checks. Users, groups, and roles not assigned to a tenant lose access to any resources scoped to that tenant.
+- Disable this setting to allow tenants to be created and principals assigned without enforcing checks. All data maps to the `<default>` tenant.
+
+This setting is disabled by default. Only organization admins can change it, and it is available for clusters running generation 8.8 and later. The setting is reversible: disabling it restores the implicit `<default>`-tenant behavior.
+
+For details on creating tenants and managing assignments, see [tenant management](/components/identity/tenant.md).
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
 ## Automatic cluster updates

--- a/versioned_docs/version-8.8/components/identity/identity-introduction.md
+++ b/versioned_docs/version-8.8/components/identity/identity-introduction.md
@@ -29,7 +29,7 @@ Depending on your setup, Identity allows you to manage Orchestration Cluster acc
 | [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
 | [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
 | [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
-| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | All deployments |
+| [Tenants](tenant.md)               | Logically isolate data within a single cluster. This is useful for multi-tenancy applications.                                      | All deployments |
 
 :::info Identity in Self-Managed
 For documentation on deploying Identity as part of Camunda 8 Self-Managed, see [Identity in Self-Managed](/self-managed/components/orchestration-cluster/identity/overview.md).

--- a/versioned_docs/version-8.8/components/identity/identity-introduction.md
+++ b/versioned_docs/version-8.8/components/identity/identity-introduction.md
@@ -23,13 +23,13 @@ Identity includes the following features:
 
 Depending on your setup, Identity allows you to manage Orchestration Cluster access as follows:
 
-| Entity                             | Description                                                                                                                         | Availability      |
-| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :---------------- |
-| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments   |
-| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments   |
-| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments   |
-| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments   |
-| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | Self-Managed only |
+| Entity                             | Description                                                                                                                         | Availability    |
+| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :-------------- |
+| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments |
+| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
+| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
+| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
+| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | All deployments |
 
 :::info Identity in Self-Managed
 For documentation on deploying Identity as part of Camunda 8 Self-Managed, see [Identity in Self-Managed](/self-managed/components/orchestration-cluster/identity/overview.md).

--- a/versioned_docs/version-8.8/components/identity/tenant.md
+++ b/versioned_docs/version-8.8/components/identity/tenant.md
@@ -8,7 +8,7 @@ description: "Manage tenants within the Orchestration Cluster Identity to logica
 Use Identity to manage Orchestration Cluster tenants and isolate data within a single cluster. Tenant management is available on both Camunda 8 SaaS and Self-Managed.
 
 :::note
-On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks. Before enabling checks, confirm your tenant assignments so users retain the access they need.
 :::
 
 ## About tenants

--- a/versioned_docs/version-8.8/components/identity/tenant.md
+++ b/versioned_docs/version-8.8/components/identity/tenant.md
@@ -5,9 +5,11 @@ sidebar_label: "Tenants"
 description: "Manage tenants within the Orchestration Cluster Identity to logically separate your infrastructure."
 ---
 
-<span class="badge badge--platform">Self-Managed only</span>
+Use Identity to manage Orchestration Cluster tenants and isolate data within a single cluster. Tenant management is available on both Camunda 8 SaaS and Self-Managed.
 
-Use Identity to manage Orchestration Cluster tenants and isolate data within a single cluster.
+:::note
+On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+:::
 
 ## About tenants
 
@@ -21,12 +23,19 @@ To learn more about tenants, see [multi-tenancy](../concepts/multi-tenancy.md).
 
 You can manage your Orchestration Cluster tenants directly in [Identity](identity-introduction.md).
 
-- **Tenancy** is enabled by default.
-- **Tenancy checks** are disabled by default. All data maps to the `<default>` tenant.
+- **Multi-tenancy** is enabled by default.
+- **Multi-tenancy checks** are disabled by default. All data maps to the `<default>` tenant.
 
-This allows administrators to set up tenants and assignments before enforcing tenancy checks.
+This allows administrators to set up tenants and assignments before enforcing multi-tenancy checks.
 
-To enable multi-tenancy checks, see [Self-Managed configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+How you enable multi-tenancy checks depends on your deployment model:
+
+- **SaaS**: Enable the **Multi-tenancy** toggle per cluster in [Console cluster settings](/components/console/manage-clusters/settings.md#multi-tenancy).
+- **Self-Managed**: Configure multi-tenancy through [Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
+:::
 
 ## Create a tenant
 
@@ -108,7 +117,7 @@ You can manage these assignments by selecting the relevant tab on the tenant det
 ### Assign mapping rules to a tenant
 
 :::note
-Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed).
+Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed). On SaaS, identity is managed by Camunda, so mapping rules cannot map claims from a customer identity provider.
 :::
 
 1. Select the **Mapping rules** tab.

--- a/versioned_docs/version-8.9/components/admin/admin-introduction.md
+++ b/versioned_docs/version-8.9/components/admin/admin-introduction.md
@@ -37,7 +37,7 @@ Depending on your setup, Admin allows you to manage Orchestration Cluster access
 | [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
 | [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
 | [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
-| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | All deployments |
+| [Tenants](tenant.md)               | Logically isolate data within a single cluster. This is useful for multi-tenancy applications.                                      | All deployments |
 
 :::info Admin in Self-Managed
 For documentation on deploying Admin as part of Camunda 8 Self-Managed, see [Admin in Self-Managed](/self-managed/components/orchestration-cluster/admin/overview.md).

--- a/versioned_docs/version-8.9/components/admin/admin-introduction.md
+++ b/versioned_docs/version-8.9/components/admin/admin-introduction.md
@@ -31,13 +31,13 @@ For details about authorization concepts, resources, and configuration, see
 
 Depending on your setup, Admin allows you to manage Orchestration Cluster access as follows:
 
-| Entity                             | Description                                                                                                                         | Availability      |
-| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :---------------- |
-| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments   |
-| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments   |
-| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments   |
-| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments   |
-| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | Self-Managed only |
+| Entity                             | Description                                                                                                                         | Availability    |
+| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :-------------- |
+| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments |
+| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
+| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
+| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
+| [Tenants](tenant.md)               | Isolate data within a single cluster. This is useful for multi-tenancy applications.                                                | All deployments |
 
 :::info Admin in Self-Managed
 For documentation on deploying Admin as part of Camunda 8 Self-Managed, see [Admin in Self-Managed](/self-managed/components/orchestration-cluster/admin/overview.md).

--- a/versioned_docs/version-8.9/components/admin/tenant.md
+++ b/versioned_docs/version-8.9/components/admin/tenant.md
@@ -5,9 +5,11 @@ sidebar_label: "Tenants"
 description: "Manage tenants within the Orchestration Cluster Admin to logically separate your infrastructure."
 ---
 
-<span class="badge badge--platform">Self-Managed only</span>
+Use Admin to manage Orchestration Cluster tenants and isolate data within a single cluster. Tenant management is available on both Camunda 8 SaaS and Self-Managed.
 
-Use Admin to manage Orchestration Cluster tenants and isolate data within a single cluster.
+:::note
+On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+:::
 
 ## About tenants
 
@@ -21,12 +23,19 @@ To learn more about tenants, see [multi-tenancy](../concepts/multi-tenancy.md).
 
 You can manage your Orchestration Cluster tenants directly in [Admin](admin-introduction.md).
 
-- **Tenancy** is enabled by default.
-- **Tenancy checks** are disabled by default. All data maps to the `<default>` tenant.
+- **Multi-tenancy** is enabled by default.
+- **Multi-tenancy checks** are disabled by default. All data maps to the `<default>` tenant.
 
-This allows administrators to set up tenants and assignments before enforcing tenancy checks.
+This allows administrators to set up tenants and assignments before enforcing multi-tenancy checks.
 
-To enable multi-tenancy checks, see [Self-Managed configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+How you enable multi-tenancy checks depends on your deployment model:
+
+- **SaaS**: Enable the **Multi-tenancy** toggle per cluster in [Console cluster settings](/components/console/manage-clusters/settings.md#multi-tenancy).
+- **Self-Managed**: Configure multi-tenancy through [Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
+:::
 
 ## Create a tenant
 
@@ -108,7 +117,7 @@ You can manage these assignments by selecting the relevant tab on the tenant det
 ### Assign mapping rules to a tenant
 
 :::note
-Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed).
+Assignment of [mapping rules](../concepts/access-control/mapping-rules.md) is only available for [OIDC authentication in Self-Managed](../concepts/access-control/connect-to-identity-provider.md#self-managed). On SaaS, identity is managed by Camunda, so mapping rules cannot map claims from a customer identity provider.
 :::
 
 1. Select the **Mapping rules** tab.

--- a/versioned_docs/version-8.9/components/admin/tenant.md
+++ b/versioned_docs/version-8.9/components/admin/tenant.md
@@ -8,7 +8,7 @@ description: "Manage tenants within the Orchestration Cluster Admin to logically
 Use Admin to manage Orchestration Cluster tenants and isolate data within a single cluster. Tenant management is available on both Camunda 8 SaaS and Self-Managed.
 
 :::note
-On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks.
+On SaaS, the **Tenants** tab is visible to organization admins on clusters running generation 8.8 and later, even before multi-tenancy checks are enabled. This allows admins to set up tenants and assignments before enforcing checks. Before enabling checks, confirm your tenant assignments so users retain the access they need.
 :::
 
 ## About tenants

--- a/versioned_docs/version-8.9/components/concepts/multi-tenancy.md
+++ b/versioned_docs/version-8.9/components/concepts/multi-tenancy.md
@@ -2,14 +2,12 @@
 id: multi-tenancy
 title: "Multi-tenancy"
 sidebar_label: "Multi-tenancy"
-description: "Multi-tenancy allows you to host multiple tenants within a single Camunda installation."
+description: "Multi-tenancy lets you host multiple isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
 ---
 
-:::info
-Multi-tenancy is only supported in Camunda 8 Self-Managed. It is not available in Camunda 8 SaaS.
-:::
-
 [Multi-tenancy](/reference/glossary.md#multi-tenancy) in Camunda 8 enables a single installation to serve multiple [tenants](/reference/glossary.md#tenant) such as departments, teams, or external clients, while keeping each tenant's data and processes logically isolated.
+
+Multi-tenancy (logical tenancy) is available on both **Camunda 8 SaaS** and **Camunda 8 Self-Managed**.
 
 The following sections explain how multi-tenancy works in Camunda 8.
 
@@ -76,7 +74,11 @@ Multi-tenancy checks enforce tenant-based access control.
 
 By default, multi-tenancy checks are **disabled**. This means that although tenants can be created and assigned, the system does not restrict access based on those assignments. All data is associated with the `<default>` tenant.
 
-When **enabled**, the system verifies that users can only access resources associated with their assigned tenants.
+When **enabled**, the system verifies that users can only access resources associated with their assigned tenants. Users, groups, and roles not assigned to a tenant lose access to resources scoped to that tenant.
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
+:::
 
 ### Inherited tenant ownership
 
@@ -86,6 +88,28 @@ A user can only deploy resources to authorized tenants. Any data created by thos
 The following diagram illustrates tenant ownership inheritance:
 
 ![Tenant ownership inheritance diagram](img/multi-tenancy.png)
+
+## Enable multi-tenancy checks
+
+Tenants can be created and principals assigned regardless of whether checks are enabled. Enabling checks enforces the assignments. How you enable checks depends on your deployment model.
+
+### SaaS
+
+On SaaS, enable multi-tenancy checks per cluster using the **Multi-tenancy** toggle in Console:
+
+1. Navigate to **Console**, and select the **Clusters** tab.
+2. Select the cluster you want to manage, and select the **Settings** tab.
+3. Enable the **Multi-tenancy** setting.
+
+For details on the toggle, see [cluster settings](/components/console/manage-clusters/settings.md#multi-tenancy). The toggle is available for clusters running generation 8.8 and later, is disabled by default, and can be changed only by organization admins.
+
+### Self-Managed
+
+On Self-Managed, operators enable multi-tenancy checks through configuration properties. See [Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#multi-tenancy).
+
+## Optimize and multi-tenancy
+
+Optimize multi-tenancy is available in **Self-Managed only**. On SaaS, Optimize can only access data from the `<default>` tenant.
 
 ## Management Identity
 

--- a/versioned_docs/version-8.9/components/concepts/multi-tenancy.md
+++ b/versioned_docs/version-8.9/components/concepts/multi-tenancy.md
@@ -2,7 +2,7 @@
 id: multi-tenancy
 title: "Multi-tenancy"
 sidebar_label: "Multi-tenancy"
-description: "Multi-tenancy lets you host multiple isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
+description: "Multi-tenancy lets you host multiple logically isolated tenants within a single Camunda 8 installation, on both SaaS and Self-Managed."
 ---
 
 [Multi-tenancy](/reference/glossary.md#multi-tenancy) in Camunda 8 enables a single installation to serve multiple [tenants](/reference/glossary.md#tenant) such as departments, teams, or external clients, while keeping each tenant's data and processes logically isolated.

--- a/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
+++ b/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
@@ -21,10 +21,25 @@ To manage your cluster settings:
 You can enable authorizations on a per-cluster basis to control the level of access users and clients have over Orchestration Cluster resources.
 
 - Enable this setting to use [authorizations](/components/concepts/access-control/authorizations.md) in the cluster.
-- Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Admin, but they are only applied to cluster when you enable this setting.
+- Disable this setting if you do not want to use authorizations in the cluster. You can still configure authorizations in the Orchestration Cluster Admin, but they are only applied to the cluster when you enable this setting.
 
 :::tip
-For more information, see [authorizations](/components/concepts/access-control/authorizations.md).
+Learn more about [resource-based authorizations](/components/concepts/access-control/authorizations.md).
+:::
+
+## Multi-tenancy
+
+You can enable multi-tenancy checks on a per-cluster basis to enforce tenant-level authorization for Orchestration Cluster resources.
+
+- Enable this setting to enforce tenant-level authorization checks. Users, groups, and roles not assigned to a tenant lose access to any resources scoped to that tenant.
+- Disable this setting to allow tenants to be created and principals assigned without enforcing checks. All data maps to the `<default>` tenant.
+
+This setting is disabled by default. Only organization admins can change it, and it is available for clusters running generation 8.8 and later. The setting is reversible: disabling it restores the implicit `<default>`-tenant behavior.
+
+For details on creating tenants and managing assignments, see [tenant management](/components/admin/tenant.md).
+
+:::warning
+Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
 ## Automatic cluster updates


### PR DESCRIPTION
## Description

Reconcile the multi-tenancy (logical tenancy) documentation now that the feature is available on Camunda 8 SaaS (via the new Console multi-tenancy cluster toggle), not just Self-Managed. Closes camunda-docs#9120.

### Changes

- **`components/concepts/multi-tenancy.md`** -- adjusted from a Self-Managed-only stub into the primary SaaS-inclusive conceptual reference. Removed the "not available in SaaS" callout; added an **Enable multi-tenancy checks** section split by deployment model (SaaS Console toggle vs. Self-Managed config properties); scoped Optimize as Self-Managed-only (SaaS Optimize sees only the `<default>` tenant); cross-references the SM overview for the full model comparison.
- **`components/admin/tenant.md`** -- removed the `Self-Managed only` badge. Noted that the **Tenants** tab is visible to org admins on SaaS clusters (8.8+) before checks are enabled. Split enable-checks guidance into SaaS/SM, with a pre-enable assignment warning.
- **`components/hub/organization/manage-clusters/settings.md`** -- added a **Multi-tenancy** section below Authorizations (behavior, disabled by default, org-admins only, 8.8+, reversible, pre-enable warning). Updated the Authorizations "Learn more" link text to "resource-based authorizations".
- **`components/admin/admin-introduction.md`** -- updated the access table: **Tenants** availability changed from `Self-Managed only` to `All deployments`.

### Notes

- Contains `TODO` comments flagging open questions for engineering: whether the mapping-rules "OIDC in SM only" restriction applies to SaaS, and the exact minimum cluster generation/final toggle-label casing.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
