### PR TITLE
docs(optimize): clarify stuck agents are excluded from control plane metrics

### DIFF
--- a/docs/components/hub/organization/analyze-operations/index.md
+++ b/docs/components/hub/organization/analyze-operations/index.md
@@ -15,12 +15,12 @@ Monitor cluster health, track job and process execution, and measure business va
 link: "./job-dashboard",
 title: "Monitor the job dashboard",
 image: DocsIcon,
-description: "Use the job dashboard to see which job types are active, how many jobs are created, completed, and failed, and which job workers are involved.",
+description: "Track active job types, job outcomes, and job worker activity.",
 },
 {
 link: "../../../optimize/userguide/agentic-control-plane/",
 title: "Monitor the agentic control plane",
 image: OptimizeIcon,
-description: "Use the agentic control plane in Optimize to monitor AI agent adoption, token costs, reliability, and performance across your processes.",
+description: "Monitor AI agent adoption, token costs, reliability, and performance in Optimize.",
 },
 ]} columns={2}/>

--- a/docs/components/hub/organization/analyze-operations/index.md
+++ b/docs/components/hub/organization/analyze-operations/index.md
@@ -5,6 +5,7 @@ description: "Monitor cluster health, track job and process execution, and measu
 ---
 
 import DocsIcon from "@site/docs/components/assets/icon-docs.png";
+import OptimizeIcon from "@site/docs/components/assets/icon-optimize.png";
 import AoGrid from '../../../react-components/\_ao-card';
 
 Monitor cluster health, track job and process execution, and measure business value across your Camunda organization.
@@ -17,9 +18,9 @@ image: DocsIcon,
 description: "Use the job dashboard to see which job types are active, how many jobs are created, completed, and failed, and which job workers are involved.",
 },
 {
-link: "/components/optimize/userguide/agentic-control-plane",
+link: "../../../optimize/userguide/agentic-control-plane/",
 title: "Monitor the agentic control plane",
-image: DocsIcon,
+image: OptimizeIcon,
 description: "Use the agentic control plane in Optimize to monitor AI agent adoption, token costs, reliability, and performance across your processes.",
 },
 ]} columns={2}/>

--- a/docs/components/hub/organization/analyze-operations/index.md
+++ b/docs/components/hub/organization/analyze-operations/index.md
@@ -8,3 +8,18 @@ import DocsIcon from "@site/docs/components/assets/icon-docs.png";
 import AoGrid from '../../../react-components/\_ao-card';
 
 Monitor cluster health, track job and process execution, and measure business value across your Camunda organization.
+
+<AoGrid ao={[
+{
+link: "./job-dashboard",
+title: "Monitor the job dashboard",
+image: DocsIcon,
+description: "Use the job dashboard to see which job types are active, how many jobs are created, completed, and failed, and which job workers are involved.",
+},
+{
+link: "/components/optimize/userguide/agentic-control-plane",
+title: "Monitor the agentic control plane",
+image: DocsIcon,
+description: "Use the agentic control plane in Optimize to monitor AI agent adoption, token costs, reliability, and performance across your processes.",
+},
+]} columns={2}/>

--- a/docs/components/optimize/userguide/agentic-control-plane.md
+++ b/docs/components/optimize/userguide/agentic-control-plane.md
@@ -77,6 +77,7 @@ The available metrics are grouped into four themes: key numbers, token usage, re
 
 :::info Metric data scope
 The metrics only reflect completed process instances that used at least one [Camunda AI agent](/reference/glossary.md#camunda-ai-agent).
+This excludes both normal in-flight runs and agents stuck mid-execution, such as one hanging on a tool call, so a hung agent won't show up in **Incident rate** until its instance completes.
 If a metric looks empty, there's usually no agentic data yet for the selected process or period.
 :::
 

--- a/docs/components/optimize/userguide/agentic-control-plane.md
+++ b/docs/components/optimize/userguide/agentic-control-plane.md
@@ -77,7 +77,7 @@ The available metrics are grouped into four themes: key numbers, token usage, re
 
 :::info Metric data scope
 The metrics only reflect completed process instances that used at least one [Camunda AI agent](/reference/glossary.md#camunda-ai-agent).
-This excludes both normal in-flight runs and agents stuck mid-execution, such as one hanging on a tool call, so a hung agent won't show up in **Incident rate** until its instance completes.
+This excludes both normal in-flight runs and agents stuck mid-execution, such as an agent hanging on a tool call. As a result, a hung agent won’t appear in **Incident rate** until its instance completes.
 If a metric looks empty, there's usually no agentic data yet for the selected process or period.
 :::
 


### PR DESCRIPTION
## Description

Clarifies the "Metric data scope" caveat on the [Agentic control plane](docs/components/optimize/userguide/agentic-control-plane.md) user guide page to call out that agents stuck mid-execution (for example, hanging on a tool call) are part of the excluded set, not just normal in-flight runs.

Addresses feedback from https://github.com/camunda/camunda-docs/issues/9246#issuecomment-4896928636 on #9340: the "completed runs only" semantics mean a hung agent never lands in **Incident rate**, and that wasn't explicitly called out.

Also links the new [Agentic control plane](docs/components/optimize/userguide/agentic-control-plane.md) guide from the Hub [Analyze operations](docs/components/hub/organization/analyze-operations/index.md) landing page, alongside the existing job dashboard card, and simplifies both card descriptions.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
