### PR TITLE
docs(self-managed): collapse the deployment readiness script into a details block

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,0 +1,16 @@
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>See the check-deployment-ready.sh script</summary>
+```bash reference
+https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+```
+</details>

--- a/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,6 +1,14 @@
 The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
 
-Configure it with the following environment variables:
+If you don't have a local copy of the reference architecture, download the script and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
+chmod +x check-deployment-ready.sh
+./check-deployment-ready.sh
+```
+
+Review the script before you run it. Configure it with the following environment variables:
 
 | Variable                            | Default   | Purpose                                                          |
 | ----------------------------------- | --------- | ---------------------------------------------------------------- |

--- a/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,14 +1,10 @@
+import DeploymentReadinessDownload from './\_deployment-readiness-download.md'
+
 The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
 
-If you don't have a local copy of the reference architecture, download the script and run it:
+{props.download && <DeploymentReadinessDownload />}
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
-chmod +x check-deployment-ready.sh
-./check-deployment-ready.sh
-```
-
-Review the script before you run it. Configure it with the following environment variables:
+Configure it with the following environment variables:
 
 | Variable                            | Default   | Purpose                                                          |
 | ----------------------------------- | --------- | ---------------------------------------------------------------- |

--- a/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-download.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-download.md
@@ -1,0 +1,9 @@
+Download the script and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
+chmod +x check-deployment-ready.sh
+./check-deployment-ready.sh
+```
+
+Review the script before you run it.

--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -435,11 +435,26 @@ This command:
 
 <HelmUpgradeNote />
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -17,6 +17,7 @@ import NoDomainInfo from '../../\_partials/\_no-domain-info.md'
 import HelmUpgradeNote from '../../\_partials/\_helm-upgrade-note.md'
 import KubefwdTip from '../../\_partials/\_kubefwd-tip.md'
 import PortForwardServices from '../../\_partials/\_port-forward-services.md'
+import DeploymentReadinessCheck from '../../\_partials/\_deployment-readiness-check.md'
 
 This guide provides a comprehensive walkthrough for installing the Camunda 8 Helm chart on your existing AWS Kubernetes EKS cluster. It also includes instructions for setting up optional DNS configurations and other optional AWS-managed services, such as OpenSearch and PostgreSQL.
 
@@ -437,24 +438,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -438,7 +438,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-<DeploymentReadinessCheck />
+<DeploymentReadinessCheck download />
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/docs/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -16,6 +16,7 @@ import HelmUpgradeNote from '../../\_partials/\_helm-upgrade-note.md'
 import KubefwdTip from '../../\_partials/\_kubefwd-tip.md'
 import PortForwardServices from '../../\_partials/\_port-forward-services.md'
 import DeployECKElasticsearch from '../../\_partials/\_deploy-eck-elasticsearch.md'
+import DeploymentReadinessCheck from '../../\_partials/\_deployment-readiness-check.md'
 
 This guide provides a comprehensive walkthrough for installing the Camunda 8 Helm chart on your existing Azure Kubernetes Service (AKS) cluster and confirming that it is working as intended.
 
@@ -460,24 +461,7 @@ This script:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 ## Verify connectivity to Camunda 8
 

--- a/docs/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -458,11 +458,26 @@ This script:
 
 <HelmUpgradeNote />
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 ## Verify connectivity to Camunda 8
 

--- a/docs/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -461,7 +461,7 @@ This script:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-<DeploymentReadinessCheck />
+<DeploymentReadinessCheck download />
 
 ## Verify connectivity to Camunda 8
 

--- a/docs/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/kind.md
@@ -9,6 +9,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 import IdentitySecret from './\_partials/\_identity-secret.md'
+import DeploymentReadinessCheck from './\_partials/\_deployment-readiness-check.md'
 
 With this guide, you'll deploy Camunda 8 Self-Managed to a local Kubernetes cluster using [kind (Kubernetes in Docker)](https://kind.sigs.k8s.io/). The setup is optimized for learning, development, and testing, with reduced resource requirements suitable for a personal machine.
 
@@ -433,24 +434,7 @@ export CAMUNDA_NAMESPACE=camunda
 ./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 Finally, verify the Helm release:
 

--- a/docs/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/kind.md
@@ -430,11 +430,27 @@ You can also use the deployment readiness check script from the root directory o
 
 ```bash
 export CAMUNDA_NAMESPACE=camunda
+./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 Finally, verify the Helm release:
 

--- a/docs/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -19,6 +19,7 @@ import KubefwdTip from '../\_partials/\_kubefwd-tip.md'
 import PortForwardServices from '../\_partials/\_port-forward-services.md'
 import DeployECKElasticsearch from '../\_partials/\_deploy-eck-elasticsearch.md'
 import SecondaryStorageOptionsNote from '../\_partials/\_secondary-storage-options-note.md'
+import DeploymentReadinessCheck from '../\_partials/\_deployment-readiness-check.md'
 
 Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift), provides options for both managed and on-premises hosting.
 
@@ -708,24 +709,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 ## Verify connectivity to Camunda 8
 

--- a/docs/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -706,11 +706,26 @@ This command:
 
 <HelmUpgradeNote />
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/main/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 ## Verify connectivity to Camunda 8
 

--- a/docs/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -709,7 +709,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-<DeploymentReadinessCheck />
+<DeploymentReadinessCheck download />
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,0 +1,16 @@
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>See the check-deployment-ready.sh script</summary>
+```bash reference
+https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+```
+</details>

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,14 +1,10 @@
+import DeploymentReadinessDownload from './\_deployment-readiness-download.md'
+
 The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
 
-If you don't have a local copy of the reference architecture, download the script and run it:
+{props.download && <DeploymentReadinessDownload />}
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
-chmod +x check-deployment-ready.sh
-./check-deployment-ready.sh
-```
-
-Review the script before you run it. Configure it with the following environment variables:
+Configure it with the following environment variables:
 
 | Variable                            | Default   | Purpose                                                          |
 | ----------------------------------- | --------- | ---------------------------------------------------------------- |

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,6 +1,14 @@
 The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
 
-Configure it with the following environment variables:
+If you don't have a local copy of the reference architecture, download the script and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
+chmod +x check-deployment-ready.sh
+./check-deployment-ready.sh
+```
+
+Review the script before you run it. Configure it with the following environment variables:
 
 | Variable                            | Default   | Purpose                                                          |
 | ----------------------------------- | --------- | ---------------------------------------------------------------- |

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-download.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-download.md
@@ -1,0 +1,9 @@
+Download the script and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
+chmod +x check-deployment-ready.sh
+./check-deployment-ready.sh
+```
+
+Review the script before you run it.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -17,6 +17,7 @@ import NoDomainInfo from '../../\_partials/\_no-domain-info.md'
 import HelmUpgradeNote from '../../\_partials/\_helm-upgrade-note.md'
 import KubefwdTip from '../../\_partials/\_kubefwd-tip.md'
 import PortForwardServices from '../../\_partials/\_port-forward-services.md'
+import DeploymentReadinessCheck from '../../\_partials/\_deployment-readiness-check.md'
 
 This guide provides a comprehensive walkthrough for installing the Camunda 8 Helm chart on your existing AWS Kubernetes EKS cluster. It also includes instructions for setting up optional DNS configurations and other optional AWS-managed services, such as OpenSearch and PostgreSQL.
 
@@ -437,24 +438,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -435,11 +435,26 @@ This command:
 
 <HelmUpgradeNote />
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -438,7 +438,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-<DeploymentReadinessCheck />
+<DeploymentReadinessCheck download />
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -461,7 +461,7 @@ This script:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-<DeploymentReadinessCheck />
+<DeploymentReadinessCheck download />
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -458,11 +458,26 @@ This script:
 
 <HelmUpgradeNote />
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -16,6 +16,7 @@ import HelmUpgradeNote from '../../\_partials/\_helm-upgrade-note.md'
 import KubefwdTip from '../../\_partials/\_kubefwd-tip.md'
 import PortForwardServices from '../../\_partials/\_port-forward-services.md'
 import DeployECKElasticsearch from '../../\_partials/\_deploy-eck-elasticsearch.md'
+import DeploymentReadinessCheck from '../../\_partials/\_deployment-readiness-check.md'
 
 This guide provides a comprehensive walkthrough for installing the Camunda 8 Helm chart on your existing Azure Kubernetes Service (AKS) cluster and confirming that it is working as intended.
 
@@ -460,24 +461,7 @@ This script:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
@@ -430,11 +430,27 @@ You can also use the deployment readiness check script from the root directory o
 
 ```bash
 export CAMUNDA_NAMESPACE=camunda
+./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 Finally, verify the Helm release:
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
@@ -9,6 +9,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 import IdentitySecret from './\_partials/\_identity-secret.md'
+import DeploymentReadinessCheck from './\_partials/\_deployment-readiness-check.md'
 
 With this guide, you'll deploy Camunda 8 Self-Managed to a local Kubernetes cluster using [kind (Kubernetes in Docker)](https://kind.sigs.k8s.io/). The setup is optimized for learning, development, and testing, with reduced resource requirements suitable for a personal machine.
 
@@ -433,24 +434,7 @@ export CAMUNDA_NAMESPACE=camunda
 ./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 Finally, verify the Helm release:
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -706,11 +706,26 @@ This command:
 
 <HelmUpgradeNote />
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>Source of <code>check-deployment-ready.sh</code></summary>
 
 ```bash reference
 https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
+
+</details>
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -19,6 +19,7 @@ import KubefwdTip from '../\_partials/\_kubefwd-tip.md'
 import PortForwardServices from '../\_partials/\_port-forward-services.md'
 import DeployECKElasticsearch from '../\_partials/\_deploy-eck-elasticsearch.md'
 import SecondaryStorageOptionsNote from '../\_partials/\_secondary-storage-options-note.md'
+import DeploymentReadinessCheck from '../\_partials/\_deployment-readiness-check.md'
 
 Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift), provides options for both managed and on-premises hosting.
 
@@ -708,24 +709,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
-
-Configure it with the following environment variables:
-
-| Variable                            | Default   | Purpose                                                          |
-| ----------------------------------- | --------- | ---------------------------------------------------------------- |
-| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
-| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
-| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
-
-<details>
-<summary>Source of <code>check-deployment-ready.sh</code></summary>
-
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.9/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
-
-</details>
+<DeploymentReadinessCheck />
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -709,7 +709,7 @@ This command:
 
 You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-<DeploymentReadinessCheck />
+<DeploymentReadinessCheck download />
 
 ## Verify connectivity to Camunda 8
 


### PR DESCRIPTION
## Description

The `check-deployment-ready.sh` reference script grows from 14 to roughly 140 lines in [camunda-deployment-references#2939](https://github.com/camunda/camunda-deployment-references/pull/2939). Four pages embed that file verbatim with ` ```bash reference `, so the moment the reference PR merges, each of them renders a wall of defensive bash — argument validation, three `jq` filter functions, a diagnostics printer — in the middle of a "track the progress of the installation" step. The prose on three of those pages even says "using the following command", which stops being accurate.

This PR keeps the auto-synced reference but stops it from dominating the page.

- A short paragraph describing what the script does: it polls until every pod is ready, and on a stall it reports the unready containers with restart counts, `CrashLoopBackOff`, `OOMKilled` and exit codes, plus recent warning events.
- A table of the environment variables the script now accepts: `CAMUNDA_NAMESPACE`, `DEPLOYMENT_READY_TIMEOUT_SECONDS`, `DEPLOYMENT_READY_INTERVAL_SECONDS`.
- The full source moved into a `details` block.

That content lives in a single partial, `_partials/_deployment-readiness-check.md`, following the existing pattern of `_identity-secret.md`. The four guides import it rather than repeating it, so there is one copy per version instead of one per page. Partials sit next to the docs they serve, so each version keeps the reference URL pinned to its own branch, which a shared React component in `src` could not do.

On the Kind page the reader has already obtained a local copy of the reference architecture through `get-your-copy.sh`, so the invocation is shown directly:

```bash
export CAMUNDA_NAMESPACE=camunda
./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
```

The EKS, AKS, and OpenShift pages never instruct a clone and treat embedded scripts as copy-paste material, so on those the source stays visible inside the `details` block rather than being replaced by a command the reader could not run.

### Scope

Only `docs` (Next) and `versioned_docs/version-8.9` are touched, eight files in total. The 8.8 and 8.7 pages pin their reference URLs to `stable/8.8` and `stable/8.7`, which keep the original 14-line script, so changing them would describe something that does not exist on those branches.

The `openshift/dual-region.md` pages reference a different script, `generic/openshift/dual-region/procedure/check-deployment-ready.sh`, which is untouched by the reference PR and therefore left alone here.

### Dependency

This PR is a draft on purpose. It describes behavior that only exists once [camunda-deployment-references#2939](https://github.com/camunda/camunda-deployment-references/pull/2939) and its 8.9 backport [#2963](https://github.com/camunda/camunda-deployment-references/pull/2963) are merged. Merging earlier would document environment variables the released scripts do not yet support.

Related: [camunda-docs#9499](https://github.com/camunda/camunda-docs/pull/9499) adds the Identity troubleshooting entry that motivated the reference change.

### Validation

`npm run build` completes successfully and `prettier` reports no formatting issues on the eight files. The broken-anchor warnings the build emits are pre-existing and unrelated, they appear identically on an unmodified tree.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

