### PR TITLE
docs: document configurable Gateway listener ports and route sectionName overrides

### DIFF
--- a/docs/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
@@ -145,6 +145,10 @@ You are responsible for creating all resources that expose Camunda's services.
 | `global.gateway.labels`                | map     | `{}`    | Labels added to the Gateway and all Route resources.                                                                                                                                                                                                                                   |
 | `global.gateway.annotations`           | map     | `{}`    | Annotations added to the Gateway and all Route resources.                                                                                                                                                                                                                              |
 | `global.gateway.tls.enabled`           | boolean | `false` | Enable TLS on the Gateway listener. Requires `global.gateway.tls.secretName` to be set.                                                                                                                                                                                                |
+| `global.gateway.port`                  | integer | `80`    | The port of the plaintext (HTTP) Gateway listener. Change this when your Gateway controller exposes HTTP on a non-standard port.                                                                                                                                                       |
+| `global.gateway.tls.port`              | integer | `443`   | The port of the HTTPS Gateway listener. Change this when your Gateway controller exposes HTTPS on a non-standard port (for example, Traefik's `8443` `websecure` entrypoint).                                                                                                          |
+| `global.gateway.httpSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the HTTPRoutes. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below).                                                                                                    |
+| `global.gateway.grpcSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the GRPCRoute. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below).                                                                                                     |
 | `global.gateway.tls.secretName`        | string  | `""`    | Name of the Kubernetes `Secret` containing the TLS certificate and private key.                                                                                                                                                                                                        |
 | `global.gateway.name`                  | string  | `""`    | The name of the Gateway resource that Routes attach to. Defaults to the Helm release fullname when unset. Set this when the shared Gateway has a different name than your release (Scenario B).                                                                                        |
 | `global.gateway.namespace`             | string  | `""`    | The namespace where the Gateway resource lives. Set this only when using a shared Gateway in a different namespace than your Camunda components (see [Scenario B](#scenario-b-shared-gateway-in-a-different-namespace)). When unset, Kubernetes defaults to the Route's own namespace. |
@@ -169,6 +173,44 @@ global:
 ```
 
 When TLS is enabled, the chart configures the Gateway listener on port 443 with `protocol: HTTPS` and sets `sectionName: https` on all HTTPRoutes, and sets `sectionName: grpcs` on the GRPCRoute (used by Zeebe).
+
+### Custom listener ports
+
+By default the Gateway listens on port `80` for HTTP and port `443` for HTTPS. Set `global.gateway.port` and `global.gateway.tls.port` when your Gateway controller exposes these on non-standard ports, for example Traefik's `websecure` entrypoint on `8443`:
+
+```yaml
+global:
+  host: "camunda.example.com"
+  gateway:
+    enabled: true
+    createGatewayResource: true
+    className: nginx
+    port: 8080
+    tls:
+      enabled: true
+      secretName: camunda-platform
+      port: 8443
+```
+
+### Externally-managed Gateway with custom listener names
+
+When attaching Routes to a Gateway you do not manage (for example, one owned by a Cluster Operator), its listener names may not match the chart defaults (`http`, `https`, `grpc`, `grpcs`). Use `global.gateway.httpSectionName` and `global.gateway.grpcSectionName` to point the Routes' `parentRefs.sectionName` at the listener names the target Gateway actually defines:
+
+```yaml
+global:
+  host: "camunda.example.com"
+  gateway:
+    enabled: true
+    createGatewayResource: false
+    name: shared-gateway
+    namespace: shared-infra
+    httpSectionName: web
+    grpcSectionName: grpc-web
+```
+
+:::warning
+The `sectionName` overrides act only on the Route resources and must match a listener name on the target Gateway. When the chart manages the Gateway (`createGatewayResource: true`), the listener names are fixed to `http`, `https`, `grpc`, and `grpcs`, so setting an override there detaches the Route from the Gateway silently.
+:::
 
 ### NGINX Gateway Fabric: ProxySettingsPolicy
 

--- a/docs/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
@@ -147,8 +147,8 @@ You are responsible for creating all resources that expose Camunda's services.
 | `global.gateway.tls.enabled`           | boolean | `false` | Enable TLS on the Gateway listener. Requires `global.gateway.tls.secretName` to be set.                                                                                                                                                                                                |
 | `global.gateway.port`                  | integer | `80`    | The port of the plaintext (HTTP) Gateway listener. Change this when your Gateway controller exposes HTTP on a non-standard port.                                                                                                                                                       |
 | `global.gateway.tls.port`              | integer | `443`   | The port of the HTTPS Gateway listener. Change this when your Gateway controller exposes HTTPS on a non-standard port (for example, Traefik's `8443` `websecure` entrypoint).                                                                                                          |
-| `global.gateway.httpSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the HTTPRoutes. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below).                                                                                                    |
-| `global.gateway.grpcSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the GRPCRoute. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below).                                                                                                     |
+| `global.gateway.httpSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the HTTPRoutes. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway. See [externally-managed gateway with custom listener names](#externally-managed-gateway-with-custom-listener-names).       |
+| `global.gateway.grpcSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the GRPCRoute. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway. See [externally-managed gateway with custom listener names](#externally-managed-gateway-with-custom-listener-names).        |
 | `global.gateway.tls.secretName`        | string  | `""`    | Name of the Kubernetes `Secret` containing the TLS certificate and private key.                                                                                                                                                                                                        |
 | `global.gateway.name`                  | string  | `""`    | The name of the Gateway resource that Routes attach to. Defaults to the Helm release fullname when unset. Set this when the shared Gateway has a different name than your release (Scenario B).                                                                                        |
 | `global.gateway.namespace`             | string  | `""`    | The namespace where the Gateway resource lives. Set this only when using a shared Gateway in a different namespace than your Camunda components (see [Scenario B](#scenario-b-shared-gateway-in-a-different-namespace)). When unset, Kubernetes defaults to the Route's own namespace. |
@@ -176,7 +176,7 @@ When TLS is enabled, the chart configures the Gateway listener on port 443 with 
 
 ### Custom listener ports
 
-By default the Gateway listens on port `80` for HTTP and port `443` for HTTPS. Set `global.gateway.port` and `global.gateway.tls.port` when your Gateway controller exposes these on non-standard ports, for example Traefik's `websecure` entrypoint on `8443`:
+By default the Gateway listens on port `80` for HTTP and port `443` for HTTPS. Set `global.gateway.port` and `global.gateway.tls.port` when your Gateway controller exposes these on non-standard ports, for example, Traefik's `websecure` entrypoint on `8443`:
 
 ```yaml
 global:
@@ -209,7 +209,7 @@ global:
 ```
 
 :::warning
-The `sectionName` overrides act only on the Route resources and must match a listener name on the target Gateway. When the chart manages the Gateway (`createGatewayResource: true`), the listener names are fixed to `http`, `https`, `grpc`, and `grpcs`, so setting an override there detaches the Route from the Gateway silently.
+Only set the `sectionName` overrides for an externally-managed Gateway, and make sure each value matches a listener name on that Gateway. When the chart manages the Gateway (`createGatewayResource: true`), the listener names are always `http`, `https`, `grpc`, and `grpcs`. Setting an override in that case detaches the Routes from the Gateway with no error.
 :::
 
 ### NGINX Gateway Fabric: ProxySettingsPolicy

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
@@ -33,18 +33,22 @@ In testing, we use the [NGINX Gateway Fabric](https://github.com/nginx/nginx-gat
 
 ## Configure the Helm chart
 
-| Parameter                              | Type    | Default | Description                                                                                                               |
-| -------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `global.host`                          | string  | `""`    | The external-facing URL hostname where Camunda will be installed.                                                         |
-| `global.gateway.enabled`               | boolean | `false` | Enable creating resources for the Kubernetes Gateway API.                                                                 |
-| `global.gateway.createGatewayResource` | boolean | `true`  | Create the Gateway CustomResource. Do not enable if you already have a Gateway resource.                                  |
-| `global.gateway.external`              | boolean | `true`  | Set this to true if you are using the Gateway API but want to create the resources yourself.                              |
-| `global.gateway.className`             | string  | `""`    | Name of the GatewayClass resource that defines which Gateway controller operates on your Gateway and HTTPRoute resources. |
-| `global.gateway.labels`                | map     | `{}`    | Labels to add to the Gateway and HTTPRoute resources.                                                                     |
-| `global.gateway.annotations`           | map     | `{}`    | Annotations to add to the Gateway and HTTPRoute resources.                                                                |
-| `global.gateway.tls.enabled`           | boolean | `false` | Enable TLS.                                                                                                               |
-| `global.gateway.tls.secretName`        | string  | `""`    | Name of the Kubernetes Secret resource containing a TLS cert                                                              |
-| `global.gateway.controllerNamespace`   | string  | `""`    | The namespace where the Gateway controller is installed.                                                                  |
+| Parameter                              | Type    | Default | Description                                                                                                                                                                         |
+| -------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `global.host`                          | string  | `""`    | The external-facing URL hostname where Camunda will be installed.                                                                                                                   |
+| `global.gateway.enabled`               | boolean | `false` | Enable creating resources for the Kubernetes Gateway API.                                                                                                                           |
+| `global.gateway.createGatewayResource` | boolean | `true`  | Create the Gateway CustomResource. Do not enable if you already have a Gateway resource.                                                                                            |
+| `global.gateway.external`              | boolean | `true`  | Set this to true if you are using the Gateway API but want to create the resources yourself.                                                                                        |
+| `global.gateway.className`             | string  | `""`    | Name of the GatewayClass resource that defines which Gateway controller operates on your Gateway and HTTPRoute resources.                                                           |
+| `global.gateway.labels`                | map     | `{}`    | Labels to add to the Gateway and HTTPRoute resources.                                                                                                                               |
+| `global.gateway.annotations`           | map     | `{}`    | Annotations to add to the Gateway and HTTPRoute resources.                                                                                                                          |
+| `global.gateway.tls.enabled`           | boolean | `false` | Enable TLS.                                                                                                                                                                         |
+| `global.gateway.tls.secretName`        | string  | `""`    | Name of the Kubernetes Secret resource containing a TLS cert                                                                                                                        |
+| `global.gateway.port`                  | integer | `80`    | The port of the plaintext (HTTP) Gateway listener. Change this when your Gateway controller exposes HTTP on a non-standard port.                                                    |
+| `global.gateway.tls.port`              | integer | `443`   | The port of the HTTPS Gateway listener. Change this when your Gateway controller exposes HTTPS on a non-standard port (for example, Traefik's `8443` `websecure` entrypoint).       |
+| `global.gateway.httpSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the HTTPRoutes. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below). |
+| `global.gateway.grpcSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the GRPCRoute. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below).  |
+| `global.gateway.controllerNamespace`   | string  | `""`    | The namespace where the Gateway controller is installed.                                                                                                                            |
 
 ## Example configuration
 
@@ -62,6 +66,43 @@ global:
       external-dns.alpha.kubernetes.io/hostname: "{{ .Values.global.gateway.hostname }}"
       external-dns.alpha.kubernetes.io/ttl: "60"
 ```
+
+### Custom listener ports
+
+By default the Gateway listens on port `80` for HTTP and port `443` for HTTPS. Set `global.gateway.port` and `global.gateway.tls.port` when your Gateway controller exposes these on non-standard ports, for example Traefik's `websecure` entrypoint on `8443`:
+
+```yaml
+global:
+  host: "camunda.example.com"
+  gateway:
+    createGatewayResource: true
+    enabled: true
+    className: nginx
+    port: 8080
+    tls:
+      enabled: true
+      secretName: camunda-platform
+      port: 8443
+```
+
+### Externally-managed Gateway with custom listener names
+
+When attaching Routes to a Gateway you do not manage, its listener names may not match the chart defaults (`http`, `https`, `grpc`, `grpcs`). Use `global.gateway.httpSectionName` and `global.gateway.grpcSectionName` to point the Routes' `parentRefs.sectionName` at the listener names the target Gateway actually defines:
+
+```yaml
+global:
+  host: "camunda.example.com"
+  gateway:
+    enabled: true
+    createGatewayResource: false
+    className: nginx
+    httpSectionName: web
+    grpcSectionName: grpc-web
+```
+
+:::warning
+The `sectionName` overrides act only on the Route resources and must match a listener name on the target Gateway. When the chart manages the Gateway (`createGatewayResource: true`), the listener names are fixed to `http`, `https`, `grpc`, and `grpcs`, so setting an override there detaches the Route from the Gateway silently.
+:::
 
 ### NGINX Gateway Fabric: ProxySettingsPolicy
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/ingress/gateway-api-setup.md
@@ -33,22 +33,24 @@ In testing, we use the [NGINX Gateway Fabric](https://github.com/nginx/nginx-gat
 
 ## Configure the Helm chart
 
-| Parameter                              | Type    | Default | Description                                                                                                                                                                         |
-| -------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `global.host`                          | string  | `""`    | The external-facing URL hostname where Camunda will be installed.                                                                                                                   |
-| `global.gateway.enabled`               | boolean | `false` | Enable creating resources for the Kubernetes Gateway API.                                                                                                                           |
-| `global.gateway.createGatewayResource` | boolean | `true`  | Create the Gateway CustomResource. Do not enable if you already have a Gateway resource.                                                                                            |
-| `global.gateway.external`              | boolean | `true`  | Set this to true if you are using the Gateway API but want to create the resources yourself.                                                                                        |
-| `global.gateway.className`             | string  | `""`    | Name of the GatewayClass resource that defines which Gateway controller operates on your Gateway and HTTPRoute resources.                                                           |
-| `global.gateway.labels`                | map     | `{}`    | Labels to add to the Gateway and HTTPRoute resources.                                                                                                                               |
-| `global.gateway.annotations`           | map     | `{}`    | Annotations to add to the Gateway and HTTPRoute resources.                                                                                                                          |
-| `global.gateway.tls.enabled`           | boolean | `false` | Enable TLS.                                                                                                                                                                         |
-| `global.gateway.tls.secretName`        | string  | `""`    | Name of the Kubernetes Secret resource containing a TLS cert                                                                                                                        |
-| `global.gateway.port`                  | integer | `80`    | The port of the plaintext (HTTP) Gateway listener. Change this when your Gateway controller exposes HTTP on a non-standard port.                                                    |
-| `global.gateway.tls.port`              | integer | `443`   | The port of the HTTPS Gateway listener. Change this when your Gateway controller exposes HTTPS on a non-standard port (for example, Traefik's `8443` `websecure` entrypoint).       |
-| `global.gateway.httpSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the HTTPRoutes. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below). |
-| `global.gateway.grpcSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the GRPCRoute. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway (see the warning below).  |
-| `global.gateway.controllerNamespace`   | string  | `""`    | The namespace where the Gateway controller is installed.                                                                                                                            |
+| Parameter                              | Type    | Default | Description                                                                                                                                                                                                                                                                      |
+| -------------------------------------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `global.host`                          | string  | `""`    | The external-facing URL hostname where Camunda will be installed.                                                                                                                                                                                                                |
+| `global.gateway.enabled`               | boolean | `false` | Enable creating resources for the Kubernetes Gateway API.                                                                                                                                                                                                                        |
+| `global.gateway.createGatewayResource` | boolean | `true`  | Create the Gateway CustomResource. Do not enable if you already have a Gateway resource.                                                                                                                                                                                         |
+| `global.gateway.external`              | boolean | `true`  | Set this to true if you are using the Gateway API but want to create the resources yourself.                                                                                                                                                                                     |
+| `global.gateway.className`             | string  | `""`    | Name of the GatewayClass resource that defines which Gateway controller operates on your Gateway and HTTPRoute resources.                                                                                                                                                        |
+| `global.gateway.labels`                | map     | `{}`    | Labels to add to the Gateway and HTTPRoute resources.                                                                                                                                                                                                                            |
+| `global.gateway.annotations`           | map     | `{}`    | Annotations to add to the Gateway and HTTPRoute resources.                                                                                                                                                                                                                       |
+| `global.gateway.tls.enabled`           | boolean | `false` | Enable TLS.                                                                                                                                                                                                                                                                      |
+| `global.gateway.tls.secretName`        | string  | `""`    | Name of the Kubernetes Secret resource containing a TLS cert                                                                                                                                                                                                                     |
+| `global.gateway.port`                  | integer | `80`    | The port of the plaintext (HTTP) Gateway listener. Change this when your Gateway controller exposes HTTP on a non-standard port.                                                                                                                                                 |
+| `global.gateway.tls.port`              | integer | `443`   | The port of the HTTPS Gateway listener. Change this when your Gateway controller exposes HTTPS on a non-standard port (for example, Traefik's `8443` `websecure` entrypoint).                                                                                                    |
+| `global.gateway.httpSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the HTTPRoutes. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway. See [externally-managed gateway with custom listener names](#externally-managed-gateway-with-custom-listener-names). |
+| `global.gateway.grpcSectionName`       | string  | `""`    | Override the `parentRefs.sectionName` on the GRPCRoute. Must match a listener name on the target Gateway. Only set this for an externally-managed Gateway. See [externally-managed gateway with custom listener names](#externally-managed-gateway-with-custom-listener-names).  |
+| `global.gateway.name`                  | string  | `""`    | The name of the Gateway resource that Routes attach to. Defaults to the Helm release fullname when unset. Set this when the target Gateway has a different name than your release.                                                                                               |
+| `global.gateway.namespace`             | string  | `""`    | The namespace where the Gateway resource lives. Set this only when using a shared Gateway in a different namespace than your Camunda components. When unset, Kubernetes defaults to the Route's own namespace.                                                                   |
+| `global.gateway.controllerNamespace`   | string  | `""`    | The namespace where the Gateway controller is installed.                                                                                                                                                                                                                         |
 
 ## Example configuration
 
@@ -69,7 +71,7 @@ global:
 
 ### Custom listener ports
 
-By default the Gateway listens on port `80` for HTTP and port `443` for HTTPS. Set `global.gateway.port` and `global.gateway.tls.port` when your Gateway controller exposes these on non-standard ports, for example Traefik's `websecure` entrypoint on `8443`:
+By default the Gateway listens on port `80` for HTTP and port `443` for HTTPS. Set `global.gateway.port` and `global.gateway.tls.port` when your Gateway controller exposes these on non-standard ports, for example, Traefik's `websecure` entrypoint on `8443`:
 
 ```yaml
 global:
@@ -95,13 +97,14 @@ global:
   gateway:
     enabled: true
     createGatewayResource: false
-    className: nginx
+    name: shared-gateway
+    namespace: shared-infra
     httpSectionName: web
     grpcSectionName: grpc-web
 ```
 
 :::warning
-The `sectionName` overrides act only on the Route resources and must match a listener name on the target Gateway. When the chart manages the Gateway (`createGatewayResource: true`), the listener names are fixed to `http`, `https`, `grpc`, and `grpcs`, so setting an override there detaches the Route from the Gateway silently.
+Only set the `sectionName` overrides for an externally-managed Gateway, and make sure each value matches a listener name on that Gateway. When the chart manages the Gateway (`createGatewayResource: true`), the listener names are always `http`, `https`, `grpc`, and `grpcs`. Setting an override in that case detaches the Routes from the Gateway with no error.
 :::
 
 ### NGINX Gateway Fabric: ProxySettingsPolicy


### PR DESCRIPTION
## Description

Documents the four `global.gateway` values added to the `8.9` and `8.10` charts in camunda/camunda-platform-helm#6535, on the Gateway API setup page (both the `8.9` versioned copy and the `docs/` next copy):

- `global.gateway.port` / `global.gateway.tls.port` — configurable Gateway listener ports, with a non-443 example (Traefik `websecure` on `8443`).
- `global.gateway.httpSectionName` / `global.gateway.grpcSectionName` — route `parentRefs.sectionName` overrides, with a BYO / externally-managed Gateway example.

Also adds a `:::warning` footgun: the `sectionName` overrides act only on the Route resources and must match a listener name on the target Gateway; when the chart owns the Gateway (`createGatewayResource: true`) the listener names are fixed (`http`/`https`/`grpc`/`grpcs`), so setting an override there detaches the Route silently.

Closes camunda/camunda-platform-helm#6546.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
