### PR TITLE
fix(best-practices): correct unhandled BPMN error behavior

### DIFF
--- a/docs/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/docs/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -163,7 +163,7 @@ jobClient.newThrowErrorCommand(job)
 
 ### Thinking about unhandled BPMN exceptions
 
-It is crucial to understand that according to the BPMN spec, a BPMN error is either handled via the process or **terminates the process instance**. It does not lead to an incident being raised. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
+It is crucial to understand that if a BPMN error is not handled anywhere in the process, Camunda 8 raises an [incident](/components/concepts/incidents.md) (for example, `Unhandled error event`) instead of silently terminating the process instance. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
 
 <div bpmn="best-practices/dealing-with-problems-and-exceptions-assets/handling-a-bpmn-error.bpmn" callouts="boundary_event_good_unavailable" />
 

--- a/versioned_docs/version-8.7/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.7/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -167,7 +167,7 @@ jobClient.newThrowErrorCommand(job)
 
 ### Thinking about unhandled BPMN exceptions
 
-It is crucial to understand that according to the BPMN spec, a BPMN error is either handled via the process or **terminates the process instance**. It does not lead to an incident being raised. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
+It is crucial to understand that if a BPMN error is not handled anywhere in the process, Camunda 8 raises an [incident](/components/concepts/incidents.md) (for example, `Unhandled error event`) instead of silently terminating the process instance. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
 
 <div bpmn="best-practices/dealing-with-problems-and-exceptions-assets/handling-a-bpmn-error.bpmn" callouts="boundary_event_good_unavailable" />
 

--- a/versioned_docs/version-8.8/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.8/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -163,7 +163,7 @@ jobClient.newThrowErrorCommand(job)
 
 ### Thinking about unhandled BPMN exceptions
 
-It is crucial to understand that according to the BPMN spec, a BPMN error is either handled via the process or **terminates the process instance**. It does not lead to an incident being raised. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
+It is crucial to understand that if a BPMN error is not handled anywhere in the process, Camunda 8 raises an [incident](/components/concepts/incidents.md) (for example, `Unhandled error event`) instead of silently terminating the process instance. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
 
 <div bpmn="best-practices/dealing-with-problems-and-exceptions-assets/handling-a-bpmn-error.bpmn" callouts="boundary_event_good_unavailable" />
 

--- a/versioned_docs/version-8.9/components/best-practices/development/dealing-with-problems-and-exceptions.md
+++ b/versioned_docs/version-8.9/components/best-practices/development/dealing-with-problems-and-exceptions.md
@@ -163,7 +163,7 @@ jobClient.newThrowErrorCommand(job)
 
 ### Thinking about unhandled BPMN exceptions
 
-It is crucial to understand that according to the BPMN spec, a BPMN error is either handled via the process or **terminates the process instance**. It does not lead to an incident being raised. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
+It is crucial to understand that if a BPMN error is not handled anywhere in the process, Camunda 8 raises an [incident](/components/concepts/incidents.md) (for example, `Unhandled error event`) instead of silently terminating the process instance. Therefore, you can and normally should always handle the BPMN error. You can, of course, also handle it in a parent process scope like in the example below:
 
 <div bpmn="best-practices/dealing-with-problems-and-exceptions-assets/handling-a-bpmn-error.bpmn" callouts="boundary_event_good_unavailable" />
 


### PR DESCRIPTION
## Description

Fixes an inaccurate statement in the [Dealing with problems and exceptions](https://docs.camunda.io/docs/components/best-practices/development/dealing-with-problems-and-exceptions/#thinking-about-unhandled-bpmn-exceptions) best practices guide, reported [here](https://camunda.slack.com/archives/C026U8GBNSW/p1784037620555729).


## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
