### PR TITLE
docs(app-integrations): document Enable App Integrations cluster setting for Teams notifications

### DIFF
--- a/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -110,7 +110,7 @@ To configure notifications, see [notification rules](./ms-teams-notifications.md
 
 Notification cards are interactive. You can assign, complete, or manage tasks directly from the card.
 
-Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9 gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
+Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9 gen13` or later with [app integrations extensions enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
 
 ## Error handling
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -110,7 +110,7 @@ To configure notifications, see [notification rules](./ms-teams-notifications.md
 
 Notification cards are interactive. You can assign, complete, or manage tasks directly from the card.
 
-Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task.
+Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9+gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
 
 ## Error handling
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -110,7 +110,7 @@ To configure notifications, see [notification rules](./ms-teams-notifications.md
 
 Notification cards are interactive. You can assign, complete, or manage tasks directly from the card.
 
-Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9+gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
+Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9 gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
 
 ## Error handling
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -13,15 +13,15 @@ Each rule applies to a specific organization and cluster and can filter user tas
 
 On Camunda 8 SaaS, the notifications a cluster delivers depend on its generation.
 
-Clusters running generation `8.9 gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but the cluster delivers no notifications.
+Clusters running generation `8.9 gen13` or later require the **Enable app integrations extensions** setting in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations-extensions). Until an organization admin turns it on, you can create and save rules, but the cluster delivers no notifications.
 
 Clusters running earlier generations need no configuration. They deliver a notification when a matching user task is created.
 
-| Notification                                                     | Earlier generations | `8.9 gen13` or later, with App Integrations enabled |
-| :--------------------------------------------------------------- | :------------------ | :-------------------------------------------------- |
-| A matching user task is created                                  | Yes                 | Yes                                                 |
-| A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                 |
-| An existing task is later assigned to you                        | No                  | Yes                                                 |
+| Notification                                                     | Earlier generations | `8.9 gen13` or later, with app integrations extensions enabled |
+| :--------------------------------------------------------------- | :------------------ | :------------------------------------------------------------- |
+| A matching user task is created                                  | Yes                 | Yes                                                            |
+| A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                            |
+| An existing task is later assigned to you                        | No                  | Yes                                                            |
 
 Clusters running generation `8.9 gen13` or later also receive new notification capabilities as they become available.
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -9,6 +9,22 @@ Notification rules let you control which user tasks trigger notifications in Mic
 
 Each rule applies to a specific organization and cluster and can filter user task events by process definition, user task elements, candidate users, or candidate groups.
 
+## Enable notification delivery for your cluster
+
+On Camunda 8 SaaS, which notifications a cluster delivers depends on its generation.
+
+Clusters running generation `8.9+gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but no notifications are delivered.
+
+Clusters running earlier generations need no configuration. They deliver a notification when a matching user task is created.
+
+| Notification                                                     | Earlier generations | `8.9+gen13` or later, with App Integrations enabled |
+| :--------------------------------------------------------------- | :------------------ | :-------------------------------------------------- |
+| A matching user task is created                                  | Yes                 | Yes                                                 |
+| A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                 |
+| An existing task is later assigned to you                        | No                  | Yes                                                 |
+
+Clusters running generation `8.9+gen13` and later also receive new notification capabilities as they become available.
+
 ## Channel vs. personal rules
 
 Where you create a rule determines who receives notifications.

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -11,19 +11,19 @@ Each rule applies to a specific organization and cluster and can filter user tas
 
 ## Enable notification delivery for your cluster
 
-On Camunda 8 SaaS, which notifications a cluster delivers depends on its generation.
+On Camunda 8 SaaS, the notifications a cluster delivers depend on its generation.
 
-Clusters running generation `8.9+gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but no notifications are delivered.
+Clusters running generation `8.9 gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but the cluster delivers no notifications.
 
 Clusters running earlier generations need no configuration. They deliver a notification when a matching user task is created.
 
-| Notification                                                     | Earlier generations | `8.9+gen13` or later, with App Integrations enabled |
+| Notification                                                     | Earlier generations | `8.9 gen13` or later, with App Integrations enabled |
 | :--------------------------------------------------------------- | :------------------ | :-------------------------------------------------- |
 | A matching user task is created                                  | Yes                 | Yes                                                 |
 | A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                 |
 | An existing task is later assigned to you                        | No                  | Yes                                                 |
 
-Clusters running generation `8.9+gen13` and later also receive new notification capabilities as they become available.
+Clusters running generation `8.9 gen13` or later also receive new notification capabilities as they become available.
 
 ## Channel vs. personal rules
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -69,7 +69,7 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 
 ### Notifications are not delivered
 
-- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
+- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations Extensions not enabled** message when the setting is off.
 - Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
 - If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9 gen13` or later.
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -67,6 +67,12 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 - If notifications are not shown, ensure Microsoft Teams notifications are enabled and verify that the relevant [notification rules](./ms-teams-notifications.md) are configured for the channel or personal chat.
 - This could be due to an expired Camunda session or missing permissions. Sign out and sign in again.
 
+### Notifications are not delivered
+
+- On SaaS clusters running generation `8.9+gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
+- Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
+- If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9+gen13` or later.
+
 ## Get help
 
 - Contact [Camunda support](/reference/contact.md) for assistance.

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -69,7 +69,7 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 
 ### Notifications are not delivered
 
-- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations Extensions not enabled** message when the setting is off.
+- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable app integrations extensions** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations-extensions). Microsoft Teams shows an **App Integrations Extensions not enabled** message when the setting is off.
 - Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
 - If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9 gen13` or later.
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -69,9 +69,9 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 
 ### Notifications are not delivered
 
-- On SaaS clusters running generation `8.9+gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
+- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
 - Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
-- If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9+gen13` or later.
+- If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9 gen13` or later.
 
 ## Get help
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams.md
@@ -76,11 +76,12 @@ You can use `appContext` in your BPMN processes to implement conditional logic b
 
 <TabItem value="saas">
 
-| Prerequisite                     | Description                                                                                                                                                                |
-| :------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                      |
-| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization. |
-| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                              |
+| Prerequisite                     | Description                                                                                                                                                                                                                                         |
+| :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                               |
+| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                          |
+| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                                       |
+| App Integrations enabled         | For clusters running generation `8.9+gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
 
 </TabItem>
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams.md
@@ -76,12 +76,12 @@ You can use `appContext` in your BPMN processes to implement conditional logic b
 
 <TabItem value="saas">
 
-| Prerequisite                     | Description                                                                                                                                                                                                                                         |
-| :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                               |
-| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                          |
-| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                                       |
-| App Integrations enabled         | For clusters running generation `8.9 gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
+| Prerequisite                     | Description                                                                                                                                                                                                                                                               |
+| :------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                                                     |
+| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                                                |
+| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                                                             |
+| App integrations extensions      | For clusters running generation `8.9 gen13` or later, **Enable app integrations extensions** must be turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations-extensions) to receive user task notifications. |
 
 </TabItem>
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams.md
@@ -81,7 +81,7 @@ You can use `appContext` in your BPMN processes to implement conditional logic b
 | Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                               |
 | Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                          |
 | Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                                       |
-| App Integrations enabled         | For clusters running generation `8.9+gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
+| App Integrations enabled         | For clusters running generation `8.9 gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
 
 </TabItem>
 

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -46,12 +46,12 @@ For details on creating tenants and managing assignments, see [tenant management
 Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
-## Enable App Integrations
+## Enable app integrations extensions
 
-You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so App Integrations can deliver task notifications to your collaboration tool.
+You can allow a cluster to exchange events with App Integrations, such as Camunda for Microsoft Teams, so App Integrations can deliver task notifications to your collaboration tool.
 
 - Enable this setting to deliver user task notifications to Microsoft Teams based on your [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md). Notification cards also update as the task is assigned, completed, or canceled.
-- Disable this setting if you do not want the cluster to send user task events. The cluster delivers no notifications. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
+- Disable this setting if you do not want the cluster to exchange events. App Integrations then work with reduced functionality: the cluster delivers no notifications, but you can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
 
 This setting is disabled by default. It is available for clusters running generation `8.9 gen13` or later, and organization admins can change it.
 

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -48,12 +48,12 @@ Before you enable multi-tenancy checks, assign all users, groups, and roles that
 
 ## Enable App Integrations
 
-You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so task notifications can be delivered to your collaboration tool.
+You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so App Integrations can deliver task notifications to your collaboration tool.
 
 - Enable this setting to deliver user task notifications to Microsoft Teams based on your [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md). Notification cards also update as the task is assigned, completed, or canceled.
-- Disable this setting if you do not want the cluster to send user task events. Notifications are not delivered. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
+- Disable this setting if you do not want the cluster to send user task events. The cluster delivers no notifications. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
 
-This setting is disabled by default. It is available for clusters running generation `8.9+gen13` and later, and organization admins can change it.
+This setting is disabled by default. It is available for clusters running generation `8.9 gen13` or later, and organization admins can change it.
 
 ## Data filters
 

--- a/docs/components/hub/organization/manage-clusters/settings.md
+++ b/docs/components/hub/organization/manage-clusters/settings.md
@@ -46,6 +46,15 @@ For details on creating tenants and managing assignments, see [tenant management
 Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
+## Enable App Integrations
+
+You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so task notifications can be delivered to your collaboration tool.
+
+- Enable this setting to deliver user task notifications to Microsoft Teams based on your [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md). Notification cards also update as the task is assigned, completed, or canceled.
+- Disable this setting if you do not want the cluster to send user task events. Notifications are not delivered. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
+
+This setting is disabled by default. It is available for clusters running generation `8.9+gen13` and later, and organization admins can change it.
+
 ## Data filters
 
 <!-- TODO: Confirm with Console team (camunda-cloud-management-apps#8885) which exact docs anchor the Console UI tooltip links to. Update the #data-filters anchor below if different. -->

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -131,17 +131,18 @@ Camunda 8.9 now supports Elasticsearch 9.2+ and OpenSearch 3.4+, allowing you to
 
 ### 8.9.x patch releases
 
-The following key changes were also released as part of an 8.9.x patch release.
+The following key changes were also released as part of an 8.9.x patch release or a Camunda 8 SaaS generation update.
 
-| Patch release                                                    | Type            | Key change                                                                                                       |
-| :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                   |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)  |
-| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                     |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                    |
+| Patch release                                                    | Type            | Key change                                                                                                             |
+| :--------------------------------------------------------------- | :-------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                        |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)       |
+| SaaS `8.9 gen13`                                                 | Change          | [Microsoft Teams notifications require App Integrations to be enabled](#teams-notifications-require-app-integrations) |
+| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                          |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)      |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)               |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                         |
 
 ## Agentic orchestration
 
@@ -1566,6 +1567,27 @@ Admin is the cluster-level admin UI hosting identity management and other admini
 - Documentation paths are updated: `/components/identity/` is now `/components/admin/`.
 
 <p className="link-arrow">[Introduction to Admin](/components/admin/admin-introduction.md)</p>
+
+</div>
+</div>
+
+## Integrations
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--change">Change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Microsoft Teams notifications require App Integrations to be enabled {#teams-notifications-require-app-integrations}
+
+Camunda 8 SaaS clusters running generation `8.9 gen13` or later deliver user task notifications to Microsoft Teams only when **Enable App Integrations** is turned on in the cluster settings. The setting is disabled by default, and only organization admins can change it.
+
+Clusters running earlier generations are unaffected and continue to deliver notifications without additional configuration.
+
+**Action:** After a cluster updates to generation `8.9 gen13` or later, an organization admin must turn on **Enable App Integrations** for existing [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md) to keep delivering. Enabling the setting also delivers notifications when an existing task is later assigned to you, and updates notification cards as a task is assigned, completed, or canceled.
+
+<p className="link-arrow">[Enable App Integrations](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations)</p>
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/890/890-announcements.md
+++ b/docs/reference/announcements-release-notes/890/890-announcements.md
@@ -133,16 +133,16 @@ Camunda 8.9 now supports Elasticsearch 9.2+ and OpenSearch 3.4+, allowing you to
 
 The following key changes were also released as part of an 8.9.x patch release or a Camunda 8 SaaS generation update.
 
-| Patch release                                                    | Type            | Key change                                                                                                             |
-| :--------------------------------------------------------------- | :-------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                        |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)       |
-| SaaS `8.9 gen13`                                                 | Change          | [Microsoft Teams notifications require App Integrations to be enabled](#teams-notifications-require-app-integrations) |
-| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                          |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)      |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)               |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                         |
+| Patch release                                                    | Type            | Key change                                                                                                                    |
+| :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                               |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)              |
+| SaaS `8.9 gen13`                                                 | Change          | [Microsoft Teams notifications require app integrations extensions](#teams-notifications-require-app-integrations-extensions) |
+| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                 |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)             |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                       |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                      |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                                |
 
 ## Agentic orchestration
 
@@ -1579,15 +1579,15 @@ Admin is the cluster-level admin UI hosting identity management and other admini
 </div>
 <div className="release-announcement-content">
 
-#### Microsoft Teams notifications require App Integrations to be enabled {#teams-notifications-require-app-integrations}
+#### Microsoft Teams notifications require app integrations extensions {#teams-notifications-require-app-integrations-extensions}
 
-Camunda 8 SaaS clusters running generation `8.9 gen13` or later deliver user task notifications to Microsoft Teams only when **Enable App Integrations** is turned on in the cluster settings. The setting is disabled by default, and only organization admins can change it.
+Camunda 8 SaaS clusters running generation `8.9 gen13` or later deliver user task notifications to Microsoft Teams only when **Enable app integrations extensions** is turned on in the cluster settings. The setting is disabled by default, and only organization admins can change it.
 
 Clusters running earlier generations are unaffected and continue to deliver notifications without additional configuration.
 
-**Action:** After a cluster updates to generation `8.9 gen13` or later, an organization admin must turn on **Enable App Integrations** for existing [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md) to keep delivering. Enabling the setting also delivers notifications when an existing task is later assigned to you, and updates notification cards as a task is assigned, completed, or canceled.
+**Action:** After a cluster updates to generation `8.9 gen13` or later, an organization admin must turn on **Enable app integrations extensions** for existing [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md) to keep delivering. Enabling the setting also delivers notifications when an existing task is later assigned to you, and updates notification cards as a task is assigned, completed, or canceled.
 
-<p className="link-arrow">[Enable App Integrations](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations)</p>
+<p className="link-arrow">[Enable app integrations extensions](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations-extensions)</p>
 
 </div>
 </div>

--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -340,6 +340,15 @@ The Camunda for Microsoft Teams app is now available for Self-Managed environmen
 
 <p class="link-arrow">[Camunda for Microsoft Teams](/components/camunda-integrations/ms-teams/ms-teams.md)</p>
 
+### Live task updates and assignment notifications in Microsoft Teams
+
+Camunda for Microsoft Teams now updates a notification card as its task is assigned, completed, or canceled, and notifies you when an existing task is later assigned to you. On SaaS, these capabilities require a cluster running generation `8.9 gen13` or later with **Enable App Integrations** turned on in the cluster settings.
+
+<ul>
+  <li><span class="link-arrow">[Enable notification delivery for your cluster](/components/camunda-integrations/ms-teams/ms-teams-notifications.md#enable-notification-delivery-for-your-cluster)</span></li>
+  <li><span class="link-arrow">[Enable App Integrations](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations)</span></li>
+</ul>
+
 ## Migration from Camunda 7 to Camunda 8
 
 ### Conditional events support in Migration Analyzer and Diagram Converter

--- a/docs/reference/announcements-release-notes/890/890-release-notes.md
+++ b/docs/reference/announcements-release-notes/890/890-release-notes.md
@@ -342,11 +342,11 @@ The Camunda for Microsoft Teams app is now available for Self-Managed environmen
 
 ### Live task updates and assignment notifications in Microsoft Teams
 
-Camunda for Microsoft Teams now updates a notification card as its task is assigned, completed, or canceled, and notifies you when an existing task is later assigned to you. On SaaS, these capabilities require a cluster running generation `8.9 gen13` or later with **Enable App Integrations** turned on in the cluster settings.
+Camunda for Microsoft Teams now updates a notification card as its task is assigned, completed, or canceled, and notifies you when an existing task is later assigned to you. On SaaS, these capabilities require a cluster running generation `8.9 gen13` or later with **Enable app integrations extensions** turned on in the cluster settings.
 
 <ul>
   <li><span class="link-arrow">[Enable notification delivery for your cluster](/components/camunda-integrations/ms-teams/ms-teams-notifications.md#enable-notification-delivery-for-your-cluster)</span></li>
-  <li><span class="link-arrow">[Enable App Integrations](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations)</span></li>
+  <li><span class="link-arrow">[Enable app integrations extensions](/components/hub/organization/manage-clusters/settings.md#enable-app-integrations-extensions)</span></li>
 </ul>
 
 ## Migration from Camunda 7 to Camunda 8

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -110,7 +110,7 @@ To configure notifications, see [notification rules](./ms-teams-notifications.md
 
 Notification cards are interactive. You can assign, complete, or manage tasks directly from the card.
 
-Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9 gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
+Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9 gen13` or later with [app integrations extensions enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
 
 ## Error handling
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -110,7 +110,7 @@ To configure notifications, see [notification rules](./ms-teams-notifications.md
 
 Notification cards are interactive. You can assign, complete, or manage tasks directly from the card.
 
-Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task.
+Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9+gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
 
 ## Error handling
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-chatbot.md
@@ -110,7 +110,7 @@ To configure notifications, see [notification rules](./ms-teams-notifications.md
 
 Notification cards are interactive. You can assign, complete, or manage tasks directly from the card.
 
-Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9+gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
+Cards update automatically to reflect the latest task state. For example, when someone else completes or assigns the task. On SaaS, automatic updates require a cluster running generation `8.9 gen13` or later with [App Integrations enabled](./ms-teams-notifications.md#enable-notification-delivery-for-your-cluster).
 
 ## Error handling
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -13,15 +13,15 @@ Each rule applies to a specific organization and cluster and can filter user tas
 
 On Camunda 8 SaaS, the notifications a cluster delivers depend on its generation.
 
-Clusters running generation `8.9 gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but the cluster delivers no notifications.
+Clusters running generation `8.9 gen13` or later require the **Enable app integrations extensions** setting in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations-extensions). Until an organization admin turns it on, you can create and save rules, but the cluster delivers no notifications.
 
 Clusters running earlier generations need no configuration. They deliver a notification when a matching user task is created.
 
-| Notification                                                     | Earlier generations | `8.9 gen13` or later, with App Integrations enabled |
-| :--------------------------------------------------------------- | :------------------ | :-------------------------------------------------- |
-| A matching user task is created                                  | Yes                 | Yes                                                 |
-| A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                 |
-| An existing task is later assigned to you                        | No                  | Yes                                                 |
+| Notification                                                     | Earlier generations | `8.9 gen13` or later, with app integrations extensions enabled |
+| :--------------------------------------------------------------- | :------------------ | :------------------------------------------------------------- |
+| A matching user task is created                                  | Yes                 | Yes                                                            |
+| A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                            |
+| An existing task is later assigned to you                        | No                  | Yes                                                            |
 
 Clusters running generation `8.9 gen13` or later also receive new notification capabilities as they become available.
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -11,19 +11,19 @@ Each rule applies to a specific organization and cluster and can filter user tas
 
 ## Enable notification delivery for your cluster
 
-On Camunda 8 SaaS, which notifications a cluster delivers depends on its generation.
+On Camunda 8 SaaS, the notifications a cluster delivers depend on its generation.
 
-Clusters running generation `8.9+gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but no notifications are delivered.
+Clusters running generation `8.9 gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but the cluster delivers no notifications.
 
 Clusters running earlier generations need no configuration. They deliver a notification when a matching user task is created.
 
-| Notification                                                     | Earlier generations | `8.9+gen13` or later, with App Integrations enabled |
+| Notification                                                     | Earlier generations | `8.9 gen13` or later, with App Integrations enabled |
 | :--------------------------------------------------------------- | :------------------ | :-------------------------------------------------- |
 | A matching user task is created                                  | Yes                 | Yes                                                 |
 | A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                 |
 | An existing task is later assigned to you                        | No                  | Yes                                                 |
 
-Clusters running generation `8.9+gen13` and later also receive new notification capabilities as they become available.
+Clusters running generation `8.9 gen13` or later also receive new notification capabilities as they become available.
 
 ## Channel vs. personal rules
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -9,6 +9,22 @@ Notification rules let you control which user tasks trigger notifications in Mic
 
 Each rule applies to a specific organization and cluster and can filter user task events by process definition, user task elements, candidate users, or candidate groups.
 
+## Enable notification delivery for your cluster
+
+On Camunda 8 SaaS, which notifications a cluster delivers depends on its generation.
+
+Clusters running generation `8.9+gen13` or later require the **Enable App Integrations** setting in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Until an organization admin turns it on, you can create and save rules, but no notifications are delivered.
+
+Clusters running earlier generations need no configuration. They deliver a notification when a matching user task is created.
+
+| Notification                                                     | Earlier generations | `8.9+gen13` or later, with App Integrations enabled |
+| :--------------------------------------------------------------- | :------------------ | :-------------------------------------------------- |
+| A matching user task is created                                  | Yes                 | Yes                                                 |
+| A card updates when the task is assigned, completed, or canceled | No                  | Yes                                                 |
+| An existing task is later assigned to you                        | No                  | Yes                                                 |
+
+Clusters running generation `8.9+gen13` and later also receive new notification capabilities as they become available.
+
 ## Channel vs. personal rules
 
 Where you create a rule determines who receives notifications.

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -67,6 +67,12 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 - If notifications are not shown, ensure Microsoft Teams notifications are enabled and verify that the relevant [notification rules](./ms-teams-notifications.md) are configured for the channel or personal chat.
 - This could be due to an expired Camunda session or missing permissions. Sign out and sign in again.
 
+### Notifications are not delivered
+
+- On SaaS clusters running generation `8.9+gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
+- Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
+- If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9+gen13` or later.
+
 ## Get help
 
 - Contact [Camunda support](/reference/contact.md) for assistance.

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -69,9 +69,9 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 
 ### Notifications are not delivered
 
-- On SaaS clusters running generation `8.9+gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
+- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
 - Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
-- If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9+gen13` or later.
+- If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9 gen13` or later.
 
 ## Get help
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -69,7 +69,7 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 
 ### Notifications are not delivered
 
-- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations Extensions not enabled** message when the setting is off.
+- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable app integrations extensions** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations-extensions). Microsoft Teams shows an **App Integrations Extensions not enabled** message when the setting is off.
 - Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
 - If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9 gen13` or later.
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-troubleshoot.md
@@ -69,7 +69,7 @@ Troubleshoot Camunda for Microsoft Teams to fix common setup and connectivity is
 
 ### Notifications are not delivered
 
-- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations disabled in Cluster configuration** message when the setting is off.
+- On SaaS clusters running generation `8.9 gen13` or later, check that **Enable App Integrations** is turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations). Microsoft Teams shows an **App Integrations Extensions not enabled** message when the setting is off.
 - Verify that a [notification rule](./ms-teams-notifications.md) matches the user task, and that the rule is configured for the channel or personal chat you expect.
 - If notifications arrive but cards do not update when a task is assigned, completed, or canceled, check that the cluster runs generation `8.9 gen13` or later.
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams.md
@@ -76,12 +76,12 @@ You can use `appContext` in your BPMN processes to implement conditional logic b
 
 <TabItem value="saas">
 
-| Prerequisite                     | Description                                                                                                                                                                                                                                |
-| :------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                      |
-| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                 |
-| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                              |
-| App Integrations enabled         | For clusters running generation `8.9 gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
+| Prerequisite                     | Description                                                                                                                                                                                                                                                      |
+| :------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                                            |
+| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                                       |
+| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                                                    |
+| App integrations extensions      | For clusters running generation `8.9 gen13` or later, **Enable app integrations extensions** must be turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations-extensions) to receive user task notifications. |
 
 </TabItem>
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams.md
@@ -81,7 +81,7 @@ You can use `appContext` in your BPMN processes to implement conditional logic b
 | Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                      |
 | Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                 |
 | Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                              |
-| App Integrations enabled         | For clusters running generation `8.9+gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
+| App Integrations enabled         | For clusters running generation `8.9 gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
 
 </TabItem>
 

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams.md
@@ -76,11 +76,12 @@ You can use `appContext` in your BPMN processes to implement conditional logic b
 
 <TabItem value="saas">
 
-| Prerequisite                     | Description                                                                                                                                                                |
-| :------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                      |
-| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization. |
-| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                              |
+| Prerequisite                     | Description                                                                                                                                                                                                                                |
+| :------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Camunda 8 SaaS account           | You must have a valid working Camunda 8 SaaS account.                                                                                                                                                                                      |
+| Microsoft Teams                  | Microsoft Teams with permissions to add apps from the Microsoft Store. Microsoft Teams administrators can manage app permissions and availability across the organization.                                                                 |
+| Camunda organization and cluster | Access to a Camunda organization and cluster.                                                                                                                                                                                              |
+| App Integrations enabled         | For clusters running generation `8.9+gen13` or later, **Enable App Integrations** must be turned on in the [cluster settings](/components/console/manage-clusters/settings.md#enable-app-integrations) to receive user task notifications. |
 
 </TabItem>
 

--- a/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
+++ b/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
@@ -42,6 +42,15 @@ For details on creating tenants and managing assignments, see [tenant management
 Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
+## Enable App Integrations
+
+You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so task notifications can be delivered to your collaboration tool.
+
+- Enable this setting to deliver user task notifications to Microsoft Teams based on your [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md). Notification cards also update as the task is assigned, completed, or canceled.
+- Disable this setting if you do not want the cluster to send user task events. Notifications are not delivered. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
+
+This setting is disabled by default. It is available for clusters running generation `8.9+gen13` and later, and organization admins can change it.
+
 ## Automatic cluster updates
 
 You can set the cluster to automatically update to newer versions of Camunda 8 when they are released.

--- a/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
+++ b/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
@@ -44,12 +44,12 @@ Before you enable multi-tenancy checks, assign all users, groups, and roles that
 
 ## Enable App Integrations
 
-You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so task notifications can be delivered to your collaboration tool.
+You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so App Integrations can deliver task notifications to your collaboration tool.
 
 - Enable this setting to deliver user task notifications to Microsoft Teams based on your [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md). Notification cards also update as the task is assigned, completed, or canceled.
-- Disable this setting if you do not want the cluster to send user task events. Notifications are not delivered. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
+- Disable this setting if you do not want the cluster to send user task events. The cluster delivers no notifications. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
 
-This setting is disabled by default. It is available for clusters running generation `8.9+gen13` and later, and organization admins can change it.
+This setting is disabled by default. It is available for clusters running generation `8.9 gen13` or later, and organization admins can change it.
 
 ## Automatic cluster updates
 

--- a/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
+++ b/versioned_docs/version-8.9/components/console/manage-clusters/settings.md
@@ -42,12 +42,12 @@ For details on creating tenants and managing assignments, see [tenant management
 Before you enable multi-tenancy checks, assign all users, groups, and roles that need access to their tenants and to the `<default>` tenant. Once checks are enforced, any principal not assigned to a tenant loses access to the resources scoped to that tenant.
 :::
 
-## Enable App Integrations
+## Enable app integrations extensions
 
-You can allow a cluster to exchange user task events with App Integrations, such as Camunda for Microsoft Teams, so App Integrations can deliver task notifications to your collaboration tool.
+You can allow a cluster to exchange events with App Integrations, such as Camunda for Microsoft Teams, so App Integrations can deliver task notifications to your collaboration tool.
 
 - Enable this setting to deliver user task notifications to Microsoft Teams based on your [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md). Notification cards also update as the task is assigned, completed, or canceled.
-- Disable this setting if you do not want the cluster to send user task events. The cluster delivers no notifications. You can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
+- Disable this setting if you do not want the cluster to exchange events. App Integrations then work with reduced functionality: the cluster delivers no notifications, but you can still use Camunda for Microsoft Teams to browse tasks, start processes, and act on tasks.
 
 This setting is disabled by default. It is available for clusters running generation `8.9 gen13` or later, and organization admins can change it.
 

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -133,17 +133,17 @@ Camunda 8.9 now supports Elasticsearch 9.2+ and OpenSearch 3.4+, allowing you to
 
 The following key changes were also released as part of an 8.9.x patch release or a Camunda 8 SaaS generation update.
 
-| Patch release                                                    | Type            | Key change                                                                                                             |
-| :--------------------------------------------------------------- | :-------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                          |
-| [8.9.12](https://github.com/camunda/camunda/releases/tag/8.9.12) | Breaking change | [Individual component Docker images no longer produced](#individual-component-docker-images-no-longer-produced)       |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                        |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)       |
-| SaaS `8.9 gen13`                                                 | Change          | [Microsoft Teams notifications require App Integrations to be enabled](#teams-notifications-require-app-integrations) |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)      |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)               |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                         |
+| Patch release                                                    | Type            | Key change                                                                                                                    |
+| :--------------------------------------------------------------- | :-------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                                 |
+| [8.9.12](https://github.com/camunda/camunda/releases/tag/8.9.12) | Breaking change | [Individual component Docker images no longer produced](#individual-component-docker-images-no-longer-produced)              |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                               |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)              |
+| SaaS `8.9 gen13`                                                 | Change          | [Microsoft Teams notifications require app integrations extensions](#teams-notifications-require-app-integrations-extensions) |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)             |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                       |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)                      |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                                |
 
 ## Agentic orchestration
 
@@ -1598,15 +1598,15 @@ Admin is the cluster-level admin UI hosting identity management and other admini
 </div>
 <div className="release-announcement-content">
 
-#### Microsoft Teams notifications require App Integrations to be enabled {#teams-notifications-require-app-integrations}
+#### Microsoft Teams notifications require app integrations extensions {#teams-notifications-require-app-integrations-extensions}
 
-Camunda 8 SaaS clusters running generation `8.9 gen13` or later deliver user task notifications to Microsoft Teams only when **Enable App Integrations** is turned on in the cluster settings. The setting is disabled by default, and only organization admins can change it.
+Camunda 8 SaaS clusters running generation `8.9 gen13` or later deliver user task notifications to Microsoft Teams only when **Enable app integrations extensions** is turned on in the cluster settings. The setting is disabled by default, and only organization admins can change it.
 
 Clusters running earlier generations are unaffected and continue to deliver notifications without additional configuration.
 
-**Action:** After a cluster updates to generation `8.9 gen13` or later, an organization admin must turn on **Enable App Integrations** for existing [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md) to keep delivering. Enabling the setting also delivers notifications when an existing task is later assigned to you, and updates notification cards as a task is assigned, completed, or canceled.
+**Action:** After a cluster updates to generation `8.9 gen13` or later, an organization admin must turn on **Enable app integrations extensions** for existing [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md) to keep delivering. Enabling the setting also delivers notifications when an existing task is later assigned to you, and updates notification cards as a task is assigned, completed, or canceled.
 
-<p className="link-arrow">[Enable App Integrations](/components/console/manage-clusters/settings.md#enable-app-integrations)</p>
+<p className="link-arrow">[Enable app integrations extensions](/components/console/manage-clusters/settings.md#enable-app-integrations-extensions)</p>
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-announcements.md
@@ -131,18 +131,19 @@ Camunda 8.9 now supports Elasticsearch 9.2+ and OpenSearch 3.4+, allowing you to
 
 ### 8.9.x patch releases
 
-The following key changes were also released as part of an 8.9.x patch release.
+The following key changes were also released as part of an 8.9.x patch release or a Camunda 8 SaaS generation update.
 
-| Patch release                                                    | Type            | Key change                                                                                                       |
-| :--------------------------------------------------------------- | :-------------- | :--------------------------------------------------------------------------------------------------------------- |
-| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                     |
-| [8.9.12](https://github.com/camunda/camunda/releases/tag/8.9.12) | Breaking change | [Individual component Docker images no longer produced](#individual-component-docker-images-no-longer-produced)  |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                   |
-| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)  |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression) |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                           |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)          |
-| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                    |
+| Patch release                                                    | Type            | Key change                                                                                                             |
+| :--------------------------------------------------------------- | :-------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| [8.9.10](https://github.com/camunda/camunda/releases/tag/8.9.10) | Regression      | [Tasklist V1: candidate group task visibility](#tasklist-v1-candidate-group-task-visibility)                          |
+| [8.9.12](https://github.com/camunda/camunda/releases/tag/8.9.12) | Breaking change | [Individual component Docker images no longer produced](#individual-component-docker-images-no-longer-produced)       |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Nested input mappings can silently drop sibling fields](#nested-input-mapping-sibling-fields)                        |
+| [8.9.15](https://github.com/camunda/camunda/releases/tag/8.9.15) | Regression      | [Chained input mappings can silently drop FEEL temporal value types](#chained-input-mapping-temporal-type-loss)       |
+| SaaS `8.9 gen13`                                                 | Change          | [Microsoft Teams notifications require App Integrations to be enabled](#teams-notifications-require-app-integrations) |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Multi-instance sub-process output mapping variable scope regression](#multi-instance-output-mapping-regression)      |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Regression      | [Output mapping behavior change for object variables](#output-mapping-behavior-change)                                |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Breaking change | [`getMessageKeys()` removed from the exporter record](#getmessagekeys-removed-from-the-exporter-record)               |
+| [8.9.1](https://github.com/camunda/camunda/releases/tag/8.9.1)   | Change          | [Message TTL cleanup batch size pacing change](#message-ttl-cleanup-batch-size-pacing-change)                         |
 
 ## Agentic orchestration
 
@@ -1585,6 +1586,27 @@ Admin is the cluster-level admin UI hosting identity management and other admini
 - Documentation paths are updated: `/components/identity/` is now `/components/admin/`.
 
 <p className="link-arrow">[Introduction to Admin](/components/admin/admin-introduction.md)</p>
+
+</div>
+</div>
+
+## Integrations
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--change">Change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Microsoft Teams notifications require App Integrations to be enabled {#teams-notifications-require-app-integrations}
+
+Camunda 8 SaaS clusters running generation `8.9 gen13` or later deliver user task notifications to Microsoft Teams only when **Enable App Integrations** is turned on in the cluster settings. The setting is disabled by default, and only organization admins can change it.
+
+Clusters running earlier generations are unaffected and continue to deliver notifications without additional configuration.
+
+**Action:** After a cluster updates to generation `8.9 gen13` or later, an organization admin must turn on **Enable App Integrations** for existing [notification rules](/components/camunda-integrations/ms-teams/ms-teams-notifications.md) to keep delivering. Enabling the setting also delivers notifications when an existing task is later assigned to you, and updates notification cards as a task is assigned, completed, or canceled.
+
+<p className="link-arrow">[Enable App Integrations](/components/console/manage-clusters/settings.md#enable-app-integrations)</p>
 
 </div>
 </div>

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -354,11 +354,11 @@ The Camunda for Microsoft Teams app is now available for Self-Managed environmen
 
 ### Live task updates and assignment notifications in Microsoft Teams
 
-Camunda for Microsoft Teams now updates a notification card as its task is assigned, completed, or canceled, and notifies you when an existing task is later assigned to you. On SaaS, these capabilities require a cluster running generation `8.9 gen13` or later with **Enable App Integrations** turned on in the cluster settings.
+Camunda for Microsoft Teams now updates a notification card as its task is assigned, completed, or canceled, and notifies you when an existing task is later assigned to you. On SaaS, these capabilities require a cluster running generation `8.9 gen13` or later with **Enable app integrations extensions** turned on in the cluster settings.
 
 <ul>
   <li><span class="link-arrow">[Enable notification delivery for your cluster](/components/camunda-integrations/ms-teams/ms-teams-notifications.md#enable-notification-delivery-for-your-cluster)</span></li>
-  <li><span class="link-arrow">[Enable App Integrations](/components/console/manage-clusters/settings.md#enable-app-integrations)</span></li>
+  <li><span class="link-arrow">[Enable app integrations extensions](/components/console/manage-clusters/settings.md#enable-app-integrations-extensions)</span></li>
 </ul>
 
 ## Migration from Camunda 7 to Camunda 8

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/890/890-release-notes.md
@@ -352,6 +352,15 @@ The Camunda for Microsoft Teams app is now available for Self-Managed environmen
 
 <p class="link-arrow">[Camunda for Microsoft Teams](/components/camunda-integrations/ms-teams/ms-teams.md)</p>
 
+### Live task updates and assignment notifications in Microsoft Teams
+
+Camunda for Microsoft Teams now updates a notification card as its task is assigned, completed, or canceled, and notifies you when an existing task is later assigned to you. On SaaS, these capabilities require a cluster running generation `8.9 gen13` or later with **Enable App Integrations** turned on in the cluster settings.
+
+<ul>
+  <li><span class="link-arrow">[Enable notification delivery for your cluster](/components/camunda-integrations/ms-teams/ms-teams-notifications.md#enable-notification-delivery-for-your-cluster)</span></li>
+  <li><span class="link-arrow">[Enable App Integrations](/components/console/manage-clusters/settings.md#enable-app-integrations)</span></li>
+</ul>
+
 ## Migration from Camunda 7 to Camunda 8
 
 ### Conditional events support in Migration Analyzer and Diagram Converter


### PR DESCRIPTION
## Description

Documents the new **Enable App Integrations** cluster setting and what it means for Camunda for Microsoft Teams notifications.

On Camunda 8 SaaS, clusters running generation `8.9+gen13` or later deliver user task notifications to Microsoft Teams only after this setting is turned on in the cluster settings. Until then, notification rules can be created and saved but nothing is delivered. In exchange, these clusters get more than the older behavior: alongside the "a task was created" notification, cards now refresh in place as a task is assigned, completed, or canceled, and tasks assigned to you later also notify you. Clusters on earlier generations need no configuration and continue to receive the task-creation notification only.

Changes:

- **Cluster settings** — a new `Enable App Integrations` section describing what the setting does, that it is off by default, which generations offer it, and who can change it.
- **Notification rules** — a new section explaining that delivery depends on the cluster generation, with a table comparing what each delivers.
- **Getting started** — a prerequisite row for the SaaS tab.
- **Chatbot** — the automatic card update behavior is now correctly qualified rather than stated unconditionally.
- **Troubleshooting** — a new entry for notifications that are not delivered, including the message Teams shows when the setting is off.

Scope is deliberately limited to SaaS and to Microsoft Teams. Self-Managed behavior is unchanged and untouched.

Applied to `docs/` (8.10) and `versioned_docs/version-8.9/`. 8.8 needs no change: its Teams documentation already describes notifications as new-task-only, which remains accurate for that generation.

Relates to the App Integrations SaaS exporter rollout.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

> Added `hold` because this documents behavior tied to the `8.9+gen13` generation rollout. If that generation is already live, drop the label and release.

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
