### PR TITLE
docs: document skipVariableWriteWithoutUserTasks exporter option and its migration limitation

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -155,10 +155,7 @@ indices. The history can be configured as follows:
 
 <TabItem value="tasklist">
 
-Helm property path prefix for this option:
-`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
-
-Tasklist-specific export options:
+Helm property path prefix for this Tasklist-specific export option: `camunda.data.secondary-storage.{elasticsearch|opensearch}.`
 
 | Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -38,7 +38,7 @@ For example, set history rollover using:
 ### Options
 
 <Tabs groupId="configuration" defaultValue="index" queryString
-values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Other', value: 'other' }]} >
+values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Tasklist', value: 'tasklist' },{label: 'Other', value: 'other' }]} >
 
 <TabItem value="connect">
 
@@ -153,6 +153,23 @@ indices. The history can be configured as follows:
 
 </TabItem>
 
+<TabItem value="tasklist">
+
+Helm property path prefix for this option:
+`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
+
+Tasklist-specific export options:
+
+| Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| skipVariableWriteWithoutUserTasks | If `true`, the exporter skips writing task variable data to the `tasklist-task` index for process definitions that do not contain any user task flow node instances. This reduces index size and improves write and read performance by avoiding the persistence of task data that is never queried through Tasklist. The exporter uses the process cache to determine whether a deployed process definition contains at least one user task. | `false` |
+
+:::warning Process instance migration limitation
+When `skipVariableWriteWithoutUserTasks` is enabled, task variable data is not exported for process definitions without user tasks. If a process instance is later [migrated](/components/concepts/process-instance-migration.md) to a process definition version that **does** contain user tasks, variable data that was previously skipped is **not** retroactively backfilled. As a result, process-level variable filters in task search only match process instances that were created on a process definition version that already contained user tasks (that is, on or after the version introducing user tasks). For migrated instances, only variables exported **after** the migration (from new variable update events) appear in task search results.
+:::
+
+</TabItem>
+
 <TabItem value="other">
 
 Helm property path prefix for these options:
@@ -214,6 +231,8 @@ exporters:
 
         batchOperation:
           exportItemsOnCreation: true
+
+      skipVariableWriteWithoutUserTasks: false
 
       createSchema: true
 ```

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -59,7 +59,7 @@ zeebe:
 ### Options
 
 <Tabs groupId="configuration" defaultValue="index" queryString
-values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Other', value: 'other' }]} >
+values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Tasklist', value: 'tasklist' },{label: 'Other', value: 'other' }]} >
 
 <TabItem value="connect">
 
@@ -170,6 +170,23 @@ indices. The history can be configured as follows:
 
 </TabItem>
 
+<TabItem value="tasklist">
+
+Helm property path prefix for this option:
+`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
+
+Tasklist-specific export options:
+
+| Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| skipVariableWriteWithoutUserTasks | If `true`, the exporter skips writing task variable data to the `tasklist-task` index for process definitions that do not contain any user task flow node instances. This reduces index size and improves write and read performance by avoiding the persistence of task data that is never queried through Tasklist. The exporter uses the process cache to determine whether a deployed process definition contains at least one user task. | `false` |
+
+:::warning Process instance migration limitation
+When `skipVariableWriteWithoutUserTasks` is enabled, task variable data is not exported for process definitions without user tasks. If a process instance is later [migrated](/components/concepts/process-instance-migration.md) to a process definition version that **does** contain user tasks, variable data that was previously skipped is **not** retroactively backfilled. As a result, process-level variable filters in task search only match process instances that were created on a process definition version that already contained user tasks (that is, on or after the version introducing user tasks). For migrated instances, only variables exported **after** the migration (from new variable update events) appear in task search results.
+:::
+
+</TabItem>
+
 <TabItem value="other">
 
 Helm property path prefix for these options:
@@ -230,6 +247,8 @@ exporters:
 
         batchOperation:
           exportItemsOnCreation: true
+
+      skipVariableWriteWithoutUserTasks: false
 
       createSchema: true
 ```

--- a/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/versioned_docs/version-8.8/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -172,10 +172,7 @@ indices. The history can be configured as follows:
 
 <TabItem value="tasklist">
 
-Helm property path prefix for this option:
-`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
-
-Tasklist-specific export options:
+Helm property path prefix for this Tasklist-specific export option: `camunda.data.secondary-storage.{elasticsearch|opensearch}.`
 
 | Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -155,10 +155,7 @@ indices. The history can be configured as follows:
 
 <TabItem value="tasklist">
 
-Helm property path prefix for this option:
-`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
-
-Tasklist-specific export options:
+Helm property path prefix for this Tasklist-specific export option: `camunda.data.secondary-storage.{elasticsearch|opensearch}.`
 
 | Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
+++ b/versioned_docs/version-8.9/self-managed/components/orchestration-cluster/zeebe/exporters/camunda-exporter.md
@@ -38,7 +38,7 @@ For example, set history rollover using:
 ### Options
 
 <Tabs groupId="configuration" defaultValue="index" queryString
-values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Other', value: 'other' }]} >
+values={[{label: 'Connect', value: 'connect' },{label: 'Index', value: 'index' },{label: 'Bulk', value: 'bulk' },{label: 'Retention', value: 'retention' },{label: 'History', value: 'history' },{label: 'Tasklist', value: 'tasklist' },{label: 'Other', value: 'other' }]} >
 
 <TabItem value="connect">
 
@@ -153,6 +153,23 @@ indices. The history can be configured as follows:
 
 </TabItem>
 
+<TabItem value="tasklist">
+
+Helm property path prefix for this option:
+`camunda.data.secondary-storage.{elasticsearch|opensearch}.`
+
+Tasklist-specific export options:
+
+| Option                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| skipVariableWriteWithoutUserTasks | If `true`, the exporter skips writing task variable data to the `tasklist-task` index for process definitions that do not contain any user task flow node instances. This reduces index size and improves write and read performance by avoiding the persistence of task data that is never queried through Tasklist. The exporter uses the process cache to determine whether a deployed process definition contains at least one user task. | `false` |
+
+:::warning Process instance migration limitation
+When `skipVariableWriteWithoutUserTasks` is enabled, task variable data is not exported for process definitions without user tasks. If a process instance is later [migrated](/components/concepts/process-instance-migration.md) to a process definition version that **does** contain user tasks, variable data that was previously skipped is **not** retroactively backfilled. As a result, process-level variable filters in task search only match process instances that were created on a process definition version that already contained user tasks (that is, on or after the version introducing user tasks). For migrated instances, only variables exported **after** the migration (from new variable update events) appear in task search results.
+:::
+
+</TabItem>
+
 <TabItem value="other">
 
 Helm property path prefix for these options:
@@ -214,6 +231,8 @@ exporters:
 
         batchOperation:
           exportItemsOnCreation: true
+
+      skipVariableWriteWithoutUserTasks: false
 
       createSchema: true
 ```


### PR DESCRIPTION
## Description

Documents the Camunda Exporter option `skipVariableWriteWithoutUserTasks` (added in camunda/camunda#47843, available since 8.8) on the Camunda Exporter configuration page, in `docs/` (next), `versioned_docs/version-8.9/`, and `versioned_docs/version-8.8/`.

It also documents a known limitation as a warning note: when the option is enabled and a process instance is later migrated to a process definition version that contains user tasks, previously skipped variable data is not retroactively backfilled — process-level variable filters in task search only match process instances created on a version that already contained user tasks. Per the decision in camunda/camunda#49963, we document this limitation instead of implementing a backfill, which proved too complex and brittle for a niche scenario.

Re-raises the previously closed #8396 with the limitation note added.

Relates to camunda/camunda#49963.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a specific schedule and the assignee will coordinate a release with the DevEx team. (create a new issue to track the work)
- [ ] This can go live whenever. (add `hold` label)

## PR Checklist

- [x] My changes are for an already released minor and are in `versioned_docs` directory.
- [x] My changes are for the next minor and are in `docs` directory (aka `/next/`).
