### PR TITLE
docs(release-notes): document Azure Blob Storage support for document handling in 8.9

### DIFF
--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -324,6 +324,12 @@ A new migration tooling set is available to move existing Self-Managed deploymen
 
 Camunda 8.9 adds IDP document classification templates and lets you choose a text extraction engine per template. This gives teams more control over how different document types are categorized and processed, whether they need lightweight parsing, OCR, or multimodal LLM interpretation.
 
+### Azure Blob Storage support for document handling
+
+Camunda 8.9 adds Azure Blob Storage as a supported document store for Self-Managed environments, alongside the existing Google Cloud Platform (GCP) and AWS S3 options. Configure it via Camunda 8 Run, Docker Compose, or Helm.
+
+<p class="link-arrow">[Document handling configuration](/self-managed/concepts/document-handling/configuration/index.md#supported-storage-options)</p>
+
 ## Integrations
 
 <div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--long" title="This feature affects SaaS">SaaS</span><span class="badge badge--medium" title="This feature affects Camunda integrations">Integrations</span></div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -336,6 +336,12 @@ A new migration tooling set is available to move existing Self-Managed deploymen
 
 Camunda 8.9 adds IDP document classification templates and lets you choose a text extraction engine per template. This gives teams more control over how different document types are categorized and processed, whether they need lightweight parsing, OCR, or multimodal LLM interpretation.
 
+### Azure Blob Storage support for document handling
+
+Camunda 8.9 adds Azure Blob Storage as a supported document store for Self-Managed environments, alongside the existing Google Cloud Platform (GCP) and AWS S3 options. Configure it via Camunda 8 Run, Docker Compose, or Helm.
+
+<p class="link-arrow">[Document handling configuration](/self-managed/concepts/document-handling/configuration/index.md#supported-storage-options)</p>
+
 ## Integrations
 
 <div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--long" title="This feature affects SaaS">SaaS</span><span class="badge badge--medium" title="This feature affects Camunda integrations">Integrations</span></div>


### PR DESCRIPTION
## Description

Adds a missing 8.9 release notes entry for Azure Blob Storage support in document handling.

Azure Blob Storage shipped as a supported document store in 8.9 (see [camunda/camunda-docs#9417](https://github.com/camunda/camunda-docs/pull/9417), which fixed the getting-started overview page), but this was never called out in the [8.9 release notes](https://docs.camunda.io/reference/announcements-release-notes/890/890-release-notes/#intelligent-document-processing-idp) themselves. This was flagged by a customer (LBBW) via #pod-idp-rpa, who found the feature undocumented in the release notes/announcements despite being implemented and already documented in the config guides.

This adds a short "Azure Blob Storage support for document handling" entry under the Intelligent document processing (IDP) section, in both the `/docs` and `/versioned_docs/version-8.9` copies of the 8.9 release notes.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
