### PR TITLE
docs(rdbms): add MySQL 9.7 LTS to supported versions

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -106,6 +106,21 @@ Camunda 8.10 adds support for MariaDB 12.3 LTS. Supported versions are now 10.11
 
 <div className="release-announcement-row">
 <div className="release-announcement-badge">
+<span className="badge badge--new">New</span>
+</div>
+<div className="release-announcement-content">
+
+#### MySQL 9.7 now supported
+
+Camunda 8.10 adds support for MySQL 9.7 LTS. Supported versions are now 8.4 and 9.7.
+
+<p className="link-arrow">[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">

--- a/docs/self-managed/components/hub/configuration/database.md
+++ b/docs/self-managed/components/hub/configuration/database.md
@@ -370,7 +370,7 @@ webModeler:
           [
             "sh",
             "-c",
-            "wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-9.5.0.tar.gz -O /driver-lib/mysql.tar.gz && tar -xzf /driver-lib/mysql.tar.gz -C /driver-lib --strip-components=1",
+            "wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-9.7.0.tar.gz -O /driver-lib/mysql.tar.gz && tar -xzf /driver-lib/mysql.tar.gz -C /driver-lib --strip-components=1",
           ]
         volumeMounts:
           - name: mysql-driver

--- a/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -30,7 +30,7 @@ The following relational databases are officially supported when used as an RDBM
 | PostgreSQL               | 15, 16, 17, 18          |
 | Amazon Aurora PostgreSQL | 15, 16, 17, 18          |
 | MariaDB                  | 10.11, 11.4, 11.8, 12.3 |
-| MySQL                    | 8.4                     |
+| MySQL                    | 8.4, 9.7                |
 | Microsoft SQL Server     | 2022, 2025              |
 | Oracle                   | 19c, 26ai               |
 | H2                       | 2.4                     |
@@ -135,7 +135,7 @@ The following databases require you to provide a compatible JDBC driver at runti
 | Database | Driver artifact                   | Tested version | Notes                                                                   |
 | :------- | :-------------------------------- | :------------- | :---------------------------------------------------------------------- |
 | Oracle   | `com.oracle.database.jdbc:ojdbc*` | 23.7.0.25.01   | Must be provided by you. May be OS/architecture-specific (amd64/arm64). |
-| MySQL    | `com.mysql:mysql-connector-j`     | 9.5.0          | Must be provided by you.                                                |
+| MySQL    | `com.mysql:mysql-connector-j`     | 9.7.0          | Must be provided by you.                                                |
 
 :::info
 Camunda validates driver compatibility in CI by testing against the oldest and newest supported database versions. A single driver version is expected to work across the supported database versions listed on this page.

--- a/docs/self-managed/quickstart/developer-quickstart/c8run/secondary-storage.md
+++ b/docs/self-managed/quickstart/developer-quickstart/c8run/secondary-storage.md
@@ -172,7 +172,7 @@ docker run -d --name camunda-mysql \
   -e MYSQL_USER=camunda \
   -e MYSQL_PASSWORD=camunda \
   -e MYSQL_DATABASE=camunda_secondary \
-  -p 3306:3306 mysql:8.4
+  -p 3306:3306 mysql:9.7
 ```
 
 :::note

--- a/docs/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage.md
+++ b/docs/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage.md
@@ -134,7 +134,7 @@ services:
       - ./driver-lib:/driver-lib
 
   mysql:
-    image: mysql:8.4
+    image: mysql:9.7
     environment:
       MYSQL_DATABASE: camunda_secondary
       MYSQL_USER: camunda


### PR DESCRIPTION
## Description

MySQL 9.7 was released 2026-04-21 as a new LTS release (EOL 2034-04-21). This PR documents its addition to the Camunda 8 supported RDBMS matrix, tracked in camunda/camunda#56839.

**Changes:**

- `rdbms-support-policy.md`: add `9.7` to supported MySQL versions; bump tested Connector/J version to `9.7.0`
- `8100-announcements.md`: new "MySQL 9.7 now supported" announcement block
- `c8run/secondary-storage.md`: update Docker quickstart example to `mysql:9.7`
- `docker-compose/secondary-storage.md`: update compose example to `mysql:9.7`
- `hub/configuration/database.md`: update Connector/J download URL to `9.7.0`

Companion code PR: camunda/camunda#57042