### PR TITLE
fix(dual-region-ops): remove incorrect force=true when re-adding brokers on failback

### DIFF
--- a/docs/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
+++ b/docs/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
@@ -1564,7 +1564,7 @@ desired={<img src={Fourteen} alt="Desired state diagram" style={{border: 'none',
     <TabItem value="redistribute-to-even" label="Add the uneven brokers" default>
 
          ```bash
-         curl -XPATCH 'http://localhost:9600/actuator/cluster?force=true' \
+         curl -XPATCH 'http://localhost:9600/actuator/cluster' \
            -H 'Content-Type: application/json' \
            -d '{
              "brokers": {
@@ -1580,7 +1580,7 @@ desired={<img src={Fourteen} alt="Desired state diagram" style={{border: 'none',
          <TabItem value="redistribute-to-odd" label="Add the even brokers">
 
          ```bash
-         curl -XPATCH 'http://localhost:9600/actuator/cluster?force=true' \
+         curl -XPATCH 'http://localhost:9600/actuator/cluster' \
            -H 'Content-Type: application/json' \
            -d '{
              "brokers": {

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
@@ -1494,7 +1494,7 @@ desired={<img src={Fourteen} alt="Desired state diagram" style={{border: 'none',
     <TabItem value="redistribute-to-even" label="Add the uneven brokers" default>
 
          ```bash
-         curl -XPATCH 'http://localhost:9600/actuator/cluster?force=true' \
+         curl -XPATCH 'http://localhost:9600/actuator/cluster' \
            -H 'Content-Type: application/json' \
            -d '{
              "brokers": {
@@ -1510,7 +1510,7 @@ desired={<img src={Fourteen} alt="Desired state diagram" style={{border: 'none',
          <TabItem value="redistribute-to-odd" label="Add the even brokers">
 
          ```bash
-         curl -XPATCH 'http://localhost:9600/actuator/cluster?force=true' \
+         curl -XPATCH 'http://localhost:9600/actuator/cluster' \
            -H 'Content-Type: application/json' \
            -d '{
              "brokers": {

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/dual-region-ops.md
@@ -1564,7 +1564,7 @@ desired={<img src={Fourteen} alt="Desired state diagram" style={{border: 'none',
     <TabItem value="redistribute-to-even" label="Add the uneven brokers" default>
 
          ```bash
-         curl -XPATCH 'http://localhost:9600/actuator/cluster?force=true' \
+         curl -XPATCH 'http://localhost:9600/actuator/cluster' \
            -H 'Content-Type: application/json' \
            -d '{
              "brokers": {
@@ -1580,7 +1580,7 @@ desired={<img src={Fourteen} alt="Desired state diagram" style={{border: 'none',
          <TabItem value="redistribute-to-odd" label="Add the even brokers">
 
          ```bash
-         curl -XPATCH 'http://localhost:9600/actuator/cluster?force=true' \
+         curl -XPATCH 'http://localhost:9600/actuator/cluster' \
            -H 'Content-Type: application/json' \
            -d '{
              "brokers": {


### PR DESCRIPTION
## Description

The failback "Add new brokers to the Zeebe cluster" step in the dual-region operational guide sent `PATCH /actuator/cluster?force=true` when re-adding brokers after a region recovers.

`force=true` is documented in the [Cluster Scaling APIs](https://github.com/camunda/camunda-docs/blob/main/docs/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md) for removing *unreachable* brokers during failover, not for adding brokers back once the cluster is healthy. Using it here is unnecessary and, per the API's own caution note, can risk a split-brain or unhealthy cluster if misused. The older 8.7 version of this doc never included `force=true` on the add-brokers step, confirming it was accidentally carried over from the failover (remove) step's curl command when 8.8/8.9 restructured the doc.

Fixed the "Add the uneven brokers" / "Add the even brokers" curl commands in:
- `docs/self-managed/deployment/helm/operational-tasks/dual-region-ops.md`
- `versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/dual-region-ops.md`
- `versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/dual-region-ops.md`

The failover (broker-removal) usage of `force=true` elsewhere in the same doc is correct and untouched.

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
