### PR TITLE
business ID visibility, filtering, and correlation

### DIFF
--- a/docs/components/concepts/messages.md
+++ b/docs/components/concepts/messages.md
@@ -151,6 +151,55 @@ By combining the principles of message correlation, message uniqueness, and mess
 | empty string    | set        | set > 0      | Start event        | A new instance is started if there is no [equal message](#message-uniqueness) in the buffer.                                                                                                    |
 | empty string    | set        | set > 0      | Intermediate event | The message is correlated during the lifetime of the message if a matching subscription to the empty string is active and there is no [equal message](#message-uniqueness) in the buffer.       |
 
+## Business ID in message correlation
+
+Starting in Camunda 8.10, you can include a business ID in message publication and correlation. Business ID acts as an additional filter constraint on top of the message name and correlation key.
+
+### Supported combinations
+
+Message name is always required. The following additional fields are supported per event type:
+
+| Event type                                                       | Supported correlation fields                 |
+| :--------------------------------------------------------------- | :------------------------------------------- |
+| Start event                                                      | Message name                                 |
+| Start event                                                      | Message name + business ID                   |
+| Start event                                                      | Message name + correlation key               |
+| Start event                                                      | Message name + correlation key + business ID |
+| Non-start event (intermediate catch, boundary, event subprocess) | Message name + correlation key               |
+| Non-start event                                                  | Message name + correlation key + business ID |
+
+For non-start events, a business ID can only be used together with an existing correlation key. Business ID alone is not sufficient to correlate to a non-start subscription.
+
+When both a correlation key and a business ID are provided, **both must match** for the message to correlate.
+
+### Matching semantics
+
+A message subscription **snapshots** the process instance's business ID at the time the subscription is opened. Matching is asymmetric at evaluation time:
+
+- A message published **without** a business ID correlates to any matching subscription, regardless of whether the subscription's instance has a business ID.
+- A message published **with** a business ID correlates only to subscriptions whose stored business ID matches exactly.
+
+If a [late business ID assignment](/components/concepts/process-instance-creation.md#late-business-id-assignment) updates a process instance after a subscription is already open, the existing subscription is not updated. Only subscriptions opened after the assignment carry the new business ID.
+
+### Message-start buffering with uniqueness
+
+When business ID uniqueness is enabled, a message-start event that would create a new instance with a business ID already held by an active instance is not dropped immediately. The message stays buffered and is retried until either:
+
+- The active instance releases the business ID (by completing or terminating), or
+- The message's TTL expires.
+
+If the TTL expires before the business ID is released, the message is discarded without starting a new instance.
+
+:::note
+`TTL = 0` (fire-and-forget) message-start events are not retried. They activate on first arrival only and are discarded immediately if blocked by uniqueness.
+:::
+
+### API reference
+
+- [Publish message](/apis-tools/orchestration-cluster-api-rest/specifications/publish-message.api.mdx) — `businessId` request field.
+- [Correlate message](/apis-tools/orchestration-cluster-api-rest/specifications/correlate-message.api.mdx) — `businessId` request field.
+- [Search correlated message subscriptions](/apis-tools/orchestration-cluster-api-rest/specifications/search-correlated-message-subscriptions.api.mdx) — `businessId` as a filter and sort field.
+
 ## Message patterns
 
 The following patterns describe solutions for common problems that can be solved using message correlation.

--- a/docs/components/concepts/messages.md
+++ b/docs/components/concepts/messages.md
@@ -170,14 +170,13 @@ Message name is always required. The following additional fields are supported p
 
 For non-start events, a business ID can only be used together with an existing correlation key. Business ID alone is not sufficient to correlate to a non-start subscription.
 
-When both a correlation key and a business ID are provided, **both must match** for the message to correlate.
+When both a correlation key and a business ID are provided, the message correlates only if both fields match the corresponding values stored on the subscription.
 
 ### Matching semantics
 
-A message subscription **snapshots** the process instance's business ID at the time the subscription is opened. Matching is asymmetric at evaluation time:
+A business ID on a message is an optional narrowing filter. A message with no business ID correlates on name and correlation key alone, regardless of the subscription's business ID. A message that carries a business ID correlates only to a subscription whose business ID matches exactly; a subscription with no business ID does not match a message that carries one. A business ID never replaces the correlation key.
 
-- A message published **without** a business ID correlates to any matching subscription, regardless of whether the subscription's instance has a business ID.
-- A message published **with** a business ID correlates only to subscriptions whose stored business ID matches exactly.
+A message subscription snapshots the process instance's business ID at the time the subscription is opened.
 
 If a [late business ID assignment](/components/concepts/process-instance-creation.md#late-business-id-assignment) updates a process instance after a subscription is already open, the existing subscription is not updated. Only subscriptions opened after the assignment carry the new business ID.
 

--- a/docs/components/concepts/process-instance-creation.md
+++ b/docs/components/concepts/process-instance-creation.md
@@ -200,9 +200,7 @@ For example, consider a process that ships book orders where each order already 
 
 You set the business ID at process instance creation time via the `businessId` field in the creation request. The business ID is **immutable**; once set, it cannot be changed or removed for the lifetime of the process instance. The maximum length for a business ID is **256 characters**.
 
-:::note
-The business ID feature is currently only available through the API (REST and gRPC) and the official clients. You can't set a business ID when creating process instances from other tools, such as the modeler in Camunda Hub.
-:::
+Starting in 8.10, you can also set a business ID when starting a process instance from **Camunda Hub** or **Desktop Modeler**.
 
 <details>
    <summary>Create a process instance with a business ID via Orchestration Cluster REST API</summary>
@@ -226,16 +224,88 @@ See the [API reference for process instance creation](/apis-tools/orchestration-
 
 ### Propagation to child instances
 
-When a process instance with a business ID creates a child process instance via a [call activity](/components/modeler/bpmn/call-activities/call-activities.md), the business ID is automatically propagated to the child.
+When a process instance with a business ID creates a child process instance via a [call activity](/components/modeler/bpmn/call-activities/call-activities.md), the business ID is automatically propagated to the child by default.
 
-Each child instance inherits the same business ID as its parent. As a result, the entire process hierarchy ultimately shares the root instance's business ID, and child instances cannot override it. This lets you trace an entire process hierarchy using a single domain identifier.
+Each child instance inherits the same business ID as its parent, letting you trace an entire process hierarchy using a single domain identifier.
 
-### Retrieving process instances by business ID
+Starting in 8.10, a call activity can override the inherited business ID by setting a literal value or [FEEL expression](/components/concepts/expressions.md) on the call activity. The value is resolved once at child creation and is then immutable. See [Business ID propagation](/components/modeler/bpmn/call-activities/call-activities.md#business-id-propagation) for configuration details.
 
-The business ID is available as a property on the process instance. You can use it to look up or filter process instances through the API:
+### Searching and filtering by business ID
 
-- [Get process instance](/apis-tools/orchestration-cluster-api-rest/specifications/get-process-instance.api.mdx) — retrieve a single process instance and inspect its `businessId` field.
-- [Search process instances](/apis-tools/orchestration-cluster-api-rest/specifications/search-process-instances.api.mdx) — filter process instances using the `businessId` field to find all instances linked to a specific business case.
+Starting in 8.10, `businessId` is available across multiple entity types. Searchability varies by entity:
+
+| Entity                | Searchable | Visible | Notes                                                                               |
+| :-------------------- | :--------- | :------ | :---------------------------------------------------------------------------------- |
+| Process instances     | Yes        | Yes     | Available since 8.9.                                                                |
+| Decision instances    | Yes        | Yes     | Available since 8.10.                                                               |
+| User tasks            | Yes        | Yes     | Available since 8.10.                                                               |
+| Messages              | Yes        | Yes     | API only. Not shown in the Operate process instance details view.                   |
+| Message subscriptions | Yes        | Yes     | API only.                                                                           |
+| Jobs                  | No         | Yes     | Visible in job activation response. Not searchable, filterable, or shown in the UI. |
+
+#### Advanced filter operators
+
+The API supports the following operators for `businessId`. Operate and Tasklist expose a subset in their filter UI.
+
+| Operator  | Description                 | Wildcards                           | UI label  |
+| :-------- | :-------------------------- | :---------------------------------- | :-------- |
+| `$eq`     | Exact match                 | —                                   | Equals    |
+| `$neq`    | Does not match              | —                                   | API only  |
+| `$exists` | Field is set or absent      | —                                   | API only  |
+| `$like`   | Pattern match               | `*` (multi-char), `?` (single-char) | Contains  |
+| `$in`     | Matches any value in a list | —                                   | Is one of |
+
+#### API reference
+
+| Entity                | Endpoints                                                                                                                                                                                              |
+| :-------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Process instances     | [Get](/apis-tools/orchestration-cluster-api-rest/specifications/get-process-instance.api.mdx) · [Search](/apis-tools/orchestration-cluster-api-rest/specifications/search-process-instances.api.mdx)   |
+| Decision instances    | [Get](/apis-tools/orchestration-cluster-api-rest/specifications/get-decision-instance.api.mdx) · [Search](/apis-tools/orchestration-cluster-api-rest/specifications/search-decision-instances.api.mdx) |
+| User tasks            | [Get](/apis-tools/orchestration-cluster-api-rest/specifications/get-user-task.api.mdx) · [Search](/apis-tools/orchestration-cluster-api-rest/specifications/search-user-tasks.api.mdx)                 |
+| Message subscriptions | [Search](/apis-tools/orchestration-cluster-api-rest/specifications/search-correlated-message-subscriptions.api.mdx)                                                                                    |
+| Jobs (visible only)   | [Search](/apis-tools/orchestration-cluster-api-rest/specifications/search-jobs.api.mdx) · [Activate](/apis-tools/orchestration-cluster-api-rest/specifications/activate-jobs.api.mdx)                  |
+
+#### Retroactive visibility
+
+Business IDs assigned to process instances in 8.9 remain traceable because the business ID is stored on the process instance record. However, related artifacts — user tasks, decision instances, jobs, and message subscriptions — snapshot the business ID at their own creation time. Artifacts created before business ID visibility shipped for that entity type are not retroactively enriched and carry no `businessId` value.
+
+### Late Business ID assignment
+
+You can assign a business ID to a running process instance that has none. This is useful when the domain identifier (for example, an order number or case reference) is not available at instance creation time.
+
+:::note
+Late assignment requires business ID uniqueness to be **disabled**. See [Uniqueness control](#uniqueness-control) for details.
+:::
+
+| Constraint              | Detail                                                                                                                                |
+| :---------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| Single and irreversible | Once set, the business ID cannot be changed or removed.                                                                               |
+| Root instances only     | Call-activity children are always rejected.                                                                                           |
+| No re-assignment        | Any attempt to assign to an instance that already has a business ID — whether the value matches or differs — returns `INVALID_STATE`. |
+| Max length              | 256 characters.                                                                                                                       |
+
+**Propagation is forward-only.** Only artifacts created after the assignment carry the business ID: future jobs, user tasks, decision instances, message subscriptions, and call-activity children. Pre-existing artifacts retain an empty `businessId`. An instance in this state shows a mixed view — older artifacts have no business ID, newer ones do.
+
+**API surfaces:**
+
+| Surface        | Details                                                                                                                                 |
+| :------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| REST           | `POST /process-instances/{processInstanceKey}/business-id-assignment`                                                                   |
+| gRPC           | `AssignProcessInstanceBusinessId`                                                                                                       |
+| Job completion | Include `businessId` in the `CompleteJob` request. If assignment fails, the entire complete is rejected — the job is **not** completed. |
+
+**Rejection contract:**
+
+| Failure                                                      | Rejection                    |
+| :----------------------------------------------------------- | :--------------------------- |
+| Instance not found or wrong tenant                           | `NOT_FOUND`                  |
+| Target is a call-activity child                              | `INVALID_STATE`              |
+| Business ID uniqueness is enabled                            | `INVALID_STATE`              |
+| Instance already has a business ID (same or different value) | `INVALID_STATE`              |
+| Value fails validation (for example, exceeds 256 characters) | `INVALID_ARGUMENT`           |
+| Not authorized                                               | `UNAUTHORIZED` / `FORBIDDEN` |
+
+Required permission: `UPDATE_PROCESS_INSTANCE` on the process definition.
 
 ### Uniqueness control
 
@@ -274,7 +344,7 @@ Migration intentionally **bypasses uniqueness control checks**, because migratio
 
 ### Limitations
 
-- You cannot currently search related entities (for example, jobs, user tasks, or incidents) **directly by business ID**.
+- **Jobs** carry the business ID in the job activation response but cannot be searched or filtered by business ID. No UI surface exposes job-level business ID visibility.
 - When using [cluster scaling](/self-managed/components/orchestration-cluster/zeebe/operations/cluster-scaling.md) to increase the number of partitions, new process instances created with a business ID are only distributed across the original set of partitions, not to any newly added partitions.
 
 ## Tags

--- a/docs/components/concepts/process-instance-creation.md
+++ b/docs/components/concepts/process-instance-creation.md
@@ -194,7 +194,7 @@ A process can also have one or more [timer start events](/components/modeler/bpm
 
 A business ID is a domain-specific identifier you can assign to a process instance. Unlike the system-generated process instance key, it represents a domain concept such as an order number, case reference, or customer ticket ID.
 
-A business ID does **not need to be unique** unless uniqueness control is enabled. See [Uniqueness control](#uniqueness-control) for details.
+A business ID does **not need to be unique** unless uniqueness control is enabled. See [uniqueness control](#uniqueness-control) for details.
 
 For example, consider a process that ships book orders where each order already has an identifier in your order management system. When you start the process to ship an order, you can use the order ID as the business ID. This lets you easily find all process instances related to a particular order.
 
@@ -228,7 +228,7 @@ When a process instance with a business ID creates a child process instance via 
 
 Each child instance inherits the same business ID as its parent, letting you trace an entire process hierarchy using a single domain identifier.
 
-Starting in 8.10, a call activity can override the inherited business ID by setting a literal value or [FEEL expression](/components/concepts/expressions.md) on the call activity. The value is resolved once at child creation and is then immutable. See [Business ID propagation](/components/modeler/bpmn/call-activities/call-activities.md#business-id-propagation) for configuration details.
+Starting in 8.10, a call activity can override the inherited business ID by setting a literal value or [FEEL expression](/components/concepts/expressions.md) on the call activity. The value is resolved once at child creation and is then immutable. See [business ID propagation](/components/modeler/bpmn/call-activities/call-activities.md#business-id-propagation) for configuration details.
 
 ### Searching and filtering by business ID
 
@@ -274,7 +274,7 @@ Business IDs assigned to process instances in 8.9 remain traceable because the b
 You can assign a business ID to a running process instance that has none. This is useful when the domain identifier (for example, an order number or case reference) is not available at instance creation time.
 
 :::note
-Late assignment requires business ID uniqueness to be **disabled**. See [Uniqueness control](#uniqueness-control) for details.
+Late assignment requires business ID uniqueness to be **disabled**. See [uniqueness control](#uniqueness-control) for details.
 :::
 
 | Constraint              | Detail                                                                                                                                |

--- a/docs/components/modeler/bpmn/call-activities/call-activities.md
+++ b/docs/components/modeler/bpmn/call-activities/call-activities.md
@@ -52,6 +52,52 @@ By default, all variables of the call activity scope are copied to the created p
 
 By disabling this attribute, variables existing at higher scopes are no longer copied. If the attribute `propagateAllParentVariables` is set (default: `true`), all variables are propagated to the child process instance.
 
+## Business ID propagation
+
+When a parent process instance has a business ID, child instances created by call activities inherit it by default. Starting in 8.10, you can configure each call activity to override this behavior.
+
+### Default behavior
+
+If no `businessId` configuration is set on the call activity, the child instance inherits the parent's business ID automatically. This is the 8.9 default. Existing models are unaffected.
+
+### Override with a literal value or FEEL expression
+
+To set a different business ID on the child instance, configure the `businessId` attribute on the `zeebe:calledElement` extension element. The value is resolved once at child creation and is then immutable.
+
+<!-- TODO: Add the exact XML attribute shape once ADR camunda/camunda#56154 and Modeler UI #51694 are finalized. -->
+
+You can use the FEEL expression context variable `camunda.processInstance.businessId` to reference the parent instance's business ID in the expression.
+
+| Configuration                           | Effect                                                                                             |
+| :-------------------------------------- | :------------------------------------------------------------------------------------------------- |
+| Attribute absent                        | Child inherits the parent's business ID (default).                                                 |
+| Literal string                          | Child is created with that exact string as its business ID.                                        |
+| FEEL expression (prefixed with `=`)     | Child gets the evaluated result. Access the parent's ID with `camunda.processInstance.businessId`. |
+| Empty string `""` or expression `=null` | Child starts with no business ID. No incident is raised.                                           |
+
+### Validation and error handling
+
+Business ID values go through two validation stages:
+
+:::danger Deploy-time rejection
+The process cannot be deployed if:
+
+- The `businessId` attribute contains an invalid FEEL expression syntax.
+- A static literal value exceeds 256 characters.
+  :::
+
+If the value is empty or intentionally `null` at runtime (for example, `=null` or a FEEL expression that cleanly evaluates to `null`), the child starts with no business ID and no incident is raised.
+
+:::warning Runtime incident (resolvable)
+An incident is raised on the call activity if the FEEL expression:
+
+- Evaluates to `null` due to evaluation warnings — for example, a missing variable caused the null rather than an intentional `=null`.
+- Evaluates to a string exceeding 256 characters.
+- Evaluates to a non-string, non-null type (number, boolean, or list).
+  :::
+
+To resolve the incident: correct the variables or expression, then retry activation. The child instance is created with the corrected business ID.
+
 ## Additional resources
 
 ### XML representation

--- a/docs/components/modeler/bpmn/call-activities/call-activities.md
+++ b/docs/components/modeler/bpmn/call-activities/call-activities.md
@@ -73,10 +73,6 @@ To set a different business ID on the child instance, configure the `businessId`
 </bpmn:callActivity>
 ```
 
-:::note
-Modeler UI support for configuring the `businessId` attribute in the properties panel is not yet available. Configure it directly in the XML until UI support ships.
-:::
-
 You can use the FEEL expression context variable `camunda.processInstance.businessId` to reference the parent instance's business ID in the expression.
 
 | Configuration                           | Effect                                                                                             |

--- a/docs/components/modeler/bpmn/call-activities/call-activities.md
+++ b/docs/components/modeler/bpmn/call-activities/call-activities.md
@@ -64,7 +64,18 @@ If no `businessId` configuration is set on the call activity, the child instance
 
 To set a different business ID on the child instance, configure the `businessId` attribute on the `zeebe:calledElement` extension element. The value is resolved once at child creation and is then immutable.
 
-<!-- TODO: Add the exact XML attribute shape once ADR camunda/camunda#56154 and Modeler UI #51694 are finalized. -->
+```xml
+<bpmn:callActivity id="Call_Activity" name="Call Process A">
+  <bpmn:extensionElements>
+    <zeebe:calledElement processId="child-process"
+                         businessId="= camunda.processInstance.businessId" />
+  </bpmn:extensionElements>
+</bpmn:callActivity>
+```
+
+:::note
+Modeler UI support for configuring the `businessId` attribute in the properties panel is not yet available. Configure it directly in the XML until UI support ships.
+:::
 
 You can use the FEEL expression context variable `camunda.processInstance.businessId` to reference the parent instance's business ID in the expression.
 

--- a/docs/components/operate/userguide/filter-process-instances.md
+++ b/docs/components/operate/userguide/filter-process-instances.md
@@ -30,6 +30,7 @@ The **Filter** panel appears on the left side of the **Processes** page. Open it
 
 - **Batch Process Instance Key** — Filter by batch operation ID
 - **Process Instance Key** — Filter by exact instance ID
+- **Business ID** — Filter by domain-specific identifier (order number, case reference, etc.); see [Business ID filter](#business-id-filter)
 
 **Variable filters** (new in 8.10):
 
@@ -185,6 +186,20 @@ Enter the value as you would compare it (for example, `42` for numbers, `2024-01
 :::note
 Numeric comparison operators are not supported. Use **equals** or **contains** as alternatives.
 :::
+
+## Business ID filter
+
+A [business ID](/components/concepts/process-instance-creation.md#business-id) is a domain-specific identifier assigned to a process instance at creation — for example, an order number, case reference, or ticket ID. Starting in 8.10, you can filter process instances by business ID directly in the Operate UI.
+
+To filter by business ID, open the **Filter** panel and use the **Business ID** field.
+
+| UI operator   | Behavior                                           | Wildcards                                                   |
+| :------------ | :------------------------------------------------- | :---------------------------------------------------------- |
+| **Equals**    | Exact match on the business ID value.              | —                                                           |
+| **Contains**  | Pattern match.                                     | `*` matches multiple characters, `?` matches one character. |
+| **Is one of** | Matches any business ID in a comma-separated list. | —                                                           |
+
+For additional operators (`$neq`, `$exists`), use the [Search process instances API](/apis-tools/orchestration-cluster-api-rest/specifications/search-process-instances.api.mdx) with the `businessId` filter field.
 
 ## Known limitations
 

--- a/docs/components/operate/userguide/filter-process-instances.md
+++ b/docs/components/operate/userguide/filter-process-instances.md
@@ -30,7 +30,7 @@ The **Filter** panel appears on the left side of the **Processes** page. Open it
 
 - **Batch Process Instance Key** — Filter by batch operation ID
 - **Process Instance Key** — Filter by exact instance ID
-- **Business ID** — Filter by domain-specific identifier (order number, case reference, etc.); see [Business ID filter](#business-id-filter)
+- **Business ID** — Filter by domain-specific identifier (order number, case reference, etc.); see [business ID filter](#business-id-filter)
 
 **Variable filters** (new in 8.10):
 
@@ -199,7 +199,7 @@ To filter by business ID, open the **Filter** panel and use the **Business ID** 
 | **Contains**  | Pattern match.                                     | `*` matches multiple characters, `?` matches one character. |
 | **Is one of** | Matches any business ID in a comma-separated list. | —                                                           |
 
-For additional operators (`$neq`, `$exists`), use the [Search process instances API](/apis-tools/orchestration-cluster-api-rest/specifications/search-process-instances.api.mdx) with the `businessId` filter field.
+For additional operators (`$neq`, `$exists`), use the [search process instances API](/apis-tools/orchestration-cluster-api-rest/specifications/search-process-instances.api.mdx) with the `businessId` filter field.
 
 ## Known limitations
 

--- a/docs/components/tasklist/userguide/using-filters.md
+++ b/docs/components/tasklist/userguide/using-filters.md
@@ -35,6 +35,7 @@ In the dialog, you can define various rules based on task attributes. The suppor
 - Processes tasks belong to
 - Dates (due date and follow up date)
 - Task ID
+- Business ID
 - Task variables
 
 ![tasklist-filter-dialog-with-advanced-options](img/task-filters/tasklist-filter-dialog-with-advanced-options.jpg "Available filter attributes")

--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -157,6 +157,16 @@ FEEL expressions in the variable outline now use the same syntax highlighting as
 
 <p class="link-arrow">[Inspect variables](/components/modeler/data-handling.md#inspecting-variables)</p>
 
+#### Start a process instance with a business ID
+
+<!-- https://github.com/camunda/product-hub/issues/3436 -->
+
+<div class="release"><span class="badge badge--medium" title="This feature affects Web Modeler">Web Modeler</span><span class="badge badge--medium" title="This feature affects Desktop Modeler">Desktop Modeler</span></div>
+
+You can now set a business ID when starting a process instance directly from Camunda Hub or Desktop Modeler. The business ID field is available in the start process instance dialog alongside variables.
+
+<p class="link-arrow">[Business ID](/components/concepts/process-instance-creation.md#business-id)</p>
+
 ### Operate
 
 #### Multi-variable filtering
@@ -182,6 +192,16 @@ Operate now shows what an active process instance is waiting for. When you inspe
 Wait state tracking is enabled by default and writes records to secondary storage. In Camunda 8 Self-Managed, you can [disable it](/self-managed/concepts/wait-states/configure.md) if you do not want to track this data.
 
 <p class="link-arrow">[Wait states](/components/wait-states/overview.md)</p>
+
+#### Business ID filtering in Operate
+
+<!-- https://github.com/camunda/product-hub/issues/3436 -->
+
+<div class="release"><span class="badge badge--medium" title="This feature affects Operate">Operate</span></div>
+
+Operate now exposes business ID as a filter field for process instances. You can filter using **Equals**, **Contains** (with `*` and `?` wildcards), and **Is one of** — or use the full operator set (`$eq`, `$neq`, `$exists`, `$like`, `$in`) via the API.
+
+<p class="link-arrow">[Business ID](/components/concepts/process-instance-creation.md#searching-and-filtering-by-business-id)</p>
 
 ### Optimize
 
@@ -302,6 +322,32 @@ Camunda 8.10 introduces region awareness to the Orchestration Cluster. Operators
 Leader election priorities respect region boundaries, preferring region-local leaders under normal conditions and adjusting automatically when a region becomes unavailable. The same mechanism extends to availability zone or datacenter isolation using the same configuration.
 
 <p class="link-arrow">[Orchestration Cluster configuration properties](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md)</p>
+
+#### Business ID in message correlation
+
+<!-- https://github.com/camunda/product-hub/issues/3436 -->
+
+<div class="release"><span class="badge badge--medium" title="This feature affects Orchestration Cluster API">Orchestration Cluster API</span></div>
+
+You can now include a business ID when publishing or correlating a message. Business ID acts as an additional filter alongside the message name and correlation key.
+
+Supported combinations for start events: message name alone; name + business ID; name + correlation key; name + correlation key + business ID. For non-start events, business ID is usable alongside name + correlation key. When both a correlation key and business ID are provided, both must match.
+
+If business ID uniqueness is enabled, a blocked message-start waits in the buffer until the active instance releases the business ID or the TTL expires — it is not dropped immediately.
+
+<p class="link-arrow">[Business ID in message correlation](/components/concepts/messages.md#business-id-in-message-correlation)</p>
+
+#### Business ID propagation in call activities
+
+<!-- https://github.com/camunda/product-hub/issues/3436 -->
+
+<div class="release"><span class="badge badge--medium" title="This feature affects Orchestration Cluster">Orchestration Cluster</span></div>
+
+Call activities now support configuring the business ID assigned to the child process instance. Child instances inherit the parent's business ID by default (unchanged from 8.9). You can override this per call activity with a literal value or FEEL expression. The FEEL context variable `camunda.processInstance.businessId` provides access to the parent's ID within the expression.
+
+The resolved value is set once at child creation and is immutable.
+
+<p class="link-arrow">[Business ID propagation](/components/modeler/bpmn/call-activities/call-activities.md#business-id-propagation)</p>
 
 ### Helm chart deployment
 
@@ -436,6 +482,18 @@ The default RocksDB memory allocation strategy changes from `PARTITION` to `FRAC
 To keep the previous behavior, explicitly set the strategy to `PARTITION`. See the [release announcement](/reference/announcements-release-notes/8100/8100-announcements.md#rocksdb-memory-allocation-strategy) for more details.
 
 <p class="link-arrow">[Zeebe memory allocation](/self-managed/components/orchestration-cluster/zeebe/operations/resource-planning.md#memory)</p>
+
+### Operate
+
+#### Business ID visibility in Operate
+
+<!-- https://github.com/camunda/product-hub/issues/3436 -->
+
+<div class="release"><span class="badge badge--medium" title="This feature affects Operate">Operate</span></div>
+
+Business ID is now visible in Operate for process instances. The `businessId` field appears in the process instance list and the process instance details view. You can filter the process instance list by business ID using an exact-match filter.
+
+<p class="link-arrow">[Business ID](/components/concepts/process-instance-creation.md#business-id)</p>
 
 ### Optimize
 

--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -491,7 +491,7 @@ To keep the previous behavior, explicitly set the strategy to `PARTITION`. See t
 
 <div class="release"><span class="badge badge--medium" title="This feature affects Operate">Operate</span></div>
 
-Business ID is now visible in Operate for process instances. The `businessId` field appears in the process instance list and the process instance details view. You can filter the process instance list by business ID using an exact-match filter.
+Business ID is now visible in Operate for process instances. The `businessId` field appears in the process instance list and the process instance details view.
 
 <p class="link-arrow">[Business ID](/components/concepts/process-instance-creation.md#business-id)</p>
 

--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -331,7 +331,7 @@ Leader election priorities respect region boundaries, preferring region-local le
 
 You can now include a business ID when publishing or correlating a message. Business ID acts as an additional filter alongside the message name and correlation key.
 
-Supported combinations for start events: message name alone; name + business ID; name + correlation key; name + correlation key + business ID. For non-start events, business ID is usable alongside name + correlation key. When both a correlation key and business ID are provided, both must match.
+Supported combinations for start events: message name alone; name + business ID; name + correlation key; name + correlation key + business ID. For non-start events, business ID is usable alongside name + correlation key. When both a correlation key and business ID are provided, both fields must match the corresponding values stored on the subscription.
 
 If business ID uniqueness is enabled, a blocked message-start waits in the buffer until the active instance releases the business ID or the TTL expires — it is not dropped immediately.
 

--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -52,6 +52,20 @@ Wait state tracking is enabled by default and writes records to secondary storag
 
 <p class="link-arrow">[Wait states](/components/wait-states/overview.md)</p>
 
+## Business ID
+
+Business ID is now a first-class, searchable attribute across the Orchestration Cluster. Introduced in 8.9 as an immutable domain-specific identifier, Business ID in 8.10 can be searched and filtered across process instances, decision instances, user tasks, messages, and message subscriptions. Jobs expose the Business ID in the activation response (visible, not searchable).
+
+**What's new in 8.10:**
+
+- **Search and filter** across entity types using advanced operators (`$eq`, `$neq`, `$exists`, `$like` with `*`/`?` wildcards, `$in`). Operate and Tasklist expose Equals, Contains, and Is one of in their filter UI.
+- **Message correlation** — include a Business ID in published or correlated messages as an additional filter constraint. If both a correlation key and Business ID are supplied, both must match.
+- **Call Activity propagation** — child instances inherit the parent's Business ID by default. Configure a literal value or FEEL expression on the call activity to override it. Use `camunda.processInstance.businessId` in FEEL expressions to reference the parent's ID.
+- **Start with a Business ID** from Camunda Hub or Desktop Modeler.
+- **Late assignment** — assign a Business ID to a running instance that has none, when uniqueness is disabled. Assignment is forward-only: only artifacts created after the assignment carry it.
+
+<p class="link-arrow">[Business ID](/components/concepts/process-instance-creation.md#business-id)</p>
+
 ## Helm chart deployment
 
 Important changes to Helm chart deployment in 8.10 are as follows:

--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -59,7 +59,7 @@ Business ID is now a first-class, searchable attribute across the Orchestration 
 **What's new in 8.10:**
 
 - **Search and filter** across entity types using advanced operators (`$eq`, `$neq`, `$exists`, `$like` with `*`/`?` wildcards, `$in`). Operate and Tasklist expose Equals, Contains, and Is one of in their filter UI.
-- **Message correlation** — include a Business ID in published or correlated messages as an additional filter constraint. If both a correlation key and Business ID are supplied, both must match.
+- **Message correlation** — include a Business ID in published or correlated messages as an additional filter constraint. If both a correlation key and Business ID are supplied, both fields must match the corresponding values stored on the subscription.
 - **Call Activity propagation** — child instances inherit the parent's Business ID by default. Configure a literal value or FEEL expression on the call activity to override it. Use `camunda.processInstance.businessId` in FEEL expressions to reference the parent's ID.
 - **Start with a Business ID** from Camunda Hub or Desktop Modeler.
 - **Late assignment** — assign a Business ID to a running instance that has none, when uniqueness is disabled. Assignment is forward-only: only artifacts created after the assignment carry it.


### PR DESCRIPTION
## Description

Closes https://github.com/camunda/camunda-docs/issues/9363

Documents Business ID as a first-class, searchable attribute in Camunda 8.10.

### Changes

- **`components/concepts/process-instance-creation.md`** -- Updated Business ID section:
  - Replaced API-only note; Hub and Desktop Modeler now support setting a business ID (since alpha3)
  - Updated child propagation: default inherit; Call Activity can override (links to new section)
  - Expanded entity coverage with searchability table (process instances, decision instances, user tasks, messages, subscriptions, jobs)
  - Added advanced filter operators table ($eq/$neq/$exists/$like/$in; UI vs API-only)
  - Added Late Business ID assignment section (constraints, forward-only propagation, rejection contract)
  - Updated Limitations: removed now-false "cannot search related entities" bullet
  - Added retroactive visibility caveat
- **`components/concepts/messages.md`** -- Added "Business ID in message correlation" section: supported combinations table, asymmetric matching semantics, TTL buffering behavior for message-start uniqueness
- **`components/modeler/bpmn/call-activities/call-activities.md`** -- Added "Business ID propagation" section: default inherit, override config table (literal/FEEL/null), three-tier validation (deploy-time rejection/runtime discard/runtime incident)
- **`components/operate/userguide/filter-process-instances.md`** -- Added Business ID to Instance filters list + `## Business ID filter` section with UI operator table (Equals/Contains with wildcards/Is one of)
- **`components/tasklist/userguide/using-filters.md`** -- Added Business ID to Create new filter supported attributes
- **`reference/announcements-release-notes/8100/8100-release-notes.md`** -- Added entries across alphas:
  - **Alpha2**: Business ID visibility in Operate (process instances)
  - **Alpha3**: Start PI with business ID from Hub/Desktop Modeler; Business ID filtering in Operate; message correlation; Call Activity propagation
- **`reference/announcements-release-notes/8100/whats-new-in-810.md`** -- Added `## Business ID` section

### Inline TODOs (blocked)

- `call-activities.md` — XML attribute shape for `businessId` on `zeebe:calledElement`, blocked on ADR `camunda/camunda#56154` + Modeler UI `#51694`

### Deferred (separate PR when unblocked)

- Decision instance Business ID visibility in Operate (alpha4)
- Tasklist task list + task detail Business ID display (alpha4)
- FEEL expressions reference for `camunda.processInstance.businessId`
- Alpha4 release note entries

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
