### PR TITLE
docs: describe how Fix and Autofill behave in assisted tool configuration

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
@@ -253,10 +253,10 @@ When a `fromAi()` key or output key is a near-miss, for example a value close to
 
 Two buttons appear, and they make different promises:
 
-| Button       | What it does                                                                | What happens to your text                       |
-| :----------- | :-------------------------------------------------------------------------- | :---------------------------------------------- |
-| **Fix**      | Corrects a part that is wrong and has exactly one valid form                | Kept. Only the invalid part is rewritten        |
-| **Autofill** | Fills in what is missing, or resets a call that cannot be parsed at all     | Kept where readable, replaced by defaults where not |
+| Button       | What it does                                                            | What happens to your text                           |
+| :----------- | :---------------------------------------------------------------------- | :-------------------------------------------------- |
+| **Fix**      | Corrects a part that is wrong and has exactly one valid form            | Kept. Only the invalid part is rewritten            |
+| **Autofill** | Fills in what is missing, or resets a call that cannot be parsed at all | Kept where readable, replaced by defaults where not |
 
 Correcting an invalid `fromAi()` key rewrites the key and preserves any description and type arguments you entered. If the call cannot be parsed at all, for example because an argument is half-written, Autofill resets the whole call to a working default and you re-enter the rest. Hover the button to see which of the two will happen, and use undo if the result is not what you wanted.
 

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
@@ -217,23 +217,26 @@ For supported file types and details on how documents are resolved, see [documen
 
 In the properties panel, Web Modeler helps you fill in both parts of the tool contract: [`fromAi()`](#ai-generated-parameters-via-fromai) inputs and the [`toolCallResult`](#tool-call-responses) output. This assistance appears only inside an ad-hoc sub-process marked as agentic through either the `io.camunda.agenticai.toolContainer` property or an out-of-the-box AI Agent element template. It does not appear in a plain sub-process.
 
-Assisted configuration follows three rules:
+Two affordances appear, and they apply to different fields:
 
-1. **Best-effort.** It keeps every decision you made and it can still read. A description or type you wrote is a decision; a key it cannot parse is not.
-2. **Reset when nothing can be salvaged.** A call that will not parse is unusable, so Web Modeler offers a working default and you redo the rest. Undo is always available.
-3. **It says which of the two just happened.** The button shows no preview of the value it writes, so hover it to see what will change before you accept.
+| Affordance   | Where it appears                      | What it does                                                              |
+| :----------- | :------------------------------------ | :------------------------------------------------------------------------ |
+| **Autofill** | On a blank field only                 | Seeds a correctly structured value. It never overwrites an existing value |
+| **Fix**      | On a field that already holds a value | Rewrites only the invalid part of that value and keeps the rest           |
 
-Autofill on a blank field never overwrites anything, because there is nothing there to keep.
+**Autofill** disappears as soon as a field holds any value, so it can never replace something you entered. **Fix** edits only the part it identifies as invalid, so it preserves the rest of the expression. Both actions are undoable.
 
 ### Autofill a `fromAi()` input
 
 On a tool's root node (the activity with no incoming flows), an autofill icon appears for a blank input mapping or blank FEEL-capable element-template field. Select the icon to add a correctly structured call:
 
 ```feel
-=fromAi(toolCall.parameterName, "Description of the parameter")
+=fromAi(toolCall.parameterName, "Description of the parameter", "string")
 ```
 
 Replace the placeholder key and description with values for your tool. The autofill icon appears only on a blank field, so it never replaces a value you entered.
+
+Web Modeler derives the key from the field's target and infers the type argument from the field's description or name. This inferred type is a heuristic, not a guaranteed match for the target's real shape, so check it when a tool call fails with a type mismatch.
 
 ### Autofill a `toolCallResult` output
 
@@ -247,20 +250,25 @@ If a tool-flow element does not yet produce a contract-readable result, you can 
 
 For a multi-instance tool, autofill also sets the output collection and output element so the agent collects a result for every iteration instead of returning `null`.
 
-### Accept a correction
+### Fix an invalid key
 
-When a `fromAi()` key or output key is a near-miss, for example a value close to `toolCallResult` but not exact, Web Modeler detects it locally and offers a correction you can accept in one click.
+When a `fromAi()` key or an output key is invalid, Web Modeler detects it locally by re-parsing the element's own fields and offers a **Fix** button. No modeling-guidance report is involved.
 
-Two buttons appear, and they make different promises:
+Web Modeler offers **Fix** for:
 
-| Button       | What it does                                                            | What happens to your text                           |
-| :----------- | :---------------------------------------------------------------------- | :-------------------------------------------------- |
-| **Fix**      | Corrects a part that is wrong and has exactly one valid form            | Kept. Only the invalid part is rewritten            |
-| **Autofill** | Fills in what is missing, or resets a call that cannot be parsed at all | Kept where readable, replaced by defaults where not |
+- A `fromAi()` key with a missing `toolCall.` prefix, bracket notation, a quoted string, or an over-long path.
+- A `fromAi` function name with incorrect casing, since only the exact name is recognized.
+- A description that is not a string literal.
+- An output key that is a near-miss of `toolCallResult`, such as `toolcallresult`.
+- A `fromAi()` key that cannot be recovered as written, such as a missing or numeric key. Web Modeler fills in a key derived from the field's own target.
 
-Correcting an invalid `fromAi()` key rewrites the key and preserves any description and type arguments you entered. If the call cannot be parsed at all, for example because an argument is half-written, Autofill resets the whole call to a working default and you re-enter the rest. Hover the button to see which of the two will happen, and use undo if the result is not what you wanted.
+In every case, **Fix** rewrites only the invalid key or the `fromAi(...)` span and leaves the rest of the field intact. A field such as `=concat("prefix-", fromAi(...), "-suffix")` keeps both surrounding literals, and correcting an invalid key preserves any description and type arguments you entered.
 
-If a `fromAi()` call is on an element other than the tool's root node, the AI Agent connector cannot resolve it. Web Modeler offers to move the call to the root node.
+The button is always labeled **Fix**, so hover it to see the specific change it makes before you select it.
+
+If a field's expression cannot be parsed at all, Web Modeler cannot identify what to correct and offers no fix. Repair the expression yourself.
+
+If a `fromAi()` call is on an element other than the tool's root node, the AI Agent connector cannot resolve it. Web Modeler offers a move action, labeled with the root node's name, that declares the input on the root node and rewrites only the `fromAi(...)` span on the original field.
 
 This assistance complements the agent [modeling-guidance rules](/components/modeler/reference/modeling-guidance/rules/agent-fromai-contract.md), which flag the same contract problems. The rules report what is wrong, assisted configuration offers to fix it.
 

--- a/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
+++ b/docs/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md
@@ -215,7 +215,15 @@ For supported file types and details on how documents are resolved, see [documen
 
 ## Assisted tool configuration in Web Modeler
 
-In the properties panel, Web Modeler helps you fill in both parts of the tool contract: [`fromAi()`](#ai-generated-parameters-via-fromai) inputs and the [`toolCallResult`](#tool-call-responses) output. This assistance appears only inside an ad-hoc sub-process marked as agentic through either the `io.camunda.agenticai.toolContainer` property or an out-of-the-box AI Agent element template. It does not appear in a plain sub-process and only fills blank fields, so it does not overwrite values you already entered.
+In the properties panel, Web Modeler helps you fill in both parts of the tool contract: [`fromAi()`](#ai-generated-parameters-via-fromai) inputs and the [`toolCallResult`](#tool-call-responses) output. This assistance appears only inside an ad-hoc sub-process marked as agentic through either the `io.camunda.agenticai.toolContainer` property or an out-of-the-box AI Agent element template. It does not appear in a plain sub-process.
+
+Assisted configuration follows three rules:
+
+1. **Best-effort.** It keeps every decision you made and it can still read. A description or type you wrote is a decision; a key it cannot parse is not.
+2. **Reset when nothing can be salvaged.** A call that will not parse is unusable, so Web Modeler offers a working default and you redo the rest. Undo is always available.
+3. **It says which of the two just happened.** The button shows no preview of the value it writes, so hover it to see what will change before you accept.
+
+Autofill on a blank field never overwrites anything, because there is nothing there to keep.
 
 ### Autofill a `fromAi()` input
 
@@ -225,7 +233,7 @@ On a tool's root node (the activity with no incoming flows), an autofill icon ap
 =fromAi(toolCall.parameterName, "Description of the parameter")
 ```
 
-Replace the placeholder key and description with values for your tool. Autofill does not overwrite existing field values.
+Replace the placeholder key and description with values for your tool. The autofill icon appears only on a blank field, so it never replaces a value you entered.
 
 ### Autofill a `toolCallResult` output
 
@@ -241,7 +249,16 @@ For a multi-instance tool, autofill also sets the output collection and output e
 
 ### Accept a correction
 
-When a `fromAi()` key or output key is a near-miss—for example, a value close to `toolCallResult` but not exact—Web Modeler detects it locally and offers a correction you can accept in one click. A correction changes only the invalid part. For example, correcting an invalid `fromAi()` key rewrites the key but preserves any description and type arguments you entered.
+When a `fromAi()` key or output key is a near-miss, for example a value close to `toolCallResult` but not exact, Web Modeler detects it locally and offers a correction you can accept in one click.
+
+Two buttons appear, and they make different promises:
+
+| Button       | What it does                                                                | What happens to your text                       |
+| :----------- | :-------------------------------------------------------------------------- | :---------------------------------------------- |
+| **Fix**      | Corrects a part that is wrong and has exactly one valid form                | Kept. Only the invalid part is rewritten        |
+| **Autofill** | Fills in what is missing, or resets a call that cannot be parsed at all     | Kept where readable, replaced by defaults where not |
+
+Correcting an invalid `fromAi()` key rewrites the key and preserves any description and type arguments you entered. If the call cannot be parsed at all, for example because an argument is half-written, Autofill resets the whole call to a working default and you re-enter the rest. Hover the button to see which of the two will happen, and use undo if the result is not what you wanted.
 
 If a `fromAi()` call is on an element other than the tool's root node, the AI Agent connector cannot resolve it. Web Modeler offers to move the call to the root node.
 


### PR DESCRIPTION
## Description

Documents the assisted tool configuration affordances in Web Modeler's properties panel, in the **Assisted tool configuration in Web Modeler** section of the AI Agent tool definitions page.

Web Modeler offers two affordances in the properties panel of an element inside an agentic ad-hoc sub-process, and the section is organized around which field each one applies to:

| Affordance   | Where it appears                      | What it does                                                    |
| :----------- | :------------------------------------ | :-------------------------------------------------------------- |
| **Autofill** | On a blank field only                 | Seeds a correctly structured value, never overwriting an entry  |
| **Fix**      | On a field that already holds a value | Rewrites only the invalid part of that value and keeps the rest |

The section covers:

- Autofilling a `fromAi()` input on a tool's root node, and autofilling a `toolCallResult` output into an element's native result field.
- The cases **Fix** covers: a wrong or missing `toolCall.` prefix, bracket notation, a quoted key, an over-long path, incorrect `fromAi` casing, a non-literal description, and a near-miss of `toolCallResult`.
- The unrecoverable-key case, where **Fix** derives a replacement key from the field's own target.
- That **Fix** rewrites only the invalid key or the `fromAi(...)` span, so surrounding expression text survives.
- That an expression which cannot be parsed at all gets no offer, and needs manual repair.
- The move action offered when a `fromAi()` call sits on a non-root element.

The seeded example includes the `type` argument that Web Modeler always emits, with a note that the type is inferred heuristically and is worth checking when a tool call fails on a type mismatch.

Source of truth: `frontend/apps/hub/src/features/agent-config-autofill/` on `camunda-hub` `main`, shipped in camunda/camunda-hub#26699 via `@camunda/linting@3.54.0`.

### Scope

`docs/` only. The 8.8 and 8.9 copies of this page carry no assisted-configuration section, autofill mention, or `#autofill-a-fromai-input` anchor, so there is nothing to backport.

### How to verify

1. Open an agentic AI Agent diagram in Implement mode.
2. On a tool's root node, confirm the autofill icon appears only on blank fields and disappears once a field holds a value.
3. Enter `=fromAi(null, "Customer wording", "number")`. Confirm the button reads **Fix**, and that the description and type survive the correction.
4. Enter an expression that cannot be parsed, and confirm no fix is offered.
5. Confirm a plain, non-agentic sub-process shows none of these affordances.

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.