### PR TITLE
docs(self-managed): add multi-tenancy configuration to the Docker Compose quickstart guide

### DIFF
--- a/docs/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
+++ b/docs/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
@@ -106,23 +106,27 @@ For details, see [Orchestration Cluster REST API authentication](/apis-tools/orc
 
 ## Enable multi-tenancy
 
-[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. To enable it in the lightweight configuration, create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
+[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. How you enable it depends on the configuration you run.
+
+### Lightweight configuration
+
+Create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
 
 ```yaml
 services:
   orchestration:
     environment:
-      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
-      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
-      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+      CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: "false"
+      CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED: "true"
+      CAMUNDA_SECURITY_MULTITENANCY_APIENABLED: "true"
   connectors:
     environment:
-      - CAMUNDA_CLIENT_AUTH_METHOD=basic
-      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
-      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+      CAMUNDA_CLIENT_AUTH_METHOD: basic
+      CAMUNDA_CLIENT_AUTH_USERNAME: demo
+      CAMUNDA_CLIENT_AUTH_PASSWORD: demo
 ```
 
-Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Identity UI at [http://localhost:8080/identity](http://localhost:8080/identity):
+Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Orchestration Cluster Admin UI at [http://localhost:8080/admin](http://localhost:8080/admin):
 
 ```bash
 # Create a tenant
@@ -133,6 +137,27 @@ curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
 ```
 
 With the API protected, clients must authenticate with Basic authentication (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
+### Full configuration
+
+The full configuration already protects the API through Keycloak, so only the tenancy checks need to be switched on. Add the following to `.env`:
+
+```bash
+CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+```
+
+Start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) with an OAuth token, or the Orchestration Cluster Admin UI at [http://localhost:8080/admin](http://localhost:8080/admin):
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials' -d 'client_id=orchestration' -d 'client_secret=secret' | jq -r .access_token)
+# Create a tenant
+curl -X POST http://localhost:8080/v2/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# Assign the demo user to it
+curl -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo -H "Authorization: Bearer $TOKEN"
+```
 
 ## Next steps
 

--- a/docs/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
+++ b/docs/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
@@ -104,6 +104,36 @@ By default, the lightweight configuration uses [Basic authentication for the Orc
 
 For details, see [Orchestration Cluster REST API authentication](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-authentication.md).
 
+## Enable multi-tenancy
+
+[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. To enable it in the lightweight configuration, create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
+
+```yaml
+services:
+  orchestration:
+    environment:
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+  connectors:
+    environment:
+      - CAMUNDA_CLIENT_AUTH_METHOD=basic
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+```
+
+Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Identity UI at [http://localhost:8080/identity](http://localhost:8080/identity):
+
+```bash
+# Create a tenant
+curl -u demo:demo -X POST http://localhost:8080/v2/tenants \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# Assign the demo user to it
+curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
+```
+
+With the API protected, clients must authenticate with Basic authentication (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
 ## Next steps
 
 - Review [install and start with Docker Compose](./install-start.md).

--- a/versioned_docs/version-8.8/self-managed/quickstart/developer-quickstart/docker-compose.md
+++ b/versioned_docs/version-8.8/self-managed/quickstart/developer-quickstart/docker-compose.md
@@ -290,20 +290,24 @@ You can access emails in Mailpit's web UI at [http://localhost:8075](http://loca
 
 ## Enable multi-tenancy
 
-[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. To enable it in the lightweight configuration, create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
+[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. How you enable it depends on the configuration you run.
+
+### Lightweight configuration
+
+Create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
 
 ```yaml
 services:
   orchestration:
     environment:
-      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
-      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
-      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+      CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: "false"
+      CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED: "true"
+      CAMUNDA_SECURITY_MULTITENANCY_APIENABLED: "true"
   connectors:
     environment:
-      - CAMUNDA_CLIENT_AUTH_METHOD=basic
-      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
-      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+      CAMUNDA_CLIENT_AUTH_METHOD: basic
+      CAMUNDA_CLIENT_AUTH_USERNAME: demo
+      CAMUNDA_CLIENT_AUTH_PASSWORD: demo
 ```
 
 Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Identity UI at [http://localhost:8088/identity](http://localhost:8088/identity):
@@ -317,6 +321,27 @@ curl -u demo:demo -X PUT http://localhost:8088/v2/tenants/tenant-a/users/demo
 ```
 
 With the API protected, clients must authenticate with Basic authentication (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
+### Full configuration
+
+The full configuration already protects the API through Keycloak, so only the tenancy checks need to be switched on. Add the following to `.env`:
+
+```bash
+CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+```
+
+Start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) with an OAuth token, or the Identity UI at [http://localhost:8088/identity](http://localhost:8088/identity):
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials' -d 'client_id=orchestration' -d 'client_secret=secret' | jq -r .access_token)
+# Create a tenant
+curl -X POST http://localhost:8088/v2/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# Assign the demo user to it
+curl -X PUT http://localhost:8088/v2/tenants/tenant-a/users/demo -H "Authorization: Bearer $TOKEN"
+```
 
 ## Next steps
 

--- a/versioned_docs/version-8.8/self-managed/quickstart/developer-quickstart/docker-compose.md
+++ b/versioned_docs/version-8.8/self-managed/quickstart/developer-quickstart/docker-compose.md
@@ -288,6 +288,36 @@ The Docker Compose setup includes [Mailpit](https://github.com/axllent/mailpit) 
 
 You can access emails in Mailpit's web UI at [http://localhost:8075](http://localhost:8075).
 
+## Enable multi-tenancy
+
+[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. To enable it in the lightweight configuration, create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
+
+```yaml
+services:
+  orchestration:
+    environment:
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+  connectors:
+    environment:
+      - CAMUNDA_CLIENT_AUTH_METHOD=basic
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+```
+
+Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Identity UI at [http://localhost:8088/identity](http://localhost:8088/identity):
+
+```bash
+# Create a tenant
+curl -u demo:demo -X POST http://localhost:8088/v2/tenants \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# Assign the demo user to it
+curl -u demo:demo -X PUT http://localhost:8088/v2/tenants/tenant-a/users/demo
+```
+
+With the API protected, clients must authenticate with Basic authentication (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
 ## Next steps
 
 Now that you have Camunda 8 running locally, explore these resources:

--- a/versioned_docs/version-8.9/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
+++ b/versioned_docs/version-8.9/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
@@ -106,23 +106,27 @@ For details, see [Orchestration Cluster REST API authentication](/apis-tools/orc
 
 ## Enable multi-tenancy
 
-[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. To enable it in the lightweight configuration, create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
+[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. How you enable it depends on the configuration you run.
+
+### Lightweight configuration
+
+Create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
 
 ```yaml
 services:
   orchestration:
     environment:
-      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
-      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
-      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+      CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: "false"
+      CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED: "true"
+      CAMUNDA_SECURITY_MULTITENANCY_APIENABLED: "true"
   connectors:
     environment:
-      - CAMUNDA_CLIENT_AUTH_METHOD=basic
-      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
-      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+      CAMUNDA_CLIENT_AUTH_METHOD: basic
+      CAMUNDA_CLIENT_AUTH_USERNAME: demo
+      CAMUNDA_CLIENT_AUTH_PASSWORD: demo
 ```
 
-Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Identity UI at [http://localhost:8080/identity](http://localhost:8080/identity):
+Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Orchestration Cluster Admin UI at [http://localhost:8080/admin](http://localhost:8080/admin):
 
 ```bash
 # Create a tenant
@@ -133,6 +137,27 @@ curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
 ```
 
 With the API protected, clients must authenticate with Basic authentication (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
+### Full configuration
+
+The full configuration already protects the API through Keycloak, so only the tenancy checks need to be switched on. Add the following to `.env`:
+
+```bash
+CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+```
+
+Start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) with an OAuth token, or the Orchestration Cluster Admin UI at [http://localhost:8080/admin](http://localhost:8080/admin):
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials' -d 'client_id=orchestration' -d 'client_secret=secret' | jq -r .access_token)
+# Create a tenant
+curl -X POST http://localhost:8080/v2/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# Assign the demo user to it
+curl -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo -H "Authorization: Bearer $TOKEN"
+```
 
 ## Next steps
 

--- a/versioned_docs/version-8.9/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
+++ b/versioned_docs/version-8.9/self-managed/quickstart/developer-quickstart/docker-compose/configuration.md
@@ -104,6 +104,36 @@ By default, the lightweight configuration uses [Basic authentication for the Orc
 
 For details, see [Orchestration Cluster REST API authentication](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-authentication.md).
 
+## Enable multi-tenancy
+
+[Multi-tenancy](/components/concepts/multi-tenancy.md) requires an authenticated API. To enable it in the lightweight configuration, create a `docker-compose.override.yaml` next to the compose file that protects the API and switches on the tenancy checks:
+
+```yaml
+services:
+  orchestration:
+    environment:
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+  connectors:
+    environment:
+      - CAMUNDA_CLIENT_AUTH_METHOD=basic
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+```
+
+Start the stack with `docker compose up -d` and manage tenants through the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant.api.mdx) or the Identity UI at [http://localhost:8080/identity](http://localhost:8080/identity):
+
+```bash
+# Create a tenant
+curl -u demo:demo -X POST http://localhost:8080/v2/tenants \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# Assign the demo user to it
+curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
+```
+
+With the API protected, clients must authenticate with Basic authentication (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
 ## Next steps
 
 - Review [install and start with Docker Compose](./install-start.md).


### PR DESCRIPTION
## Description

Adds an "Enable multi-tenancy" section to the Docker Compose quickstart configuration page in `docs/` (the unreleased "next" docs, upcoming 8.10) and in the released 8.9 and 8.8 versioned docs.

The Docker Compose quickstart has no multi-tenancy coverage today — the property reference and Helm guides do, and users in camunda/camunda-distributions#186 and several forum threads spent multiple alpha cycles guessing at the right configuration. The new section shows a `docker-compose.override.yaml` that protects the API (`CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false`) and enables the tenancy checks and API, provides Basic authentication credentials for connectors, and includes curl examples for creating a tenant and assigning a user.

The documented configuration was verified locally against the 8.8, 8.9, and 8.10 Docker Compose distributions: unauthenticated requests return 401, tenant creation returns 201, user assignment returns 204, and connectors become healthy with the Basic authentication credentials.

Companion to camunda/camunda-distributions#509, which adds the same guidance to the per-version READMEs.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
