### PR TITLE
docs(hub): remove feature flag

### DIFF
--- a/docs/apis-tools/hub-api-sm/overview.md
+++ b/docs/apis-tools/hub-api-sm/overview.md
@@ -11,30 +11,8 @@ import TabItem from '@theme/TabItem';
 
 <PageDescription />
 
-:::note
-The Camunda Hub API is not exposed, by default, in Camunda 8 Self-Managed.
-
-Enable it with the public API v2 feature flag, and restart the service:
-
-<Tabs groupId="configType" defaultValue="application.yaml">
-<TabItem value="application.yaml" label="Application properties">
-
-```yaml
-camunda:
-  modeler:
-    feature:
-      public-api-v2-enabled: true
-```
-
-</TabItem>
-<TabItem value="env" label="Environment variables">
-
-```bash
-CAMUNDA_MODELER_FEATURE_PUBLIC_API_V2_ENABLED=true
-```
-
-</TabItem>
-</Tabs>
+:::note WORK IN PROGRESS
+The Camunda Hub API is not yet exposed in Camunda 8 Self-Managed.
 :::
 
 ## Authentication


### PR DESCRIPTION
## Description

As discussed with the Hub team, we don't want to reference feature flags. This will help avoid confusion and users coming across unfinished features.

## When should this change go live?

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
