### PR TITLE
fix(self-managed): add camunda index filter to OpenSearch restore delete loop

### DIFF
--- a/docs/self-managed/operational-guides/backup-restore/elasticsearch/restore.md
+++ b/docs/self-managed/operational-guides/backup-restore/elasticsearch/restore.md
@@ -517,7 +517,7 @@ The following uses the [OpenSearch CAT API](https://docs.opensearch.org/docs/lat
 
 ```bash
 for index in $(curl -s "$OPENSEARCH_ENDPOINT/_cat/indices?h=index" \
-   | grep -E 'operate|tasklist|optimize|zeebe'); do
+   | grep -E 'camunda|operate|tasklist|optimize|zeebe'); do
       echo "Deleting index: $index"
       curl -X DELETE "$OPENSEARCH_ENDPOINT/$index"
 done

--- a/versioned_docs/version-8.8/self-managed/operational-guides/backup-restore/restore.md
+++ b/versioned_docs/version-8.8/self-managed/operational-guides/backup-restore/restore.md
@@ -528,7 +528,7 @@ The following uses the [OpenSearch CAT API](https://docs.opensearch.org/docs/lat
 
 ```bash
 for index in $(curl -s "$OPENSEARCH_ENDPOINT/_cat/indices?h=index" \
-   | grep -E 'operate|tasklist|optimize|zeebe'); do
+   | grep -E 'camunda|operate|tasklist|optimize|zeebe'); do
       echo "Deleting index: $index"
       curl -X DELETE "$OPENSEARCH_ENDPOINT/$index"
 done

--- a/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/elasticsearch/restore.md
+++ b/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/elasticsearch/restore.md
@@ -517,7 +517,7 @@ The following uses the [OpenSearch CAT API](https://docs.opensearch.org/docs/lat
 
 ```bash
 for index in $(curl -s "$OPENSEARCH_ENDPOINT/_cat/indices?h=index" \
-   | grep -E 'operate|tasklist|optimize|zeebe'); do
+   | grep -E 'camunda|operate|tasklist|optimize|zeebe'); do
       echo "Deleting index: $index"
       curl -X DELETE "$OPENSEARCH_ENDPOINT/$index"
 done


### PR DESCRIPTION
## Description

The OpenSearch **Delete all indices** loop in the backup/restore documentation filtered indices on `operate|tasklist|optimize|zeebe`, omitting `camunda`. The Elasticsearch delete loop in the same files already includes `camunda`.

Since Camunda 8.8 introduced the unified `camunda-*` indices, any `camunda-*` indices present in an OpenSearch datastore were **not** deleted by the documented loop. Leftover indices block a successful snapshot restore, so users following the OpenSearch instructions could hit a failed restore.

This aligns the OpenSearch delete loop with the Elasticsearch delete loop (`camunda|operate|tasklist|optimize|zeebe`) in the current (`/docs`), 8.9, and 8.8 versions. Only the delete loop is changed; the index-template listing filters are intentionally left untouched. Version 8.7 is excluded because it predates the unified `camunda-*` indices.

Files changed:

- `docs/self-managed/operational-guides/backup-restore/elasticsearch/restore.md`
- `versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/elasticsearch/restore.md`
- `versioned_docs/version-8.8/self-managed/operational-guides/backup-restore/restore.md`

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.