### PR TITLE
docs: remove c8ctl alpha status

### DIFF
--- a/docs/apis-tools/react-components/_apitools-card-data.js
+++ b/docs/apis-tools/react-components/_apitools-card-data.js
@@ -96,7 +96,7 @@ export const clientCards = [
     title: "c8ctl CLI",
     image: IconCliImg,
     description:
-      "Inspect clusters, deploy resources, and manage processes from the terminal. (Alpha)",
+      "Inspect clusters, deploy resources, and manage processes from the terminal.",
     type: "",
   },
   {

--- a/docs/components/early-access/alpha/alpha-features.md
+++ b/docs/components/early-access/alpha/alpha-features.md
@@ -56,12 +56,6 @@ href: '/docs/next/components/early-access/alpha/a2a-client/',
 label: 'A2A Client',
 docId: 'components/early-access/alpha/a2a-client/a2a-client',
 },
-{
-type: 'link',
-href: '/docs/next/apis-tools/c8ctl/getting-started/',
-label: 'c8ctl CLI',
-docId: 'apis-tools/c8ctl/getting-started',
-},
 ]}
 />
 

--- a/versioned_docs/version-8.9/apis-tools/c8ctl/cluster-inspection.md
+++ b/versioned_docs/version-8.9/apis-tools/c8ctl/cluster-inspection.md
@@ -5,10 +5,6 @@ sidebar_label: "Cluster inspection"
 description: "Use c8ctl to list, search, and manage process instances, user tasks, incidents, jobs, messages, and forms in a Camunda 8 cluster."
 ---
 
-:::warning Alpha feature
-`c8ctl` is in alpha and not intended for production use. Commands and flags may change between releases. See [Getting started](getting-started.md) for details.
-:::
-
 `c8ctl` follows a `<verb> <resource>` command structure. Most resources have short aliases to reduce typing:
 
 | Resource                | Alias         |

--- a/versioned_docs/version-8.9/apis-tools/c8ctl/development-workflows.md
+++ b/versioned_docs/version-8.9/apis-tools/c8ctl/development-workflows.md
@@ -5,10 +5,6 @@ sidebar_label: "Development workflows"
 description: "Use c8ctl to deploy resources, auto-redeploy on file changes, manage profiles, and bridge MCP connections for AI assistants."
 ---
 
-:::warning Alpha feature
-`c8ctl` is in alpha and is not intended for production use. Commands and flags may change between releases. For more information, see [Getting started](getting-started.md).
-:::
-
 `c8ctl` includes commands that support local development and deployment workflows. You can deploy resources, run processes, watch for changes, manage profiles and sessions, and bridge MCP connections for AI assistants.
 
 :::tip

--- a/versioned_docs/version-8.9/apis-tools/c8ctl/getting-started.md
+++ b/versioned_docs/version-8.9/apis-tools/c8ctl/getting-started.md
@@ -10,10 +10,6 @@ import PageDescription from '@site/src/components/PageDescription';
 
 <PageDescription />
 
-:::warning Alpha feature
-`c8ctl` is in alpha and is not intended for production use. APIs, commands, and flags may change without notice between releases. See [alpha features](/components/early-access/alpha/alpha-features.md) for more information. Report issues and request features in the [`c8ctl` GitHub repository](https://github.com/camunda/c8ctl).
-:::
-
 ## About
 
 `c8ctl` is a minimal-dependency CLI for Camunda 8. It is built on top of the [`@camunda8/orchestration-cluster-api`](https://www.npmjs.com/package/@camunda8/orchestration-cluster-api) TypeScript SDK and provides two equivalent bin aliases: `c8ctl` and `c8`.

--- a/versioned_docs/version-8.9/apis-tools/c8ctl/plugins.md
+++ b/versioned_docs/version-8.9/apis-tools/c8ctl/plugins.md
@@ -5,10 +5,6 @@ sidebar_label: "Plugins"
 description: "Scaffold, install, and manage c8ctl plugins to add custom commands to the Camunda 8 CLI."
 ---
 
-:::warning Alpha feature
-`c8ctl` is in alpha and not intended for production use. Commands and flags may change between releases. See [Getting started](getting-started.md) for details.
-:::
-
 `c8ctl` supports a global plugin system that lets you add custom commands. Plugins are installed globally to a user-specific directory and tracked in a registry file (`plugins.json`).
 
 ## Plugin storage locations

--- a/versioned_docs/version-8.9/apis-tools/react-components/_apitools-card-data.js
+++ b/versioned_docs/version-8.9/apis-tools/react-components/_apitools-card-data.js
@@ -95,7 +95,7 @@ export const clientCards = [
     title: "c8ctl CLI",
     image: IconCliImg,
     description:
-      "Inspect clusters, deploy resources, and manage processes from the terminal. (Alpha)",
+      "Inspect clusters, deploy resources, and manage processes from the terminal.",
     type: "",
   },
   {

--- a/versioned_docs/version-8.9/components/early-access/alpha/alpha-features.md
+++ b/versioned_docs/version-8.9/components/early-access/alpha/alpha-features.md
@@ -56,12 +56,6 @@ href: '/docs/next/components/early-access/alpha/a2a-client/',
 label: 'A2A Client',
 docId: 'components/early-access/alpha/a2a-client/a2a-client',
 },
-{
-type: 'link',
-href: '/docs/next/apis-tools/c8ctl/getting-started/',
-label: 'c8ctl CLI',
-docId: 'apis-tools/c8ctl/getting-started',
-},
 ]}
 />
 


### PR DESCRIPTION
## Description

c8ctl is no longer in alpha. This removes the alpha framing from the non-synced c8ctl docs:

- **Alpha warning admonitions** removed from the versioned 8.9 c8ctl pages: `cluster-inspection.md`, `development-workflows.md`, `getting-started.md`, `plugins.md`.
- **Alpha features catalog** — dropped the `c8ctl CLI` entry from the `DocCardList` in `alpha-features.md` (both `docs/` and versioned 8.9).
- **API tools card** — stripped the `(Alpha)` tag from the c8ctl description in `_apitools-card-data.js` (both `docs/` and versioned 8.9).

The `docs/apis-tools/c8ctl/*` pages are auto-synced from the c8ctl repo and are handled at source in camunda/c8ctl#481, so they are intentionally not touched here.

## Notes for reviewers

Left the `890-release-notes.md` c8ctl section alone — it announces c8ctl under "APIs & tools" with no alpha framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)