### PR TITLE
docs(dx): add auto-retries to staging

### DIFF
--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "retry-staging"
     tags-ignore:
       - "*"
 
@@ -54,6 +55,26 @@ jobs:
           remote_host: ${{ steps.secrets.outputs.HOST }}
           remote_user: ${{ steps.secrets.outputs.USER }}
           remote_key: ${{ steps.secrets.outputs.PRIVATE_KEY }}
+  retry-shutdowns:
+    # Because we run these jobs on preemptible runners, they can be shut down
+    # automatically at any time. Instead of requiring a manual rerun every time
+    # this happens, use the reusable action developed by the infra team to retry.
+    runs-on: ubuntu-latest
+    needs:
+      - publish
+    if: failure() && fromJSON(github.run_attempt) < 3
+    steps:
+      - name: Retry job
+        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        with:
+          error-messages: |
+            The runner has received a shutdown signal.
+            The operation was canceled.
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
   notify-failure:
     needs:
       - publish

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "retry-staging"
     tags-ignore:
       - "*"
 


### PR DESCRIPTION
## Description

We've been seeing a lot of intermittent "Operation was cancelled" errors when deploying staging. This PR adds automatic retries.

## When should this change go live?

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
