### PR TITLE
Physical Tenants: Actuator Health and Readiness Behavior

### DIFF
--- a/docs/self-managed/concepts/physical-tenants/api-routing.md
+++ b/docs/self-managed/concepts/physical-tenants/api-routing.md
@@ -44,6 +44,8 @@ GET /physical-tenants/default/v2/process-definitions/search
 
 A cluster-wide endpoint applies to the whole cluster rather than a single Physical Tenant. The cluster-wide topology is exposed under a dedicated `/cluster/v2/...` path prefix, at `/cluster/v2/topology`.
 
+The legacy `/v2/status` endpoint is deprecated. It continues to serve the default Physical Tenant only for backward compatibility. Use `/cluster/v2/status` for overall cluster status or `/physical-tenants/{id}/v2/topology` for per-tenant status.
+
 Most other endpoints are scoped to a Physical Tenant, even when they are not tenant-specific in nature. A plain `/v2/...` request targets the `default` tenant. For example:
 
 - `/v2/topology` returns the topology for the targeted Physical Tenant (the `default` tenant when no tenant prefix is used), not a cluster-wide view. For the cluster-wide topology, use `/cluster/v2/topology`.

--- a/docs/self-managed/concepts/physical-tenants/index.md
+++ b/docs/self-managed/concepts/physical-tenants/index.md
@@ -80,9 +80,32 @@ To provision new tenants and understand lifecycle behavior in 8.10, including ro
 
 Configuration validation should fail fast when two tenants point to the same backend location or another unsupported path. For document store, the final naming convention depends on the provider, so validate uniqueness at startup rather than relying on a hard-coded path format.
 
+## Health and status endpoints
+
+Physical Tenants expose three distinct endpoints for health and status:
+
+| Endpoint                             | Scope   | Use when                                                                                                            |
+| :----------------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------ |
+| `/actuator/health`                   | Node    | Checking whether the individual broker or gateway node is healthy, ready, or live (for example, Kubernetes probes). |
+| `/cluster/v2/status`                 | Cluster | Determining whether the cluster as a whole is operational.                                                          |
+| `/physical-tenants/{id}/v2/topology` | Tenant  | Checking whether a specific Physical Tenant can accept work and which of its partitions are available.              |
+
+The legacy `/v2/status` endpoint is deprecated. It remains available for the default Physical Tenant only to preserve backward compatibility. Switch to `/cluster/v2/status` for overall cluster status or `/physical-tenants/{id}/v2/topology` for per-tenant status.
+
 ## Readiness
 
-The intended model is that readiness remains broker-scoped, not tenant-scoped. If one physical tenant loses access to its secondary storage, that should not fail readiness for the entire cluster.
+:::note Known limitation
+In 8.10, readiness failure propagates across all tenants co-located on a broker pod:
+
+- If one tenant's RDBMS schema is unreachable at broker startup, the entire Spring context fails and all tenants on that pod go offline.
+- If secondary storage becomes unavailable after startup, Kubernetes removes the broker pod from traffic, affecting all tenants co-located on that pod.
+
+This is the highest-impact noisy-neighbor limitation in 8.10. A fix is tracked in [camunda/camunda#54299](https://github.com/camunda/camunda/issues/54299).
+:::
+
+The intended long-term model is broker-scoped readiness that isolates per-tenant data-layer failures from other tenants. Until the fix lands, use `/physical-tenants/{id}/v2/topology` to inspect per-tenant partition availability and determine whether a specific tenant can accept work.
+
+When configuring Kubernetes readiness probes, point the probe at `/actuator/health/readiness` for node-level readiness. To check whether a specific Physical Tenant can accept work independently of the node probe, poll `/physical-tenants/{id}/v2/topology` from your own health-check logic.
 
 ## Document store details
 

--- a/docs/self-managed/concepts/physical-tenants/index.md
+++ b/docs/self-managed/concepts/physical-tenants/index.md
@@ -84,26 +84,15 @@ Configuration validation should fail fast when two tenants point to the same bac
 
 Physical Tenants expose three distinct endpoints for health and status:
 
-| Endpoint                             | Scope   | Use when                                                                                                            |
-| :----------------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------ |
-| `/actuator/health`                   | Node    | Checking whether the individual broker or gateway node is healthy, ready, or live (for example, Kubernetes probes). |
-| `/cluster/v2/status`                 | Cluster | Determining whether the cluster as a whole is operational.                                                          |
-| `/physical-tenants/{id}/v2/topology` | Tenant  | Checking whether a specific Physical Tenant can accept work and which of its partitions are available.              |
+| Endpoint                             | Scope   | Use when                                                                                                                                                                                                                                                      |
+| :----------------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/actuator/health`                   | Node    | Checking whether the individual broker or gateway node is healthy, ready, or live (for example, Kubernetes probes). Exposed on port 9600 by default (brokers and gateways); the other endpoints below are exposed on the Gateway REST port (8080 by default). |
+| `/cluster/v2/status`                 | Cluster | Determining whether the cluster as a whole is operational.                                                                                                                                                                                                    |
+| `/physical-tenants/{id}/v2/topology` | Tenant  | Checking whether a specific Physical Tenant can accept work and which of its partitions are available.                                                                                                                                                        |
 
 The legacy `/v2/status` endpoint is deprecated. It remains available for the default Physical Tenant only to preserve backward compatibility. Switch to `/cluster/v2/status` for overall cluster status or `/physical-tenants/{id}/v2/topology` for per-tenant status.
 
 ## Readiness
-
-:::note Known limitation
-In 8.10, readiness failure propagates across all tenants co-located on a broker pod:
-
-- If one tenant's RDBMS schema is unreachable at broker startup, the entire Spring context fails and all tenants on that pod go offline.
-- If secondary storage becomes unavailable after startup, Kubernetes removes the broker pod from traffic, affecting all tenants co-located on that pod.
-
-This is the highest-impact noisy-neighbor limitation in 8.10. A fix is tracked in [camunda/camunda#54299](https://github.com/camunda/camunda/issues/54299).
-:::
-
-The intended long-term model is broker-scoped readiness that isolates per-tenant data-layer failures from other tenants. Until the fix lands, use `/physical-tenants/{id}/v2/topology` to inspect per-tenant partition availability and determine whether a specific tenant can accept work.
 
 When configuring Kubernetes readiness probes, point the probe at `/actuator/health/readiness` for node-level readiness. To check whether a specific Physical Tenant can accept work independently of the node probe, poll `/physical-tenants/{id}/v2/topology` from your own health-check logic.
 

--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -295,6 +295,20 @@ The following image shows an example of the Zeebe Grafana dashboard after import
 
 ![Example Zeebe Grafana dashboard](assets/grafana-preview.png)
 
+#### Physical Tenant filtering
+
+All Zeebe metrics include a `physicalTenant` label. The Zeebe dashboard supports filtering and aggregating metrics by `physicalTenant` and `partition`, and exposes `physicalTenant` as a variable selector, so you can monitor throughput, latency, and resource usage for each Physical Tenant independently.
+
+To compare across tenants in Prometheus queries, use the `physicalTenant` label directly. For example:
+
+```promql
+sum by (physicalTenant) (zeebe_broker_processing_latency_seconds_count)
+```
+
+:::note
+Other Grafana dashboards (API panels, gateway panels) are being updated to include `physicalTenant` filtering, tracked in [camunda/camunda#56250](https://github.com/camunda/camunda/issues/56250).
+:::
+
 ### Data layer
 
 A pre-built Grafana dashboard is available for the data layer in the repository:

--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -297,12 +297,12 @@ The following image shows an example of the Zeebe Grafana dashboard after import
 
 #### Physical Tenant filtering
 
-All Zeebe metrics include a `physicalTenant` label. The Zeebe dashboard supports filtering and aggregating metrics by `physicalTenant` and `partition`, and exposes `physicalTenant` as a variable selector, so you can monitor throughput, latency, and resource usage for each Physical Tenant independently.
+Partition-scoped Zeebe metrics include a `physicalTenant` label. Node-level metrics that are not partition-scoped do not carry this label. The Zeebe dashboard supports filtering and aggregating metrics by `physicalTenant` and `partition`, and exposes `physicalTenant` as a variable selector, so you can monitor throughput, latency, and resource usage for each Physical Tenant independently.
 
 To compare across tenants in Prometheus queries, use the `physicalTenant` label directly. For example:
 
 ```promql
-sum by (physicalTenant) (zeebe_broker_processing_latency_seconds_count)
+sum by (physicalTenant) (zeebe_stream_processor_latency_seconds_count)
 ```
 
 :::note


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/camunda-docs/issues/8893.

Documents actuator health and readiness behavior for Physical Tenants, the `physicalTenant` Prometheus label, and the known readiness propagation limitation in 8.10.

- **`self-managed/concepts/physical-tenants/index.md`**: Added "Health and status endpoints" table comparing `/actuator/health` (node), `/cluster/v2/status` (cluster), and `/physical-tenants/{id}/v2/topology` (tenant); deprecated `/v2/status` noted. Replaced aspirational readiness text with actual 8.10 behavior: readiness failure propagates across all tenants co-located on a broker pod (known limitation, fix tracked in camunda/camunda#54299). Added Kubernetes readiness probe guidance.
- **`self-managed/operational-guides/monitoring/metrics.md`**: Added "Physical Tenant filtering" subsection under Zeebe Grafana -- documents the `physicalTenant` label, per-tenant Prometheus query pattern, dashboard variable selector, and in-progress tracking for other dashboards (camunda/camunda#56250).
- **`self-managed/concepts/physical-tenants/api-routing.md`**: Added deprecation note for `/v2/status` with migration guidance to `/cluster/v2/status` or `/physical-tenants/{id}/v2/topology`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
