### PR TITLE
docs(connectors): document the createDocument FEEL function

### DIFF
--- a/docs/components/connectors/protocol/http-webhook.md
+++ b/docs/components/connectors/protocol/http-webhook.md
@@ -620,3 +620,7 @@ If the `documents` list is not empty, document items are returned in the followi
 :::note
 Request parts are automatically stored in the configured document store when sending a multipart request.
 :::
+
+To extract a document from a base64-encoded field embedded in the request body (for example, a JSON request that is
+not sent as multipart), use the [`createDocument`](/components/connectors/use-connectors/index.md#function-createdocument)
+FEEL function in the **Result expression** field.

--- a/docs/components/connectors/protocol/http-webhook.md
+++ b/docs/components/connectors/protocol/http-webhook.md
@@ -621,6 +621,4 @@ If the `documents` list is not empty, document items are returned in the followi
 Request parts are automatically stored in the configured document store when sending a multipart request.
 :::
 
-To extract a document from a base64-encoded field embedded in the request body (for example, a JSON request that is
-not sent as multipart), use the [`createDocument`](/components/connectors/use-connectors/index.md#function-createdocument)
-FEEL function in the **Result expression** field.
+To extract a document from a base64-encoded field in a non-multipart request body, use the [`createDocument` FEEL function](/components/connectors/use-connectors/index.md#function-createdocument) in the **Result expression** field.

--- a/docs/components/connectors/protocol/rest.md
+++ b/docs/components/connectors/protocol/rest.md
@@ -220,9 +220,7 @@ The following variables are available in the context of the response expression:
 Starting from version 8.7.0, the REST connector supports storing the response as a document. See additional details and limitations in [document handling](/components/document-handling/getting-started.md).
 :::
 
-To store only part of the response as a document instead of the entire response, use the
-[`createDocument`](/components/connectors/use-connectors/index.md#function-createdocument) FEEL function in the
-**Result expression** field.
+To store part of the response as a document, use the [`createDocument` FEEL function](/components/connectors/use-connectors/index.md#function-createdocument) in the **Result expression** field.
 
 ## Output mapping
 

--- a/docs/components/connectors/protocol/rest.md
+++ b/docs/components/connectors/protocol/rest.md
@@ -220,6 +220,10 @@ The following variables are available in the context of the response expression:
 Starting from version 8.7.0, the REST connector supports storing the response as a document. See additional details and limitations in [document handling](/components/document-handling/getting-started.md).
 :::
 
+To store only part of the response as a document instead of the entire response, use the
+[`createDocument`](/components/connectors/use-connectors/index.md#function-createdocument) FEEL function in the
+**Result expression** field.
+
 ## Output mapping
 
 ### Result variable

--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -184,17 +184,18 @@ In that case, you could declare **Result Expression** as follows:
 }
 ```
 
-### Function createDocument
+### `createDocument` function
 
-Starting from version 8.10.0, `createDocument` is available in the **Result expression** and **Error expression** fields.
-It converts part of a connector's response into a real [document](/components/document-handling/getting-started.md)
-reference, so you can store only the relevant part of a response as a document instead of the entire response.
+Starting with 8.10.0, you can use `createDocument` in the **Result expression** and **Error expression** fields.
 
-- Parameters:
-  - `value`: string or context (see fields below)
-- Result: context, resolved into a document reference
+The function converts part of a Connector response into a [document reference](/components/document-handling/getting-started.md), so you can store the relevant content without storing the entire response.
 
-If `value` is a string, it's treated as base64-encoded content with no metadata:
+| Item | Type | Description |
+| --- | --- | --- |
+| `value` | String or context | Content and optional metadata used to create the document reference. |
+| Result | Context | The generated document reference. |
+
+If `value` is a string, `createDocument` treats it as base64-encoded content without metadata:
 
 ```feel
 createDocument(response.body.file[1].document.data)
@@ -205,8 +206,8 @@ If `value` is a context, it can contain the following fields:
 | Field                | Required | Description                                                                                                                                                                |
 | -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `content` or `data`  | Yes      | The base64-encoded document content. Either key name is accepted.                                                                                                          |
-| `name` or `fileName` | No       | The filename. If omitted, a UUID is generated automatically.                                                                                                               |
-| `contentType`        | No       | The MIME type of the content. If omitted, it's inferred from the file extension of `name`/`fileName`; defaults to `application/octet-stream` if no extension is available. |
+| `name` or `fileName` | No       | The filename. If you omit this field, `createDocument` automatically generates a UUID.                                                                                                               |
+| `contentType`        | No       | The MIME type of the content. If you omit this field, `createDocument` infers the type from the file extension in `name` or `fileName`. If neither field contains an extension, the value defaults to `application/octet-stream`. |
 
 ```feel
 createDocument({
@@ -215,16 +216,13 @@ createDocument({
 })
 ```
 
-There is no plural `createDocuments` function. Use FEEL's native iteration to extract multiple documents:
+The Connector runtime does not provide a `createDocuments` function. To extract multiple documents, use a FEEL iteration:
 
 ```feel
 = { documents: for f in response.body.file return createDocument(f.document) }
 ```
 
-:::note
-`createDocument` requires the runtime to have access to a configured document store. See
-[document handling](/components/document-handling/getting-started.md).
-:::
+Before using `createDocument`, configure a document store for the Connector runtime. For configuration details, see [Document handling](/components/document-handling/getting-started.md).
 
 ## Activation
 

--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -184,6 +184,48 @@ In that case, you could declare **Result Expression** as follows:
 }
 ```
 
+### Function createDocument
+
+Starting from version 8.10.0, `createDocument` is available in the **Result expression** and **Error expression** fields.
+It converts part of a connector's response into a real [document](/components/document-handling/getting-started.md)
+reference, so you can store only the relevant part of a response as a document instead of the entire response.
+
+- Parameters:
+  - `value`: string or context (see fields below)
+- Result: context, resolved into a document reference
+
+If `value` is a string, it's treated as base64-encoded content with no metadata:
+
+```feel
+createDocument(response.body.file[1].document.data)
+```
+
+If `value` is a context, it can contain the following fields:
+
+| Field                | Required | Description                                                                                                                                                                |
+| -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content` or `data`  | Yes      | The base64-encoded document content. Either key name is accepted.                                                                                                          |
+| `name` or `fileName` | No       | The filename. If omitted, a UUID is generated automatically.                                                                                                               |
+| `contentType`        | No       | The MIME type of the content. If omitted, it's inferred from the file extension of `name`/`fileName`; defaults to `application/octet-stream` if no extension is available. |
+
+```feel
+createDocument({
+  data: response.body.file[1].document.data,
+  name: response.body.file[1].filename
+})
+```
+
+There is no plural `createDocuments` function. Use FEEL's native iteration to extract multiple documents:
+
+```feel
+= { documents: for f in response.body.file return createDocument(f.document) }
+```
+
+:::note
+`createDocument` requires the runtime to have access to a configured document store. See
+[document handling](/components/document-handling/getting-started.md).
+:::
+
 ## Activation
 
 The **Activation** section pertains specifically to [inbound connectors](/components/connectors/connector-types.md).


### PR DESCRIPTION
## Description

Documents the new `createDocument(value)` FEEL function added in [camunda/connectors#8175](https://github.com/camunda/connectors/pull/8175). This function lets a **Result expression** or **Error expression** extract part of a connector's response (or request) into a real document reference, instead of the REST connector's all-or-nothing "store response as document" toggle.

Changes:

- `docs/components/connectors/use-connectors/index.md`: new **Function createDocument** reference section (parameters, string vs. context argument forms, the `content`/`data` and `name`/`fileName` field table, an iteration example for multiple documents), following the existing `bpmnError`/`jobError`/`ignoreError` function docs style.
- `docs/components/connectors/protocol/rest.md`: cross-reference to `createDocument` next to the existing `storeResponse` note.
- `docs/components/connectors/protocol/http-webhook.md`: cross-reference to `createDocument` next to the `documents` object docs, for the non-multipart (base64-in-JSON-body) case.

Added to `docs/` only, since this hasn't shipped in a versioned release yet.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
