### PR TITLE
docs(apis-tools): document the completeUserTask MCP tool

### DIFF
--- a/docs/apis-tools/orchestration-cluster-api-mcp/orchestration-cluster-api-mcp-overview.md
+++ b/docs/apis-tools/orchestration-cluster-api-mcp/orchestration-cluster-api-mcp-overview.md
@@ -79,13 +79,13 @@ For production environments and other deployment types, the MCP server must be e
 
 The MCP server exposes tools across the following domains:
 
-| Domain              | Capabilities                                                    |
-| :------------------ | :-------------------------------------------------------------- |
-| Cluster             | Check cluster health and retrieve topology information.         |
-| Incidents           | Search, retrieve, and resolve incidents.                        |
-| Process definitions | Search process definitions and retrieve BPMN XML.               |
-| Process instances   | Search, retrieve, and create process instances.                 |
-| User tasks          | Search, retrieve, and assign user tasks. Search task variables. |
-| Variables           | Search and retrieve variables.                                  |
+| Domain              | Capabilities                                                              |
+| :------------------ | :------------------------------------------------------------------------ |
+| Cluster             | Check cluster health and retrieve topology information.                   |
+| Incidents           | Search, retrieve, and resolve incidents.                                  |
+| Process definitions | Search process definitions and retrieve BPMN XML.                         |
+| Process instances   | Search, retrieve, and create process instances.                           |
+| User tasks          | Search, retrieve, assign, and complete user tasks. Search task variables. |
+| Variables           | Search and retrieve variables.                                            |
 
 For the full list of available tools, see [Available tools](./orchestration-cluster-api-mcp-tools.md).

--- a/docs/apis-tools/orchestration-cluster-api-mcp/orchestration-cluster-api-mcp-tools.md
+++ b/docs/apis-tools/orchestration-cluster-api-mcp/orchestration-cluster-api-mcp-tools.md
@@ -48,6 +48,7 @@ Tool names, parameters, and response schemas are fully discoverable by MCP clien
 | :------------------------ | :---------------------------------------------------------------------------------- |
 | `searchUserTasks`         | Search user tasks with filters such as assignee, state, and process definition key. |
 | `getUserTask`             | Retrieve a user task by key.                                                        |
+| `completeUserTask`        | Complete a user task, optionally providing variables or a custom action.            |
 | `assignUserTask`          | Update the assignment of a user task.                                               |
 | `searchUserTaskVariables` | Search variables scoped to a specific user task.                                    |
 


### PR DESCRIPTION
## Description

Documents the `completeUserTask` tool added to the Orchestration Cluster MCP server in [camunda/camunda#59213](https://github.com/camunda/camunda/pull/59213), which was missing from:

- The [Available tools](./docs/apis-tools/orchestration-cluster-api-mcp/orchestration-cluster-api-mcp-tools.md) reference table (User tasks section).
- The domain-capability summary on the [Orchestration Cluster MCP Server overview](./docs/apis-tools/orchestration-cluster-api-mcp/orchestration-cluster-api-mcp-overview.md) page.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
