### PR TITLE
improve rdbms aesthetics

### DIFF
--- a/docs/self-managed/concepts/databases/relational-db/configuration.md
+++ b/docs/self-managed/concepts/databases/relational-db/configuration.md
@@ -49,7 +49,7 @@ Liquibase creates two internal management tables:
 
 These tables must not be modified or deleted.
 
-For Helm deployments requiring manual schema control or access to vendor-specific SQL, see [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
+For Helm deployments requiring manual schema control or access to vendor-specific SQL, see [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 
 ### Configure table prefix
 

--- a/docs/self-managed/concepts/databases/relational-db/configuration.md
+++ b/docs/self-managed/concepts/databases/relational-db/configuration.md
@@ -1,6 +1,7 @@
 ---
 id: database-configuration
 title: "RDBMS configuration overview"
+sidebar_label: "Configuration overview"
 description: Learn how to configure Camunda to use a relational database as secondary storage, including exporter setup, schema management, privileges, and connection settings.
 ---
 
@@ -11,11 +12,10 @@ This page explains how RDBMS configuration works at the application level. If yo
 - [RDBMS configuration in Helm](/self-managed/deployment/helm/configure/database/rdbms.md)
 - [Access native SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)
 
-For supported database vendors and versions, see the  
-[RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
+For supported database vendors and versions, see the [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
 
 :::tip Need end-to-end guidance?
-For a unified setup guide covering provisioning, topology decisions, driver management, and backup strategies across both Orchestration Cluster and Web Modeler, see the [end-to-end RDBMS setup guide](/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md). This guide is useful both when starting a new setup and when harmonizing existing component configurations.
+For a unified setup guide covering provisioning, topology decisions, driver management, and backup strategies across both Orchestration Cluster and Camunda Hub, see the [end-to-end RDBMS setup guide](/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md). This guide is useful both when starting a new setup and when harmonizing existing component configurations.
 :::
 
 ## Enable RDBMS as secondary storage
@@ -49,8 +49,7 @@ Liquibase creates two internal management tables:
 
 These tables must not be modified or deleted.
 
-For Helm deployments requiring manual schema control or access to vendor-specific SQL, see:  
-**[Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)**.
+For Helm deployments requiring manual schema control or access to vendor-specific SQL, see [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 
 ### Configure table prefix
 
@@ -93,20 +92,6 @@ If using the RDBMS purge feature, the following privilege is required:
 
 - TRUNCATE
 
-## History cleanup
-
-The RDBMS exporter performs automatic history cleanup using two mechanisms:
-
-1. **TTL-based marking**  
-   Finished process instances and related data are marked for deletion after their configured history TTL expires.
-
-2. **Periodic cleanup job**  
-   A scheduled cleanup process deletes marked data in batches, adjusting its interval dynamically:
-
-- If no data is deleted → interval doubles (up to `max-history-cleanup-interval`)
-- If the batch limit is reached → interval halves (down to `min-history-cleanup-interval`)
-- Otherwise → the interval remains unchanged
-
 ## Database driver
 
 Camunda images include JDBC drivers for all supported databases except Oracle and MySQL.
@@ -129,9 +114,7 @@ Place the driver JAR directly inside the mounted directory (not in subfolders).
 
 ### Helm
 
-If you are using the Helm charts, refer to the database configuration guide for the supported driver configuration options:
-
-- [Helm database configuration](../../../../self-managed/deployment/helm/configure/database/index.md)
+When deploying with Helm, see [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md).
 
 ## Database configuration
 
@@ -199,8 +182,7 @@ The RDBMS exporter provides automatic history cleanup, which works in two stages
 - If no records are deleted → interval doubles (up to `max-history-cleanup-interval`)
 - If the batch size is fully used → interval halves (down to `min-history-cleanup-interval`)
 - Otherwise → interval remains unchanged
-- additionally the cleanup is only allowed to take a maximum of `max-history-cleanup-usage` execution time. This will not
-  cut off the current execution, but it will affect the interval for the next one.
+- Additionally, cleanup execution is capped by `max-history-cleanup-usage`. The current cleanup run is not interrupted, but the next interval is adjusted.
 
 ### History cleanup configuration
 
@@ -236,16 +218,11 @@ camunda.data.secondary-storage.rdbms.history.*
 
 ## Multi-region support
 
-The RDBMS Exporter currently has no multi-region support. Only one RDBMS Exporter instance and one JDBC database connection can be configured per Orchestration Cluster.
-
-:::note
-Multi-region support for the RDBMS Exporter is not planned at this time. For multi-region setups, multi-region replication must be handled within the RDBMS itself, for example using a managed database service such as AWS Aurora.
-:::
+One RDBMS Exporter instance and one JDBC database connection can be configured per Orchestration Cluster. Multi-region support is not planned. For multi-region setups, handle replication within the RDBMS itself, for example using AWS Aurora.
 
 ## Usage with AWS Aurora PostgreSQL
 
-Camunda supports **PostgreSQL** as a secondary storage backend.  
-AWS Aurora PostgreSQL is a PostgreSQL-compatible managed service and is expected to work when configured like a standard PostgreSQL database.
+Camunda supports **PostgreSQL** as a secondary storage backend. AWS Aurora PostgreSQL is a PostgreSQL-compatible managed service and works when configured like a standard PostgreSQL database.
 
 In addition to the standard PostgreSQL JDBC driver, you can use the **AWS Advanced JDBC Wrapper** to take advantage of Aurora-specific features such as improved failover handling and IAM-based authentication.
 
@@ -276,5 +253,4 @@ camunda:
         username: camunda
 ```
 
-The AWS JDBC wrapper JAR is shipped with the Camunda distribution, alongside most of the other JDBC drivers. There is
-no need to provide it separately.
+The AWS JDBC wrapper JAR is shipped with the Camunda distribution alongside most of the other JDBC drivers. There is no need to provide it separately.

--- a/docs/self-managed/concepts/databases/relational-db/index.md
+++ b/docs/self-managed/concepts/databases/relational-db/index.md
@@ -5,6 +5,8 @@ sidebar_label: Overview
 description: Learn how relational databases work in Camunda 8 Self-Managed as a core Orchestration Cluster capability and navigate to setup, support, and configuration guides.
 ---
 
+import DocCardList from '@theme/DocCardList';
+
 Relational database (RDBMS) support is a core capability of the Orchestration Cluster in Camunda 8 Self-Managed.
 
 RDBMS is a standard secondary storage option for Orchestration Cluster installations, alongside Elasticsearch and OpenSearch.
@@ -30,16 +32,12 @@ graph LR
     style rdbms fill:#fde8da,stroke:#fc5d0d,color:#14082c
 ```
 
-## Start here
-
-- New to RDBMS in Camunda: [End-to-end RDBMS setup guide](/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md)
-- Need supported versions and compatibility details: [RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
-- Need application-level settings and behavior: [RDBMS configuration overview](/self-managed/concepts/databases/relational-db/configuration.md)
+<DocCardList />
 
 ## Deployment guides
 
-- Helm deployments: [Configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md)
-- Manual deployments: [Configure RDBMS for manual installation](/self-managed/deployment/manual/rdbms/configuration.md)
+- Helm: [Configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md)
+- Manual: [Configure RDBMS for manual installation](/self-managed/deployment/manual/rdbms/configuration.md)
 
 ## Related concepts
 

--- a/docs/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md
@@ -1,7 +1,8 @@
 ---
 id: rdbms-setup-guide
 title: End-to-end RDBMS setup guide
-description: Configure relational databases for the Orchestration Cluster and Web Modeler with unified provisioning, authentication, and driver management strategies.
+sidebar_label: "End-to-end setup guide"
+description: Configure relational databases for the Orchestration Cluster and Camunda Hub with unified provisioning, authentication, and driver management strategies.
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -1,6 +1,7 @@
 ---
 id: rdbms-support-policy
 title: RDBMS version support policy
+sidebar_label: "Version support policy"
 description: Defines Camunda’s official RDBMS support policy, including supported databases, LTS-based version rules, managed PostgreSQL guidance, JDBC driver expectations, and component compatibility.
 ---
 
@@ -79,36 +80,14 @@ Camunda may remove support for a version if it contains known issues that preven
 
 ## Database-specific support notes
 
-### PostgreSQL
-
-Camunda supports multiple active PostgreSQL major versions concurrently.
-
-### MariaDB
-
-Camunda supports **MariaDB LTS releases only**.
-
-### MySQL
-
-Camunda supports **MySQL LTS releases only**.
-
-### Microsoft SQL Server
-
-Camunda supports SQL Server versions that are in mainstream or extended vendor support.
-
-### Oracle Database
-
-Camunda supports **Oracle LTS releases**.
-
-### H2
-
-Camunda recommends H2 for development, testing, and evaluation. It is not recommended for production workloads.
-
-For Camunda Orchestration Cluster secondary storage, H2 is best suited to single-broker setups:
-
-- Multi-broker clusters with H2 are not a valid architecture.
-- H2 does not provide a shared database across brokers.
-- In-memory H2 is ephemeral and does not survive restarts.
-- File-based H2 persists on local disk and is best suited to local and developer-focused usage.
+| Database             | LTS policy                                    | Production use | Notes                                                                                     |
+| :------------------- | :-------------------------------------------- | :------------- | :---------------------------------------------------------------------------------------- |
+| PostgreSQL           | All active major LTS versions                 | ✅             | —                                                                                         |
+| MariaDB              | LTS releases only                             | ✅             | —                                                                                         |
+| MySQL                | LTS releases only                             | ✅             | —                                                                                         |
+| Microsoft SQL Server | Mainstream or extended vendor support         | ✅             | —                                                                                         |
+| Oracle Database      | LTS releases                                  | ✅             | —                                                                                         |
+| H2                   | Development, testing, and evaluation use only | ❌             | Not for multi-broker clusters. File-based H2 persists on disk; in-memory H2 is ephemeral. |
 
 ## Supported JDBC driver versions
 

--- a/docs/self-managed/concepts/secondary-storage/index.md
+++ b/docs/self-managed/concepts/secondary-storage/index.md
@@ -4,6 +4,8 @@ title: "Secondary storage"
 description: "Learn how secondary storage works in Camunda Self-Managed environments, how it interacts with the Zeebe engine, and how to configure or manage it effectively."
 ---
 
+import DocCardList from '@theme/DocCardList';
+
 Camunda uses a layered storage model that separates workflow execution data from data used by web applications and APIs.
 
 If you are designing Physical Tenant isolation, see [Physical Tenant isolation model](../physical-tenants/index.md) for the tenant-level execution and routing boundaries that sit on top of secondary storage.
@@ -23,11 +25,7 @@ Secondary storage is not a duplicate of primary data. It represents exported wor
 
 ### Supported storage options
 
-Camunda supports multiple secondary storage backends.  
-For the latest list of supported database versions, see the  
-[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
-
-Both document-store and RDBMS backends are valid secondary storage choices in Self-Managed deployments. Support maturity can vary by product area and version (for example, the Orchestration Cluster API, Operate, Tasklist, Admin, or Optimize), so confirm current compatibility details before choosing a backend.
+Camunda supports multiple secondary storage backends. Both document-store and RDBMS backends are valid choices in Self-Managed deployments. Support maturity can vary by product area and version (for example, the Orchestration Cluster API, Operate, Tasklist, Admin, or Optimize), so confirm current compatibility details before choosing a backend. For supported database versions, see the [RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
 
 | Database type          | Availability         | Use case                                                                                                                                                                                          |
 | :--------------------- | :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -79,9 +77,9 @@ Starting in 8.9, Camunda 8 Run and default lightweight installs use H2 as the de
 H2 is a convenience default for local development, testing, and evaluation. It is not a production reference architecture and is not a valid backend for multi-broker Helm clusters.
 :::
 
-1. The Zeebe Broker executes workflow instances and stores state in primary storage.
-1. Exporters, running as part of Zeebe, write orchestration data to the configured secondary storage backend and can write to multiple targets when needed.
-1. Operate, Tasklist, and Admin use the Orchestration Cluster API, which reads data from the configured secondary storage backend.
+### How secondary storage works
+
+The Zeebe Broker executes workflow instances and stores state in primary storage. Exporters running as part of Zeebe write orchestration data to the configured secondary storage backend and can write to multiple targets when needed. Operate, Tasklist, and Admin use the Orchestration Cluster API, which reads from the configured secondary storage backend.
 
 ## Choosing a secondary storage backend
 
@@ -98,24 +96,8 @@ For guidance on supported vendors, versions, and configuration, see:
 The documentation is intentionally descriptive rather than prescriptive. Use benchmarking and sizing based on your own workload to choose the secondary storage backend that best meets your requirements.
 :::
 
-Learn how to configure secondary storage in Self-Managed environments using Helm, Docker, or manual deployment.
-
-<p><a href="./configuring-secondary-storage" class="link-arrow">Configure secondary storage</a></p>
-
 :::note
 Although you should use secondary storage in nearly all production environments, you can choose to disable secondary storage in limited scenarios, such as lightweight development environments, specialized technical use cases, or resource-constrained deployments. See [run without secondary storage](no-secondary-storage.md).
 :::
 
-## Manage secondary storage
-
-Learn about best practices for data management, backups, and monitoring to ensure data integrity and performance.
-
-Effective secondary storage management ensures stability, scalability, and data integrity across your Camunda environment. By following Camunda best practices, you can avoid data corruption, maintain compliance, and ensure your orchestration environment remains performant and reliable.
-
-<p><a href="./managing-secondary-storage" class="link-arrow">Manage secondary storage</a></p>
-
-## Benchmark results
-
-Review current benchmark results and caveats for PostgreSQL-based secondary storage.
-
-<p><a href="./rdbms-benchmark-results" class="link-arrow">RDBMS benchmark results</a></p>
+<DocCardList />

--- a/docs/self-managed/concepts/secondary-storage/rdbms-benchmark-results.md
+++ b/docs/self-managed/concepts/secondary-storage/rdbms-benchmark-results.md
@@ -1,7 +1,7 @@
 ---
 id: rdbms-benchmark-results
 title: "RDBMS benchmarking results"
-sidebar_label: "RDBMS benchmark results"
+sidebar_label: "Benchmark results"
 description: "Benchmark results and methodology summary for using PostgreSQL as Orchestration Cluster secondary storage compared with Elasticsearch/OpenSearch."
 ---
 

--- a/docs/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md
+++ b/docs/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md
@@ -63,7 +63,7 @@ Drop scripts are not provided.
 ## Usage guidance
 
 - **Version matching:** Always use scripts corresponding to your Camunda 8 version.
-- **Database selection:** Use the folder for your target database flavor (PostgreSQL, Oracle, MariaDB, etc.).
+- **Database selection:** Use the folder for your target database (PostgreSQL, Oracle, MariaDB, MySQL, SQL Server, or H2).
 - **Automatic schema management:** Camunda will manage the schema by default. Manual management requires disabling auto-DDL:
 
 ```yaml
@@ -74,13 +74,16 @@ camunda:
         auto-ddl: false
 ```
 
-- **SQL vs. Liquibase**
-  - Do not mix SQL upgrade scripts with Liquibase-managed schema.
-  - Liquibase changelogs are **forward-only**. Rollbacks are not supported.
+- **SQL vs. Liquibase:** Liquibase changelogs are **forward-only**. Rollbacks are not supported.
+
+:::warning
+Do not mix SQL upgrade scripts with Liquibase-managed schema. Applying SQL scripts to a Liquibase-managed schema causes checksum mismatches and schema inconsistencies.
+:::
+
 - **Liquibase lock recovery:** If a pod is interrupted during Liquibase execution, Camunda waits for stale DDL locks using `camunda.data.secondary-storage.rdbms.ddl-lock-wait-timeout` (default: `PT15M`). Increase this timeout for long-running migrations and only release `databasechangeloglock` manually after confirming no migration is running. See [RDBMS troubleshooting](rdbms-troubleshooting.md#liquibase-lock-after-pod-crash-or-restart).
 - **Backup first:** Always [back up](/self-managed/operational-guides/backup-restore/backup-and-restore.md) your database before applying scripts manually.
 
-## Optional
+## Additional resources
 
 - **Checksums:** SHA1 or SHA256 checksums are provided in GitHub release assets.
 - **Liquibase CLI example:** See [Liquibase getting started](https://www.liquibase.org/get-started/running-your-first-update).

--- a/docs/self-managed/deployment/helm/configure/database/rdbms-schema-management.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms-schema-management.md
@@ -314,7 +314,7 @@ Then redeploy.
 
 **Symptom:** Logs show "permission denied" or "cannot create table."
 
-**Fix:** Verify database user has DDL permissions (see [Database user permissions](#database-user-permissions) above).
+**Fix:** Verify database user has DDL permissions (see [database user permissions](#database-user-permissions) above).
 
 ### Out-of-sync schema
 

--- a/docs/self-managed/deployment/helm/configure/database/rdbms-schema-management.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms-schema-management.md
@@ -5,6 +5,9 @@ title: Schema creation and management
 description: "Manage database schemas for RDBMS deployments using Liquibase or SQL scripts."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 This page covers schema creation, upgrades, and management for RDBMS deployments. For configuration reference and troubleshooting, see [configure RDBMS in Helm charts](/self-managed/deployment/helm/configure/database/rdbms.md).
 
 :::note Related pages
@@ -35,7 +38,14 @@ Additional database-specific requirements:
 
 ## Database user permissions
 
-### PostgreSQL
+<Tabs groupId="rdbms-permissions" defaultValue="postgresql" values={[
+{label: "PostgreSQL", value: "postgresql"},
+{label: "Oracle", value: "oracle"},
+{label: "MariaDB / MySQL", value: "mariadb"},
+{label: "SQL Server", value: "mssql"},
+]}>
+
+<TabItem value="postgresql">
 
 ```sql
 CREATE ROLE camunda WITH LOGIN PASSWORD 'password';
@@ -44,7 +54,8 @@ GRANT USAGE ON SCHEMA public TO camunda;
 GRANT CREATE ON SCHEMA public TO camunda;
 ```
 
-### Oracle
+</TabItem>
+<TabItem value="oracle">
 
 ```sql
 CREATE USER camunda IDENTIFIED BY password;
@@ -52,7 +63,8 @@ GRANT CREATE TABLE TO camunda;
 GRANT UNLIMITED TABLESPACE TO camunda;
 ```
 
-### MariaDB/MySQL
+</TabItem>
+<TabItem value="mariadb">
 
 ```sql
 CREATE USER camunda@'%' IDENTIFIED BY 'password';
@@ -60,7 +72,8 @@ GRANT ALL PRIVILEGES ON camunda.* TO camunda@'%';
 FLUSH PRIVILEGES;
 ```
 
-### SQL Server
+</TabItem>
+<TabItem value="mssql">
 
 ```sql
 CREATE LOGIN camunda WITH PASSWORD = 'password';
@@ -68,6 +81,9 @@ CREATE USER camunda FOR LOGIN camunda;
 GRANT CREATE TABLE TO camunda;
 GRANT ALTER ON SCHEMA::dbo TO camunda;
 ```
+
+</TabItem>
+</Tabs>
 
 ## Manual schema management
 

--- a/docs/self-managed/deployment/helm/configure/database/rdbms-troubleshooting.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms-troubleshooting.md
@@ -105,9 +105,9 @@ orchestration:
                 auto-ddl: false # Confirm this is set
 ```
 
-3. Test database user permissions (see [Schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md#database-user-permissions)).
+3. Test database user permissions (see [schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md#database-user-permissions)).
 
-**Fix:** Ensure database user has DDL permissions or disable autoDDL and apply schema manually. See [Schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md).
+**Fix:** Ensure database user has DDL permissions or disable autoDDL and apply schema manually. See [schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md).
 
 ## Liquibase lock after pod crash or restart
 

--- a/docs/self-managed/deployment/helm/configure/database/rdbms-troubleshooting.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms-troubleshooting.md
@@ -5,6 +5,9 @@ title: RDBMS troubleshooting and operations
 description: "Troubleshoot common RDBMS connectivity issues, TLS configuration, and post-deployment operations."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 This page covers troubleshooting common issues, TLS configuration, and post-deployment operations for RDBMS deployments. For configuration reference, see [configure RDBMS in Helm charts](/self-managed/deployment/helm/configure/database/rdbms.md).
 
 :::note Related pages
@@ -72,7 +75,7 @@ kubectl exec <pod-name> -- ls -la /driver-lib/
 kubectl logs <pod-name> -c fetch-jdbc-drivers
 ```
 
-3. Verify the JDBC URL matches the driver type (e.g., Oracle URL with Oracle driver).
+3. Verify the JDBC URL matches the driver type (for example, Oracle URL with Oracle driver).
 
 **Fix:** Re-apply the init container configuration or verify the custom image includes the driver. See [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md).
 
@@ -170,7 +173,14 @@ orchestration:
 
 ## TLS/SSL configuration
 
-### PostgreSQL with TLS
+<Tabs groupId="rdbms-tls" defaultValue="postgresql" values={[
+{label: "PostgreSQL", value: "postgresql"},
+{label: "Oracle", value: "oracle"},
+{label: "SQL Server", value: "mssql"},
+{label: "MariaDB / MySQL", value: "mariadb"},
+]}>
+
+<TabItem value="postgresql">
 
 Add SSL parameters to the JDBC URL:
 
@@ -182,7 +192,8 @@ orchestration:
         url: jdbc:postgresql://hostname:5432/camunda?ssl=true&sslmode=require
 ```
 
-### Oracle with TLS
+</TabItem>
+<TabItem value="oracle">
 
 Oracle uses TCPS (TLS over Oracle protocol):
 
@@ -193,6 +204,38 @@ orchestration:
       rdbms:
         url: jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=hostname)(PORT=2484))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)))
 ```
+
+</TabItem>
+<TabItem value="mssql">
+
+SQL Server enables encryption via the JDBC URL:
+
+```yaml
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:sqlserver://hostname:1433;databaseName=camunda;encrypt=true;trustServerCertificate=false
+```
+
+</TabItem>
+<TabItem value="mariadb">
+
+MariaDB and MySQL enable SSL via the JDBC URL:
+
+```yaml
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # MariaDB
+        url: jdbc:mariadb://hostname:3306/camunda?sslMode=verify-full
+        # MySQL
+        url: jdbc:mysql://hostname:3306/camunda?useSSL=true&requireSSL=true
+```
+
+</TabItem>
+</Tabs>
 
 ### Self-signed certificates
 

--- a/docs/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms.md
@@ -143,16 +143,9 @@ Camunda bundles JDBC drivers for some databases. For others, you must supply a c
 
 ## Search APIs and result limits
 
-RDBMS search APIs return a `totalResults` field capped at **10,000** to improve performance. However, actual query performance depends on filter selectivity and database optimization.
+RDBMS search APIs return a `totalResults` field capped at **10,000** by default (configurable via `maxTotalHits`). Actual query performance depends on filter selectivity and database optimization.
 
-Key concepts:
-
-- **Total count cap**: `totalResults` is capped at 10,000 by default (configurable via `maxTotalHits`).
-- **hasMoreTotalItems flag**: Indicates if results exist beyond the cap.
-- **Query optimization**: Apply selective filtering and pagination for better performance.
-- **Database tuning**: Configure PostgreSQL for write-heavy workloads.
-
-**See:** [Search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
+See [Search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
 
 ## Schema creation and management
 
@@ -188,7 +181,7 @@ SELECT table_name FROM information_schema.tables
 WHERE table_schema = 'public';
 ```
 
-2. Deploy a process and start an instance using Web Modeler.
+2. Deploy a process and start an instance using Camunda Hub or the REST API.
 
 3. Query the database to confirm the instance was recorded:
 
@@ -219,7 +212,7 @@ For details and examples, see [using AWS Aurora PostgreSQL with Camunda](../../.
 
 - **Orchestration Cluster**: ✅ Full RDBMS support for secondary storage (includes Zeebe, Operate, Tasklist, Orchestration Identity).
 - **Connectors**: ✅ Supports RDBMS for process definitions and state.
-- **Web Modeler**: ✅ RDBMS support available in 8.9.
+- **Camunda Hub**: ✅ RDBMS support available in 8.9.
 - **Optimize**: ❌ **Requires Elasticsearch or OpenSearch only.** Optimize cannot use RDBMS.
 
 If you deploy Optimize, you must still provision Elasticsearch or OpenSearch.

--- a/docs/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms.md
@@ -71,7 +71,7 @@ Most tuning options are configured as application properties via [extraConfigura
 
 | Parameter                                                      | Type    | Default | Description                                                                                                                                                                                                                                                  |
 | -------------------------------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.query.maxTotalHits` | integer | `10000` | Maximum result count cap for search APIs. Limits COUNT(\*) queries to improve performance. See [Search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for details and performance implications. |
+| `orchestration.data.secondaryStorage.rdbms.query.maxTotalHits` | integer | `10000` | Maximum result count cap for search APIs. Limits COUNT(\*) queries to improve performance. See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for details and performance implications. |
 
 ### Schema and table management
 
@@ -145,7 +145,7 @@ Camunda bundles JDBC drivers for some databases. For others, you must supply a c
 
 RDBMS search APIs return a `totalResults` field capped at **10,000** by default (configurable via `maxTotalHits`). Actual query performance depends on filter selectivity and database optimization.
 
-See [Search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
+See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
 
 ## Schema creation and management
 

--- a/docs/self-managed/deployment/manual/rdbms/index.md
+++ b/docs/self-managed/deployment/manual/rdbms/index.md
@@ -71,7 +71,7 @@ graph LR
 
 - **Supported RDBMS**: See [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
 - **JDBC drivers**: See [RDBMS configuration](/self-managed/deployment/manual/rdbms/configuration.md).
-- **Schemas and scripts**: Use the bundled SQL or Liquibase scripts for schema creation and upgrades. See [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
+- **Schemas and scripts**: Use the bundled SQL or Liquibase scripts for schema creation and upgrades. See [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 
 ## When to choose manual installation
 

--- a/docs/self-managed/deployment/manual/rdbms/index.md
+++ b/docs/self-managed/deployment/manual/rdbms/index.md
@@ -5,6 +5,8 @@ title: Manual installation with RDBMS
 description: Install Camunda 8 manually on VMs or bare metal with RDBMS as secondary storage.
 ---
 
+import DocCardList from '@theme/DocCardList';
+
 Install Camunda 8 Self-Managed manually on a VM, bare-metal server, or standalone Java runtime while using a relational database (RDBMS) as **secondary storage**.
 
 :::caution
@@ -83,9 +85,7 @@ The Orchestration Cluster is fully supported with RDBMS secondary storage for wo
 
 ## Get started
 
-1. [Configure drivers and connections](/self-managed/deployment/manual/rdbms/configuration.md).
-2. Review [operations and maintenance](/self-managed/deployment/manual/rdbms/operations.md) for backup, upgrades, troubleshooting, and tuning.
-3. Review [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs and [manual production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for manual deployment topology guidance.
+<DocCardList />
 
 ## Related documentation
 

--- a/docs/self-managed/deployment/manual/rdbms/operations.md
+++ b/docs/self-managed/deployment/manual/rdbms/operations.md
@@ -7,11 +7,9 @@ description: Backup, restore, upgrade, troubleshoot, tune, and secure RDBMS for 
 
 Operate and maintain RDBMS secondary storage for manual Camunda 8 installations (VM, bare metal, or standalone Java).
 
-## Operations
+## Backup and restore
 
-### Backup and restore
-
-**DBA owns backups** using native RDBMS tools (pg_dump, mysqldump, RMAN, etc.). Camunda handles consistency.
+**DBA owns backups** using native RDBMS tools (pg_dump, mysqldump, RMAN, and similar). Camunda handles consistency.
 
 - Use vendor-recommended backup procedures.
 - Backup frequency depends on your RPO (Recovery Point Objective).
@@ -24,14 +22,14 @@ Operate and maintain RDBMS secondary storage for manual Camunda 8 installations 
 2. Start Camunda pointing to restored database.
 3. Check logs for Liquibase completion and RdbmsExporter success.
 
-### Schema upgrades
+## Schema upgrades
 
 1. Backup your database.
 2. Download scripts for target version: [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 3. **If using autoDDL (default)**: Liquibase runs on Zeebe startup.
 4. **If using manual schema management**: Apply scripts manually, then start new Camunda version.
 
-### Disabling automatic schema updates
+## Disabling automatic schema updates
 
 For strict change control environments:
 
@@ -151,7 +149,7 @@ Create user with minimum required privileges:
 CREATE ROLE camunda LOGIN PASSWORD 'secure-password';
 GRANT CONNECT ON DATABASE camunda TO camunda;
 GRANT USAGE ON SCHEMA public TO camunda;
-GRANT CREATE ON DATABASE camunda TO camunda;
+GRANT CREATE ON SCHEMA public TO camunda;
 ```
 
 Avoid DROP, TRUNCATE, SUPERUSER, or other unnecessary privileges.

--- a/docs/self-managed/deployment/manual/rdbms/operations.md
+++ b/docs/self-managed/deployment/manual/rdbms/operations.md
@@ -25,7 +25,7 @@ Operate and maintain RDBMS secondary storage for manual Camunda 8 installations 
 ## Schema upgrades
 
 1. Backup your database.
-2. Download scripts for target version: [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
+2. Download scripts for target version: [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 3. **If using autoDDL (default)**: Liquibase runs on Zeebe startup.
 4. **If using manual schema management**: Apply scripts manually, then start new Camunda version.
 
@@ -164,4 +164,4 @@ Before deploying to production, review [secondary storage architecture](/self-ma
 - [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
-- [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)
+- [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)

--- a/docs/self-managed/operational-guides/backup-restore/rdbms/backup.md
+++ b/docs/self-managed/operational-guides/backup-restore/rdbms/backup.md
@@ -50,7 +50,7 @@ The following prerequisites are required before you can create a backup.
 When Camunda uses an RDBMS as **secondary storage**, backups involve **two independent systems**:
 
 - **Zeebe (primary storage)**: Backs up its internal state (log stream, snapshots) to an external blob store (S3, GCS, Azure, or filesystem). These are called **primary storage backups**.
-- **The external RDBMS**: Backed up using your database vendor's native tools (pg_dump, mysqldump, RMAN, etc.). This is the **secondary storage backup**.
+- **The external RDBMS**: Backed up using your database vendor's native tools (pg_dump, mysqldump, RMAN, and similar). This is the **secondary storage backup**.
 
 During restore, Zeebe uses the exporter position stored in the RDBMS to find the correct primary storage backup, or backups, that match the RDBMS state. This ensures consistency between the two systems without requiring synchronized backup timing.
 

--- a/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/configuration.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/configuration.md
@@ -1,6 +1,7 @@
 ---
 id: database-configuration
 title: "RDBMS configuration overview"
+sidebar_label: "Configuration overview"
 description: Learn how to configure Camunda to use a relational database as secondary storage, including exporter setup, schema management, privileges, and connection settings.
 ---
 
@@ -11,8 +12,7 @@ This page explains how RDBMS configuration works at the application level. If yo
 - [RDBMS configuration in Helm](/self-managed/deployment/helm/configure/database/rdbms.md)
 - [Access native SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)
 
-For supported database vendors and versions, see the  
-[RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
+For supported database vendors and versions, see the [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
 
 :::tip Need end-to-end guidance?
 For a unified setup guide covering provisioning, topology decisions, driver management, and backup strategies across both Orchestration Cluster and Web Modeler, see the [end-to-end RDBMS setup guide](/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md). This guide is useful both when starting a new setup and when harmonizing existing component configurations.
@@ -49,8 +49,7 @@ Liquibase creates two internal management tables:
 
 These tables must not be modified or deleted.
 
-For Helm deployments requiring manual schema control or access to vendor-specific SQL, see:  
-**[Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)**.
+For Helm deployments requiring manual schema control or access to vendor-specific SQL, see [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 
 ### Configure table prefix
 
@@ -93,20 +92,6 @@ If using the RDBMS purge feature, the following privilege is required:
 
 - TRUNCATE
 
-## History cleanup
-
-The RDBMS exporter performs automatic history cleanup using two mechanisms:
-
-1. **TTL-based marking**  
-   Finished process instances and related data are marked for deletion after their configured history TTL expires.
-
-2. **Periodic cleanup job**  
-   A scheduled cleanup process deletes marked data in batches, adjusting its interval dynamically:
-
-- If no data is deleted → interval doubles (up to `max-history-cleanup-interval`)
-- If the batch limit is reached → interval halves (down to `min-history-cleanup-interval`)
-- Otherwise → the interval remains unchanged
-
 ## Database driver
 
 Camunda images include JDBC drivers for all supported databases except Oracle and MySQL.
@@ -129,9 +114,7 @@ Place the driver JAR directly inside the mounted directory (not in subfolders).
 
 ### Helm
 
-If you are using the Helm charts, refer to the database configuration guide for the supported driver configuration options:
-
-- [Helm database configuration](../../../../self-managed/deployment/helm/configure/database/index.md)
+When deploying with Helm, see [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md).
 
 ## Database configuration
 
@@ -233,16 +216,11 @@ camunda.data.secondary-storage.rdbms.history.*
 
 ## Multi-region support
 
-The RDBMS Exporter currently has no multi-region support. Only one RDBMS Exporter instance and one JDBC database connection can be configured per Orchestration Cluster.
-
-:::note
-Multi-region support for the RDBMS Exporter is not planned at this time. For multi-region setups, multi-region replication must be handled within the RDBMS itself, for example using a managed database service such as AWS Aurora.
-:::
+One RDBMS Exporter instance and one JDBC database connection can be configured per Orchestration Cluster. Multi-region support is not planned. For multi-region setups, handle replication within the RDBMS itself, for example using AWS Aurora.
 
 ## Usage with AWS Aurora PostgreSQL
 
-Camunda supports **PostgreSQL** as a secondary storage backend.  
-AWS Aurora PostgreSQL is a PostgreSQL-compatible managed service and is expected to work when configured like a standard PostgreSQL database.
+Camunda supports **PostgreSQL** as a secondary storage backend. AWS Aurora PostgreSQL is a PostgreSQL-compatible managed service and works when configured like a standard PostgreSQL database.
 
 In addition to the standard PostgreSQL JDBC driver, you can use the **AWS Advanced JDBC Wrapper** to take advantage of Aurora-specific features such as improved failover handling and IAM-based authentication.
 
@@ -273,5 +251,4 @@ camunda:
         username: camunda
 ```
 
-The AWS JDBC wrapper JAR is shipped with the Camunda distribution, alongside most of the other JDBC drivers. There is
-no need to provide it separately.
+The AWS JDBC wrapper JAR is shipped with the Camunda distribution alongside most of the other JDBC drivers. There is no need to provide it separately.

--- a/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/index.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/index.md
@@ -5,6 +5,8 @@ sidebar_label: Overview
 description: Learn how relational databases work in Camunda 8 Self-Managed as a core Orchestration Cluster capability and navigate to setup, support, and configuration guides.
 ---
 
+import DocCardList from '@theme/DocCardList';
+
 Relational database (RDBMS) support is a core capability of the Orchestration Cluster in Camunda 8 Self-Managed.
 
 RDBMS is a standard secondary storage option for Orchestration Cluster installations, alongside Elasticsearch and OpenSearch.
@@ -30,16 +32,12 @@ graph LR
     style rdbms fill:#fde8da,stroke:#fc5d0d,color:#14082c
 ```
 
-## Start here
-
-- New to RDBMS in Camunda: [End-to-end RDBMS setup guide](/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md)
-- Need supported versions and compatibility details: [RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
-- Need application-level settings and behavior: [RDBMS configuration overview](/self-managed/concepts/databases/relational-db/configuration.md)
+<DocCardList />
 
 ## Deployment guides
 
-- Helm deployments: [Configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md)
-- Manual deployments: [Configure RDBMS for manual installation](/self-managed/deployment/manual/rdbms/configuration.md)
+- Helm: [Configure RDBMS in Helm](/self-managed/deployment/helm/configure/database/rdbms.md)
+- Manual: [Configure RDBMS for manual installation](/self-managed/deployment/manual/rdbms/configuration.md)
 
 ## Related concepts
 

--- a/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/rdbms-setup-guide.md
@@ -1,6 +1,7 @@
 ---
 id: rdbms-setup-guide
 title: End-to-end RDBMS setup guide
+sidebar_label: "End-to-end setup guide"
 description: Configure relational databases for the Orchestration Cluster and Web Modeler with unified provisioning, authentication, and driver management strategies.
 ---
 

--- a/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/databases/relational-db/rdbms-support-policy.md
@@ -1,6 +1,7 @@
 ---
 id: rdbms-support-policy
 title: RDBMS version support policy
+sidebar_label: "Version support policy"
 description: Defines Camunda’s official RDBMS support policy, including supported databases, LTS-based version rules, managed PostgreSQL guidance, JDBC driver expectations, and component compatibility.
 ---
 
@@ -79,36 +80,14 @@ Camunda may remove support for a version if it contains known issues that preven
 
 ## Database-specific support notes
 
-### PostgreSQL
-
-Camunda supports multiple active PostgreSQL major versions concurrently.
-
-### MariaDB
-
-Camunda supports **MariaDB LTS releases only**.
-
-### MySQL
-
-Camunda supports **MySQL LTS releases only**.
-
-### Microsoft SQL Server
-
-Camunda supports SQL Server versions that are in mainstream or extended vendor support.
-
-### Oracle Database
-
-Camunda supports **Oracle LTS releases**.
-
-### H2
-
-Camunda recommends H2 for development, testing, and evaluation. It is not recommended for production workloads.
-
-For Camunda Orchestration Cluster secondary storage, H2 is best suited to single-broker setups:
-
-- Multi-broker clusters with H2 are not a valid architecture.
-- H2 does not provide a shared database across brokers.
-- In-memory H2 is ephemeral and does not survive restarts.
-- File-based H2 persists on local disk and is best suited to local and developer-focused usage.
+| Database             | LTS policy                                    | Production use | Notes                                                                                     |
+| :------------------- | :-------------------------------------------- | :------------- | :---------------------------------------------------------------------------------------- |
+| PostgreSQL           | All active major LTS versions                 | ✅             | —                                                                                         |
+| MariaDB              | LTS releases only                             | ✅             | —                                                                                         |
+| MySQL                | LTS releases only                             | ✅             | —                                                                                         |
+| Microsoft SQL Server | Mainstream or extended vendor support         | ✅             | —                                                                                         |
+| Oracle Database      | LTS releases                                  | ✅             | —                                                                                         |
+| H2                   | Development, testing, and evaluation use only | ❌             | Not for multi-broker clusters. File-based H2 persists on disk; in-memory H2 is ephemeral. |
 
 ## Supported JDBC driver versions
 

--- a/versioned_docs/version-8.9/self-managed/concepts/secondary-storage/index.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/secondary-storage/index.md
@@ -4,6 +4,8 @@ title: "Secondary storage"
 description: "Learn how secondary storage works in Camunda Self-Managed environments, how it interacts with the Zeebe engine, and how to configure or manage it effectively."
 ---
 
+import DocCardList from '@theme/DocCardList';
+
 Camunda uses a layered storage model that separates workflow execution data from data used by web applications and APIs.
 
 ## About secondary storage
@@ -21,11 +23,7 @@ Secondary storage is not a duplicate of primary data. It represents exported wor
 
 ### Supported storage options
 
-Camunda supports multiple secondary storage backends.  
-For the latest list of supported database versions, see the  
-[RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
-
-Both document-store and RDBMS backends are valid secondary storage choices in Self-Managed deployments. Support maturity can vary by product area and version (for example, the Orchestration Cluster API, Operate, Tasklist, Admin, or Optimize), so confirm current compatibility details before choosing a backend.
+Camunda supports multiple secondary storage backends. Both document-store and RDBMS backends are valid choices in Self-Managed deployments. Support maturity can vary by product area and version (for example, the Orchestration Cluster API, Operate, Tasklist, Admin, or Optimize), so confirm current compatibility details before choosing a backend. For supported database versions, see the [RDBMS version support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
 
 | Database type          | Availability         | Use case                                                                                                                                                                                          |
 | :--------------------- | :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -77,9 +75,9 @@ Starting in 8.9, Camunda 8 Run and default lightweight installs use H2 as the de
 H2 is a convenience default for local development, testing, and evaluation. It is not a production reference architecture and is not a valid backend for multi-broker Helm clusters.
 :::
 
-1. The Zeebe Broker executes workflow instances and stores state in primary storage.
-1. Exporters, running as part of Zeebe, write orchestration data to the configured secondary storage backend and can write to multiple targets when needed.
-1. Operate, Tasklist, and Admin use the Orchestration Cluster API, which reads data from the configured secondary storage backend.
+### How secondary storage works
+
+The Zeebe Broker executes workflow instances and stores state in primary storage. Exporters running as part of Zeebe write orchestration data to the configured secondary storage backend and can write to multiple targets when needed. Operate, Tasklist, and Admin use the Orchestration Cluster API, which reads from the configured secondary storage backend.
 
 ## Choosing a secondary storage backend
 
@@ -96,24 +94,8 @@ For guidance on supported vendors, versions, and configuration, see:
 The documentation is intentionally descriptive rather than prescriptive. Use benchmarking and sizing based on your own workload to choose the secondary storage backend that best meets your requirements.
 :::
 
-Learn how to configure secondary storage in Self-Managed environments using Helm, Docker, or manual deployment.
-
-<p><a href="./configuring-secondary-storage" class="link-arrow">Configure secondary storage</a></p>
-
 :::note
 Although you should use secondary storage in nearly all production environments, you can choose to disable secondary storage in limited scenarios, such as lightweight development environments, specialized technical use cases, or resource-constrained deployments. See [run without secondary storage](no-secondary-storage.md).
 :::
 
-## Manage secondary storage
-
-Learn about best practices for data management, backups, and monitoring to ensure data integrity and performance.
-
-Effective secondary storage management ensures stability, scalability, and data integrity across your Camunda environment. By following Camunda best practices, you can avoid data corruption, maintain compliance, and ensure your orchestration environment remains performant and reliable.
-
-<p><a href="./managing-secondary-storage" class="link-arrow">Manage secondary storage</a></p>
-
-## Benchmark results
-
-Review current benchmark results and caveats for PostgreSQL-based secondary storage.
-
-<p><a href="./rdbms-benchmark-results" class="link-arrow">RDBMS benchmark results</a></p>
+<DocCardList />

--- a/versioned_docs/version-8.9/self-managed/concepts/secondary-storage/rdbms-benchmark-results.md
+++ b/versioned_docs/version-8.9/self-managed/concepts/secondary-storage/rdbms-benchmark-results.md
@@ -1,7 +1,7 @@
 ---
 id: rdbms-benchmark-results
 title: "RDBMS benchmarking results"
-sidebar_label: "RDBMS benchmark results"
+sidebar_label: "Benchmark results"
 description: "Benchmark results and methodology summary for using PostgreSQL as Orchestration Cluster secondary storage compared with Elasticsearch/OpenSearch."
 ---
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md
@@ -63,7 +63,7 @@ Drop scripts are not provided.
 ## Usage guidance
 
 - **Version matching:** Always use scripts corresponding to your Camunda 8 version.
-- **Database selection:** Use the folder for your target database flavor (PostgreSQL, Oracle, MariaDB, etc.).
+- **Database selection:** Use the folder for your target database (PostgreSQL, Oracle, MariaDB, MySQL, SQL Server, or H2).
 - **Automatic schema management:** Camunda will manage the schema by default. Manual management requires disabling auto-DDL:
 
 ```yaml
@@ -74,13 +74,16 @@ camunda:
         auto-ddl: false
 ```
 
-- **SQL vs. Liquibase**
-  - Do not mix SQL upgrade scripts with Liquibase-managed schema.
-  - Liquibase changelogs are **forward-only**. Rollbacks are not supported.
+- **SQL vs. Liquibase:** Liquibase changelogs are **forward-only**. Rollbacks are not supported.
+
+:::warning
+Do not mix SQL upgrade scripts with Liquibase-managed schema. Applying SQL scripts to a Liquibase-managed schema causes checksum mismatches and schema inconsistencies.
+:::
+
 - **Liquibase lock recovery:** If a pod is interrupted during Liquibase execution, Camunda waits for stale DDL locks using `camunda.data.secondary-storage.rdbms.ddl-lock-wait-timeout` (default: `PT15M`). Increase this timeout for long-running migrations and only release `databasechangeloglock` manually after confirming no migration is running. See [RDBMS troubleshooting](rdbms-troubleshooting.md#liquibase-lock-after-pod-crash-or-restart).
 - **Backup first:** Always [back up](/self-managed/operational-guides/backup-restore/backup-and-restore.md) your database before applying scripts manually.
 
-## Optional
+## Additional resources
 
 - **Checksums:** SHA1 or SHA256 checksums are provided in GitHub release assets.
 - **Liquibase CLI example:** See [Liquibase getting started](https://www.liquibase.org/get-started/running-your-first-update).

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms-schema-management.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms-schema-management.md
@@ -5,6 +5,9 @@ title: Schema creation and management
 description: "Manage database schemas for RDBMS deployments using Liquibase or SQL scripts."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 This page covers schema creation, upgrades, and management for RDBMS deployments. For configuration reference and troubleshooting, see [configure RDBMS in Helm charts](/self-managed/deployment/helm/configure/database/rdbms.md).
 
 :::note Related pages
@@ -35,16 +38,24 @@ Additional database-specific requirements:
 
 ## Database user permissions
 
-### PostgreSQL
+<Tabs groupId="rdbms-permissions" defaultValue="postgresql" values={[
+{label: "PostgreSQL", value: "postgresql"},
+{label: "Oracle", value: "oracle"},
+{label: "MariaDB / MySQL", value: "mariadb"},
+{label: "SQL Server", value: "mssql"},
+]}>
+
+<TabItem value="postgresql">
 
 ```sql
 CREATE ROLE camunda WITH LOGIN PASSWORD 'password';
 GRANT CONNECT ON DATABASE camunda TO camunda;
 GRANT USAGE ON SCHEMA public TO camunda;
-GRANT CREATE ON DATABASE camunda TO camunda;
+GRANT CREATE ON SCHEMA public TO camunda;
 ```
 
-### Oracle
+</TabItem>
+<TabItem value="oracle">
 
 ```sql
 CREATE USER camunda IDENTIFIED BY password;
@@ -52,7 +63,8 @@ GRANT CREATE TABLE TO camunda;
 GRANT UNLIMITED TABLESPACE TO camunda;
 ```
 
-### MariaDB/MySQL
+</TabItem>
+<TabItem value="mariadb">
 
 ```sql
 CREATE USER camunda@'%' IDENTIFIED BY 'password';
@@ -60,7 +72,8 @@ GRANT ALL PRIVILEGES ON camunda.* TO camunda@'%';
 FLUSH PRIVILEGES;
 ```
 
-### SQL Server
+</TabItem>
+<TabItem value="mssql">
 
 ```sql
 CREATE LOGIN camunda WITH PASSWORD = 'password';
@@ -68,6 +81,9 @@ CREATE USER camunda FOR LOGIN camunda;
 GRANT CREATE TABLE TO camunda;
 GRANT ALTER ON SCHEMA::dbo TO camunda;
 ```
+
+</TabItem>
+</Tabs>
 
 ## Manual schema management
 
@@ -224,7 +240,7 @@ Then redeploy.
 
 **Symptom:** Logs show "permission denied" or "cannot create table."
 
-**Fix:** Verify database user has DDL permissions (see [Database user permissions](#database-user-permissions) above).
+**Fix:** Verify database user has DDL permissions (see [database user permissions](#database-user-permissions) above).
 
 ### Out-of-sync schema
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms-troubleshooting.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms-troubleshooting.md
@@ -5,6 +5,9 @@ title: RDBMS troubleshooting and operations
 description: "Troubleshoot common RDBMS connectivity issues, TLS configuration, and post-deployment operations."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 This page covers troubleshooting common issues, TLS configuration, and post-deployment operations for RDBMS deployments. For configuration reference, see [configure RDBMS in Helm charts](/self-managed/deployment/helm/configure/database/rdbms.md).
 
 :::note Related pages
@@ -72,7 +75,7 @@ kubectl exec <pod-name> -- ls -la /driver-lib/
 kubectl logs <pod-name> -c fetch-jdbc-drivers
 ```
 
-3. Verify the JDBC URL matches the driver type (e.g., Oracle URL with Oracle driver).
+3. Verify the JDBC URL matches the driver type (for example, Oracle URL with Oracle driver).
 
 **Fix:** Re-apply the init container configuration or verify the custom image includes the driver. See [JDBC driver management](/self-managed/deployment/helm/configure/database/rdbms-jdbc-drivers.md).
 
@@ -102,9 +105,9 @@ orchestration:
                 auto-ddl: false # Confirm this is set
 ```
 
-3. Test database user permissions (see [Schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md#database-user-permissions)).
+3. Test database user permissions (see [schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md#database-user-permissions)).
 
-**Fix:** Ensure database user has DDL permissions or disable autoDDL and apply schema manually. See [Schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md).
+**Fix:** Ensure database user has DDL permissions or disable autoDDL and apply schema manually. See [schema management](/self-managed/deployment/helm/configure/database/rdbms-schema-management.md).
 
 ## Liquibase lock after pod crash or restart
 
@@ -170,7 +173,14 @@ orchestration:
 
 ## TLS/SSL configuration
 
-### PostgreSQL with TLS
+<Tabs groupId="rdbms-tls" defaultValue="postgresql" values={[
+{label: "PostgreSQL", value: "postgresql"},
+{label: "Oracle", value: "oracle"},
+{label: "SQL Server", value: "mssql"},
+{label: "MariaDB / MySQL", value: "mariadb"},
+]}>
+
+<TabItem value="postgresql">
 
 Add SSL parameters to the JDBC URL:
 
@@ -182,7 +192,8 @@ orchestration:
         url: jdbc:postgresql://hostname:5432/camunda?ssl=true&sslmode=require
 ```
 
-### Oracle with TLS
+</TabItem>
+<TabItem value="oracle">
 
 Oracle uses TCPS (TLS over Oracle protocol):
 
@@ -193,6 +204,38 @@ orchestration:
       rdbms:
         url: jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=hostname)(PORT=2484))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)))
 ```
+
+</TabItem>
+<TabItem value="mssql">
+
+SQL Server enables encryption via the JDBC URL:
+
+```yaml
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:sqlserver://hostname:1433;databaseName=camunda;encrypt=true;trustServerCertificate=false
+```
+
+</TabItem>
+<TabItem value="mariadb">
+
+MariaDB and MySQL enable SSL via the JDBC URL:
+
+```yaml
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # MariaDB
+        url: jdbc:mariadb://hostname:3306/camunda?sslMode=verify-full
+        # MySQL
+        url: jdbc:mysql://hostname:3306/camunda?useSSL=true&requireSSL=true
+```
+
+</TabItem>
+</Tabs>
 
 ### Self-signed certificates
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms.md
@@ -71,7 +71,7 @@ Most tuning options are configured as application properties via [extraConfigura
 
 | Parameter                                                      | Type    | Default | Description                                                                                                                                                                                                                                                  |
 | -------------------------------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.query.maxTotalHits` | integer | `10000` | Maximum result count cap for search APIs. Limits COUNT(\*) queries to improve performance. See [Search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for details and performance implications. |
+| `orchestration.data.secondaryStorage.rdbms.query.maxTotalHits` | integer | `10000` | Maximum result count cap for search APIs. Limits COUNT(\*) queries to improve performance. See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for details and performance implications. |
 
 ### Schema and table management
 
@@ -145,14 +145,7 @@ Camunda bundles JDBC drivers for some databases. For others, you must supply a c
 
 RDBMS search APIs return a `totalResults` field capped at **10,000** to improve performance. However, actual query performance depends on filter selectivity and database optimization.
 
-Key concepts:
-
-- **Total count cap**: `totalResults` is capped at 10,000 by default (configurable via `maxTotalHits`).
-- **hasMoreTotalItems flag**: Indicates if results exist beyond the cap.
-- **Query optimization**: Apply selective filtering and pagination for better performance.
-- **Database tuning**: Configure PostgreSQL for write-heavy workloads.
-
-**See:** [Search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
+See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
 
 ## Schema creation and management
 

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/index.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/index.md
@@ -5,6 +5,8 @@ title: Manual installation with RDBMS
 description: Install Camunda 8 manually on VMs or bare metal with RDBMS as secondary storage.
 ---
 
+import DocCardList from '@theme/DocCardList';
+
 Install Camunda 8 Self-Managed manually on a VM, bare-metal server, or standalone Java runtime while using a relational database (RDBMS) as **secondary storage**.
 
 :::caution
@@ -69,7 +71,7 @@ graph LR
 
 - **Supported RDBMS**: See [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md).
 - **JDBC drivers**: See [RDBMS configuration](/self-managed/deployment/manual/rdbms/configuration.md).
-- **Schemas and scripts**: Use the bundled SQL or Liquibase scripts for schema creation and upgrades. See [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
+- **Schemas and scripts**: Use the bundled SQL or Liquibase scripts for schema creation and upgrades. See [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 
 ## When to choose manual installation
 
@@ -83,9 +85,7 @@ The Orchestration Cluster is fully supported with RDBMS secondary storage for wo
 
 ## Get started
 
-1. [Configure drivers and connections](/self-managed/deployment/manual/rdbms/configuration.md).
-2. Review [operations and maintenance](/self-managed/deployment/manual/rdbms/operations.md) for backup, upgrades, troubleshooting, and tuning.
-3. Review [secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture) for backend trade-offs and [manual production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md) for manual deployment topology guidance.
+<DocCardList />
 
 ## Related documentation
 

--- a/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/operations.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/manual/rdbms/operations.md
@@ -7,11 +7,9 @@ description: Backup, restore, upgrade, troubleshoot, tune, and secure RDBMS for 
 
 Operate and maintain RDBMS secondary storage for manual Camunda 8 installations (VM, bare metal, or standalone Java).
 
-## Operations
+## Backup and restore
 
-### Backup and restore
-
-**DBA owns backups** using native RDBMS tools (pg_dump, mysqldump, RMAN, etc.). Camunda handles consistency.
+**DBA owns backups** using native RDBMS tools (pg_dump, mysqldump, RMAN, and similar). Camunda handles consistency.
 
 - Use vendor-recommended backup procedures.
 - Backup frequency depends on your RPO (Recovery Point Objective).
@@ -24,14 +22,14 @@ Operate and maintain RDBMS secondary storage for manual Camunda 8 installations 
 2. Start Camunda pointing to restored database.
 3. Check logs for Liquibase completion and RdbmsExporter success.
 
-### Schema upgrades
+## Schema upgrades
 
 1. Backup your database.
-2. Download scripts for target version: [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
+2. Download scripts for target version: [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md).
 3. **If using autoDDL (default)**: Liquibase runs on Zeebe startup.
 4. **If using manual schema management**: Apply scripts manually, then start new Camunda version.
 
-### Disabling automatic schema updates
+## Disabling automatic schema updates
 
 For strict change control environments:
 
@@ -151,7 +149,7 @@ Create user with minimum required privileges:
 CREATE ROLE camunda LOGIN PASSWORD 'secure-password';
 GRANT CONNECT ON DATABASE camunda TO camunda;
 GRANT USAGE ON SCHEMA public TO camunda;
-GRANT CREATE ON DATABASE camunda TO camunda;
+GRANT CREATE ON SCHEMA public TO camunda;
 ```
 
 Avoid DROP, TRUNCATE, SUPERUSER, or other unnecessary privileges.
@@ -166,4 +164,4 @@ Before deploying to production, review [secondary storage architecture](/self-ma
 - [Secondary storage architecture](/self-managed/reference-architecture/reference-architecture.md#secondary-storage-architecture)
 - [RDBMS production architecture](/self-managed/deployment/manual/rdbms/rdbms-production-architecture.md)
 - [RDBMS support policy](/self-managed/concepts/databases/relational-db/rdbms-support-policy.md)
-- [Access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)
+- [access SQL and Liquibase scripts](/self-managed/deployment/helm/configure/database/access-sql-liquibase-scripts.md)

--- a/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/rdbms/backup.md
+++ b/versioned_docs/version-8.9/self-managed/operational-guides/backup-restore/rdbms/backup.md
@@ -44,7 +44,7 @@ The following prerequisites are required before you can create a backup.
 When Camunda uses an RDBMS as **secondary storage**, backups involve **two independent systems**:
 
 - **Zeebe (primary storage)**: Backs up its internal state (log stream, snapshots) to an external blob store (S3, GCS, Azure, or filesystem). These are called **primary storage backups**.
-- **The external RDBMS**: Backed up using your database vendor's native tools (pg_dump, mysqldump, RMAN, etc.). This is the **secondary storage backup**.
+- **The external RDBMS**: Backed up using your database vendor's native tools (pg_dump, mysqldump, RMAN, and similar). This is the **secondary storage backup**.
 
 During restore, Zeebe uses the exporter position stored in the RDBMS to find the correct primary storage backup, or backups, that match the RDBMS state. This ensures consistency between the two systems without requiring synchronized backup timing.
 


### PR DESCRIPTION
## Summary

Note: This isn't really a technical content change, this is largely for user digestion and aesthetics. 

Polish pass across RDBMS and secondary storage documentation for clarity, visual quality, and terminology consistency.

**Visual improvements**
- Replaced plain link lists with `<DocCardList />` on `relational-db/index.md`, `secondary-storage/index.md`, and `manual/rdbms/index.md`
- Converted 4 DB-specific permission SQL blocks in `rdbms-schema-management.md` to a tabbed interface (PostgreSQL, Oracle, MariaDB/MySQL, SQL Server)
- Converted TLS/SSL section in `rdbms-troubleshooting.md` to tabs- added missing SQL Server and MariaDB/MySQL TLS JDBC URL examples
- Replaced 6 verbose database subsections in `rdbms-support-policy.md` with a single summary table

**Sidebar cleanup**
- Added `sidebar_label` to child pages under "Relational databases" to drop the redundant "RDBMS" prefix from sidebar display: "Version support policy", "Configuration overview", "End-to-end setup guide", "Benchmark results" (page titles unchanged)

**Wording and accuracy fixes**
- Fixed broken line-break sentences across `configuration.md` and `secondary-storage/index.md`
- Fixed PostgreSQL permissions in `operations.md`: `GRANT CREATE ON DATABASE` to `GRANT CREATE ON SCHEMA public`
- Replaced all remaining "Web Modeler" references with "Camunda Hub" across `rdbms.md`, `configuration.md`, and `rdbms-setup-guide.md`
- Converted `:::warning` bullet in `access-sql-liquibase-scripts.md` to a callout block; renamed `## Optional` to `## Additional resources`
- Fixed relative path to absolute in `configuration.md` Helm driver section
- Removed redundant content: duplicate `## History cleanup` intro, filler paragraph in `secondary-storage/index.md`, redundant "Key concepts" bullets in `rdbms.md`

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
