### PR TITLE
fix(guides): update migration card column layout

### DIFF
--- a/docs/guides/migrating-from-camunda-7/index.md
+++ b/docs/guides/migrating-from-camunda-7/index.md
@@ -24,7 +24,7 @@ It is not sufficient to exchange a library; you might have to adjust your BPMN m
 
 This guide covers the following main aspects involved in migrating from Camunda 7 to Camunda 8.
 
-<MigrationsGrid migrations={gettingStartedCards} />
+<MigrationsGrid migrations={gettingStartedCards} columns={2} />
 
 <!-- TODO: However, the [migration tooling roadmap](https://roadmap.camunda.com/) can inform your time planning. -->
 

--- a/docs/guides/react-components/_migration-card.js
+++ b/docs/guides/react-components/_migration-card.js
@@ -11,9 +11,11 @@ const MigrationCard = ({ link, title, image, description }) => {
   );
 };
 
-const MigrationsGrid = ({ migrations }) => {
+const MigrationsGrid = ({ migrations, className, columns = 3 }) => {
+  // allow override via className and/or columns prop
+  const colsClass = `migration-grid-cols-${columns}`;
   return (
-    <div className="migration-grid">
+    <div className={`migration-grid ${colsClass} ${className || ""}`.trim()}>
       {migrations.map((migration, index) => (
         <MigrationCard
           key={index}

--- a/docs/guides/react-components/_migration-table.css
+++ b/docs/guides/react-components/_migration-table.css
@@ -1,5 +1,6 @@
 .migration-grid {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;

--- a/docs/guides/react-components/_migration-table.css
+++ b/docs/guides/react-components/_migration-table.css
@@ -1,9 +1,18 @@
 .migration-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;
+}
+
+/* default (3 cols) */
+.migration-grid.migration-grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* two-column option */
+.migration-grid.migration-grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 a.migration-card {
@@ -70,13 +79,14 @@ a.migration-card {
 }
 
 @media (max-width: 1024px) {
-  .migration-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .migration-grid.migration-grid-cols-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 768px) {
-  .migration-grid {
+  .migration-grid.migration-grid-cols-3,
+  .migration-grid.migration-grid-cols-2 {
     grid-template-columns: 1fr;
   }
 }

--- a/versioned_docs/version-8.7/guides/react-components/_migration-card.js
+++ b/versioned_docs/version-8.7/guides/react-components/_migration-card.js
@@ -11,9 +11,11 @@ const MigrationCard = ({ link, title, image, description }) => {
   );
 };
 
-const MigrationsGrid = ({ migrations }) => {
+const MigrationsGrid = ({ migrations, className, columns = 3 }) => {
+  // allow override via className and/or columns prop
+  const colsClass = `migration-grid-cols-${columns}`;
   return (
-    <div className="migration-grid">
+    <div className={`migration-grid ${colsClass} ${className || ""}`.trim()}>
       {migrations.map((migration, index) => (
         <MigrationCard
           key={index}

--- a/versioned_docs/version-8.7/guides/react-components/_migration-table.css
+++ b/versioned_docs/version-8.7/guides/react-components/_migration-table.css
@@ -1,9 +1,18 @@
 .migration-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;
+}
+
+/* default (3 cols) */
+.migration-grid.migration-grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* two-column option */
+.migration-grid.migration-grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 a.migration-card {
@@ -70,13 +79,14 @@ a.migration-card {
 }
 
 @media (max-width: 1024px) {
-  .migration-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .migration-grid.migration-grid-cols-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 768px) {
-  .migration-grid {
+  .migration-grid.migration-grid-cols-3,
+  .migration-grid.migration-grid-cols-2 {
     grid-template-columns: 1fr;
   }
 }

--- a/versioned_docs/version-8.7/guides/react-components/_migration-table.css
+++ b/versioned_docs/version-8.7/guides/react-components/_migration-table.css
@@ -1,5 +1,6 @@
 .migration-grid {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;

--- a/versioned_docs/version-8.8/guides/migrating-from-camunda-7/index.md
+++ b/versioned_docs/version-8.8/guides/migrating-from-camunda-7/index.md
@@ -24,7 +24,7 @@ It is not sufficient to exchange a library; you might have to adjust your BPMN m
 
 This guide covers the following main aspects involved in migrating from Camunda 7 to Camunda 8.
 
-<MigrationsGrid migrations={gettingStartedCards} />
+<MigrationsGrid migrations={gettingStartedCards} columns={2} />
 
 <!-- TODO: However, the [migration tooling roadmap](https://roadmap.camunda.com/) can inform your time planning. -->
 

--- a/versioned_docs/version-8.8/guides/react-components/_migration-card.js
+++ b/versioned_docs/version-8.8/guides/react-components/_migration-card.js
@@ -11,9 +11,11 @@ const MigrationCard = ({ link, title, image, description }) => {
   );
 };
 
-const MigrationsGrid = ({ migrations }) => {
+const MigrationsGrid = ({ migrations, className, columns = 3 }) => {
+  // allow override via className and/or columns prop
+  const colsClass = `migration-grid-cols-${columns}`;
   return (
-    <div className="migration-grid">
+    <div className={`migration-grid ${colsClass} ${className || ""}`.trim()}>
       {migrations.map((migration, index) => (
         <MigrationCard
           key={index}

--- a/versioned_docs/version-8.8/guides/react-components/_migration-table.css
+++ b/versioned_docs/version-8.8/guides/react-components/_migration-table.css
@@ -1,5 +1,6 @@
 .migration-grid {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;

--- a/versioned_docs/version-8.8/guides/react-components/_migration-table.css
+++ b/versioned_docs/version-8.8/guides/react-components/_migration-table.css
@@ -1,9 +1,18 @@
 .migration-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;
+}
+
+/* default (3 cols) */
+.migration-grid.migration-grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* two-column option */
+.migration-grid.migration-grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 a.migration-card {
@@ -70,13 +79,14 @@ a.migration-card {
 }
 
 @media (max-width: 1024px) {
-  .migration-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .migration-grid.migration-grid-cols-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 768px) {
-  .migration-grid {
+  .migration-grid.migration-grid-cols-3,
+  .migration-grid.migration-grid-cols-2 {
     grid-template-columns: 1fr;
   }
 }

--- a/versioned_docs/version-8.9/guides/migrating-from-camunda-7/index.md
+++ b/versioned_docs/version-8.9/guides/migrating-from-camunda-7/index.md
@@ -24,7 +24,7 @@ It is not sufficient to exchange a library; you might have to adjust your BPMN m
 
 This guide covers the following main aspects involved in migrating from Camunda 7 to Camunda 8.
 
-<MigrationsGrid migrations={gettingStartedCards} />
+<MigrationsGrid migrations={gettingStartedCards} columns={2} />
 
 <!-- TODO: However, the [migration tooling roadmap](https://roadmap.camunda.com/) can inform your time planning. -->
 

--- a/versioned_docs/version-8.9/guides/react-components/_migration-card.js
+++ b/versioned_docs/version-8.9/guides/react-components/_migration-card.js
@@ -11,9 +11,11 @@ const MigrationCard = ({ link, title, image, description }) => {
   );
 };
 
-const MigrationsGrid = ({ migrations }) => {
+const MigrationsGrid = ({ migrations, className, columns = 3 }) => {
+  // allow override via className and/or columns prop
+  const colsClass = `migration-grid-cols-${columns}`;
   return (
-    <div className="migration-grid">
+    <div className={`migration-grid ${colsClass} ${className || ""}`.trim()}>
       {migrations.map((migration, index) => (
         <MigrationCard
           key={index}

--- a/versioned_docs/version-8.9/guides/react-components/_migration-table.css
+++ b/versioned_docs/version-8.9/guides/react-components/_migration-table.css
@@ -1,5 +1,6 @@
 .migration-grid {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;

--- a/versioned_docs/version-8.9/guides/react-components/_migration-table.css
+++ b/versioned_docs/version-8.9/guides/react-components/_migration-table.css
@@ -1,9 +1,18 @@
 .migration-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   gap: 20px;
   margin-top: 25px;
   margin-bottom: 30px;
+}
+
+/* default (3 cols) */
+.migration-grid.migration-grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* two-column option */
+.migration-grid.migration-grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 a.migration-card {
@@ -70,13 +79,14 @@ a.migration-card {
 }
 
 @media (max-width: 1024px) {
-  .migration-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .migration-grid.migration-grid-cols-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 768px) {
-  .migration-grid {
+  .migration-grid.migration-grid-cols-3,
+  .migration-grid.migration-grid-cols-2 {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Description

Follow-up fix to #9532.

In #9532, the [migration guide overview](https://docs.camunda.io/docs/next/guides/migrating-from-camunda-7/#what-you-will-learn) cards were changed from three to two per row by editing the base `.migration-grid` rule in `guides/react-components/_migration-table.css`.

That approach does not hold on the built site. `_migration-table.css` exists once per docs version (`/docs` plus `version-8.9`, `version-8.8`, `version-8.7`), all four copies are plain global CSS that Docusaurus bundles together, and they all declare the same `.migration-grid` selector. The `version-8.7` copy was never updated and still declared `repeat(3, 1fr)`, so whichever copy is emitted last wins — which is why staging still renders three columns.

This PR uses the same pattern already used elsewhere in the docs — `UsingGrid` in `components/react-components/_using-card.js` with `_using-table.css`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
