### PR TITLE
docs: add Python and C# to the getting-started example guide

### DIFF
--- a/docs/guides/getting-started-example.md
+++ b/docs/guides/getting-started-example.md
@@ -3,7 +3,19 @@ id: getting-started-example
 title: "Run your first Spring Boot, Node.js, Python, or C# project with Camunda 8"
 sidebar_label: Run your first Spring Boot, Node.js, Python, or C# project
 description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot, Node.js, Python, or C#."
-keywords: [java, spring, spring camunda, python, c#, csharp, .net, getting started, user guide, tutorial]
+keywords:
+  [
+    java,
+    spring,
+    spring camunda,
+    python,
+    c#,
+    csharp,
+    .net,
+    getting started,
+    user guide,
+    tutorial,
+  ]
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/guides/getting-started-example.md
+++ b/docs/guides/getting-started-example.md
@@ -55,7 +55,7 @@ You will:
 <TabItem value="javaspring">
 
 <ul>
-    <li>[JDK 21-25](https://www.oracle.com/de/java/technologies/downloads/)</li>
+    <li>[JDK 21-26](https://www.oracle.com/de/java/technologies/downloads/)</li>
     <li>[Maven 3](https://maven.apache.org/index.html)</li>
     </ul>
   </TabItem>

--- a/docs/guides/getting-started-example.md
+++ b/docs/guides/getting-started-example.md
@@ -302,13 +302,13 @@ You have completed your first process instance by:
 
 ## Next steps
 
-For further information about the Node.js SDK, refer to [the Camunda 8 JavaScript SDK API documentation](https://camunda.github.io/camunda-8-js-sdk/).
+To learn more about our SDKs, visit their respective documentation pages:
 
-For further information about the Python SDK, refer to [the Python SDK documentation](/apis-tools/python-sdk.md).
-
-For further information about the C# SDK, refer to [the C# SDK documentation](/apis-tools/csharp-sdk.md).
-
-Find more examples on the [Developer Portal](https://camunda.com/developers/).
+- Java SDK - [Camunda Java client documentation](/apis-tools/java-client/getting-started.md)
+- Spring Boot starter - [Camunda Spring Boot Starter documentation](/apis-tools/camunda-spring-boot-starter/getting-started.md)
+- Node.js SDK - [Camunda 8 JavaScript SDK API documentation](https://camunda.github.io/camunda-8-js-sdk/)
+- Python SDK - [Python SDK documentation](/apis-tools/python-sdk.md)
+- C# SDK - [C# SDK documentation](/apis-tools/csharp-sdk.md)
 
 ## Teardown
 

--- a/docs/guides/getting-started-example.md
+++ b/docs/guides/getting-started-example.md
@@ -287,23 +287,6 @@ dotnet run
 
 The workers start, connect to the engine, and request work. You will see the workers processing the jobs for the process instance.
 
-<Tabs groupId="language" defaultValue="javaspring" values={
-[
-{ label: 'Java + Spring', value: 'javaspring', },
-{ label: 'Node.js', value: 'nodejs', },
-] }>
-<TabItem value="javaspring">
-
-    ![Worker output](./img/get-started-example-output-java.png)
-
-   </TabItem>
-   <TabItem value="nodejs">
-
-    ![Worker output](./img/getting-started-example-output.png)
-
-   </TabItem>
-</Tabs>
-
 ## Complete!
 
 Navigate back to Operate and verify that your active process instance in Operate has transitioned to completed.

--- a/docs/guides/getting-started-example.md
+++ b/docs/guides/getting-started-example.md
@@ -3,7 +3,7 @@ id: getting-started-example
 title: "Run your first Spring Boot or Node.js project with Camunda 8"
 sidebar_label: Run your first Spring Boot or Node.js project
 description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot or Node.js."
-keywords: [java, spring, spring camunda, getting started, user guide, tutorial]
+keywords: [java, spring, spring camunda, python, c#, csharp, .net, getting started, user guide, tutorial]
 ---
 
 import Tabs from "@theme/Tabs";
@@ -12,7 +12,11 @@ import TabItem from "@theme/TabItem";
 <span class="badge badge--beginner">Beginner</span>
 <span class="badge badge--medium">1 hour</span>
 
-This guide is tailored for developers who want to implement process automation solutions using Java (Spring) or JavaScript (Node.js). You'll work with a local, self-managed, lightweight Camunda 8 environment.
+This guide is tailored for developers who want to implement process automation solutions using Java (Spring), JavaScript (Node.js), Python, or C#. You'll work with a local, self-managed, lightweight Camunda 8 environment.
+
+:::caution Technical Preview
+The C# SDK is a **technical preview** available from Camunda 8.9. It will become fully supported in Camunda 8.10.
+:::
 
 ## Get started with an example project
 
@@ -20,9 +24,11 @@ You will:
 
 - Run Camunda 8 in a local development environment using **Camunda 8 Run**.
 - Use the **Camunda Modeler** to deploy and start a business process.
-- Run workers written in either:
-  - The **Spring (Java) SDK**, or
-  - The **Node.js (JavaScript) SDK**  
+- Run workers written in one of:
+  - The **Spring (Java) SDK**,
+  - The **Node.js (JavaScript) SDK**,
+  - The **Python SDK**, or
+  - The **C# SDK** (technical preview)  
     to handle tasks in the process.
 
 ## Prerequisites
@@ -31,6 +37,8 @@ You will:
 [
 { label: 'Java + Spring', value: 'javaspring', },
 { label: 'Node.js', value: 'nodejs', },
+{ label: 'Python', value: 'python', },
+{ label: 'C# (Technical Preview)', value: 'csharp', },
 ] }>
 <TabItem value="javaspring">
 
@@ -45,6 +53,17 @@ You will:
     <li>NPM 11+</li>
 </ul>
   </TabItem>
+  <TabItem value="python">
+<ul>
+    <li>[Python](https://www.python.org/downloads/) 3.10+</li>
+    <li>pip</li>
+</ul>
+  </TabItem>
+  <TabItem value="csharp">
+<ul>
+    <li>[.NET SDK](https://dotnet.microsoft.com/download) 8 or later</li>
+</ul>
+  </TabItem>
   </Tabs>
 
 ## Download the Getting Started Package
@@ -55,7 +74,7 @@ The starter package includes the following components:
 
 - [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) – A simplified, single-application Camunda configuration for a local development environment.
 - [Camunda Modeler](/components/modeler/about-modeler.md) – An application for modeling BPMN, DMN, and Forms.
-- [Getting started project](https://github.com/camunda/camunda-8-get-started) – An example project with a simple BPMN process and workers in Java or JavaScript.
+- [Getting started project](https://github.com/camunda/camunda-8-get-started) – An example project with a simple BPMN process and workers in Java, JavaScript, Python, or C# (technical preview).
 
 All of these components are included in the starter package. You do not need to download them separately. The links above are provided for additional information.
 
@@ -65,7 +84,7 @@ The example project, located in the `camunda-8-get-started/2-order-process-with-
 
 ![Example business process](./img/getting-started-guide-example-process.png)
 
-The service tasks in the process are executed by [job workers](/reference/glossary.md#job-worker). The `java` and `nodejs` directories inside `2-order-process-with-service-workers` contain code for job workers that correspond to this process model.
+The service tasks in the process are executed by [job workers](/reference/glossary.md#job-worker). The `java`, `nodejs`, `python`, and `csharp` directories inside `2-order-process-with-service-workers` contain code for job workers that correspond to this process model.
 
 ## Instructions
 
@@ -150,6 +169,8 @@ Next, start the job workers to allow them to perform the work for the service ta
 [
 { label: 'Java + Spring', value: 'javaspring', },
 { label: 'Node.js', value: 'nodejs', },
+{ label: 'Python', value: 'python', },
+{ label: 'C# (Technical Preview)', value: 'csharp', },
 ] }>
 <TabItem value="javaspring">
 
@@ -202,6 +223,54 @@ npm start
       </li>
     </ol>
   </TabItem>
+
+  <TabItem value="python">
+    <ol>
+      <li>
+        Change into the Python SDK directory:
+```bash
+cd camunda-8-get-started/2-order-process-with-service-workers/python
+```
+      </li>
+      <li>
+        Create a virtual environment and install dependencies:
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+      </li>
+      <li>
+        Start the workers with the command:
+```bash
+python main.py
+```
+      </li>
+      <li>
+        You can stop the application via Ctrl+C.
+      </li>
+    </ol>
+  </TabItem>
+
+  <TabItem value="csharp">
+    <ol>
+      <li>
+        Change into the C# SDK directory:
+```bash
+cd camunda-8-get-started/2-order-process-with-service-workers/csharp
+```
+      </li>
+      <li>
+        Start the workers with the command:
+```bash
+dotnet run
+```
+      </li>
+      <li>
+        You can stop the application via Ctrl+C.
+      </li>
+    </ol>
+  </TabItem>
    </Tabs>
 
 The workers start, connect to the engine, and request work. You will see the workers processing the jobs for the process instance.
@@ -239,6 +308,10 @@ You have completed your first process instance by:
 ## Next steps
 
 For further information about the Node.js SDK, refer to [the Camunda 8 JavaScript SDK API documentation](https://camunda.github.io/camunda-8-js-sdk/).
+
+For further information about the Python SDK, refer to [the Python SDK documentation](/apis-tools/python-sdk.md).
+
+For further information about the C# SDK, refer to [the C# SDK documentation](/apis-tools/csharp-sdk.md).
 
 Find more examples on the [Developer Portal](https://camunda.com/developers/).
 

--- a/docs/guides/getting-started-example.md
+++ b/docs/guides/getting-started-example.md
@@ -1,8 +1,8 @@
 ---
 id: getting-started-example
-title: "Run your first Spring Boot or Node.js project with Camunda 8"
-sidebar_label: Run your first Spring Boot or Node.js project
-description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot or Node.js."
+title: "Run your first Spring Boot, Node.js, Python, or C# project with Camunda 8"
+sidebar_label: Run your first Spring Boot, Node.js, Python, or C# project
+description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot, Node.js, Python, or C#."
 keywords: [java, spring, spring camunda, python, c#, csharp, .net, getting started, user guide, tutorial]
 ---
 

--- a/versioned_docs/version-8.9/guides/getting-started-example.md
+++ b/versioned_docs/version-8.9/guides/getting-started-example.md
@@ -3,7 +3,19 @@ id: getting-started-example
 title: "Run your first Spring Boot, Node.js, Python, or C# project with Camunda 8"
 sidebar_label: Run your first Spring Boot, Node.js, Python, or C# project
 description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot, Node.js, Python, or C#."
-keywords: [java, spring, spring camunda, python, c#, csharp, .net, getting started, user guide, tutorial]
+keywords:
+  [
+    java,
+    spring,
+    spring camunda,
+    python,
+    c#,
+    csharp,
+    .net,
+    getting started,
+    user guide,
+    tutorial,
+  ]
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-8.9/guides/getting-started-example.md
+++ b/versioned_docs/version-8.9/guides/getting-started-example.md
@@ -3,7 +3,7 @@ id: getting-started-example
 title: "Run your first Spring Boot or Node.js project with Camunda 8"
 sidebar_label: Run your first Spring Boot or Node.js project
 description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot or Node.js."
-keywords: [java, spring, spring camunda, getting started, user guide, tutorial]
+keywords: [java, spring, spring camunda, python, c#, csharp, .net, getting started, user guide, tutorial]
 ---
 
 import Tabs from "@theme/Tabs";
@@ -12,7 +12,11 @@ import TabItem from "@theme/TabItem";
 <span class="badge badge--beginner">Beginner</span>
 <span class="badge badge--medium">1 hour</span>
 
-This guide is tailored for developers who want to implement process automation solutions using Java (Spring) or JavaScript (Node.js). You'll work with a local, self-managed, lightweight Camunda 8 environment.
+This guide is tailored for developers who want to implement process automation solutions using Java (Spring), JavaScript (Node.js), Python, or C#. You'll work with a local, self-managed, lightweight Camunda 8 environment.
+
+:::caution Technical Preview
+The C# SDK is a **technical preview** available from Camunda 8.9. It will become fully supported in Camunda 8.10.
+:::
 
 ## Get started with an example project
 
@@ -20,9 +24,11 @@ You will:
 
 - Run Camunda 8 in a local development environment using **Camunda 8 Run**.
 - Use the **Camunda Modeler** to deploy and start a business process.
-- Run workers written in either:
-  - The **Spring (Java) SDK**, or
-  - The **Node.js (JavaScript) SDK**  
+- Run workers written in one of:
+  - The **Spring (Java) SDK**,
+  - The **Node.js (JavaScript) SDK**,
+  - The **Python SDK**, or
+  - The **C# SDK** (technical preview)  
     to handle tasks in the process.
 
 ## Prerequisites
@@ -31,6 +37,8 @@ You will:
 [
 { label: 'Java + Spring', value: 'javaspring', },
 { label: 'Node.js', value: 'nodejs', },
+{ label: 'Python', value: 'python', },
+{ label: 'C# (Technical Preview)', value: 'csharp', },
 ] }>
 <TabItem value="javaspring">
 
@@ -46,6 +54,17 @@ You will:
     <li>NPM 11+</li>
 </ul>
   </TabItem>
+  <TabItem value="python">
+<ul>
+    <li>[Python](https://www.python.org/downloads/) 3.10+</li>
+    <li>pip</li>
+</ul>
+  </TabItem>
+  <TabItem value="csharp">
+<ul>
+    <li>[.NET SDK](https://dotnet.microsoft.com/download) 8 or later</li>
+</ul>
+  </TabItem>
   </Tabs>
 
 ## Download the Getting Started Package
@@ -56,7 +75,7 @@ The starter package includes the following components:
 
 - [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) – A simplified, single-application Camunda configuration for a local development environment.
 - [Camunda Modeler](/components/modeler/about-modeler.md) – An application for modeling BPMN, DMN, and Forms.
-- [Getting started project](https://github.com/camunda/camunda-8-get-started) – An example project with a simple BPMN process and workers in Java or JavaScript.
+- [Getting started project](https://github.com/camunda/camunda-8-get-started) – An example project with a simple BPMN process and workers in Java, JavaScript, Python, or C# (technical preview).
 
 All of these components are included in the starter package. You do not need to download them separately. The links above are provided for additional information.
 
@@ -66,7 +85,7 @@ The example project, located in the `camunda-8-get-started/2-order-process-with-
 
 ![Example business process](./img/getting-started-guide-example-process.png)
 
-The service tasks in the process are executed by [job workers](/reference/glossary.md#job-worker). The `java` and `nodejs` directories inside `2-order-process-with-service-workers` contain code for job workers that correspond to this process model.
+The service tasks in the process are executed by [job workers](/reference/glossary.md#job-worker). The `java`, `nodejs`, `python`, and `csharp` directories inside `2-order-process-with-service-workers` contain code for job workers that correspond to this process model.
 
 ## Instructions
 
@@ -151,6 +170,8 @@ Next, start the job workers to allow them to perform the work for the service ta
 [
 { label: 'Java + Spring', value: 'javaspring', },
 { label: 'Node.js', value: 'nodejs', },
+{ label: 'Python', value: 'python', },
+{ label: 'C# (Technical Preview)', value: 'csharp', },
 ] }>
 <TabItem value="javaspring">
 
@@ -203,6 +224,54 @@ npm start
       </li>
     </ol>
   </TabItem>
+
+  <TabItem value="python">
+    <ol>
+      <li>
+        Change into the Python SDK directory:
+```bash
+cd camunda-8-get-started/2-order-process-with-service-workers/python
+```
+      </li>
+      <li>
+        Create a virtual environment and install dependencies:
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+      </li>
+      <li>
+        Start the workers with the command:
+```bash
+python main.py
+```
+      </li>
+      <li>
+        You can stop the application via Ctrl+C.
+      </li>
+    </ol>
+  </TabItem>
+
+  <TabItem value="csharp">
+    <ol>
+      <li>
+        Change into the C# SDK directory:
+```bash
+cd camunda-8-get-started/2-order-process-with-service-workers/csharp
+```
+      </li>
+      <li>
+        Start the workers with the command:
+```bash
+dotnet run
+```
+      </li>
+      <li>
+        You can stop the application via Ctrl+C.
+      </li>
+    </ol>
+  </TabItem>
    </Tabs>
 
 The workers start, connect to the engine, and request work. You will see the workers processing the jobs for the process instance.
@@ -240,6 +309,10 @@ You have completed your first process instance by:
 ## Next steps
 
 For further information about the Node.js SDK, refer to [the Camunda 8 JavaScript SDK API documentation](https://camunda.github.io/camunda-8-js-sdk/).
+
+For further information about the Python SDK, refer to [the Python SDK documentation](/apis-tools/python-sdk.md).
+
+For further information about the C# SDK, refer to [the C# SDK documentation](/apis-tools/csharp-sdk.md).
 
 Find more examples on the [Developer Portal](https://camunda.com/developers/).
 

--- a/versioned_docs/version-8.9/guides/getting-started-example.md
+++ b/versioned_docs/version-8.9/guides/getting-started-example.md
@@ -305,13 +305,13 @@ You have completed your first process instance by:
 
 ## Next steps
 
-For further information about the Node.js SDK, refer to [the Camunda 8 JavaScript SDK API documentation](https://camunda.github.io/camunda-8-js-sdk/).
+To learn more about our SDKs, visit their respective documentation pages:
 
-For further information about the Python SDK, refer to [the Python SDK documentation](/apis-tools/python-sdk.md).
-
-For further information about the C# SDK, refer to [the C# SDK documentation](/apis-tools/csharp-sdk.md).
-
-Find more examples on the [Developer Portal](https://camunda.com/developers/).
+- Java SDK - [Camunda Java client documentation](/apis-tools/java-client/getting-started.md)
+- Spring Boot starter - [Camunda Spring Boot Starter documentation](/apis-tools/camunda-spring-boot-starter/getting-started.md)
+- Node.js SDK - [Camunda 8 JavaScript SDK API documentation](https://camunda.github.io/camunda-8-js-sdk/)
+- Python SDK - [Python SDK documentation](/apis-tools/python-sdk.md)
+- C# SDK - [C# SDK documentation](/apis-tools/csharp-sdk.md)
 
 ## Teardown
 

--- a/versioned_docs/version-8.9/guides/getting-started-example.md
+++ b/versioned_docs/version-8.9/guides/getting-started-example.md
@@ -61,7 +61,6 @@ You will:
   </TabItem>
   <TabItem value="nodejs">
 <ul>
-    <li>[JDK 21-25](https://www.oracle.com/de/java/technologies/downloads/)</li>
     <li>[Node.js](https://nodejs.org/en) 20+</li>
     <li>NPM 11+</li>
 </ul>
@@ -287,23 +286,6 @@ dotnet run
    </Tabs>
 
 The workers start, connect to the engine, and request work. You will see the workers processing the jobs for the process instance.
-
-<Tabs groupId="language" defaultValue="javaspring" values={
-[
-{ label: 'Java + Spring', value: 'javaspring', },
-{ label: 'Node.js', value: 'nodejs', },
-] }>
-<TabItem value="javaspring">
-
-    ![Worker output](./img/get-started-example-output-java.png)
-
-   </TabItem>
-   <TabItem value="nodejs">
-
-    ![Worker output](./img/getting-started-example-output.png)
-
-   </TabItem>
-</Tabs>
 
 ## Complete!
 

--- a/versioned_docs/version-8.9/guides/getting-started-example.md
+++ b/versioned_docs/version-8.9/guides/getting-started-example.md
@@ -55,7 +55,7 @@ You will:
 <TabItem value="javaspring">
 
 <ul>
-    <li>[JDK 21-25](https://www.oracle.com/de/java/technologies/downloads/)</li>
+    <li>[JDK 21-26](https://www.oracle.com/de/java/technologies/downloads/)</li>
     <li>[Maven 3](https://maven.apache.org/index.html)</li>
     </ul>
   </TabItem>
@@ -63,17 +63,20 @@ You will:
 <ul>
     <li>[Node.js](https://nodejs.org/en) 20+</li>
     <li>NPM 11+</li>
+    <li>[JDK 21-26](https://www.oracle.com/de/java/technologies/downloads/) (For Camunda 8 Run)</li>
 </ul>
   </TabItem>
   <TabItem value="python">
 <ul>
     <li>[Python](https://www.python.org/downloads/) 3.10+</li>
     <li>pip</li>
+    <li>[JDK 21-26](https://www.oracle.com/de/java/technologies/downloads/) (For Camunda 8 Run)</li>
 </ul>
   </TabItem>
   <TabItem value="csharp">
 <ul>
     <li>[.NET SDK](https://dotnet.microsoft.com/download) 8 or later</li>
+    <li>[JDK 21-26](https://www.oracle.com/de/java/technologies/downloads/) (For Camunda 8 Run)</li>
 </ul>
   </TabItem>
   </Tabs>

--- a/versioned_docs/version-8.9/guides/getting-started-example.md
+++ b/versioned_docs/version-8.9/guides/getting-started-example.md
@@ -1,8 +1,8 @@
 ---
 id: getting-started-example
-title: "Run your first Spring Boot or Node.js project with Camunda 8"
-sidebar_label: Run your first Spring Boot or Node.js project
-description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot or Node.js."
+title: "Run your first Spring Boot, Node.js, Python, or C# project with Camunda 8"
+sidebar_label: Run your first Spring Boot, Node.js, Python, or C# project
+description: "For developers using Camunda 8 Self-Managed, step through an example project with Spring Boot, Node.js, Python, or C#."
 keywords: [java, spring, spring camunda, python, c#, csharp, .net, getting started, user guide, tutorial]
 ---
 


### PR DESCRIPTION
## Description

`camunda-8-get-started` now ships Python and C# job worker examples for the order-process guide (alongside the existing Java and Node.js ones — see [camunda/camunda-8-get-started#58](https://github.com/camunda/camunda-8-get-started/pull/58)). This PR brings `docs/guides/getting-started-example.md` up to date:

- Adds Python and C# tabs to the prerequisites and worker-run-instructions sections.
- Updates the intro, package description, and directory listing to mention all four languages.
- Flags the C# SDK as a **technical preview** (GA planned for 8.10), matching the wording already used on its own [`csharp-sdk.md`](https://github.com/camunda/camunda-docs/blob/main/docs/apis-tools/csharp-sdk.md) page.
- Adds "Next steps" links to the Python and C# SDK doc pages, matching the existing Node.js SDK link.

Backported to `versioned_docs/version-8.9`, where the Python and C# SDKs were introduced. **Not** backported to 8.8 — neither SDK (nor its `apis-tools` docs section) existed at that version, so adding it there would reference SDKs that aren't documented for 8.8.

The output-screenshot tabs (Java/Node.js only) were left as-is — no Python/C# terminal screenshots exist yet to add there.

Both edited files pass an MDX compile check (`@mdx-js/mdx`) confirming no broken JSX/tag nesting.

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using `{type}(scope): {description}` commit message(s)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory. (version-8.9)
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style — @camunda/tech-writers, please route to an appropriate reviewer.
