### PR TITLE
docs(security): add security notices 57 and 58 for Web Modeler

### DIFF
--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -64,6 +64,8 @@ Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
 
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
+
 ## Notice 57
 
 ### Publication date
@@ -90,6 +92,8 @@ binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protecti
 Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
 
 ## Notice 56
 

--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -45,14 +45,11 @@ July 14, 2026
 
 ### Impact
 
-The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399), where a flaw in the
-HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
+The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399), where a flaw in the HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
 memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
 
-Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
-Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
-through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
-path is not reachable from external, untrusted client traffic.
+The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code path is not reachable from external, untrusted client traffic.
 
 ### How to determine if the installation is affected
 

--- a/docs/reference/notices.md
+++ b/docs/reference/notices.md
@@ -33,6 +33,64 @@ To check whether your Helm deployment is affected:
 1. In the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/), find the component versions that the chart deploys.
 1. Compare those component versions with the affected and fixed versions listed in the notice.
 
+## Notice 58
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399), where a flaw in the
+HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
+memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
+
+Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
+through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
+path is not reachable from external, untrusted client traffic.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+## Notice 57
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54291](https://nvd.nist.gov/vuln/detail/CVE-2026-54291), where database
+connections configured with `channelBinding=require` can be silently downgraded from SCRAM-SHA-256-PLUS with channel
+binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protection the setting is meant to guarantee.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+- _And_: You are using PostgreSQL with SCRAM authentication over SSL/TLS and `channelBinding=require`.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
 ## Notice 56
 
 ### Publication date

--- a/versioned_docs/version-8.7/reference/notices.md
+++ b/versioned_docs/version-8.7/reference/notices.md
@@ -29,6 +29,64 @@ To check whether your Helm deployment is affected:
 1. In the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/), find the component versions that the chart deploys.
 1. Compare those component versions with the affected and fixed versions listed in the notice.
 
+## Notice 58
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399), where a flaw in the
+HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
+memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
+
+Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
+through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
+path is not reachable from external, untrusted client traffic.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+## Notice 57
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54291](https://nvd.nist.gov/vuln/detail/CVE-2026-54291), where database
+connections configured with `channelBinding=require` can be silently downgraded from SCRAM-SHA-256-PLUS with channel
+binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protection the setting is meant to guarantee.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+- _And_: You are using PostgreSQL with SCRAM authentication over SSL/TLS and `channelBinding=require`.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
 ## Notice 56
 
 ### Publication date

--- a/versioned_docs/version-8.7/reference/notices.md
+++ b/versioned_docs/version-8.7/reference/notices.md
@@ -45,7 +45,7 @@ The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/det
 HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
 memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
 
-Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
 Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
 through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
 path is not reachable from external, untrusted client traffic.

--- a/versioned_docs/version-8.7/reference/notices.md
+++ b/versioned_docs/version-8.7/reference/notices.md
@@ -60,6 +60,8 @@ Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
 
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
+
 ## Notice 57
 
 ### Publication date
@@ -86,6 +88,8 @@ binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protecti
 Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
 
 ## Notice 56
 

--- a/versioned_docs/version-8.8/reference/notices.md
+++ b/versioned_docs/version-8.8/reference/notices.md
@@ -62,6 +62,8 @@ Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
 
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
+
 ## Notice 57
 
 ### Publication date
@@ -88,6 +90,8 @@ binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protecti
 Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
 
 ## Notice 56
 

--- a/versioned_docs/version-8.8/reference/notices.md
+++ b/versioned_docs/version-8.8/reference/notices.md
@@ -31,6 +31,64 @@ To check whether your Helm deployment is affected:
 1. In the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/), find the component versions that the chart deploys.
 1. Compare those component versions with the affected and fixed versions listed in the notice.
 
+## Notice 58
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399), where a flaw in the
+HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
+memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
+
+Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
+through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
+path is not reachable from external, untrusted client traffic.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+## Notice 57
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54291](https://nvd.nist.gov/vuln/detail/CVE-2026-54291), where database
+connections configured with `channelBinding=require` can be silently downgraded from SCRAM-SHA-256-PLUS with channel
+binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protection the setting is meant to guarantee.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+- _And_: You are using PostgreSQL with SCRAM authentication over SSL/TLS and `channelBinding=require`.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
 ## Notice 56
 
 ### Publication date

--- a/versioned_docs/version-8.8/reference/notices.md
+++ b/versioned_docs/version-8.8/reference/notices.md
@@ -47,7 +47,7 @@ The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/det
 HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
 memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
 
-Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
 Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
 through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
 path is not reachable from external, untrusted client traffic.

--- a/versioned_docs/version-8.9/reference/notices.md
+++ b/versioned_docs/version-8.9/reference/notices.md
@@ -49,7 +49,7 @@ The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/det
 HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
 memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
 
-Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
 Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
 through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
 path is not reachable from external, untrusted client traffic.

--- a/versioned_docs/version-8.9/reference/notices.md
+++ b/versioned_docs/version-8.9/reference/notices.md
@@ -64,6 +64,8 @@ Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
 
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
+
 ## Notice 57
 
 ### Publication date
@@ -90,6 +92,8 @@ binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protecti
 Camunda has provided the following releases which contain the fix:
 
 - Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+The fix was deployed to Web Modeler SaaS on July 8, 2026, 08:12 CET.
 
 ## Notice 56
 

--- a/versioned_docs/version-8.9/reference/notices.md
+++ b/versioned_docs/version-8.9/reference/notices.md
@@ -33,6 +33,64 @@ To check whether your Helm deployment is affected:
 1. In the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/), find the component versions that the chart deploys.
 1. Compare those component versions with the affected and fixed versions listed in the notice.
 
+## Notice 58
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399), where a flaw in the
+HTTP/1.1 message parser in Apache HttpComponents Core allows a remote attacker to cause a denial of service through
+memory exhaustion by sending messages with an excessive number of headers or excessively long headers.
+
+Note: The vulnerable library is only used in outgoing HTTP requests from Web Modeler to the Camunda 8 Orchestration
+Cluster API. To exploit the vulnerability, an attacker would need to be able to control or intercept the API responses
+through a prior attack. Web Modeler's inbound HTTP requests are handled by a different library, so the vulnerable code
+path is not reachable from external, untrusted client traffic.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
+## Notice 57
+
+### Publication date
+
+July 14, 2026
+
+### Products affected
+
+- Camunda Web Modeler
+
+### Impact
+
+The application was vulnerable to [CVE-2026-54291](https://nvd.nist.gov/vuln/detail/CVE-2026-54291), where database
+connections configured with `channelBinding=require` can be silently downgraded from SCRAM-SHA-256-PLUS with channel
+binding to plain SCRAM-SHA-256 without it, losing the man-in-the-middle protection the setting is meant to guarantee.
+
+### How to determine if the installation is affected
+
+- You are using Web Modeler Self-Managed ≤ 8.9.5, ≤ 8.8.16, or ≤ 8.7.23.
+- _And_: You are using PostgreSQL with SCRAM authentication over SSL/TLS and `channelBinding=require`.
+
+### Solution
+
+Camunda has provided the following releases which contain the fix:
+
+- Web Modeler Self-Managed 8.9.6, 8.8.17, 8.7.24
+
 ## Notice 56
 
 ### Publication date


### PR DESCRIPTION
## Description
Add security notices 57 and 58 for Web Modeler.

Closes https://github.com/camunda/camunda-hub/issues/26042
Closes https://github.com/camunda/camunda-hub/issues/26170

## When should this change go live?
- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.