### PR TITLE
docs(document-handling): mention Azure Blob Storage in getting-started overview

### DIFF
--- a/docs/self-managed/concepts/document-handling/overview.md
+++ b/docs/self-managed/concepts/document-handling/overview.md
@@ -26,6 +26,6 @@ Step through all of these capabilities in the [use cases section](/components/do
 ## Storage integration and configuration
 
 You can configure document storage based on your deployment setup and production requirements.
-Supported options include an external cloud storage such as Google Cloud Platform (GCP) or AWS S3, local file storage or an in-memory storage.
+Supported options include an external cloud storage such as Google Cloud Platform (GCP), AWS S3, or Azure Blob Storage, local file storage or an in-memory storage.
 
 Learn how to set it up in the [storage configuration guide](/self-managed/concepts/document-handling/configuration/index.md).

--- a/versioned_docs/version-8.9/self-managed/concepts/document-handling/overview.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/document-handling/overview.md
@@ -24,6 +24,6 @@ Step through all of these capabilities in the [use cases section](/components/do
 ## Storage integration and configuration
 
 You can configure document storage based on your deployment setup and production requirements.
-Supported options include an external cloud storage such as Google Cloud Platform (GCP) or AWS S3, local file storage or an in-memory storage.
+Supported options include an external cloud storage such as Google Cloud Platform (GCP), AWS S3, or Azure Blob Storage, local file storage or an in-memory storage.
 
 Learn how to set it up in the [storage configuration guide](/self-managed/concepts/document-handling/configuration/index.md).


### PR DESCRIPTION
## Description

Fixes a documentation inconsistency: the Helm, Docker Compose, and Camunda 8 Run configuration pages for document handling already document Azure Blob Storage as a supported store, but the ["Getting started with document handling" overview page](https://docs.camunda.io/docs/self-managed/concepts/document-handling/getting-started/#storage-integration-and-configuration) still only mentioned GCP and AWS S3. Azure Blob support shipped in 8.9.

This updates the "Storage integration and configuration" section to mention Azure Blob Storage, for both the current docs and the 8.9 versioned docs.

Closes camunda/camunda-docs#9416
Epic: camunda/product-hub#2619

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
