### PR TITLE
docs: document Micrometer 1.16+ requirement for camunda-spring-boot-3-starter

### DIFF
--- a/docs/apis-tools/camunda-spring-boot-starter/getting-started.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/getting-started.md
@@ -75,6 +75,42 @@ To use the Spring Boot 3 module, replace the default dependency in your project:
 </dependency>
 ```
 
+:::caution Micrometer version requirement
+`camunda-spring-boot-3-starter` requires **Micrometer 1.16 or newer** if you enable Micrometer-based metrics. Spring Boot 3.5.x's own dependency management defaults to an older Micrometer version (~1.15.x), which does not satisfy this requirement.
+
+If your application resolves a Micrometer version below 1.16 while metrics are enabled, job workers appear to activate jobs normally, but handler methods never run — jobs keep expiring and getting re-activated indefinitely, with no error in the logs.
+
+To avoid this, explicitly pin Micrometer to 1.16 or newer:
+
+**Maven**, import the Micrometer BOM as the first entry in `<dependencyManagement>`, before your Spring Boot BOM import (import order matters when two BOMs manage the same dependency):
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-bom</artifactId>
+      <version>1.16.6</version>
+      <scope>import</scope>
+      <type>pom</type>
+    </dependency>
+    <!-- your Spring Boot BOM import goes after this -->
+  </dependencies>
+</dependencyManagement>
+```
+
+**Gradle**, add a constraint:
+
+```groovy
+dependencies {
+  constraints {
+    implementation("io.micrometer:micrometer-core:1.16.6")
+  }
+}
+```
+
+:::
+
 ## Get started
 
 ### Step 1: Add the dependency

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/getting-started.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/getting-started.md
@@ -77,6 +77,42 @@ To use the Spring Boot 3 module, replace the default dependency in your project:
 </dependency>
 ```
 
+:::caution Micrometer version requirement
+`camunda-spring-boot-3-starter` requires **Micrometer 1.16 or newer** if you enable Micrometer-based metrics. Spring Boot 3.5.x's own dependency management defaults to an older Micrometer version (~1.15.x), which does not satisfy this requirement.
+
+If your application resolves a Micrometer version below 1.16 while metrics are enabled, job workers appear to activate jobs normally, but handler methods never run — jobs keep expiring and getting re-activated indefinitely, with no error in the logs.
+
+To avoid this, explicitly pin Micrometer to 1.16 or newer:
+
+**Maven**, import the Micrometer BOM as the first entry in `<dependencyManagement>`, before your Spring Boot BOM import (import order matters when two BOMs manage the same dependency):
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-bom</artifactId>
+      <version>1.16.6</version>
+      <scope>import</scope>
+      <type>pom</type>
+    </dependency>
+    <!-- your Spring Boot BOM import goes after this -->
+  </dependencies>
+</dependencyManagement>
+```
+
+**Gradle**, add a constraint:
+
+```groovy
+dependencies {
+  constraints {
+    implementation("io.micrometer:micrometer-core:1.16.6")
+  }
+}
+```
+
+:::
+
 ## Get started
 
 ### Step 1: Add the dependency


### PR DESCRIPTION
## Summary

Enabling Micrometer metrics on `camunda-spring-boot-3-starter` with Spring Boot 3.5.x's stock dependency management (which defaults to Micrometer ~1.15.x) causes a silent `NoSuchMethodError` inside the Camunda client on every job activation. Job workers keep polling and activating jobs but never invoke handler code — jobs expire and re-activate indefinitely, with no error surfacing in application logs.

This PR adds a caution note to the getting-started page (next docs + the shipped 8.9 version) explaining the Micrometer 1.16+ floor and how to pin it via a Maven `dependencyManagement` BOM import or a Gradle constraint.

This is a stopgap documentation caveat, not the final fix. The real resolution (enforcing a Micrometer floor in the starter itself) is tracked at camunda/camunda#59640.

## Related

https://github.com/camunda/camunda/issues/59640

## Checklist

- [x] Prose follows the technical writing style guide
- [x] All internal links include `.md` extension (no new internal links added)
- [x] New pages are added to `sidebars.js` (no new pages, existing page edited)
- [x] Images have alt text (no images added)