### PR TITLE
docs(connectors): communicate secret provider default prefix breaking change for 8.7 and 8.8

### DIFF
--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -56,6 +56,20 @@ The following key changes were also released as part of an 8.7.x patch release.
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
 
+### Default secret provider prefix change {#default-secret-provider-prefix-change}
+
+Starting with a Connectors 8.7.x patch release, the environment-based connector secret provider uses `SECRET_` as the default prefix. Unprefixed environment variables are no longer resolved as connector secrets unless you explicitly configure an empty prefix or a different custom prefix.
+
+Previously, when no prefix was configured, all environment variables available to the connector runtime process could be resolved as connector secrets. This allowed a BPMN process author with deploy access to potentially extract sensitive environment variables — such as credentials for other components sharing the same runtime environment — through connector secret references.
+
+**Action:** Choose one of the following options before or during your upgrade:
+
+- Update your secret environment variables to use the `SECRET_` prefix.
+- Configure a custom prefix via `camunda.connector.secretprovider.environment.prefix` or `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`.
+- Restore the previous behavior by setting an empty prefix, knowing that Camunda does not recommend this mode for production environments.
+
+For more information, see the [connector secrets configuration](/versioned_docs/version-8.7/self-managed/connectors-deployment/connectors-configuration.md#secrets).
+
 ### `getMessageKeys()` removed from the exporter record {#getmessagekeys-removed-from-the-exporter-record}
 
 Camunda 8.7.27 unintentionally removed the `getMessageKeys()` method (and the underlying `messageKeys` field) from the public `MessageBatchRecordValue` exporter record. Custom exporters that call `getMessageKeys()` on message batch records fail to compile against, or throw a `NoSuchMethodError` at runtime with, the updated `zeebe-protocol` dependency after upgrading to 8.7.27 or any later 8.7.x patch. The built-in Elasticsearch and OpenSearch exporters are unaffected.

--- a/docs/reference/announcements-release-notes/870/870-announcements.md
+++ b/docs/reference/announcements-release-notes/870/870-announcements.md
@@ -55,10 +55,11 @@ The following key changes were also released as part of an 8.7.x patch release.
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
 | [8.7.28](https://github.com/camunda/camunda/releases/tag/8.7.28) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
 | [8.7.27](https://github.com/camunda/camunda/releases/tag/8.7.27) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
+| [8.7.24](https://github.com/camunda/connectors/releases/tag/8.7.24) | Breaking change | [Default secret provider prefix change](#default-secret-provider-prefix-change)                                  |
 
 ### Default secret provider prefix change {#default-secret-provider-prefix-change}
 
-Starting with a Connectors 8.7.x patch release, the environment-based connector secret provider uses `SECRET_` as the default prefix. Unprefixed environment variables are no longer resolved as connector secrets unless you explicitly configure an empty prefix or a different custom prefix.
+Starting with Connectors 8.7.24, the environment-based connector secret provider uses `SECRET_` as the default prefix. Unprefixed environment variables are no longer resolved as connector secrets unless you explicitly configure an empty prefix or a different custom prefix.
 
 Previously, when no prefix was configured, all environment variables available to the connector runtime process could be resolved as connector secrets. This allowed a BPMN process author with deploy access to potentially extract sensitive environment variables — such as credentials for other components sharing the same runtime environment — through connector secret references.
 

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -545,6 +545,29 @@ To learn more, see the [TypeScript SDK](/apis-tools/typescript/typescript-sdk.md
 
 <div className="release-announcement-row">
 <div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Default secret provider prefix change
+
+Starting with a Connectors 8.8.x patch release, the environment-based connector secret provider uses `SECRET_` as the default prefix. Unprefixed environment variables are no longer resolved as connector secrets unless you explicitly configure an empty prefix or a different custom prefix.
+
+Previously, when no prefix was configured, all environment variables available to the connector runtime process could be resolved as connector secrets. This allowed a BPMN process author with deploy access to potentially extract sensitive environment variables — such as credentials for other components sharing the same runtime environment — through connector secret references.
+
+**Action:** Choose one of the following options before or during your upgrade:
+
+- Update your secret environment variables to use the `SECRET_` prefix.
+- Configure a custom prefix via `camunda.connector.secretprovider.environment.prefix` or `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`.
+- Restore the previous behavior by setting an empty prefix, knowing that Camunda does not recommend this mode for production environments.
+
+<p className="link-arrow">[connector secrets configuration](/versioned_docs/version-8.8/self-managed/components/connectors/connectors-configuration.md#secrets)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
 <span className="badge badge--change">Change</span>
 </div>
 <div className="release-announcement-content">

--- a/docs/reference/announcements-release-notes/880/880-announcements.md
+++ b/docs/reference/announcements-release-notes/880/880-announcements.md
@@ -81,6 +81,7 @@ The following key changes were also released as part of an 8.8.x patch release.
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)                                      |
 | [8.8.23](https://github.com/camunda/camunda/releases/tag/8.8.23) | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                                                |
 | [8.8.22](https://github.com/camunda/camunda/releases/tag/8.8.22) | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                                               |
+| [8.8.17](https://github.com/camunda/connectors/releases/tag/8.8.17) | Breaking change | [Default secret provider prefix change](#default-secret-provider-prefix-change)                                                                       |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Breaking change | [Webhook alerts JSON format](#webhook-alerts-json-format)                                                                                             |
 | [8.8.9](https://github.com/camunda/camunda/releases/tag/8.8.9)   | Change          | [Spring Boot 4.0 support for Camunda Spring Boot Starter and Process Test ](#spring-boot-40-support-for-camunda-spring-boot-starter-and-process-test) |
 
@@ -551,7 +552,7 @@ To learn more, see the [TypeScript SDK](/apis-tools/typescript/typescript-sdk.md
 
 #### Default secret provider prefix change
 
-Starting with a Connectors 8.8.x patch release, the environment-based connector secret provider uses `SECRET_` as the default prefix. Unprefixed environment variables are no longer resolved as connector secrets unless you explicitly configure an empty prefix or a different custom prefix.
+Starting with Connectors 8.8.17, the environment-based connector secret provider uses `SECRET_` as the default prefix. Unprefixed environment variables are no longer resolved as connector secrets unless you explicitly configure an empty prefix or a different custom prefix.
 
 Previously, when no prefix was configured, all environment variables available to the connector runtime process could be resolved as connector secrets. This allowed a BPMN process author with deploy access to potentially extract sensitive environment variables — such as credentials for other components sharing the same runtime environment — through connector secret references.
 

--- a/versioned_docs/version-8.7/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/connectors-deployment/connectors-configuration.md
@@ -296,24 +296,38 @@ Providing secrets to the runtime environment can be achieved in different ways, 
 
 <TabItem value='default'>
 
-:::caution
-By default, all environment variables can be used as connector secrets.
-:::
+Starting with a Connectors 8.7.x patch release, the environment-based secret provider applies the prefix `SECRET_` by default when resolving secrets. Only environment variables that start with this prefix are available as connector secrets.
 
-To limit the environment that can be accessed by the default secret provider, configure a prefix. For example:
+This improves security by preventing all environment variables from being exposed as connector secrets. Existing secrets that do not use the configured prefix will no longer resolve until you update either the environment variables or the prefix configuration.
+
+#### Configure a custom prefix
+
+To use a custom prefix, configure it via the Java property or environment variable and name your secrets accordingly:
 
 ```bash
 export CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX='SUPER_SECRETS_'
 export SUPER_SECRETS_MY_SECRET='foo' # This will be resolved by using {{ secrets.MY_SECRET }}
 ```
 
+#### Restore the previous behavior (unsafe)
+
+To restore the previous behavior where all environment variables can be used as connector secrets, set the prefix to an empty value:
+
+```
+camunda.connector.secretprovider.environment.prefix=
+```
+
+:::warning
+When no prefix is configured, the connector runtime logs a warning that this mode is unsafe because all environment variables are exposed as connector secrets. Camunda does not recommend this mode for production environments.
+:::
+
 The following environment variables can be used to configure the default secret provider:
 
-| Name                                                       | Description                                                              | Default value |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------ | ------------- |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`     | Whether the default secret provider is enabled.                          | `true`        |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`      | The prefix applied to the secret name before looking up the environment. | `""`          |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE` | Whether the secret provider should be tenant-aware.                      | `false`       |
+| Name                                                       | Description                                                                                                                                                       | Default value |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`     | Whether the default secret provider is enabled.                                                                                                                   | `true`        |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`      | Prefix applied to the secret name before lookup. Only environment variables starting with this prefix are available as secrets. Set to empty to disable (unsafe). | `SECRET_`     |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE` | Whether the secret provider should be tenant-aware.                                                                                                               | `false`       |
 
 If the secret provider is set to be tenant-aware, the secret format will change to `${prefix}${tenantId}_${secretName}`:
 

--- a/versioned_docs/version-8.7/self-managed/connectors-deployment/connectors-configuration.md
+++ b/versioned_docs/version-8.7/self-managed/connectors-deployment/connectors-configuration.md
@@ -296,7 +296,7 @@ Providing secrets to the runtime environment can be achieved in different ways, 
 
 <TabItem value='default'>
 
-Starting with a Connectors 8.7.x patch release, the environment-based secret provider applies the prefix `SECRET_` by default when resolving secrets. Only environment variables that start with this prefix are available as connector secrets.
+Starting with Connectors 8.7.24, the environment-based secret provider applies the prefix `SECRET_` by default when resolving secrets. Only environment variables that start with this prefix are available as connector secrets.
 
 This improves security by preventing all environment variables from being exposed as connector secrets. Existing secrets that do not use the configured prefix will no longer resolve until you update either the environment variables or the prefix configuration.
 

--- a/versioned_docs/version-8.8/self-managed/components/connectors/connectors-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/connectors/connectors-configuration.md
@@ -284,24 +284,38 @@ Providing secrets to the runtime environment can be achieved in different ways, 
 
 <TabItem value='default'>
 
-:::caution
-By default, all environment variables can be used as connector secrets.
-:::
+Starting with a Connectors 8.8.x patch release, the environment-based secret provider applies the prefix `SECRET_` by default when resolving secrets. Only environment variables that start with this prefix are available as connector secrets.
 
-To limit the environment that can be accessed by the default secret provider, configure a prefix. For example:
+This improves security by preventing all environment variables from being exposed as connector secrets. Existing secrets that do not use the configured prefix will no longer resolve until you update either the environment variables or the prefix configuration.
+
+#### Configure a custom prefix
+
+To use a custom prefix, configure it via the Java property or environment variable and name your secrets accordingly:
 
 ```bash
 export CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX='SUPER_SECRETS_'
 export SUPER_SECRETS_MY_SECRET='foo' # This will be resolved by using {{ secrets.MY_SECRET }}
 ```
 
+#### Restore the previous behavior (unsafe)
+
+To restore the previous behavior where all environment variables can be used as connector secrets, set the prefix to an empty value:
+
+```
+camunda.connector.secretprovider.environment.prefix=
+```
+
+:::warning
+When no prefix is configured, the connector runtime logs a warning that this mode is unsafe because all environment variables are exposed as connector secrets. Camunda does not recommend this mode for production environments.
+:::
+
 The following environment variables can be used to configure the default secret provider:
 
-| Name                                                       | Description                                                              | Default value |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------ | ------------- |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`     | Whether the default secret provider is enabled.                          | `true`        |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`      | The prefix applied to the secret name before looking up the environment. | `""`          |
-| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE` | Whether the secret provider should be tenant-aware.                      | `false`       |
+| Name                                                       | Description                                                                                                                                                       | Default value |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_ENABLED`     | Whether the default secret provider is enabled.                                                                                                                   | `true`        |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`      | Prefix applied to the secret name before lookup. Only environment variables starting with this prefix are available as secrets. Set to empty to disable (unsafe). | `SECRET_`     |
+| `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_TENANTAWARE` | Whether the secret provider should be tenant-aware.                                                                                                               | `false`       |
 
 If the secret provider is set to be tenant-aware, the secret format will change to `${prefix}${tenantId}_${secretName}`:
 

--- a/versioned_docs/version-8.8/self-managed/components/connectors/connectors-configuration.md
+++ b/versioned_docs/version-8.8/self-managed/components/connectors/connectors-configuration.md
@@ -284,7 +284,7 @@ Providing secrets to the runtime environment can be achieved in different ways, 
 
 <TabItem value='default'>
 
-Starting with a Connectors 8.8.x patch release, the environment-based secret provider applies the prefix `SECRET_` by default when resolving secrets. Only environment variables that start with this prefix are available as connector secrets.
+Starting with Connectors 8.8.17, the environment-based secret provider applies the prefix `SECRET_` by default when resolving secrets. Only environment variables that start with this prefix are available as connector secrets.
 
 This improves security by preventing all environment variables from being exposed as connector secrets. Existing secrets that do not use the configured prefix will no longer resolve until you update either the environment variables or the prefix configuration.
 


### PR DESCRIPTION
## Summary

- Documents the upcoming security fix that changes the connector environment secret provider's default prefix from empty to `SECRET_` on stable/8.7 and stable/8.8 (camunda/connectors#8240, camunda/connectors#8241), mirroring the existing 8.9 announcement.
- Adds a breaking-change write-up to each minor release's announcements page (`870-announcements.md`, `880-announcements.md`).
- Updates the versioned connectors configuration pages for 8.7 and 8.8, which still described the old unsafe default.

## Note

The exact 8.7.x/8.8.x patch version isn't cut yet, so the "8.x.x patch releases" summary tables are intentionally left untouched — add a row there once the patch versions are known.

## Test plan

- [x] `npx prettier --check` clean on all touched files