### PR TITLE
docs(self-managed): explain Identity as the root cause of Kind OIDC discovery failures

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/kind.md
@@ -68,7 +68,7 @@ export SECONDARY_STORAGE=postgres   # or: elasticsearch
 Before you begin, you'll need:
 
 - Terminal access with administrator/sudo privileges for modifying the hosts file (`/etc/hosts`)
-- A container runtime with at least 4 CPU cores and 8 GB RAM available:
+- A container runtime with at least 4 CPU cores and 8 GB RAM available. Allocate 12 GB or more when you set `SECONDARY_STORAGE=elasticsearch`, as the full stack then runs Elasticsearch, Keycloak, three PostgreSQL clusters, and every Camunda component:
   - [Docker Desktop](https://www.docker.com/products/docker-desktop)
   - [Docker Engine](https://docs.docker.com/engine/install/)
   - [Podman](https://podman.io/docs/installation)
@@ -582,6 +582,29 @@ kubectl describe pod <pod-name> -n camunda
 kubectl logs <pod-name> -n camunda
 ```
 
+### Components fail OIDC discovery with 404 or 503 (Domain mode)
+
+In domain mode, Identity provisions the `camunda-platform` Keycloak realm, and every other component reads its OIDC configuration from that realm at startup. When Identity never becomes ready, the realm is never created and the rest of the platform crash-loops.
+
+The other components report the missing realm instead of the missing Identity, which makes the error misleading:
+
+| Component     | Error                                                                                   |
+| ------------- | --------------------------------------------------------------------------------------- |
+| Orchestration | `503 Service Unavailable` on `https://camunda.example.com/auth/realms/camunda-platform` |
+| Connectors    | `Failed to retrieve well known configuration ... status code 404 and message Not Found` |
+
+Check whether the realm exists, then inspect Identity:
+
+```bash
+curl https://camunda.example.com/auth/realms/camunda-platform/.well-known/openid-configuration
+kubectl get pods -n camunda
+kubectl describe pod <camunda-identity-pod> -n camunda
+```
+
+If the realm returns `{"error":"Realm does not exist"}` and the Identity pod is in `CrashLoopBackOff`, Identity is the root cause. Restarting Orchestration or Connectors doesn't help, because the realm they need still doesn't exist.
+
+A `Last State: Terminated, Reason: OOMKilled` line in the `kubectl describe pod` output means Identity ran out of memory. Give the container runtime more memory, or raise `identity.resources.limits.memory` in the Helm values before you redeploy.
+
 ### Browser shows certificate errors (Domain mode)
 
 Ensure the mkcert CA is installed:
@@ -609,11 +632,13 @@ kubectl get ingress -n camunda
 
 ### Insufficient resources
 
-Ensure your container runtime has enough resources allocated (4+ CPU cores, 8GB+ RAM).
+Ensure your container runtime has enough resources allocated: 4 or more CPU cores, and 8 GB or more of RAM (12 GB or more with `SECONDARY_STORAGE=elasticsearch`).
 
 - **Docker Desktop**: Check the [Resources settings](https://docs.docker.com/desktop/settings-and-maintenance/settings/#resources)
 - **Docker Engine**: Configure the [Docker daemon](https://docs.docker.com/engine/daemon/) (configuration varies by OS)
 - **Podman**: Resources are managed by your system; ensure sufficient resources are available
+
+A pod that restarts repeatedly and shows `Last State: Terminated, Reason: OOMKilled` in `kubectl describe pod` output has hit its memory limit rather than the host limit. Raise the `resources.limits.memory` value for that component in the Helm values.
 
 ## Next steps
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
@@ -68,7 +68,7 @@ export SECONDARY_STORAGE=postgres   # or: elasticsearch
 Before you begin, you'll need:
 
 - Terminal access with administrator/sudo privileges for modifying the hosts file (`/etc/hosts`)
-- A container runtime with at least 4 CPU cores and 8 GB RAM available:
+- A container runtime with at least 4 CPU cores and 8 GB RAM available. Allocate 12 GB or more when you set `SECONDARY_STORAGE=elasticsearch`, as the full stack then runs Elasticsearch, Keycloak, three PostgreSQL clusters, and every Camunda component:
   - [Docker Desktop](https://www.docker.com/products/docker-desktop)
   - [Docker Engine](https://docs.docker.com/engine/install/)
   - [Podman](https://podman.io/docs/installation)
@@ -582,6 +582,29 @@ kubectl describe pod <pod-name> -n camunda
 kubectl logs <pod-name> -n camunda
 ```
 
+### Components fail OIDC discovery with 404 or 503 (Domain mode)
+
+In domain mode, Identity provisions the `camunda-platform` Keycloak realm, and every other component reads its OIDC configuration from that realm at startup. When Identity never becomes ready, the realm is never created and the rest of the platform crash-loops.
+
+The other components report the missing realm instead of the missing Identity, which makes the error misleading:
+
+| Component     | Error                                                                                   |
+| ------------- | --------------------------------------------------------------------------------------- |
+| Orchestration | `503 Service Unavailable` on `https://camunda.example.com/auth/realms/camunda-platform` |
+| Connectors    | `Failed to retrieve well known configuration ... status code 404 and message Not Found` |
+
+Check whether the realm exists, then inspect Identity:
+
+```bash
+curl https://camunda.example.com/auth/realms/camunda-platform/.well-known/openid-configuration
+kubectl get pods -n camunda
+kubectl describe pod <camunda-identity-pod> -n camunda
+```
+
+If the realm returns `{"error":"Realm does not exist"}` and the Identity pod is in `CrashLoopBackOff`, Identity is the root cause. Restarting Orchestration or Connectors doesn't help, because the realm they need still doesn't exist.
+
+A `Last State: Terminated, Reason: OOMKilled` line in the `kubectl describe pod` output means Identity ran out of memory. Give the container runtime more memory, or raise `identity.resources.limits.memory` in the Helm values before you redeploy.
+
 ### Browser shows certificate errors (Domain mode)
 
 Ensure the mkcert CA is installed:
@@ -609,11 +632,13 @@ kubectl get ingress -n camunda
 
 ### Insufficient resources
 
-Ensure your container runtime has enough resources allocated (4+ CPU cores, 8GB+ RAM).
+Ensure your container runtime has enough resources allocated: 4 or more CPU cores, and 8 GB or more of RAM (12 GB or more with `SECONDARY_STORAGE=elasticsearch`).
 
 - **Docker Desktop**: Check the [Resources settings](https://docs.docker.com/desktop/settings-and-maintenance/settings/#resources)
 - **Docker Engine**: Configure the [Docker daemon](https://docs.docker.com/engine/daemon/) (configuration varies by OS)
 - **Podman**: Resources are managed by your system; ensure sufficient resources are available
+
+A pod that restarts repeatedly and shows `Last State: Terminated, Reason: OOMKilled` in `kubectl describe pod` output has hit its memory limit rather than the host limit. Raise the `resources.limits.memory` value for that component in the Helm values.
 
 ## Next steps
 


### PR DESCRIPTION
## Description

Adds a troubleshooting entry for the failure reported in [camunda-deployment-references#2686](https://github.com/camunda/camunda-deployment-references/issues/2686), and corrects the memory requirement for the Kind guide.

In domain mode, Identity provisions the `camunda-platform` Keycloak realm. When Identity does not become ready, the realm is never created and every other component crash-loops while reporting the *missing realm* rather than the missing Identity:

- Orchestration: `503 Service Unavailable` on `https://camunda.example.com/auth/realms/camunda-platform`
- Connectors: `Failed to retrieve well known configuration ... status code 404 and message Not Found`

The reporter spent several weeks chasing Keycloak, DNS, and TLS because nothing pointed at Identity. In their logs Keycloak was healthy and the `master` realm resolved correctly, while `camunda-identity` sat in `CrashLoopBackOff` for over 100 minutes.

Changes:

- **New troubleshooting section**, `Components fail OIDC discovery with 404 or 503 (Domain mode)`: names Identity as the root cause, gives the commands to confirm the realm is missing and to inspect the Identity pod, and explains that restarting Orchestration or Connectors cannot help while Identity is down.
- **Prerequisites**: the stated 8 GB is not enough for `SECONDARY_STORAGE=elasticsearch`, which additionally runs Elasticsearch, Keycloak, and three PostgreSQL clusters. The guide now asks for 12 GB or more in that mode.
- **Insufficient resources**: aligned with the new figure, and now explains how to tell a container memory limit (`Reason: OOMKilled`) from a host resource shortage.

Both `/docs` (Next) and `/versioned_docs/version-8.9` received an identical patch, as 8.9 is the current version and the page the reporter followed.

Sister PR in the reference architectures repository, which raises the Kind Identity resource limits and makes the deployment scripts report the blocking component instead of looping silently: [camunda-deployment-references#2939](https://github.com/camunda/camunda-deployment-references/pull/2939)

This documentation change is independent of that PR and describes behavior that is already true today.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
