### PR TITLE
docs(pages): update getting started bundle to 8.10.0-alpha3

### DIFF
--- a/src/pages/build-with-camunda.js
+++ b/src/pages/build-with-camunda.js
@@ -878,25 +878,25 @@ function BuildWithCamunda() {
               <div className={styles.downloadButtons}>
                 <a
                   className={styles.downloadButton}
-                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-darwin-aarch64.zip"
+                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-darwin-aarch64.zip"
                 >
                   <DownloadBtnIcon /> macOS (Apple Silicon)
                 </a>
                 <a
                   className={styles.downloadButton}
-                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-darwin-x86_64.zip"
+                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-darwin-x86_64.zip"
                 >
                   <DownloadBtnIcon /> macOS (Intel)
                 </a>
                 <a
                   className={styles.downloadButton}
-                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-windows-x86_64.zip"
+                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-windows-x86_64.zip"
                 >
                   <DownloadBtnIcon /> Windows
                 </a>
                 <a
                   className={styles.downloadButton}
-                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-linux-x86_64.tar.gz"
+                  href="https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-linux-x86_64.tar.gz"
                 >
                   <DownloadBtnIcon /> Linux
                 </a>

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -380,7 +380,7 @@ function OSTabs({ activeOS, onSelect }) {
 
 const GETTING_STARTED = {
   version: "8.10.0-alpha3",
-  date: "Jul 6, 2026",
+  date: "Jul 17, 2026",
   links: {
     mac: [
       {

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -379,29 +379,29 @@ function OSTabs({ activeOS, onSelect }) {
 /* ─── Download data ─── */
 
 const GETTING_STARTED = {
-  version: "8.10.0-alpha2",
-  date: "Jun 9, 2026",
+  version: "8.10.0-alpha3",
+  date: "Jul 6, 2026",
   links: {
     mac: [
       {
         label: "Apple Silicon",
-        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-darwin-aarch64.zip",
+        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-darwin-aarch64.zip",
       },
       {
         label: "Intel",
-        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-darwin-x86_64.zip",
+        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-darwin-x86_64.zip",
       },
     ],
     windows: [
       {
         label: "Windows (x64)",
-        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-windows-x86_64.zip",
+        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-windows-x86_64.zip",
       },
     ],
     linux: [
       {
         label: "Linux (x64)",
-        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha2/camunda8-getting-started-bundle-8.10.0-alpha2-linux-x86_64.tar.gz",
+        url: "https://github.com/camunda/camunda/releases/download/8.10.0-alpha3/camunda8-getting-started-bundle-8.10.0-alpha3-linux-x86_64.tar.gz",
       },
     ],
   },


### PR DESCRIPTION
## Description

Update the "Getting Started Package" bundle links and version metadata on the Downloads and Build with Camunda pages to the latest release, `8.10.0-alpha3`:

- `camunda8-getting-started-bundle-8.10.0-alpha3-darwin-aarch64.zip` (macOS Apple Silicon)
- `camunda8-getting-started-bundle-8.10.0-alpha3-darwin-x86_64.zip` (macOS Intel)
- `camunda8-getting-started-bundle-8.10.0-alpha3-windows-x86_64.zip` (Windows)
- `camunda8-getting-started-bundle-8.10.0-alpha3-linux-x86_64.tar.gz` (Linux)

Also bumps the displayed release date to match the GitHub release (Jul 6, 2026).

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
