### PR TITLE
docs(self-managed): document Service appProtocol configuration for 8.8, 8.9 and 8.10

### DIFF
--- a/docs/self-managed/deployment/helm/chart-parameters.md
+++ b/docs/self-managed/deployment/helm/chart-parameters.md
@@ -26,6 +26,8 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
+For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+
 ### Other Camunda applications
 
 | Section      | Purpose                                             |

--- a/docs/self-managed/deployment/helm/chart-parameters.md
+++ b/docs/self-managed/deployment/helm/chart-parameters.md
@@ -26,6 +26,8 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
+For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+
 ### Other Camunda applications
 
 | Section      | Purpose                                    |

--- a/docs/self-managed/deployment/helm/chart-parameters.md
+++ b/docs/self-managed/deployment/helm/chart-parameters.md
@@ -26,7 +26,7 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
-For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+For service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
 
 ### Other Camunda applications
 

--- a/docs/self-managed/deployment/helm/configure/service-configuration.md
+++ b/docs/self-managed/deployment/helm/configure/service-configuration.md
@@ -30,7 +30,3 @@ orchestration:
     appProtocols:
       grpc: kubernetes.io/h2c
 ```
-
-:::note
-Setting a port name that isn't in the accepted list for a component fails the Helm render with an error naming the invalid key and listing the accepted port names for that component. This catches typos before they reach the cluster.
-:::

--- a/docs/self-managed/deployment/helm/configure/service-configuration.md
+++ b/docs/self-managed/deployment/helm/configure/service-configuration.md
@@ -1,0 +1,36 @@
+---
+id: service-configuration
+sidebar_label: Service configuration
+title: Configure Kubernetes Service ports
+description: Set the Kubernetes Service appProtocol hint per port for Camunda component Services in Self-Managed Helm deployments.
+---
+
+The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
+
+## AppProtocol per Service port
+
+Each component's `service.appProtocols` value accepts a map of port name to appProtocol value. It's empty by default and doesn't change existing behavior until you set it.
+
+The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
+
+| Component              | Value key                                    | Accepted port names                                 |
+| ---------------------- | -------------------------------------------- | --------------------------------------------------- |
+| Orchestration cluster  | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
+| Identity               | `identity.service.appProtocols`              | `http`, `metrics`                                   |
+| Optimize               | `optimize.service.appProtocols`              | `http`, `management`                                |
+| Connectors             | `connectors.service.appProtocols`            | `server`                                            |
+| Web Modeler REST API   | `webModeler.restapi.service.appProtocols`    | `http`, `http-management`                           |
+| Web Modeler WebSockets | `webModeler.websockets.service.appProtocols` | `http`                                              |
+
+Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
+
+```yaml
+orchestration:
+  service:
+    appProtocols:
+      grpc: kubernetes.io/h2c
+```
+
+:::note
+Setting a port name that isn't in the accepted list for a component fails the Helm render with an error naming the invalid key and listing the accepted port names for that component. This catches typos before they reach the cluster.
+:::

--- a/docs/self-managed/deployment/helm/configure/service-configuration.md
+++ b/docs/self-managed/deployment/helm/configure/service-configuration.md
@@ -7,9 +7,9 @@ description: Set the Kubernetes Service appProtocol hint per port for Camunda co
 
 The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
 
-## AppProtocol per Service port
+## `appProtocol` per Service port
 
-Each component's `service.appProtocols` value accepts a map of port name to appProtocol value. It's empty by default and doesn't change existing behavior until you set it.
+Each component's `service.appProtocols` value accepts a map of port name to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
 The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
 

--- a/docs/self-managed/deployment/helm/configure/service-configuration.md
+++ b/docs/self-managed/deployment/helm/configure/service-configuration.md
@@ -13,14 +13,14 @@ Each component's `service.appProtocols` value accepts a map of port name to `app
 
 The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
 
-| Component              | Value key                                    | Accepted port names                                 |
-| ---------------------- | -------------------------------------------- | --------------------------------------------------- |
-| Orchestration cluster  | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
-| Identity               | `identity.service.appProtocols`              | `http`, `metrics`                                   |
-| Optimize               | `optimize.service.appProtocols`              | `http`, `management`                                |
-| Connectors             | `connectors.service.appProtocols`            | `server`                                            |
-| Web Modeler REST API   | `webModeler.restapi.service.appProtocols`    | `http`, `http-management`                           |
-| Web Modeler WebSockets | `webModeler.websockets.service.appProtocols` | `http`                                              |
+| Component             | Value key                                    | Accepted port names                                 |
+| --------------------- | -------------------------------------------- | --------------------------------------------------- |
+| Orchestration cluster | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
+| Identity              | `identity.service.appProtocols`              | `http`, `metrics`                                   |
+| Optimize              | `optimize.service.appProtocols`              | `http`, `management`                                |
+| Connectors            | `connectors.service.appProtocols`            | `server`                                            |
+| Hub REST API          | `camundaHub.restapi.service.appProtocols`    | `http`, `http-management`                           |
+| Hub WebSockets        | `camundaHub.websockets.service.appProtocols` | `http`                                              |
 
 Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
 

--- a/docs/self-managed/deployment/helm/configure/service-configuration.md
+++ b/docs/self-managed/deployment/helm/configure/service-configuration.md
@@ -5,13 +5,13 @@ title: Configure Kubernetes Service ports
 description: Set the Kubernetes Service appProtocol hint per port for Camunda component Services in Self-Managed Helm deployments.
 ---
 
-The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
+The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing. For example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
 
 ## `appProtocol` per Service port
 
 Each component's `service.appProtocols` value accepts a map of logical port key to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
-The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`) — always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
+The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`). Always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
 
 | Component             | Value key                                    | Accepted logical port keys                          |
 | --------------------- | -------------------------------------------- | --------------------------------------------------- |
@@ -22,7 +22,7 @@ The following components support `appProtocols` (the accepted logical port keys 
 | Hub REST API          | `camundaHub.restapi.service.appProtocols`    | `http`, `http-management`                           |
 | Hub WebSockets        | `camundaHub.websockets.service.appProtocols` | `http`                                              |
 
-Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
+Example: set the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
 
 ```yaml
 orchestration:

--- a/docs/self-managed/deployment/helm/configure/service-configuration.md
+++ b/docs/self-managed/deployment/helm/configure/service-configuration.md
@@ -9,11 +9,11 @@ The Camunda Helm chart exposes an `appProtocols` value per component that sets t
 
 ## `appProtocol` per Service port
 
-Each component's `service.appProtocols` value accepts a map of port name to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
+Each component's `service.appProtocols` value accepts a map of logical port key to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
-The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
+The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`) — always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
 
-| Component             | Value key                                    | Accepted port names                                 |
+| Component             | Value key                                    | Accepted logical port keys                          |
 | --------------------- | -------------------------------------------- | --------------------------------------------------- |
 | Orchestration cluster | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
 | Identity              | `identity.service.appProtocols`              | `http`, `metrics`                                   |

--- a/sidebars.js
+++ b/sidebars.js
@@ -1779,6 +1779,7 @@ module.exports = {
                 // },
                 "self-managed/deployment/helm/configure/application-configs",
                 "self-managed/deployment/helm/configure/pod-networking",
+                "self-managed/deployment/helm/configure/service-configuration",
                 "self-managed/deployment/helm/configure/operator-based-infrastructure",
                 "self-managed/deployment/helm/configure/enable-additional-components",
                 "self-managed/deployment/helm/configure/data-retention",

--- a/sidebars.js
+++ b/sidebars.js
@@ -1795,6 +1795,7 @@ module.exports = {
                 "self-managed/deployment/helm/configure/application-configs",
                 "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/pod-scheduling",
+                "self-managed/deployment/helm/configure/service-configuration",
                 "self-managed/deployment/helm/configure/operator-based-infrastructure",
                 "self-managed/deployment/helm/configure/enable-additional-components",
                 "self-managed/deployment/helm/configure/multi-namespace",

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
@@ -20,6 +20,8 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
+For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+
 ### Other Camunda applications
 
 | Section      | Purpose                                             |

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
@@ -20,7 +20,7 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
-For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+For service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
 
 ### Other Camunda applications
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/service-configuration.md
@@ -5,13 +5,13 @@ title: Configure Kubernetes Service ports
 description: Set the Kubernetes Service appProtocol hint per port for Camunda component Services in Self-Managed Helm deployments.
 ---
 
-The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
+The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing. For example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
 
 ## `appProtocol` per Service port
 
 Each component's `service.appProtocols` value accepts a map of logical port key to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
-The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`) — always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
+The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`). Always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
 
 | Component              | Value key                                    | Accepted logical port keys                          |
 | ---------------------- | -------------------------------------------- | --------------------------------------------------- |
@@ -24,7 +24,7 @@ The following components support `appProtocols` (the accepted logical port keys 
 | Web Modeler webapp     | `webModeler.webapp.service.appProtocols`     | `http`, `http-management`                           |
 | Web Modeler WebSockets | `webModeler.websockets.service.appProtocols` | `http`                                              |
 
-Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
+Example: set the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
 
 ```yaml
 orchestration:

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/service-configuration.md
@@ -9,11 +9,11 @@ The Camunda Helm chart exposes an `appProtocols` value per component that sets t
 
 ## `appProtocol` per Service port
 
-Each component's `service.appProtocols` value accepts a map of port name to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
+Each component's `service.appProtocols` value accepts a map of logical port key to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
-The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
+The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`) — always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
 
-| Component              | Value key                                    | Accepted port names                                 |
+| Component              | Value key                                    | Accepted logical port keys                          |
 | ---------------------- | -------------------------------------------- | --------------------------------------------------- |
 | Orchestration cluster  | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
 | Console                | `console.service.appProtocols`               | `http`, `management`                                |

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/service-configuration.md
@@ -1,0 +1,34 @@
+---
+id: service-configuration
+sidebar_label: Service configuration
+title: Configure Kubernetes Service ports
+description: Set the Kubernetes Service appProtocol hint per port for Camunda component Services in Self-Managed Helm deployments.
+---
+
+The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
+
+## `appProtocol` per Service port
+
+Each component's `service.appProtocols` value accepts a map of port name to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
+
+The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
+
+| Component              | Value key                                    | Accepted port names                                 |
+| ---------------------- | -------------------------------------------- | --------------------------------------------------- |
+| Orchestration cluster  | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
+| Console                | `console.service.appProtocols`               | `http`, `management`                                |
+| Identity               | `identity.service.appProtocols`              | `http`, `metrics`                                   |
+| Optimize               | `optimize.service.appProtocols`              | `http`, `management`                                |
+| Connectors             | `connectors.service.appProtocols`            | `server`                                            |
+| Web Modeler REST API   | `webModeler.restapi.service.appProtocols`    | `http`, `http-management`                           |
+| Web Modeler webapp     | `webModeler.webapp.service.appProtocols`     | `http`, `http-management`                           |
+| Web Modeler WebSockets | `webModeler.websockets.service.appProtocols` | `http`                                              |
+
+Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
+
+```yaml
+orchestration:
+  service:
+    appProtocols:
+      grpc: kubernetes.io/h2c
+```

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/chart-parameters.md
@@ -26,6 +26,8 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
+For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+
 ### Other Camunda applications
 
 | Section      | Purpose                                             |

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/chart-parameters.md
@@ -26,7 +26,7 @@ The following tables show the **top-level configuration sections** in `values.ya
 
 For pod-level networking options such as `dnsPolicy`, `dnsConfig`, and `orchestration.hostNetwork`, see [configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md).
 
-For Service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
+For service-level options such as the `appProtocol` hint per port, see [configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md).
 
 ### Other Camunda applications
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
@@ -5,13 +5,13 @@ title: Configure Kubernetes Service ports
 description: Set the Kubernetes Service appProtocol hint per port for Camunda component Services in Self-Managed Helm deployments.
 ---
 
-The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
+The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing. For example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
 
 ## `appProtocol` per Service port
 
 Each component's `service.appProtocols` value accepts a map of logical port key to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
-The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`) — always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
+The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`). Always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
 
 | Component              | Value key                                    | Accepted logical port keys                          |
 | ---------------------- | -------------------------------------------- | --------------------------------------------------- |
@@ -23,7 +23,7 @@ The following components support `appProtocols` (the accepted logical port keys 
 | Web Modeler REST API   | `webModeler.restapi.service.appProtocols`    | `http`, `http-management`                           |
 | Web Modeler WebSockets | `webModeler.websockets.service.appProtocols` | `http`                                              |
 
-Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
+Example: set the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
 
 ```yaml
 orchestration:

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
@@ -1,0 +1,33 @@
+---
+id: service-configuration
+sidebar_label: Service configuration
+title: Configure Kubernetes Service ports
+description: Set the Kubernetes Service appProtocol hint per port for Camunda component Services in Self-Managed Helm deployments.
+---
+
+The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
+
+## AppProtocol per Service port
+
+Each component's `service.appProtocols` value accepts a map of port name to appProtocol value. It's empty by default and doesn't change existing behavior until you set it.
+
+The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
+
+| Component              | Value key                                    | Accepted port names                                 |
+| ---------------------- | -------------------------------------------- | --------------------------------------------------- |
+| Orchestration cluster  | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
+| Console                | `console.service.appProtocols`               | `http`, `management`                                |
+| Identity               | `identity.service.appProtocols`              | `http`, `metrics`                                   |
+| Optimize               | `optimize.service.appProtocols`              | `http`, `management`                                |
+| Connectors             | `connectors.service.appProtocols`            | `server`                                            |
+| Web Modeler REST API   | `webModeler.restapi.service.appProtocols`    | `http`, `http-management`                           |
+| Web Modeler WebSockets | `webModeler.websockets.service.appProtocols` | `http`                                              |
+
+Example — setting the orchestration cluster gRPC gateway port to use `kubernetes.io/h2c` for HTTP/2 cleartext framing:
+
+```yaml
+orchestration:
+  service:
+    appProtocols:
+      grpc: kubernetes.io/h2c
+```

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
@@ -7,9 +7,9 @@ description: Set the Kubernetes Service appProtocol hint per port for Camunda co
 
 The Camunda Helm chart exposes an `appProtocols` value per component that sets the Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on a Service port. Use this when your infrastructure needs an explicit protocol hint instead of relying on protocol sniffing — for example, a GKE NEG-backed Ingress or Gateway handling HTTP/2 cleartext (`h2c`) gRPC traffic to the orchestration cluster gateway.
 
-## AppProtocol per Service port
+## `appProtocol` per Service port
 
-Each component's `service.appProtocols` value accepts a map of port name to appProtocol value. It's empty by default and doesn't change existing behavior until you set it.
+Each component's `service.appProtocols` value accepts a map of port name to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
 The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/service-configuration.md
@@ -9,11 +9,11 @@ The Camunda Helm chart exposes an `appProtocols` value per component that sets t
 
 ## `appProtocol` per Service port
 
-Each component's `service.appProtocols` value accepts a map of port name to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
+Each component's `service.appProtocols` value accepts a map of logical port key to `appProtocol` value. It's empty by default and doesn't change existing behavior until you set it.
 
-The following components support `appProtocols` (the accepted port names for each component are listed in the last column):
+The following components support `appProtocols` (the accepted logical port keys for each component are listed in the last column). These keys are fixed and don't change if you override a component's `*Name` value (for example, `orchestration.service.grpcName`) — always use the logical key (`grpc`), not the renamed Service port. Setting a key outside the accepted list fails the Helm render instead of being silently ignored.
 
-| Component              | Value key                                    | Accepted port names                                 |
+| Component              | Value key                                    | Accepted logical port keys                          |
 | ---------------------- | -------------------------------------------- | --------------------------------------------------- |
 | Orchestration cluster  | `orchestration.service.appProtocols`         | `management`, `internal`, `command`, `http`, `grpc` |
 | Console                | `console.service.appProtocols`               | `http`, `management`                                |

--- a/versioned_sidebars/version-8.8-sidebars.json
+++ b/versioned_sidebars/version-8.8-sidebars.json
@@ -2943,6 +2943,7 @@
                 "self-managed/deployment/helm/configure/application-configs",
                 "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/pod-scheduling",
+                "self-managed/deployment/helm/configure/service-configuration",
                 "self-managed/deployment/helm/configure/enable-additional-components",
                 "self-managed/deployment/helm/configure/data-retention",
                 {

--- a/versioned_sidebars/version-8.9-sidebars.json
+++ b/versioned_sidebars/version-8.9-sidebars.json
@@ -3493,6 +3493,7 @@
                 "self-managed/deployment/helm/configure/application-configs",
                 "self-managed/deployment/helm/configure/pod-networking",
                 "self-managed/deployment/helm/configure/pod-scheduling",
+                "self-managed/deployment/helm/configure/service-configuration",
                 "self-managed/deployment/helm/configure/operator-based-infrastructure",
                 "self-managed/deployment/helm/configure/enable-additional-components",
                 "self-managed/deployment/helm/configure/data-retention",


### PR DESCRIPTION
## Description

Documents the new `<component>.service.appProtocols` Helm value added by
[camunda/camunda-platform-helm#6605](https://github.com/camunda/camunda-platform-helm/pull/6605)
(chart `camunda-platform-8.10`, merged) and backported to
[camunda/camunda-platform-helm#6664](https://github.com/camunda/camunda-platform-helm/pull/6664)
(chart `camunda-platform-8.9`) and
[camunda/camunda-platform-helm#6663](https://github.com/camunda/camunda-platform-helm/pull/6663)
(chart `camunda-platform-8.8`). It lets you set the Kubernetes
`Service.spec.ports[].appProtocol` field per port — needed for things like GKE NEG-backed
Ingress/Gateway resources handling HTTP/2 cleartext (`h2c`) gRPC traffic.

Adds a new page, [Configure Kubernetes Service ports](/self-managed/deployment/helm/configure/service-configuration.md),
following the same structure as the existing [Configure pod networking](/self-managed/deployment/helm/configure/pod-networking.md)
page (component → value key table, YAML example), and links it from the chart parameters
overview page.

Covers `/docs` (8.10), `versioned_docs/version-8.9`, and `versioned_docs/version-8.8`. The 8.9
and 8.8 pages include an additional `console.service.appProtocols` row — Console has no 8.10
equivalent, so its appProtocols support was added directly on top of the 8.10 backport in
#6664. The 8.8 page additionally has a separate `webModeler.webapp.service.appProtocols` row,
since 8.8 predates the Web Modeler consolidation into a single `restapi` container (8.9+ has
only `restapi` and `websockets`).

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I included my new page in the sidebar file(s).

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
