### PR TITLE
Fix internal tool documentation links in AI Agent task example

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md
@@ -32,7 +32,7 @@ It is important to align the **Agent context** field and the result variable. Th
 
 1. The ad-hoc sub-process is marked as a [parallel multi-instance](../../modeler/bpmn/multi-instance/multi-instance.md). This allows the process to execute the tools in parallel, and wait for all tool calls to complete before continuing with the process.
 
-1. A descriptive ID is configured for the ad-hoc sub-process. This can then be configured in the **Ad-hoc sub-process ID** field in the AI Agent connector [tools](agentic-ai-aiagent.md#tools) section.
+1. A descriptive ID is configured for the ad-hoc sub-process. This can then be configured in the **Ad-hoc sub-process ID** field in the AI Agent connector [tools](agentic-ai-aiagent-task.md#tools) section.
 
 1. A loop is modeled into the sub-process and back to the AI Agent connector.
    - The `no` flow of the `Contains tool calls?` gateway is marked as the default flow.
@@ -60,9 +60,9 @@ This allows:
 The following properties for the ad-hoc sub-process must be configured. You can use the following suggested values as a starting point and change as required or if dealing with multiple agents within the same process.
 
 - **Input collection**: Set this to the list of tool calls your AI Agent connector returns, for example `agent.toolCalls`.
-- **Input element**: Contains the individual tool call, including LLM-generated input parameters based on the [tool definition](#tool-definitions). Must aways be set to `toolCall`.
-- **Output collection**: Collects the results of all the requested tool calls. Suggested value: `toolCallResults`. Make sure you pass this value as [Tool Call Results](agentic-ai-aiagent.md#tools) in the AI Agent configuration.
-- **Output element**: Collects the individual tool call result as returned by an individual tool (see [Tool Call Responses](#tool-call-responses)). When changing this `toolCallResult` to a different value, make sure you also change your tools to write to the updated variable name.
+- **Input element**: Contains the individual tool call, including LLM-generated input parameters based on the [tool definition](agentic-ai-aiagent-tool-definitions.md#tool-definitions). Must aways be set to `toolCall`.
+- **Output collection**: Collects the results of all the requested tool calls. Suggested value: `toolCallResults`. Make sure you pass this value as [Tool Call Results](agentic-ai-aiagent-task.md#tools) in the AI Agent configuration.
+- **Output element**: Collects the individual tool call result as returned by an individual tool (see [Tool Call Responses](agentic-ai-aiagent-tool-definitions.md#tool-call-responses)). When changing this `toolCallResult` to a different value, make sure you also change your tools to write to the updated variable name.
   ```feel
   {
     id: toolCall._meta.id,

--- a/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md
+++ b/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md
@@ -32,7 +32,7 @@ It is important to align the **Agent context** field and the result variable. Th
 
 1. The ad-hoc sub-process is marked as a [parallel multi-instance](../../modeler/bpmn/multi-instance/multi-instance.md). This allows the process to execute the tools in parallel, and wait for all tool calls to complete before continuing with the process.
 
-1. A descriptive ID is configured for the ad-hoc sub-process. This can then be configured in the **Ad-hoc sub-process ID** field in the AI Agent connector [tools](agentic-ai-aiagent.md#tools) section.
+1. A descriptive ID is configured for the ad-hoc sub-process. This can then be configured in the **Ad-hoc sub-process ID** field in the AI Agent connector [tools](agentic-ai-aiagent-task.md#tools) section.
 
 1. A loop is modeled into the sub-process and back to the AI Agent connector.
    - The `no` flow of the `Contains tool calls?` gateway is marked as the default flow.
@@ -60,9 +60,9 @@ This allows:
 The following properties for the ad-hoc sub-process must be configured. You can use the following suggested values as a starting point and change as required or if dealing with multiple agents within the same process.
 
 - **Input collection**: Set this to the list of tool calls your AI Agent connector returns, for example `agent.toolCalls`.
-- **Input element**: Contains the individual tool call, including LLM-generated input parameters based on the [tool definition](#tool-definitions). Must aways be set to `toolCall`.
-- **Output collection**: Collects the results of all the requested tool calls. Suggested value: `toolCallResults`. Make sure you pass this value as [Tool Call Results](agentic-ai-aiagent.md#tools) in the AI Agent configuration.
-- **Output element**: Collects the individual tool call result as returned by an individual tool (see [Tool Call Responses](#tool-call-responses)). When changing this `toolCallResult` to a different value, make sure you also change your tools to write to the updated variable name.
+- **Input element**: Contains the individual tool call, including LLM-generated input parameters based on the [tool definition](agentic-ai-aiagent-tool-definitions.md#tool-definitions). Must aways be set to `toolCall`.
+- **Output collection**: Collects the results of all the requested tool calls. Suggested value: `toolCallResults`. Make sure you pass this value as [Tool Call Results](agentic-ai-aiagent-task.md#tools) in the AI Agent configuration.
+- **Output element**: Collects the individual tool call result as returned by an individual tool (see [Tool Call Responses](agentic-ai-aiagent-tool-definitions.md#tool-call-responses)). When changing this `toolCallResult` to a different value, make sure you also change your tools to write to the updated variable name.
   ```feel
   {
     id: toolCall._meta.id,

--- a/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md
+++ b/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md
@@ -32,7 +32,7 @@ It is important to align the **Agent context** field and the result variable. Th
 
 1. The ad-hoc sub-process is marked as a [parallel multi-instance](../../modeler/bpmn/multi-instance/multi-instance.md). This allows the process to execute the tools in parallel, and wait for all tool calls to complete before continuing with the process.
 
-1. A descriptive ID is configured for the ad-hoc sub-process. This can then be configured in the **Ad-hoc sub-process ID** field in the AI Agent connector [tools](agentic-ai-aiagent.md#tools) section.
+1. A descriptive ID is configured for the ad-hoc sub-process. This can then be configured in the **Ad-hoc sub-process ID** field in the AI Agent connector [tools](agentic-ai-aiagent-task.md#tools) section.
 
 1. A loop is modeled into the sub-process and back to the AI Agent connector.
    - The `no` flow of the `Contains tool calls?` gateway is marked as the default flow.
@@ -60,9 +60,9 @@ This allows:
 The following properties for the ad-hoc sub-process must be configured. You can use the following suggested values as a starting point and change as required or if dealing with multiple agents within the same process.
 
 - **Input collection**: Set this to the list of tool calls your AI Agent connector returns, for example `agent.toolCalls`.
-- **Input element**: Contains the individual tool call, including LLM-generated input parameters based on the [tool definition](#tool-definitions). Must aways be set to `toolCall`.
-- **Output collection**: Collects the results of all the requested tool calls. Suggested value: `toolCallResults`. Make sure you pass this value as [Tool Call Results](agentic-ai-aiagent.md#tools) in the AI Agent configuration.
-- **Output element**: Collects the individual tool call result as returned by an individual tool (see [Tool Call Responses](#tool-call-responses)). When changing this `toolCallResult` to a different value, make sure you also change your tools to write to the updated variable name.
+- **Input element**: Contains the individual tool call, including LLM-generated input parameters based on the [tool definition](agentic-ai-aiagent-tool-definitions.md#tool-definitions). Must aways be set to `toolCall`.
+- **Output collection**: Collects the results of all the requested tool calls. Suggested value: `toolCallResults`. Make sure you pass this value as [Tool Call Results](agentic-ai-aiagent-task.md#tools) in the AI Agent configuration.
+- **Output element**: Collects the individual tool call result as returned by an individual tool (see [Tool Call Responses](agentic-ai-aiagent-tool-definitions.md#tool-call-responses)). When changing this `toolCallResult` to a different value, make sure you also change your tools to write to the updated variable name.
   ```feel
   {
     id: toolCall._meta.id,


### PR DESCRIPTION
## Description

This PR corrects internal documentation links in the AI Agent task example documentation across all versions. The changes update references to point to the correct documentation pages:

- Links to `agentic-ai-aiagent.md#tools` are updated to `agentic-ai-aiagent-task.md#tools` to reference the task-specific connector documentation
- Links to `#tool-definitions` and `#tool-call-responses` are updated to `agentic-ai-aiagent-tool-definitions.md#tool-definitions` and `agentic-ai-aiagent-tool-definitions.md#tool-call-responses` respectively to reference the dedicated tool definitions documentation

These changes ensure users are directed to the correct documentation pages when reading the AI Agent task example guide.

## Changes

- Updated 3 internal documentation links in `/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md`
- Updated 3 internal documentation links in `/versioned_docs/version-8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md`
- Updated 3 internal documentation links in `/versioned_docs/version-8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task-example.md`

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up
- [x] My changes are for **an already released minor** and are in `/versioned_docs` directories
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

https://claude.ai/code/session_01433PmcBLN4izZEMH1fgaBn