### PR TITLE
docs(dx): notify on pipeline failure and successful retry

### DIFF
--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -1,6 +1,9 @@
 name: Enforce PR labels
 
 on:
+  push:
+    branches:
+      - "update-notify-docs"
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
@@ -10,3 +13,16 @@ jobs:
       - uses: yogevbd/enforce-label-action@2.2.2
         with:
           BANNED_LABELS: "hold"
+  notify-failure:
+    needs:
+      - enforce-label
+    if: failure() || success() && fromJSON(github.run_attempt) > 1
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -10,16 +10,3 @@ jobs:
       - uses: yogevbd/enforce-label-action@2.2.2
         with:
           BANNED_LABELS: "hold"
-  notify-failure:
-    needs:
-      - enforce-label
-    if: failure() || success() && fromJSON(github.run_attempt) > 1
-    uses: ./.github/workflows/notify-failure.yml
-    with:
-      # If any dependent job fails, set the dependency_status to 'failure',
-      # otherwise set it to 'success'.
-      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-    secrets:
-      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-      VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
-      VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -1,9 +1,6 @@
 name: Enforce PR labels
 
 on:
-  push:
-    branches:
-      - "update-notify-docs"
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -2,6 +2,10 @@ name: Notify Failure
 
 on:
   workflow_call:
+    inputs:
+      dependency_status:
+        required: true
+        type: string
     secrets:
       VAULT_ADDR:
         required: true
@@ -38,5 +42,6 @@ jobs:
               "github_repo": "${{ github.repository }}",
               "github_run_id": "${{ github.run_id }}",
               "github_ref_name": "${{ github.ref_name }}",
-              "github_workflow": "${{ github.workflow }}"
+              "github_workflow": "${{ github.workflow }}",
+              "dependency_status": "${{ inputs.dependency_status }}"
             }

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -96,8 +96,10 @@ jobs:
     needs:
       - publish
       - trigger-crawl
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -99,6 +99,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -80,6 +80,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -77,8 +77,10 @@ jobs:
   notify-failure:
     needs:
       - publish
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-c8ctl-docs.yaml
+++ b/.github/workflows/sync-c8ctl-docs.yaml
@@ -165,6 +165,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-c8ctl-docs.yaml
+++ b/.github/workflows/sync-c8ctl-docs.yaml
@@ -162,8 +162,10 @@ jobs:
   notify-failure:
     needs:
       - sync-c8ctl-docs
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-csharp-sdk-docs.yaml
+++ b/.github/workflows/sync-csharp-sdk-docs.yaml
@@ -223,6 +223,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-csharp-sdk-docs.yaml
+++ b/.github/workflows/sync-csharp-sdk-docs.yaml
@@ -220,8 +220,10 @@ jobs:
   notify-failure:
     needs:
       - sync-csharp-sdk-docs
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -276,6 +276,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -273,8 +273,10 @@ jobs:
       - sync-sm
       - sync-saas
       - create-pr
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-python-sdk-docs.yaml
+++ b/.github/workflows/sync-python-sdk-docs.yaml
@@ -214,6 +214,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-python-sdk-docs.yaml
+++ b/.github/workflows/sync-python-sdk-docs.yaml
@@ -211,8 +211,10 @@ jobs:
   notify-failure:
     needs:
       - sync-python-sdk-docs
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -211,6 +211,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -208,8 +208,10 @@ jobs:
   notify-failure:
     needs:
       - sync-file
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-spring-boot-docs.yaml
+++ b/.github/workflows/sync-spring-boot-docs.yaml
@@ -116,6 +116,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-spring-boot-docs.yaml
+++ b/.github/workflows/sync-spring-boot-docs.yaml
@@ -113,8 +113,10 @@ jobs:
   notify-failure:
     needs:
       - sync-spring-boot-properties
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/sync-ts-sdk-docs.yaml
+++ b/.github/workflows/sync-ts-sdk-docs.yaml
@@ -194,6 +194,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/sync-ts-sdk-docs.yaml
+++ b/.github/workflows/sync-ts-sdk-docs.yaml
@@ -191,8 +191,10 @@ jobs:
   notify-failure:
     needs:
       - sync-ts-sdk-docs
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/update-release-links.yml
+++ b/.github/workflows/update-release-links.yml
@@ -105,8 +105,10 @@ jobs:
   notify-failure:
     needs:
       - update-release-links
-    if: failure()
+    if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
+    with:
+      dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/update-release-links.yml
+++ b/.github/workflows/update-release-links.yml
@@ -108,6 +108,8 @@ jobs:
     if: failure() || (success() && fromJSON(github.run_attempt) > 1)
     uses: ./.github/workflows/notify-failure.yml
     with:
+      # If any dependent job fails, set the dependency_status to 'failure',
+      # otherwise set it to 'success'.
       dependency_status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
## Description

Notify docs channel when pipeline retries successfully. ([example](https://camunda.slack.com/archives/C0BEHQT31KN/p1784192770254599))

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)
