### PR TITLE
docs(connectors): fix property name typo in secret provider unsafe-mode snippet

### DIFF
--- a/docs/self-managed/components/connectors/connectors-configuration.md
+++ b/docs/self-managed/components/connectors/connectors-configuration.md
@@ -302,7 +302,7 @@ export SUPER_SECRETS_MY_SECRET='foo'   # Resolved via {{ secrets.MY_SECRET }}
 To restore the previous behavior where all environment variables can be used as connector secrets, set the prefix to an empty value:
 
 ```
-camunda.connector.secret-provider.environment.prefix=
+camunda.connector.secretprovider.environment.prefix=
 ```
 
 :::warning


### PR DESCRIPTION
## Summary

- The "restore the previous behavior" snippet in the connectors configuration page used `camunda.connector.secret-provider.environment.prefix` (hyphenated), which doesn't match the actual Spring property `camunda.connector.secretprovider.environment.prefix` and would silently do nothing if copy-pasted as-is.
- Found while writing up the 8.7/8.8 secret-provider breaking-change docs.

## Test plan

- [x] `npx prettier --check` clean