### PR TITLE
docs(downloads): update Desktop Modeler, Camunda 8 Run, RPA Worker, and Connectors download versions

### DIFF
--- a/src/pages/build-with-camunda.js
+++ b/src/pages/build-with-camunda.js
@@ -810,7 +810,7 @@ function BuildWithCamunda() {
               ></span>
             </p>
             <TerminalWindow copyable>
-              {`$ c8ctl cluster start 8.10.0-alpha2`}
+              {`$ c8ctl cluster start 8.10.0-alpha3`}
             </TerminalWindow>
 
             <p className={clsx(styles.cliInfoNote, styles.cliInfoNoteCentered)}>

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -408,19 +408,19 @@ const GETTING_STARTED = {
 };
 
 const DESKTOP_MODELER = {
-  version: "5.48.0",
-  date: "Jun 5, 2026",
+  version: "5.49.0",
+  date: "Jul 8, 2026",
   nightlyLabel: "Nightly",
   links: {
     mac: {
       stable: [
         {
           label: "Apple Silicon (.dmg)",
-          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.48.0/camunda-modeler-5.48.0-mac-arm64.dmg",
+          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.49.0/camunda-modeler-5.49.0-mac-arm64.dmg",
         },
         {
           label: "Intel (.dmg)",
-          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.48.0/camunda-modeler-5.48.0-mac-x64.dmg",
+          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.49.0/camunda-modeler-5.49.0-mac-x64.dmg",
         },
       ],
       experimental: [
@@ -438,7 +438,7 @@ const DESKTOP_MODELER = {
       stable: [
         {
           label: "Windows (x64)",
-          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.48.0/camunda-modeler-5.48.0-win-x64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.49.0/camunda-modeler-5.49.0-win-x64.zip",
         },
       ],
       experimental: [
@@ -452,7 +452,7 @@ const DESKTOP_MODELER = {
       stable: [
         {
           label: "Linux (x64)",
-          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.48.0/camunda-modeler-5.48.0-linux-x64.tar.gz",
+          url: "https://downloads.camunda.cloud/release/camunda-modeler/5.49.0/camunda-modeler-5.49.0-linux-x64.tar.gz",
         },
       ],
       experimental: [
@@ -468,29 +468,29 @@ const DESKTOP_MODELER = {
 };
 
 const CAMUNDA_RUN = {
-  version: "8.9.6",
-  date: "Jun 9, 2026",
-  alphaVersion: "8.10.0-alpha2",
+  version: "8.9.12",
+  date: "Jul 7, 2026",
+  alphaVersion: "8.10.0-alpha3",
   links: {
     mac: {
       stable: [
         {
           label: "Apple Silicon",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.6/camunda8-run-8.9.6-darwin-aarch64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.12/camunda8-run-8.9.12-darwin-aarch64.zip",
         },
         {
           label: "Intel",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.6/camunda8-run-8.9.6-darwin-x86_64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.12/camunda8-run-8.9.12-darwin-x86_64.zip",
         },
       ],
       experimental: [
         {
           label: "Alpha Apple Silicon",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha2/camunda8-run-8.10.0-alpha2-darwin-aarch64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha3/camunda8-run-8.10.0-alpha3-darwin-aarch64.zip",
         },
         {
           label: "Alpha Intel",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha2/camunda8-run-8.10.0-alpha2-darwin-x86_64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha3/camunda8-run-8.10.0-alpha3-darwin-x86_64.zip",
         },
       ],
     },
@@ -498,13 +498,13 @@ const CAMUNDA_RUN = {
       stable: [
         {
           label: "Windows (x64)",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.6/camunda8-run-8.9.6-windows-x86_64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.12/camunda8-run-8.9.12-windows-x86_64.zip",
         },
       ],
       experimental: [
         {
           label: "Alpha Windows",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha2/camunda8-run-8.10.0-alpha2-windows-x86_64.zip",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha3/camunda8-run-8.10.0-alpha3-windows-x86_64.zip",
         },
       ],
     },
@@ -512,13 +512,13 @@ const CAMUNDA_RUN = {
       stable: [
         {
           label: "Linux (x64)",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.6/camunda8-run-8.9.6-linux-x86_64.tar.gz",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.9.12/camunda8-run-8.9.12-linux-x86_64.tar.gz",
         },
       ],
       experimental: [
         {
           label: "Alpha Linux",
-          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha2/camunda8-run-8.10.0-alpha2-linux-x86_64.tar.gz",
+          url: "https://downloads.camunda.cloud/release/camunda/c8run/8.10.0-alpha3/camunda8-run-8.10.0-alpha3-linux-x86_64.tar.gz",
         },
       ],
     },
@@ -531,7 +531,6 @@ const CAMUNDA_RUN = {
 const RPA_WORKER = {
   version: "1.3.2",
   date: "Apr 23, 2026",
-  alphaVersion: "1.3.0-alpha.3",
   links: {
     mac: {
       stable: [
@@ -544,16 +543,6 @@ const RPA_WORKER = {
           url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.2/rpa-worker_1.3.2_darwin_amd64.zip",
         },
       ],
-      experimental: [
-        {
-          label: "Alpha Apple Silicon",
-          url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.0-alpha.3/rpa-worker_1.3.0-alpha.3_darwin_aarch64.zip",
-        },
-        {
-          label: "Alpha Intel",
-          url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.0-alpha.3/rpa-worker_1.3.0-alpha.3_darwin_x86_64.zip",
-        },
-      ],
     },
     windows: {
       stable: [
@@ -562,24 +551,12 @@ const RPA_WORKER = {
           url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.2/rpa-worker_1.3.2_win32_amd64.zip",
         },
       ],
-      experimental: [
-        {
-          label: "Alpha Windows",
-          url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.0-alpha.3/rpa-worker_1.3.0-alpha.3_windows_x86_64.zip",
-        },
-      ],
     },
     linux: {
       stable: [
         {
           label: "Linux (x64)",
           url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.2/rpa-worker_1.3.2_linux_amd64.zip",
-        },
-      ],
-      experimental: [
-        {
-          label: "Alpha Linux",
-          url: "https://downloads.camunda.cloud/release/rpa-worker/1.3.0-alpha.3/rpa-worker_1.3.0-alpha.3_linux_x86_64.zip",
         },
       ],
     },
@@ -593,8 +570,8 @@ const ADDITIONAL_RELEASES = [
     title: "Camunda Orchestration Cluster",
     description:
       "Download self-managed orchestration runtime artifacts and view all release notes.",
-    version: "8.9.8",
-    date: "Jun 10, 2026",
+    version: "8.9.13",
+    date: "Jul 15, 2026",
     primaryLink: {
       label: "View latest release on GitHub",
       url: "https://github.com/camunda/camunda/releases/latest",
@@ -606,8 +583,8 @@ const ADDITIONAL_RELEASES = [
     title: "Connectors",
     description:
       "Get prebuilt connector artifacts and review release history for connector updates.",
-    version: "8.10.0-alpha2",
-    date: "Jun 2, 2026",
+    version: "8.10.0-alpha3",
+    date: "Jul 7, 2026",
     primaryLink: {
       label: "View latest release on GitHub",
       url: "https://github.com/camunda/connectors/releases/latest",


### PR DESCRIPTION
## Description

Refreshed download links and versions on the Downloads page and the c8ctl example on the Build with Camunda page, checked against https://downloads.camunda.cloud/release/ and GitHub releases.

- Desktop Modeler: 5.48.0 → 5.49.0 (Jul 8, 2026)
- Camunda 8 Run: stable 8.9.6 → 8.9.12, alpha 8.10.0-alpha2 → 8.10.0-alpha3 (Jul 7, 2026)
- Orchestration Cluster card: 8.9.8 → 8.9.13 (Jul 15, 2026)
- Connectors card: 8.10.0-alpha2 → 8.10.0-alpha3 (Jul 7, 2026)
- RPA Worker: stable unchanged (1.3.2, already latest); removed its stale alpha link (1.3.0-alpha.3 predates current stable, no newer alpha exists)
- `build-with-camunda.js`: bumped the `c8ctl cluster start` example from 8.10.0-alpha2 → 8.10.0-alpha3
- Getting Started bundle left at 8.10.0-alpha2 — no getting-started-bundle asset has shipped for any later release (checked alpha3, 8.9.12, 8.9.13)

All updated URLs verified to return 200.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
