### PR TITLE
docs(self-managed): align document handling irsa param wording with the Helm chart [ready]

### DIFF
--- a/docs/self-managed/concepts/document-handling/configuration/helm.md
+++ b/docs/self-managed/concepts/document-handling/configuration/helm.md
@@ -35,9 +35,9 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
-                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                ## @extra global.documentStore.type.aws.irsa configuration for AWS IAM role authentication, supporting both IRSA (IAM Roles for Service Accounts) and EKS Pod Identity.
                 irsa:
-                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain. Despite its name, this supports both IRSA and EKS Pod Identity. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  ## @param global.documentStore.type.aws.irsa.enabled if true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain; this supports both IRSA and EKS Pod Identity. If false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
                   enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"

--- a/versioned_docs/version-8.7/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.7/self-managed/concepts/document-handling/configuration/helm.md
@@ -29,9 +29,9 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
-                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                ## @extra global.documentStore.type.aws.irsa configuration for AWS IAM role authentication, supporting both IRSA (IAM Roles for Service Accounts) and EKS Pod Identity.
                 irsa:
-                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain. Despite its name, this supports both IRSA and EKS Pod Identity. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  ## @param global.documentStore.type.aws.irsa.enabled if true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain; this supports both IRSA and EKS Pod Identity. If false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
                   enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"

--- a/versioned_docs/version-8.8/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.8/self-managed/concepts/document-handling/configuration/helm.md
@@ -30,9 +30,9 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
-                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                ## @extra global.documentStore.type.aws.irsa configuration for AWS IAM role authentication, supporting both IRSA (IAM Roles for Service Accounts) and EKS Pod Identity.
                 irsa:
-                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain. Despite its name, this supports both IRSA and EKS Pod Identity. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  ## @param global.documentStore.type.aws.irsa.enabled if true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain; this supports both IRSA and EKS Pod Identity. If false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
                   enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"

--- a/versioned_docs/version-8.9/self-managed/concepts/document-handling/configuration/helm.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/document-handling/configuration/helm.md
@@ -35,9 +35,9 @@ global:
             aws:
                 ## @param global.documentStore.type.aws.enabled Enable AWS document store configuration.
                 enabled: false
-                ## @extra global.documentStore.type.aws.irsa IRSA (IAM Roles for Service Accounts) configuration for AWS authentication.
+                ## @extra global.documentStore.type.aws.irsa configuration for AWS IAM role authentication, supporting both IRSA (IAM Roles for Service Accounts) and EKS Pod Identity.
                 irsa:
-                  ## @param global.documentStore.type.aws.irsa.enabled When set to true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain. Despite its name, this supports both IRSA and EKS Pod Identity. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
+                  ## @param global.documentStore.type.aws.irsa.enabled if true, no static AWS credentials are injected into pods, so the AWS SDK resolves credentials through its default provider chain; this supports both IRSA and EKS Pod Identity. If false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.
                   enabled: false
                 ## @param global.documentStore.type.aws.storeId Custom prefix for AWS. Default will generate env vars containing 'storeId' such as DOCUMENT_STORE_AWS_CLASS.
                 storeId: "AWS"


### PR DESCRIPTION
## Description

Aligns the `global.documentStore.type.aws.irsa` parameter documentation on the [document handling Helm configuration page](https://docs.camunda.io/docs/next/self-managed/concepts/document-handling/configuration/helm/) with the upstream Helm chart wording. This page renders a snapshot of the chart's `values.yaml`, so the descriptions should match it verbatim.

The chart's `@param`/`@extra` descriptions were refined in camunda/camunda-platform-helm#6519:

- The parent `global.documentStore.type.aws.irsa` section header now states it covers **both IRSA and EKS Pod Identity** (previously "IRSA … configuration for AWS authentication" only), resolving a contradiction with the child description.
- The `irsa.enabled` description now uses the chart-mandated `if true` / `If false` toggle conjunction (per the chart's `values-yaml` instructions) instead of "When set to true".

This is a follow-up to #9263 (which first documented EKS Pod Identity support here). Applied to **Next, 8.9, 8.8, and 8.7**. Content-only, no structural changes.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style.
