### PR TITLE
fix(docs): add missing space in firstChoice variable name example

### DIFF
--- a/docs/components/concepts/variables.md
+++ b/docs/components/concepts/variables.md
@@ -18,7 +18,7 @@ When accessing a variable in an expression, keep in mind the variable name is ca
 
 Restrictions of a variable name:
 
-- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice`instead).
+- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice` instead).
 - It may not contain **whitespaces** (e.g. `order number` is not allowed; you can use `orderNumber` instead).
 - It may not contain an **operator** (e.g. `+`, `-`, `*`, `/`, `=`, `>`, `?`, `.`).
 - It may not be a **literal** (e.g. `null`, `true`, `false`) or a **keyword** (e.g. `function`, `if`, `then`, `else`, `for`, `between`, `instance`, `of`, `not`).

--- a/versioned_docs/version-8.7/components/concepts/variables.md
+++ b/versioned_docs/version-8.7/components/concepts/variables.md
@@ -18,7 +18,7 @@ When accessing a variable in an expression, keep in mind the variable name is ca
 
 Restrictions of a variable name:
 
-- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice`instead).
+- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice` instead).
 - It may not contain **whitespaces** (e.g. `order number` is not allowed; you can use `orderNumber` instead).
 - It may not contain an **operator** (e.g. `+`, `-`, `*`, `/`, `=`, `>`, `?`, `.`).
 - It may not be a **literal** (e.g. `null`, `true`, `false`) or a **keyword** (e.g. `function`, `if`, `then`, `else`, `for`, `between`, `instance`, `of`, `not`).

--- a/versioned_docs/version-8.8/components/concepts/variables.md
+++ b/versioned_docs/version-8.8/components/concepts/variables.md
@@ -18,7 +18,7 @@ When accessing a variable in an expression, keep in mind the variable name is ca
 
 Restrictions of a variable name:
 
-- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice`instead).
+- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice` instead).
 - It may not contain **whitespaces** (e.g. `order number` is not allowed; you can use `orderNumber` instead).
 - It may not contain an **operator** (e.g. `+`, `-`, `*`, `/`, `=`, `>`, `?`, `.`).
 - It may not be a **literal** (e.g. `null`, `true`, `false`) or a **keyword** (e.g. `function`, `if`, `then`, `else`, `for`, `between`, `instance`, `of`, `not`).

--- a/versioned_docs/version-8.9/components/concepts/variables.md
+++ b/versioned_docs/version-8.9/components/concepts/variables.md
@@ -18,7 +18,7 @@ When accessing a variable in an expression, keep in mind the variable name is ca
 
 Restrictions of a variable name:
 
-- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice`instead).
+- It may not start with a **number** (e.g. `1stChoice` is not allowed; you can use `firstChoice` instead).
 - It may not contain **whitespaces** (e.g. `order number` is not allowed; you can use `orderNumber` instead).
 - It may not contain an **operator** (e.g. `+`, `-`, `*`, `/`, `=`, `>`, `?`, `.`).
 - It may not be a **literal** (e.g. `null`, `true`, `false`) or a **keyword** (e.g. `function`, `if`, `then`, `else`, `for`, `between`, `instance`, `of`, `not`).


### PR DESCRIPTION
## Description

Fixes a missing space in the variable name restriction example across four files. The text `you can use \`firstChoice\`instead` was missing a space before `instead` and should read `you can use \`firstChoice\` instead`.

Files changed:
- `docs/components/concepts/variables.md`
- `versioned_docs/version-8.9/components/concepts/variables.md`
- `versioned_docs/version-8.8/components/concepts/variables.md`
- `versioned_docs/version-8.7/components/concepts/variables.md`

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
