### PR TITLE
docs(helm): [TOPOLOGY 6/6] explain topology-aware deployments

### DIFF
--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -210,7 +210,9 @@ helm install camunda camunda/camunda-platform \
 
 ## Configure the orchestration namespace
 
-Create `orchestration-values.yaml`. The Management Identity URL uses the Hub release's internal Kubernetes service. The OIDC client IDs and secrets must match the clients registered by Management Identity.
+Create `orchestration-values.yaml`. An orchestration release is self-contained and uses the existing component values for its enabled state and authentication configuration. `global.topology.mode` selects the release role but doesn't duplicate component configuration.
+
+Set `identity.enabled: false` because Management Identity runs only in the Hub release. Keep `global.identity.auth.enabled: true` to enable OIDC authentication for the orchestration workloads, and set `global.identity.service.url` to the Hub release's Identity service. The component client IDs, audiences, redirects, and secrets must match the clients declared in the Hub release's cluster inventory.
 
 ```yaml
 global:
@@ -226,34 +228,6 @@ global:
       method: oidc
   topology:
     mode: orchestration
-    hub:
-      namespace: hub
-      releaseName: camunda
-    cluster:
-      id: orchestration
-      components:
-        orchestration:
-          enabled: true
-          clientId: orchestration
-          audience: orchestration-api
-          redirectUrl: https://orchestration.example.com/orchestration
-          secret:
-            existingSecret: orchestration-oidc
-            existingSecretKey: client-secret
-        optimize:
-          enabled: true
-          clientId: optimize
-          audience: optimize-api
-          redirectUrl: https://orchestration.example.com/optimize
-          secret:
-            existingSecret: optimize-oidc
-            existingSecretKey: client-secret
-        connectors:
-          enabled: true
-          clientId: connectors
-          secret:
-            existingSecret: connectors-oidc
-            existingSecretKey: client-secret
   identity:
     service:
       url: http://camunda-identity.hub.svc.cluster.local:80/identity
@@ -265,10 +239,29 @@ global:
       authUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/auth
       tokenUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/token
       jwksUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/certs
+      optimize:
+        clientId: optimize
+        audience: optimize-api
+        redirectUrl: https://orchestration.example.com/optimize
+        secret:
+          existingSecret: optimize-oidc
+          existingSecretKey: client-secret
+
+identity:
+  enabled: false
 
 orchestration:
   enabled: true
   contextPath: /orchestration
+  security:
+    authentication:
+      oidc:
+        clientId: orchestration
+        audience: orchestration-api
+        redirectUrl: https://orchestration.example.com/orchestration
+        secret:
+          existingSecret: orchestration-oidc
+          existingSecretKey: client-secret
   data:
     secondaryStorage:
       type: elasticsearch
@@ -289,9 +282,18 @@ orchestration:
         secretName: orchestration-grpc-tls
 
 connectors:
+  enabled: true
   contextPath: /connectors
+  security:
+    authentication:
+      oidc:
+        clientId: connectors
+        secret:
+          existingSecret: connectors-oidc
+          existingSecretKey: client-secret
 
 optimize:
+  enabled: true
   contextPath: /optimize
   database:
     elasticsearch:
@@ -324,11 +326,11 @@ helm install camunda camunda/camunda-platform \
 
 ## Add another Orchestration Cluster
 
-Add another entry to `global.topology.clusters` in the management release and install another orchestration release with the matching entry under `global.topology.cluster`. Use unique client IDs, audiences, and secrets for isolation.
+Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 
-Generated internal service URLs use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set `global.topology.management.identityServiceUrl` in an orchestration release when the derived Management Identity service URL isn't reachable.
+Generated internal service URLs in the management inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
 
 ## Deploy with GitOps
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -328,7 +328,15 @@ helm install camunda camunda/camunda-platform \
 
 Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
-If orchestration releases share Elasticsearch or OpenSearch, configure a unique `orchestration.index.prefix` for every release. Configure a unique Optimize record prefix with `optimize.database.elasticsearch.prefix` or `optimize.database.opensearch.prefix`, and configure a unique Optimize application index prefix with `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX`. Reusing any of these prefixes can mix one cluster's records with another cluster's Operate, Tasklist, or Optimize data. See [configure Elasticsearch and OpenSearch index prefixes](./database/elasticsearch/configure-elasticsearch-prefix-indices.md).
+If orchestration releases share Elasticsearch or OpenSearch, configure unique prefixes for every release:
+
+- Set `orchestration.index.prefix` for Orchestration Cluster indices.
+- Set `global.elasticsearch.prefix` or `global.opensearch.prefix` for Legacy Zeebe Exporter records.
+- Set `optimize.database.elasticsearch.prefix` or `optimize.database.opensearch.prefix` to the same Legacy Zeebe Exporter prefix.
+- Set `CAMUNDA_OPTIMIZE_ZEEBE_NAME` to the same Legacy Zeebe Exporter prefix.
+- Set `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX` or `CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX` for Optimize's own indices.
+
+Reusing any of these prefixes can mix one cluster's records with another cluster's Operate, Tasklist, or Optimize data. Mismatched Legacy Zeebe Exporter and Optimize record prefixes can also start Optimize without displaying process data. See [configure Elasticsearch and OpenSearch index prefixes](./database/elasticsearch/configure-elasticsearch-prefix-indices.md).
 
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -9,11 +9,19 @@ A multi-namespace deployment runs Camunda Hub and Management Identity in a Hub n
 
 This configuration supports Camunda 8.10. Camunda Hub contains Web Modeler and Console. Console isn't a separate deployment in 8.10.
 
+The chart models this as a deployment topology instead of treating namespace placement as component configuration:
+
+- `combined` is the default and preserves the existing single-release, single-namespace behavior.
+- `hub` deploys the Hub plane and describes one or more remote Orchestration Clusters.
+- `orchestration` deploys one workload plane and consumes a Hub-plane connection.
+
+This contract separates the relationship between releases from the umbrella chart packaging. The design is intended to remain usable if Hub and orchestration are published as separate charts in the future.
+
 ## Before you begin
 
 Prepare the following resources:
 
-- An external Keycloak instance that both namespaces can reach. The example uses Management Identity to register clients in Keycloak.
+- An OpenID Connect (OIDC) provider that both namespaces can reach. The example uses an external Keycloak instance and Management Identity-managed client registration.
 - Separate public hostnames and TLS certificates for the Hub and orchestration namespaces.
 - External PostgreSQL databases for Management Identity and Camunda Hub.
 - A supported secondary storage backend for the Orchestration Cluster and Optimize.
@@ -45,7 +53,7 @@ Restrict policies to the listed workloads and namespaces instead of allowing unr
 
 ## Manage secrets across namespaces
 
-Kubernetes Secrets are namespace-scoped. Create the client secrets used by both central Management Identity and a remote workload in both namespaces with identical values.
+Kubernetes Secrets are namespace-scoped. When Management Identity administers an external Keycloak, create each workload client secret in both namespaces with identical values. With another OIDC provider, Management Identity doesn't consume the workload client secrets, so project them only into the orchestration namespace.
 
 The following example uses these Secrets:
 
@@ -67,7 +75,7 @@ Use an external secret manager to synchronize the values. Don't store production
 
 ## Configure the Hub namespace
 
-Create `hub-values.yaml`. The `alwaysRegister` values instruct central Management Identity to register clients for workloads deployed by another Helm release. The `clusters` entry connects Camunda Hub to the remote Orchestration Cluster.
+Create `hub-values.yaml`. The cluster record is the source for both Management Identity presets and Camunda Hub inventory. Hub mode suppresses the umbrella chart's default Orchestration, Optimize, and Connectors workloads, so you don't configure disabled components in this release.
 
 ```yaml
 global:
@@ -81,6 +89,39 @@ global:
   security:
     authentication:
       method: oidc
+  topology:
+    mode: hub
+    clusters:
+      - id: orchestration
+        name: Orchestration
+        namespace: orchestration
+        releaseName: camunda
+        host: orchestration.example.com
+        # Match this to the Camunda version deployed by your selected chart.
+        version: "8.10.x"
+        components:
+          orchestration:
+            enabled: true
+            clientId: orchestration
+            audience: orchestration-api
+            redirectUrl: https://orchestration.example.com/orchestration
+            secret:
+              existingSecret: orchestration-oidc
+              existingSecretKey: client-secret
+          optimize:
+            enabled: true
+            clientId: optimize
+            audience: optimize-api
+            redirectUrl: https://orchestration.example.com/optimize
+            secret:
+              existingSecret: optimize-oidc
+              existingSecretKey: client-secret
+          connectors:
+            enabled: true
+            clientId: connectors
+            secret:
+              existingSecret: connectors-oidc
+              existingSecretKey: client-secret
   identity:
     keycloak:
       url:
@@ -104,16 +145,6 @@ global:
       jwksUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/certs
       camundaHub:
         redirectUrl: https://hub.example.com/modeler
-      optimize:
-        alwaysRegister: true
-        redirectUrl: https://orchestration.example.com/optimize
-        secret:
-          existingSecret: optimize-oidc
-          existingSecretKey: client-secret
-      orchestration:
-        alwaysRegister: true
-      connectors:
-        alwaysRegister: true
 
 identity:
   enabled: true
@@ -152,79 +183,15 @@ camundaHub:
       secret:
         existingSecret: hub-pusher
         existingSecretKey: app-secret
-    clusters:
-      - id: orchestration
-        name: Orchestration
-        # Match this to the Camunda version deployed by your selected chart.
-        version: "8.10.x"
-        authentication: BEARER_TOKEN
-        url:
-          grpc: grpc://camunda-zeebe-gateway.orchestration.svc.cluster.local:26500
-          rest: http://camunda-zeebe-gateway.orchestration.svc.cluster.local:8080
-          web-app: https://orchestration.example.com/orchestration
-        components:
-          - name: Optimize
-            type: optimize
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/optimize
-              readiness: http://camunda-optimize.orchestration.svc.cluster.local:80/optimize/api/readyz
-          - name: Connectors
-            type: connectors
-            version: "8.10.x"
-            urls:
-              rest: http://camunda-connectors.orchestration.svc.cluster.local:8080/connectors
-              readiness: http://camunda-connectors.orchestration.svc.cluster.local:8080/connectors/actuator/health/readiness
-          - name: Operate
-            type: operate
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/orchestration/operate
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-          - name: Tasklist
-            type: tasklist
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/orchestration/tasklist
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-          - name: Orchestration Admin
-            type: admin
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/orchestration/admin
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-          - name: Orchestration Cluster
-            type: orchestration
-            version: "8.10.x"
-            urls:
-              grpc: grpc://camunda-zeebe-gateway.orchestration.svc.cluster.local:26500
-              rest: http://camunda-zeebe-gateway.orchestration.svc.cluster.local:8080
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-
-orchestration:
-  enabled: false
-  security:
-    authentication:
-      oidc:
-        redirectUrl: https://orchestration.example.com/orchestration
-        secret:
-          existingSecret: orchestration-oidc
-          existingSecretKey: client-secret
-
-connectors:
-  enabled: false
-  security:
-    authentication:
-      oidc:
-        secret:
-          existingSecret: connectors-oidc
-          existingSecretKey: client-secret
-
-optimize:
-  enabled: false
 ```
 
-Adapt the Keycloak endpoints and client configuration for your environment. See [external Keycloak](./authentication-and-authorization/external-keycloak.md). If you use another OIDC provider, create and manage the clients in that provider instead of using `alwaysRegister`; see [external OIDC provider](./authentication-and-authorization/external-oidc-provider.md).
+Adapt the Keycloak endpoints and client configuration for your environment. See [external Keycloak](./authentication-and-authorization/external-keycloak.md).
+
+Management Identity can administer clients only in an external Keycloak instance when you provide Keycloak administrator credentials. For Microsoft Entra ID or a generic OIDC provider, first complete the provider setup, including Management Identity's confidential client, initial administrator claims, Hub clients, mapping rules, and each workload client. Then add the matching client IDs and audiences to the topology records. Management Identity initializes only its permission and role model from those records. See [external OIDC provider](./authentication-and-authorization/external-oidc-provider.md).
+
+Identity preset initialization is additive. Removing or renaming a topology entry doesn't delete the corresponding clients, resource servers, permissions, or roles from Keycloak or Management Identity. Remove obsolete resources explicitly after the related workload is retired. Existing Keycloak users also don't automatically receive roles added by a later topology update; assign the canonical roles or configured per-cluster roles through your normal access-management process.
+
+By default, every cluster contributes permissions to the canonical `Orchestration` and `Optimize` roles. Assigning either role grants access to every declared cluster of that component type. Set `components.<component>.roleName` to a unique value in each Hub topology entry when users must be authorized per cluster.
 
 Install the Hub release:
 
@@ -252,6 +219,36 @@ global:
   security:
     authentication:
       method: oidc
+  topology:
+    mode: orchestration
+    hub:
+      namespace: hub
+      releaseName: camunda
+    cluster:
+      id: orchestration
+      components:
+        orchestration:
+          enabled: true
+          clientId: orchestration
+          audience: orchestration-api
+          redirectUrl: https://orchestration.example.com/orchestration
+          secret:
+            existingSecret: orchestration-oidc
+            existingSecretKey: client-secret
+        optimize:
+          enabled: true
+          clientId: optimize
+          audience: optimize-api
+          redirectUrl: https://orchestration.example.com/optimize
+          secret:
+            existingSecret: optimize-oidc
+            existingSecretKey: client-secret
+        connectors:
+          enabled: true
+          clientId: connectors
+          secret:
+            existingSecret: connectors-oidc
+            existingSecretKey: client-secret
   identity:
     service:
       url: http://camunda-identity.hub.svc.cluster.local:80/identity
@@ -263,17 +260,6 @@ global:
       authUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/auth
       tokenUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/token
       jwksUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/certs
-      optimize:
-        redirectUrl: https://orchestration.example.com/optimize
-        secret:
-          existingSecret: optimize-oidc
-          existingSecretKey: client-secret
-
-identity:
-  enabled: false
-
-camundaHub:
-  enabled: false
 
 orchestration:
   enabled: true
@@ -286,25 +272,11 @@ orchestration:
       tls:
         enabled: true
         secretName: orchestration-grpc-tls
-  security:
-    authentication:
-      oidc:
-        redirectUrl: https://orchestration.example.com/orchestration
-        secret:
-          existingSecret: orchestration-oidc
-          existingSecretKey: client-secret
 
 connectors:
-  enabled: true
-  security:
-    authentication:
-      oidc:
-        secret:
-          existingSecret: connectors-oidc
-          existingSecretKey: client-secret
+  contextPath: /connectors
 
 optimize:
-  enabled: true
   contextPath: /optimize
 ```
 
@@ -322,6 +294,42 @@ helm install camunda camunda/camunda-platform \
 
 ## Add another Orchestration Cluster
 
-The `alwaysRegister` values register one set of Orchestration Cluster, Connectors, and Optimize clients. They don't create a separate client set for every orchestration namespace.
+Add another entry to `global.topology.clusters` in the management release and install another orchestration release with the matching entry under `global.topology.cluster`. Use unique client IDs, audiences, and secrets for isolation.
 
-To add another Orchestration Cluster, provision its clients and redirect URLs directly in your OIDC provider. Configure the additional Helm release with those client IDs and secrets, then add its endpoint to `camundaHub.restapi.clusters`. Use unique credentials when you need security isolation between clusters.
+For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
+
+Generated internal service URLs use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set `global.topology.management.identityServiceUrl` in an orchestration release when the derived Management Identity service URL isn't reachable.
+
+## Deploy with GitOps
+
+The topology values are deterministic and don't require cluster discovery or imperative deployment tooling. Store the management and orchestration values with their respective Helm release definitions.
+
+Apply resources in this order:
+
+1. Namespace-local Secret projections and TLS certificates.
+2. The management release.
+3. One or more orchestration releases.
+
+For Flux, make each orchestration `HelmRelease` depend on the management release:
+
+```yaml
+spec:
+  dependsOn:
+    # This is the Flux HelmRelease metadata.name, not Helm's releaseName.
+    - name: <management-helmrelease-name>
+      namespace: management-and-modeling
+```
+
+For Argo CD, use sync waves or separate Applications so the management release becomes healthy before orchestration releases are synchronized.
+
+For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
+
+## Existing configurations
+
+The default `global.topology.mode: combined` preserves the existing single-release and single-namespace behavior.
+
+Existing multi-namespace configurations that use `global.identity.auth.*.alwaysRegister`, component authentication values under disabled components, or manual `camundaHub.restapi.clusters` remain supported. This release doesn't deprecate or remove those values.
+
+In management mode, topology values replace the legacy Identity registration presets. An explicitly configured `camundaHub.restapi.clusters` or legacy `webModeler.restapi.clusters` list still takes precedence over generated Hub inventory.
+
+Any future removal must retain compatibility for at least one minor release, emit GitOps-visible deprecation warnings with migration guidance, and occur only in the next major chart release according to the Helm chart deprecation policy.

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -328,6 +328,8 @@ helm install camunda camunda/camunda-platform \
 
 Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
+If orchestration releases share Elasticsearch or OpenSearch, configure a unique `orchestration.index.prefix` for every release. Configure a unique Optimize record prefix with `optimize.database.elasticsearch.prefix` or `optimize.database.opensearch.prefix`, and configure a unique Optimize application index prefix with `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX`. Reusing any of these prefixes can mix one cluster's records with another cluster's Operate, Tasklist, or Optimize data. See [configure Elasticsearch and OpenSearch index prefixes](./database/elasticsearch/configure-elasticsearch-prefix-indices.md).
+
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 
 Generated internal service URLs in the management inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
@@ -356,7 +358,9 @@ For Argo CD, use sync waves or separate Applications so the management release b
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
-Chart-managed persistent volume claims (PVCs) render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim.
+The standalone chart-managed PVCs for Management Identity, Optimize, and Connectors render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim and have verified your GitOps pruning and storage reclaim policies.
+
+Orchestration Cluster broker PVCs are StatefulSet volume claim templates and don't follow this standalone PVC behavior. Changing a release to management mode suppresses the Orchestration Cluster StatefulSet. Preserve and migrate broker storage separately when you move an existing cluster between releases or namespaces.
 
 ## Upgrade and topology migration scope
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -302,6 +302,8 @@ helm install camunda camunda/camunda-platform \
 
 Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
+If orchestration releases share Elasticsearch or OpenSearch, configure a unique `orchestration.index.prefix` for every release. Configure a unique Optimize record prefix with `optimize.database.elasticsearch.prefix` or `optimize.database.opensearch.prefix`, and configure a unique Optimize application index prefix with `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX`. Reusing any of these prefixes can mix one cluster's records with another cluster's Operate, Tasklist, or Optimize data. See [configure Elasticsearch and OpenSearch index prefixes](./database/elasticsearch/configure-elasticsearch-prefix-indices.md).
+
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 
 Generated internal service URLs in the management inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
@@ -330,7 +332,9 @@ For Argo CD, use sync waves or separate Applications so the management release b
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
-Chart-managed persistent volume claims (PVCs) render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim.
+The standalone chart-managed PVCs for Management Identity, Optimize, and Connectors render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim and have verified your GitOps pruning and storage reclaim policies.
+
+Orchestration Cluster broker PVCs are StatefulSet volume claim templates and don't follow this standalone PVC behavior. Changing a release to management mode suppresses the Orchestration Cluster StatefulSet. Preserve and migrate broker storage separately when you move an existing cluster between releases or namespaces.
 
 ## Upgrade and topology migration scope
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -15,8 +15,6 @@ The chart models this as a deployment topology instead of treating namespace pla
 - `hub` deploys the Hub plane and describes one or more remote Orchestration Clusters.
 - `orchestration` deploys one workload plane and consumes a Hub-plane connection.
 
-This contract separates the relationship between releases from the umbrella chart packaging. The design is intended to remain usable if Hub and orchestration are published as separate charts in the future.
-
 ## Before you begin
 
 Prepare the following resources:

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -209,7 +209,9 @@ helm install camunda camunda/camunda-platform \
 
 ## Configure the orchestration namespace
 
-Create `orchestration-values.yaml`. The Management Identity URL uses the Hub release's internal Kubernetes service. The OIDC client IDs and secrets must match the clients registered by Management Identity.
+Create `orchestration-values.yaml`. An orchestration release is self-contained and uses the existing component values for its enabled state and authentication configuration. `global.topology.mode` selects the release role but doesn't duplicate component configuration.
+
+Set `identity.enabled: false` because Management Identity runs only in the Hub release. Keep `global.identity.auth.enabled: true` to enable OIDC authentication for the orchestration workloads, and set `global.identity.service.url` to the Hub release's Identity service. The component client IDs, audiences, redirects, and secrets must match the clients declared in the Hub release's cluster inventory.
 
 ```yaml
 global:
@@ -225,34 +227,6 @@ global:
       method: oidc
   topology:
     mode: orchestration
-    hub:
-      namespace: hub
-      releaseName: camunda
-    cluster:
-      id: orchestration
-      components:
-        orchestration:
-          enabled: true
-          clientId: orchestration
-          audience: orchestration-api
-          redirectUrl: https://orchestration.example.com/orchestration
-          secret:
-            existingSecret: orchestration-oidc
-            existingSecretKey: client-secret
-        optimize:
-          enabled: true
-          clientId: optimize
-          audience: optimize-api
-          redirectUrl: https://orchestration.example.com/optimize
-          secret:
-            existingSecret: optimize-oidc
-            existingSecretKey: client-secret
-        connectors:
-          enabled: true
-          clientId: connectors
-          secret:
-            existingSecret: connectors-oidc
-            existingSecretKey: client-secret
   identity:
     service:
       url: http://camunda-identity.hub.svc.cluster.local:80/identity
@@ -264,10 +238,29 @@ global:
       authUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/auth
       tokenUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/token
       jwksUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/certs
+      optimize:
+        clientId: optimize
+        audience: optimize-api
+        redirectUrl: https://orchestration.example.com/optimize
+        secret:
+          existingSecret: optimize-oidc
+          existingSecretKey: client-secret
+
+identity:
+  enabled: false
 
 orchestration:
   enabled: true
   contextPath: /orchestration
+  security:
+    authentication:
+      oidc:
+        clientId: orchestration
+        audience: orchestration-api
+        redirectUrl: https://orchestration.example.com/orchestration
+        secret:
+          existingSecret: orchestration-oidc
+          existingSecretKey: client-secret
   ingress:
     grpc:
       enabled: true
@@ -278,9 +271,18 @@ orchestration:
         secretName: orchestration-grpc-tls
 
 connectors:
+  enabled: true
   contextPath: /connectors
+  security:
+    authentication:
+      oidc:
+        clientId: connectors
+        secret:
+          existingSecret: connectors-oidc
+          existingSecretKey: client-secret
 
 optimize:
+  enabled: true
   contextPath: /optimize
 ```
 
@@ -298,11 +300,11 @@ helm install camunda camunda/camunda-platform \
 
 ## Add another Orchestration Cluster
 
-Add another entry to `global.topology.clusters` in the management release and install another orchestration release with the matching entry under `global.topology.cluster`. Use unique client IDs, audiences, and secrets for isolation.
+Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 
-Generated internal service URLs use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set `global.topology.management.identityServiceUrl` in an orchestration release when the derived Management Identity service URL isn't reachable.
+Generated internal service URLs in the management inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
 
 ## Deploy with GitOps
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -330,16 +330,15 @@ For Argo CD, use sync waves or separate Applications so the management release b
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
-## Move an existing combined release to split releases
+Chart-managed persistent volume claims (PVCs) render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim.
 
-Create the orchestration release before changing the existing combined release to management mode. Changing the mode suppresses the existing Orchestration, Optimize, and Connectors workloads, so reversing this order causes an outage.
+## Upgrade and topology migration scope
 
-1. Back up persistent data and verify your rollback procedure.
-2. Create the namespace-local Secrets required by the new orchestration release.
-3. Install and verify the orchestration release with component authentication values that match the planned management inventory.
-4. Add the orchestration cluster to `global.topology.clusters` in the existing release.
-5. Change the existing release to `global.topology.mode: management` only after the new orchestration workloads are ready.
-6. Verify authentication, Camunda Hub inventory, process deployment, and workload health before removing obsolete resources.
+This guide covers fresh management and orchestration releases. It doesn't define a data migration procedure for converting an existing combined release into split releases.
+
+Before you adopt this topology during a version upgrade, complete the supported in-place version upgrade while preserving the existing release name, namespace, Orchestration Cluster primary storage, and external data services. For Camunda 8.9 to 8.10 requirements, see [upgrade from 8.9 to 8.10](/self-managed/upgrade/helm/890-to-8100.md).
+
+Moving an existing Orchestration Cluster to another release or namespace requires a separate migration plan for its broker persistent volumes, cluster identity, and secondary-storage indices. Installing a fresh orchestration release creates a new, empty Orchestration Cluster; secondary storage doesn't replace the broker logs and snapshots that contain active process state.
 
 ## Existing configurations
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -326,7 +326,7 @@ helm install camunda camunda/camunda-platform \
 
 ## Add another Orchestration Cluster
 
-Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
+Add another entry to `global.topology.clusters` in the Hub release and install another orchestration release. Configure that release's existing component authentication values to match the new Hub inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
 If orchestration releases share Elasticsearch or OpenSearch, configure unique prefixes for every release:
 
@@ -340,39 +340,39 @@ Reusing any of these prefixes can mix one cluster's records with another cluster
 
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 
-Generated internal service URLs in the management inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
+Generated internal service URLs in the Hub inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
 
 ## Deploy with GitOps
 
-The topology values are deterministic and don't require cluster discovery or imperative deployment tooling. Store the management and orchestration values with their respective Helm release definitions.
+The topology values are deterministic and don't require cluster discovery or imperative deployment tooling. Store the Hub and orchestration values with their respective Helm release definitions.
 
 Apply resources in this order:
 
 1. Namespace-local Secret projections and TLS certificates.
-2. The management release.
+2. The Hub release.
 3. One or more orchestration releases.
 
-For Flux, make each orchestration `HelmRelease` depend on the management release:
+For Flux, make each orchestration `HelmRelease` depend on the Hub release:
 
 ```yaml
 spec:
   dependsOn:
     # This is the Flux HelmRelease metadata.name, not Helm's releaseName.
-    - name: <management-helmrelease-name>
-      namespace: management-and-modeling
+    - name: <hub-helmrelease-name>
+      namespace: hub
 ```
 
-For Argo CD, use sync waves or separate Applications so the management release becomes healthy before orchestration releases are synchronized.
+For Argo CD, use sync waves or separate Applications so the Hub release becomes healthy before orchestration releases are synchronized.
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
 The standalone chart-managed PVCs for Management Identity, Optimize, and Connectors render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim and have verified your GitOps pruning and storage reclaim policies.
 
-Orchestration Cluster broker PVCs are StatefulSet volume claim templates and don't follow this standalone PVC behavior. Changing a release to management mode suppresses the Orchestration Cluster StatefulSet. Preserve and migrate broker storage separately when you move an existing cluster between releases or namespaces.
+Orchestration Cluster broker PVCs are StatefulSet volume claim templates and don't follow this standalone PVC behavior. Changing a release to Hub mode suppresses the Orchestration Cluster StatefulSet. Preserve and migrate broker storage separately when you move an existing cluster between releases or namespaces.
 
 ## Upgrade and topology migration scope
 
-This guide covers fresh management and orchestration releases. It doesn't define a data migration procedure for converting an existing combined release into split releases.
+This guide covers fresh Hub and orchestration releases. It doesn't define a data migration procedure for converting an existing combined release into split releases.
 
 Before you adopt this topology during a version upgrade, complete the supported in-place version upgrade while preserving the existing release name, namespace, Orchestration Cluster primary storage, and external data services. For Camunda 8.9 to 8.10 requirements, see [upgrade from 8.9 to 8.10](/self-managed/upgrade/helm/890-to-8100.md).
 
@@ -384,6 +384,6 @@ The default `global.topology.mode: combined` preserves the existing single-relea
 
 Existing multi-namespace configurations that use `global.identity.auth.*.alwaysRegister`, component authentication values under disabled components, or manual `camundaHub.restapi.clusters` remain supported. This release doesn't deprecate or remove those values.
 
-In management mode, topology values replace the legacy Identity registration presets. An explicitly configured `camundaHub.restapi.clusters` or legacy `webModeler.restapi.clusters` list still takes precedence over generated Hub inventory.
+In Hub mode, topology values replace the legacy Identity registration presets. An explicitly configured `camundaHub.restapi.clusters` or legacy `webModeler.restapi.clusters` list still takes precedence over generated Hub inventory.
 
 Any future removal must retain compatibility for at least one minor release, emit GitOps-visible deprecation warnings with migration guidance, and occur only in the next major chart release according to the Helm chart deprecation policy.

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -9,11 +9,19 @@ A multi-namespace deployment runs Camunda Hub and Management Identity in a Hub n
 
 This configuration supports Camunda 8.10. Camunda Hub contains Web Modeler and Console. Console isn't a separate deployment in 8.10.
 
+The chart models this as a deployment topology instead of treating namespace placement as component configuration:
+
+- `combined` is the default and preserves the existing single-release, single-namespace behavior.
+- `hub` deploys the Hub plane and describes one or more remote Orchestration Clusters.
+- `orchestration` deploys one workload plane and consumes a Hub-plane connection.
+
+This contract separates the relationship between releases from the umbrella chart packaging. The design is intended to remain usable if Hub and orchestration are published as separate charts in the future.
+
 ## Before you begin
 
 Prepare the following resources:
 
-- An external Keycloak instance that both namespaces can reach. The example uses Management Identity to register clients in Keycloak.
+- An OpenID Connect (OIDC) provider that both namespaces can reach. The example uses an external Keycloak instance and Management Identity-managed client registration.
 - Separate public hostnames and TLS certificates for the Hub and orchestration namespaces.
 - External PostgreSQL databases for Management Identity and Camunda Hub.
 - A supported secondary storage backend for the Orchestration Cluster and Optimize.
@@ -45,7 +53,7 @@ Restrict policies to the listed workloads and namespaces instead of allowing unr
 
 ## Manage secrets across namespaces
 
-Kubernetes Secrets are namespace-scoped. Create the client secrets used by both central Management Identity and a remote workload in both namespaces with identical values.
+Kubernetes Secrets are namespace-scoped. When Management Identity administers an external Keycloak, create each workload client secret in both namespaces with identical values. With another OIDC provider, Management Identity doesn't consume the workload client secrets, so project them only into the orchestration namespace.
 
 The following example uses these Secrets:
 
@@ -68,7 +76,7 @@ Use an external secret manager to synchronize the values. Don't store production
 
 ## Configure the Hub namespace
 
-Create `hub-values.yaml`. The `alwaysRegister` values instruct central Management Identity to register clients for workloads deployed by another Helm release. The `clusters` entry connects Camunda Hub to the remote Orchestration Cluster.
+Create `hub-values.yaml`. The cluster record is the source for both Management Identity presets and Camunda Hub inventory. Hub mode suppresses the umbrella chart's default Orchestration, Optimize, and Connectors workloads, so you don't configure disabled components in this release.
 
 ```yaml
 global:
@@ -82,6 +90,39 @@ global:
   security:
     authentication:
       method: oidc
+  topology:
+    mode: hub
+    clusters:
+      - id: orchestration
+        name: Orchestration
+        namespace: orchestration
+        releaseName: camunda
+        host: orchestration.example.com
+        # Match this to the Camunda version deployed by your selected chart.
+        version: "8.10.x"
+        components:
+          orchestration:
+            enabled: true
+            clientId: orchestration
+            audience: orchestration-api
+            redirectUrl: https://orchestration.example.com/orchestration
+            secret:
+              existingSecret: orchestration-oidc
+              existingSecretKey: client-secret
+          optimize:
+            enabled: true
+            clientId: optimize
+            audience: optimize-api
+            redirectUrl: https://orchestration.example.com/optimize
+            secret:
+              existingSecret: optimize-oidc
+              existingSecretKey: client-secret
+          connectors:
+            enabled: true
+            clientId: connectors
+            secret:
+              existingSecret: connectors-oidc
+              existingSecretKey: client-secret
   identity:
     keycloak:
       url:
@@ -105,16 +146,6 @@ global:
       jwksUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/certs
       camundaHub:
         redirectUrl: https://hub.example.com/modeler
-      optimize:
-        alwaysRegister: true
-        redirectUrl: https://orchestration.example.com/optimize
-        secret:
-          existingSecret: optimize-oidc
-          existingSecretKey: client-secret
-      orchestration:
-        alwaysRegister: true
-      connectors:
-        alwaysRegister: true
 
 identity:
   enabled: true
@@ -153,79 +184,15 @@ camundaHub:
       secret:
         existingSecret: hub-pusher
         existingSecretKey: app-secret
-    clusters:
-      - id: orchestration
-        name: Orchestration
-        # Match this to the Camunda version deployed by your selected chart.
-        version: "8.10.x"
-        authentication: BEARER_TOKEN
-        url:
-          grpc: grpc://camunda-zeebe-gateway.orchestration.svc.cluster.local:26500
-          rest: http://camunda-zeebe-gateway.orchestration.svc.cluster.local:8080
-          web-app: https://orchestration.example.com/orchestration
-        components:
-          - name: Optimize
-            type: optimize
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/optimize
-              readiness: http://camunda-optimize.orchestration.svc.cluster.local:80/optimize/api/readyz
-          - name: Connectors
-            type: connectors
-            version: "8.10.x"
-            urls:
-              rest: http://camunda-connectors.orchestration.svc.cluster.local:8080/connectors
-              readiness: http://camunda-connectors.orchestration.svc.cluster.local:8080/connectors/actuator/health/readiness
-          - name: Operate
-            type: operate
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/orchestration/operate
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-          - name: Tasklist
-            type: tasklist
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/orchestration/tasklist
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-          - name: Orchestration Admin
-            type: admin
-            version: "8.10.x"
-            urls:
-              webapp: https://orchestration.example.com/orchestration/admin
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-          - name: Orchestration Cluster
-            type: orchestration
-            version: "8.10.x"
-            urls:
-              grpc: grpc://camunda-zeebe-gateway.orchestration.svc.cluster.local:26500
-              rest: http://camunda-zeebe-gateway.orchestration.svc.cluster.local:8080
-              readiness: http://camunda-zeebe.orchestration.svc.cluster.local:9600/orchestration/actuator/health/readiness
-
-orchestration:
-  enabled: false
-  security:
-    authentication:
-      oidc:
-        redirectUrl: https://orchestration.example.com/orchestration
-        secret:
-          existingSecret: orchestration-oidc
-          existingSecretKey: client-secret
-
-connectors:
-  enabled: false
-  security:
-    authentication:
-      oidc:
-        secret:
-          existingSecret: connectors-oidc
-          existingSecretKey: client-secret
-
-optimize:
-  enabled: false
 ```
 
-Adapt the Keycloak endpoints and client configuration for your environment. See [external Keycloak](./authentication-and-authorization/external-keycloak.md). If you use another OIDC provider, create and manage the clients in that provider instead of using `alwaysRegister`; see [external OIDC provider](./authentication-and-authorization/external-oidc-provider.md).
+Adapt the Keycloak endpoints and client configuration for your environment. See [external Keycloak](./authentication-and-authorization/external-keycloak.md).
+
+Management Identity can administer clients only in an external Keycloak instance when you provide Keycloak administrator credentials. For Microsoft Entra ID or a generic OIDC provider, first complete the provider setup, including Management Identity's confidential client, initial administrator claims, Hub clients, mapping rules, and each workload client. Then add the matching client IDs and audiences to the topology records. Management Identity initializes only its permission and role model from those records. See [external OIDC provider](./authentication-and-authorization/external-oidc-provider.md).
+
+Identity preset initialization is additive. Removing or renaming a topology entry doesn't delete the corresponding clients, resource servers, permissions, or roles from Keycloak or Management Identity. Remove obsolete resources explicitly after the related workload is retired. Existing Keycloak users also don't automatically receive roles added by a later topology update; assign the canonical roles or configured per-cluster roles through your normal access-management process.
+
+By default, every cluster contributes permissions to the canonical `Orchestration` and `Optimize` roles. Assigning either role grants access to every declared cluster of that component type. Set `components.<component>.roleName` to a unique value in each Hub topology entry when users must be authorized per cluster.
 
 Install the Hub release:
 
@@ -253,6 +220,36 @@ global:
   security:
     authentication:
       method: oidc
+  topology:
+    mode: orchestration
+    hub:
+      namespace: hub
+      releaseName: camunda
+    cluster:
+      id: orchestration
+      components:
+        orchestration:
+          enabled: true
+          clientId: orchestration
+          audience: orchestration-api
+          redirectUrl: https://orchestration.example.com/orchestration
+          secret:
+            existingSecret: orchestration-oidc
+            existingSecretKey: client-secret
+        optimize:
+          enabled: true
+          clientId: optimize
+          audience: optimize-api
+          redirectUrl: https://orchestration.example.com/optimize
+          secret:
+            existingSecret: optimize-oidc
+            existingSecretKey: client-secret
+        connectors:
+          enabled: true
+          clientId: connectors
+          secret:
+            existingSecret: connectors-oidc
+            existingSecretKey: client-secret
   identity:
     service:
       url: http://camunda-identity.hub.svc.cluster.local:80/identity
@@ -264,17 +261,6 @@ global:
       authUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/auth
       tokenUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/token
       jwksUrl: https://login.example.com/realms/camunda-platform/protocol/openid-connect/certs
-      optimize:
-        redirectUrl: https://orchestration.example.com/optimize
-        secret:
-          existingSecret: optimize-oidc
-          existingSecretKey: client-secret
-
-identity:
-  enabled: false
-
-camundaHub:
-  enabled: false
 
 orchestration:
   enabled: true
@@ -297,25 +283,11 @@ orchestration:
       tls:
         enabled: true
         secretName: orchestration-grpc-tls
-  security:
-    authentication:
-      oidc:
-        redirectUrl: https://orchestration.example.com/orchestration
-        secret:
-          existingSecret: orchestration-oidc
-          existingSecretKey: client-secret
 
 connectors:
-  enabled: true
-  security:
-    authentication:
-      oidc:
-        secret:
-          existingSecret: connectors-oidc
-          existingSecretKey: client-secret
+  contextPath: /connectors
 
 optimize:
-  enabled: true
   contextPath: /optimize
   database:
     elasticsearch:
@@ -348,6 +320,42 @@ helm install camunda camunda/camunda-platform \
 
 ## Add another Orchestration Cluster
 
-The `alwaysRegister` values register one set of Orchestration Cluster, Connectors, and Optimize clients. They don't create a separate client set for every orchestration namespace.
+Add another entry to `global.topology.clusters` in the management release and install another orchestration release with the matching entry under `global.topology.cluster`. Use unique client IDs, audiences, and secrets for isolation.
 
-To add another Orchestration Cluster, provision its clients and redirect URLs directly in your OIDC provider. Configure the additional Helm release with those client IDs and secrets, then add its endpoint to `camundaHub.restapi.clusters`. Use unique credentials when you need security isolation between clusters.
+For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
+
+Generated internal service URLs use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set `global.topology.management.identityServiceUrl` in an orchestration release when the derived Management Identity service URL isn't reachable.
+
+## Deploy with GitOps
+
+The topology values are deterministic and don't require cluster discovery or imperative deployment tooling. Store the management and orchestration values with their respective Helm release definitions.
+
+Apply resources in this order:
+
+1. Namespace-local Secret projections and TLS certificates.
+2. The management release.
+3. One or more orchestration releases.
+
+For Flux, make each orchestration `HelmRelease` depend on the management release:
+
+```yaml
+spec:
+  dependsOn:
+    # This is the Flux HelmRelease metadata.name, not Helm's releaseName.
+    - name: <management-helmrelease-name>
+      namespace: management-and-modeling
+```
+
+For Argo CD, use sync waves or separate Applications so the management release becomes healthy before orchestration releases are synchronized.
+
+For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
+
+## Existing configurations
+
+The default `global.topology.mode: combined` preserves the existing single-release and single-namespace behavior.
+
+Existing multi-namespace configurations that use `global.identity.auth.*.alwaysRegister`, component authentication values under disabled components, or manual `camundaHub.restapi.clusters` remain supported. This release doesn't deprecate or remove those values.
+
+In management mode, topology values replace the legacy Identity registration presets. An explicitly configured `camundaHub.restapi.clusters` or legacy `webModeler.restapi.clusters` list still takes precedence over generated Hub inventory.
+
+Any future removal must retain compatibility for at least one minor release, emit GitOps-visible deprecation warnings with migration guidance, and occur only in the next major chart release according to the Helm chart deprecation policy.

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -100,6 +100,10 @@ global:
         host: orchestration.example.com
         # Match this to the Camunda version deployed by your selected chart.
         version: "8.10.x"
+        contextPaths:
+          orchestration: /orchestration
+          optimize: /optimize
+          connectors: /connectors
         components:
           orchestration:
             enabled: true

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -302,7 +302,15 @@ helm install camunda camunda/camunda-platform \
 
 Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
-If orchestration releases share Elasticsearch or OpenSearch, configure a unique `orchestration.index.prefix` for every release. Configure a unique Optimize record prefix with `optimize.database.elasticsearch.prefix` or `optimize.database.opensearch.prefix`, and configure a unique Optimize application index prefix with `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX`. Reusing any of these prefixes can mix one cluster's records with another cluster's Operate, Tasklist, or Optimize data. See [configure Elasticsearch and OpenSearch index prefixes](./database/elasticsearch/configure-elasticsearch-prefix-indices.md).
+If orchestration releases share Elasticsearch or OpenSearch, configure unique prefixes for every release:
+
+- Set `orchestration.index.prefix` for Orchestration Cluster indices.
+- Set `global.elasticsearch.prefix` or `global.opensearch.prefix` for Legacy Zeebe Exporter records.
+- Set `optimize.database.elasticsearch.prefix` or `optimize.database.opensearch.prefix` to the same Legacy Zeebe Exporter prefix.
+- Set `CAMUNDA_OPTIMIZE_ZEEBE_NAME` to the same Legacy Zeebe Exporter prefix.
+- Set `CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX` or `CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX` for Optimize's own indices.
+
+Reusing any of these prefixes can mix one cluster's records with another cluster's Operate, Tasklist, or Optimize data. Mismatched Legacy Zeebe Exporter and Optimize record prefixes can also start Optimize without displaying process data. See [configure Elasticsearch and OpenSearch index prefixes](./database/elasticsearch/configure-elasticsearch-prefix-indices.md).
 
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -99,6 +99,10 @@ global:
         host: orchestration.example.com
         # Match this to the Camunda version deployed by your selected chart.
         version: "8.10.x"
+        contextPaths:
+          orchestration: /orchestration
+          optimize: /optimize
+          connectors: /connectors
         components:
           orchestration:
             enabled: true

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -330,6 +330,17 @@ For Argo CD, use sync waves or separate Applications so the management release b
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
+## Move an existing combined release to split releases
+
+Create the orchestration release before changing the existing combined release to management mode. Changing the mode suppresses the existing Orchestration, Optimize, and Connectors workloads, so reversing this order causes an outage.
+
+1. Back up persistent data and verify your rollback procedure.
+2. Create the namespace-local Secrets required by the new orchestration release.
+3. Install and verify the orchestration release with component authentication values that match the planned management inventory.
+4. Add the orchestration cluster to `global.topology.clusters` in the existing release.
+5. Change the existing release to `global.topology.mode: management` only after the new orchestration workloads are ready.
+6. Verify authentication, Camunda Hub inventory, process deployment, and workload health before removing obsolete resources.
+
 ## Existing configurations
 
 The default `global.topology.mode: combined` preserves the existing single-release and single-namespace behavior.

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -300,7 +300,7 @@ helm install camunda camunda/camunda-platform \
 
 ## Add another Orchestration Cluster
 
-Add another entry to `global.topology.clusters` in the management release and install another orchestration release. Configure that release's existing component authentication values to match the new management inventory entry. Use unique client IDs, audiences, and secrets for isolation.
+Add another entry to `global.topology.clusters` in the Hub release and install another orchestration release. Configure that release's existing component authentication values to match the new Hub inventory entry. Use unique client IDs, audiences, and secrets for isolation.
 
 If orchestration releases share Elasticsearch or OpenSearch, configure unique prefixes for every release:
 
@@ -314,39 +314,39 @@ Reusing any of these prefixes can mix one cluster's records with another cluster
 
 For Keycloak, Management Identity creates every declared client. For another OIDC provider, provision the clients before applying the Helm releases.
 
-Generated internal service URLs in the management inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
+Generated internal service URLs in the Hub inventory use Kubernetes service DNS, so this pattern supports multiple namespaces in the same Kubernetes cluster. For workloads in another Kubernetes cluster, provide equivalent cross-cluster DNS and routing or configure explicit `grpcUrl`, `restUrl`, `readinessUrl`, `operateUrl`, `tasklistUrl`, `adminUrl`, and component web application URL overrides. Set each orchestration release's `global.identity.service.url` to an address from which it can reach Management Identity.
 
 ## Deploy with GitOps
 
-The topology values are deterministic and don't require cluster discovery or imperative deployment tooling. Store the management and orchestration values with their respective Helm release definitions.
+The topology values are deterministic and don't require cluster discovery or imperative deployment tooling. Store the Hub and orchestration values with their respective Helm release definitions.
 
 Apply resources in this order:
 
 1. Namespace-local Secret projections and TLS certificates.
-2. The management release.
+2. The Hub release.
 3. One or more orchestration releases.
 
-For Flux, make each orchestration `HelmRelease` depend on the management release:
+For Flux, make each orchestration `HelmRelease` depend on the Hub release:
 
 ```yaml
 spec:
   dependsOn:
     # This is the Flux HelmRelease metadata.name, not Helm's releaseName.
-    - name: <management-helmrelease-name>
-      namespace: management-and-modeling
+    - name: <hub-helmrelease-name>
+      namespace: hub
 ```
 
-For Argo CD, use sync waves or separate Applications so the management release becomes healthy before orchestration releases are synchronized.
+For Argo CD, use sync waves or separate Applications so the Hub release becomes healthy before orchestration releases are synchronized.
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
 The standalone chart-managed PVCs for Management Identity, Optimize, and Connectors render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim and have verified your GitOps pruning and storage reclaim policies.
 
-Orchestration Cluster broker PVCs are StatefulSet volume claim templates and don't follow this standalone PVC behavior. Changing a release to management mode suppresses the Orchestration Cluster StatefulSet. Preserve and migrate broker storage separately when you move an existing cluster between releases or namespaces.
+Orchestration Cluster broker PVCs are StatefulSet volume claim templates and don't follow this standalone PVC behavior. Changing a release to Hub mode suppresses the Orchestration Cluster StatefulSet. Preserve and migrate broker storage separately when you move an existing cluster between releases or namespaces.
 
 ## Upgrade and topology migration scope
 
-This guide covers fresh management and orchestration releases. It doesn't define a data migration procedure for converting an existing combined release into split releases.
+This guide covers fresh Hub and orchestration releases. It doesn't define a data migration procedure for converting an existing combined release into split releases.
 
 Before you adopt this topology during a version upgrade, complete the supported in-place version upgrade while preserving the existing release name, namespace, Orchestration Cluster primary storage, and external data services. For Camunda 8.9 to 8.10 requirements, see [upgrade from 8.9 to 8.10](/self-managed/upgrade/helm/890-to-8100.md).
 
@@ -358,6 +358,6 @@ The default `global.topology.mode: combined` preserves the existing single-relea
 
 Existing multi-namespace configurations that use `global.identity.auth.*.alwaysRegister`, component authentication values under disabled components, or manual `camundaHub.restapi.clusters` remain supported. This release doesn't deprecate or remove those values.
 
-In management mode, topology values replace the legacy Identity registration presets. An explicitly configured `camundaHub.restapi.clusters` or legacy `webModeler.restapi.clusters` list still takes precedence over generated Hub inventory.
+In Hub mode, topology values replace the legacy Identity registration presets. An explicitly configured `camundaHub.restapi.clusters` or legacy `webModeler.restapi.clusters` list still takes precedence over generated Hub inventory.
 
 Any future removal must retain compatibility for at least one minor release, emit GitOps-visible deprecation warnings with migration guidance, and occur only in the next major chart release according to the Helm chart deprecation policy.

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -356,6 +356,17 @@ For Argo CD, use sync waves or separate Applications so the management release b
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
+## Move an existing combined release to split releases
+
+Create the orchestration release before changing the existing combined release to management mode. Changing the mode suppresses the existing Orchestration, Optimize, and Connectors workloads, so reversing this order causes an outage.
+
+1. Back up persistent data and verify your rollback procedure.
+2. Create the namespace-local Secrets required by the new orchestration release.
+3. Install and verify the orchestration release with component authentication values that match the planned management inventory.
+4. Add the orchestration cluster to `global.topology.clusters` in the existing release.
+5. Change the existing release to `global.topology.mode: management` only after the new orchestration workloads are ready.
+6. Verify authentication, Camunda Hub inventory, process deployment, and workload health before removing obsolete resources.
+
 ## Existing configurations
 
 The default `global.topology.mode: combined` preserves the existing single-release and single-namespace behavior.

--- a/docs/self-managed/deployment/helm/configure/multi-namespace.md
+++ b/docs/self-managed/deployment/helm/configure/multi-namespace.md
@@ -356,16 +356,15 @@ For Argo CD, use sync waves or separate Applications so the management release b
 
 For Keycloak-managed registration, client Secret names can be identical across namespaces, but Kubernetes Secrets remain namespace-scoped. Project both copies from the same external secret source to prevent drift.
 
-## Move an existing combined release to split releases
+Chart-managed persistent volume claims (PVCs) render when the corresponding component's `persistence.enabled` value is `true`, even when the release topology suppresses that component's workload. This behavior keeps PVC ownership declarative and produces the same desired resources with Helm, Argo CD, and Flux. Set `persistence.enabled` to `false` only after you no longer need the chart to manage that claim.
 
-Create the orchestration release before changing the existing combined release to management mode. Changing the mode suppresses the existing Orchestration, Optimize, and Connectors workloads, so reversing this order causes an outage.
+## Upgrade and topology migration scope
 
-1. Back up persistent data and verify your rollback procedure.
-2. Create the namespace-local Secrets required by the new orchestration release.
-3. Install and verify the orchestration release with component authentication values that match the planned management inventory.
-4. Add the orchestration cluster to `global.topology.clusters` in the existing release.
-5. Change the existing release to `global.topology.mode: management` only after the new orchestration workloads are ready.
-6. Verify authentication, Camunda Hub inventory, process deployment, and workload health before removing obsolete resources.
+This guide covers fresh management and orchestration releases. It doesn't define a data migration procedure for converting an existing combined release into split releases.
+
+Before you adopt this topology during a version upgrade, complete the supported in-place version upgrade while preserving the existing release name, namespace, Orchestration Cluster primary storage, and external data services. For Camunda 8.9 to 8.10 requirements, see [upgrade from 8.9 to 8.10](/self-managed/upgrade/helm/890-to-8100.md).
+
+Moving an existing Orchestration Cluster to another release or namespace requires a separate migration plan for its broker persistent volumes, cluster identity, and secondary-storage indices. Installing a fresh orchestration release creates a new, empty Orchestration Cluster; secondary storage doesn't replace the broker logs and snapshots that contain active process state.
 
 ## Existing configurations
 


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> | --- | --- | --- | --- |
> | 1/6 | [helm#6687](https://github.com/camunda/camunda-platform-helm/pull/6687) | Test foundation | Route split-host E2E traffic and require the real SM-8.10 suite. |
> | 2/6 | [helm#6711](https://github.com/camunda/camunda-platform-helm/pull/6711) | Architecture decision | Record release roles and Hub-owned topology inventory. |
> | 3/6 | [helm#6688](https://github.com/camunda/camunda-platform-helm/pull/6688) | Topology contract | Add combined, hub, and orchestration release roles. |
> | 4/6 | [e2e#2884](https://github.com/camunda/c8-cross-component-e2e-tests/pull/2884) | Multi-cluster E2E | Select the target Modeler cluster for stateful smoke flows. |
> | 5/6 | [docs#9479](https://github.com/camunda/camunda-docs/pull/9479) | Baseline guidance | Replace stale 8.9 examples with the supported split deployment. |
> | **6/6** | **[docs#9480](https://github.com/camunda/camunda-docs/pull/9480)** | **Topology guidance** | **Explain Identity, Hub, GitOps, compatibility, and lifecycle behavior. ← you are here** |

Merge test foundation and the approved ADR before the Helm topology contract, then E2E, baseline docs, and topology docs.

## Description

Updates the multi-namespace guide to document the topology-aware deployment contract introduced by the related Helm change.

The guide explains:

- Why deployment topology is the primary abstraction rather than Kubernetes namespace placement.
- `combined`, `hub`, and `orchestration` release roles, with topology inventory owned only by Hub releases.
- Self-contained orchestration releases that keep existing component auth values and use `global.identity.service.url` for Management Identity.
- Management Identity registration for external Keycloak and externally provisioned generic OIDC clients.
- Shared versus per-cluster roles, namespace-local secret projections, and additive Identity reconciliation.
- Generated Hub inventory and endpoint overrides.
- Multi-cluster scale-out and same-Kubernetes-cluster limitations.
- Flux and Argo CD ordering for deterministic GitOps deployment.
- Fresh-deployment scope and the boundary between version upgrades and topology migration.
- Declarative PVC ownership for Helm, Argo CD, and Flux, including the separate broker PVC lifecycle.
- Required per-cluster Orchestration, Legacy Zeebe Exporter, Optimize reader, and Optimize application index isolation when sharing Elasticsearch or OpenSearch.
- Compatibility with existing singular/`alwaysRegister` values and the required deprecation lifecycle.

This PR is stacked on docs #9479 so it updates the new guide without overwriting other in-flight documentation work.

## Validation

- `npm run prettier -- --check docs/self-managed/deployment/helm/configure/multi-namespace.md`
- `npm run build`
- Values checked against the related chart implementation
- Related topology deployed and smoke-tested on GKE

## When should this change go live?

- [x] This is part of a scheduled alpha or minor release.

## PR Checklist

- [x] The commit history uses `{type}(scope): {description}`.
- [x] Changes for the upcoming minor release are in `/docs`.


Fixes https://github.com/camunda/camunda-platform-helm/issues/6651

