### PR TITLE
Per-IdP playbooks

### DIFF
--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/external-keycloak.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/external-keycloak.md
@@ -142,8 +142,9 @@ global:
       realm: /realms/<realm>
       auth:
         adminUser: <keycloak_admin>
-        existingSecret: "camunda-credentials"
-        existingSecretKey: "identity-keycloak-admin-password"
+        secret:
+          existingSecret: "camunda-credentials"
+          existingSecretKey: "identity-keycloak-admin-password"
     auth:
       identity:
         clientId: <identity_client_id>
@@ -157,11 +158,15 @@ identity:
   env:
     - name: KEYCLOAK_REALM
       value: <realm>
-    - name: IDENTITY_CLIENTID
+    - name: IDENTITY_CLIENT_ID
       value: <identity_client_id>
 ```
 
 Add the section under `global.identity` to the `global` configuration you created in the previous step.
+
+:::note
+Older chart versions used a flat `global.identity.keycloak.auth.existingSecret` / `auth.existingSecretKey` form instead of the nested `auth.secret.*` shown above. The flat form still works but logs a deprecation warning — use the nested form for new deployments.
+:::
 
 The `identity.firstUser` field defines the initial user that Management Identity creates in Keycloak with full access to all Camunda components.
 By default, this user is named `demo`. To use a different name, set `identity.firstUser.username`.
@@ -201,8 +206,9 @@ global:
       realm: /realms/<realm>
       auth:
         adminUser: <keycloak_admin>
-        existingSecret: "camunda-credentials"
-        existingSecretKey: "identity-keycloak-admin-password"
+        secret:
+          existingSecret: "camunda-credentials"
+          existingSecretKey: "identity-keycloak-admin-password"
   security:
     authentication:
       method: oidc
@@ -216,7 +222,7 @@ identity:
   env:
     - name: KEYCLOAK_REALM
       value: <realm>
-    - name: IDENTITY_CLIENTID
+    - name: IDENTITY_CLIENT_ID
       value: <identity_client_id>
 
 optimize:
@@ -295,3 +301,26 @@ For example:
 - Management Identity: `http://localhost:8084`
 
 Log in with the username `demo` and the password stored in the secret key `identity-firstuser-password`.
+
+## Troubleshooting
+
+For issues common to any OIDC provider, see [Troubleshoot OIDC authentication](./troubleshooting-oidc.md). The following are specific to external Keycloak:
+
+**Management Identity pod restarts once during first startup**
+A single restart during the very first deployment is expected: Management Identity can briefly hit `403 Forbidden` while disabling Keycloak's default system clients, immediately after creating the realm — a timing issue between realm creation and Keycloak's own permission propagation, not a misconfiguration. Kubernetes' automatic pod restart resolves it. Only investigate further if the pod keeps crash-looping past the first retry.
+
+**Management Identity fails to connect to the Keycloak admin API**
+The `global.identity.keycloak.*` settings configure the admin API connection used for provisioning — a separate concern from the OIDC login flow. Verify `url.protocol`, `url.host`, `url.port`, and `contextPath` together form a URL reachable from inside the cluster:
+
+```bash
+kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+  curl https://<keycloak-internal-url>/realms/<realm>/.well-known/openid-configuration
+```
+
+A valid response confirms the realm is reachable at that URL. If this fails, double check `issuerBackendUrl` from the global configuration step, since it should resolve to the same host.
+
+**Realm already exists, but clients aren't created**
+If the realm already existed when Management Identity started, it won't re-create it — but it still attempts to create any missing clients. If clients are still missing after startup, check the Management Identity logs for provisioning errors. The most common cause is that the admin credentials don't have sufficient permission to create clients in the existing realm.
+
+**Demo user can't log in**
+The `identity-firstuser-password` secret value is only applied when the demo user is first created. If this user already exists from a previous deployment with a different password, changing the secret has no effect on it. Reset the user's password directly in the Keycloak admin console.

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -136,6 +136,30 @@ If `offline_access` is not available or not granted, users will be redirected to
 For more information, see [OpenID Connect Core specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess).
 :::
 
+## Handle separate access token and ID token signing keys
+
+Most OIDC providers sign access tokens and ID tokens with the same key, published at the single `jwks_uri` in the discovery document. Some enterprise identity provider deployments use a separate signing key for access tokens (validated by Camunda on every API request) than for ID tokens (validated only during the login callback). If your provider does this and you configure only the discovery document's `jwksUrl`, access token validation fails even though login succeeds.
+
+Check your provider's admin console for a distinct access token signing key or certificate, separate from the one used for OpenID Connect / ID tokens. If your provider exposes a separate JWKS endpoint for access tokens, configure both:
+
+- Set `global.identity.auth.jwksUrl` to the **access token** JWKS endpoint. Management Identity validates access tokens using this single URL only — it does not call the userinfo endpoint or fall back to any other source.
+- Add the same URL as an additional JWKS source for the Orchestration Cluster, which otherwise only fetches the primary JWKS from the discovery document:
+
+  ```yaml
+  orchestration:
+    env:
+      - name: CAMUNDA_SECURITY_AUTHENTICATION_OIDC_ADDITIONALJWKSETURIS_0_
+        value: "<access-token-jwks-url>"
+  ```
+
+  There is no dedicated Helm value for this setting — it maps directly to the Spring Boot property `camunda.security.authentication.oidc.additionalJwkSetUris` (a list), set via `orchestration.env` using Spring's relaxed-binding convention for list properties: one environment variable per index, with the index surrounded by underscores (`..._0_`, `..._1_`, and so on).
+
+The Orchestration Cluster merges keys from the primary JWKS endpoint and all additional endpoints, and selects whichever key matches the `kid` in the incoming token — so both ID tokens and access tokens validate correctly regardless of which key set signed them.
+
+:::tip
+If you're not sure whether your provider uses separate keys, compare the `jwks_uri` in the discovery document against the JWKS endpoint listed for access tokens (or API/runtime tokens) in your provider's admin console. If they're the same URL, you can skip this section.
+:::
+
 ## Create secrets
 
 Create two secrets in your Kubernetes namespace.

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/index.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/index.md
@@ -35,5 +35,6 @@ front channel single sign out is not supported. This means that when a user logs
 - [External IdP via Internal Keycloak guide](./external-idp-via-internal-keycloak.md)
 - [External Keycloak guide](./external-keycloak.md)
 - [Microsoft Entra guide](./microsoft-entra.md)
+- [Ping Identity guide](./ping-identity.md)
 - [Generic OIDC provider](./generic-oidc-provider.md)
 - Management Identity: [Configure an external IdP using Keycloak](/self-managed/components/management-identity/configuration/configure-external-identity-provider.md)

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/jwt-token-claims.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/jwt-token-claims.md
@@ -68,12 +68,13 @@ Specifies the intended audience of the token.
 
 ## Common claim patterns by provider
 
-| Provider        | User claim                      | Client claim         | Audience default          |
-| --------------- | ------------------------------- | -------------------- | ------------------------- |
-| Microsoft Entra | `preferred_username`            | `azp`                | Client ID                 |
-| Keycloak        | `email` or `preferred_username` | `azp` or `client_id` | May require configuration |
-| Auth0           | `email`                         | `client_id`          | Client ID                 |
-| Okta            | `email`                         | `client_id`          | Client ID                 |
+| Provider                    | User claim                      | Client claim         | Audience default                                       |
+| --------------------------- | ------------------------------- | -------------------- | ------------------------------------------------------ |
+| Microsoft Entra             | `preferred_username`            | `azp`                | Client ID                                              |
+| Keycloak                    | `email` or `preferred_username` | `azp` or `client_id` | May require configuration                              |
+| Auth0                       | `email`                         | `client_id`          | Client ID                                              |
+| Okta                        | `email`                         | `client_id`          | Client ID                                              |
+| Ping (PingFederate/PingOne) | `sub`                           | `client_id`          | Requires an Access Token Manager configured per client |
 
 ## Verify audience configuration
 

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -87,8 +87,13 @@ For **each** of the components above:
      ...
    }
    ```
-1. (Optional) In **Token configuration**, [add the optional claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims?tabs=appui) `preferred_username`. This lets you map a Camunda user ID to your users’ email addresses.
-   If you do not configure `preferred_username`, update later steps in this guide to use a different claim that uniquely identifies your users.
+1. In **Token configuration**, [add the optional claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims?tabs=appui) `preferred_username` to **both** the access token and the ID token.
+
+   :::danger Required, not optional
+   Management Identity reads user claims directly from the access token, not from a userinfo call. If `preferred_username` is missing from the access token, Management Identity finds no matching claim and grants no roles — the user authenticates successfully but immediately sees a "403 unauthorized" error, and users appear in Operate and Tasklist with an opaque identifier instead of their name.
+
+   If you don't want to use `preferred_username`, you can use a different claim that uniquely identifies your users instead (see [the note on `initialClaimName` below](#configure-management-identity)) — but whichever claim you choose, it must be added as an optional claim on both token types, since Entra doesn't include it by default.
+   :::
 
 #### Redirect URIs per Camunda component
 
@@ -206,10 +211,21 @@ orchestration:
         connectors:
           clients:
             - "<oc-app-id>"
+  env:
+    - name: CAMUNDA_SECURITY_AUTHENTICATION_OIDC_USER_INFO_ENABLED
+      value: "false"
+    - name: SERVER_MAX_HTTP_REQUEST_HEADER_SIZE
+      value: "65536"
 ```
 
 Replace `<OC_URL>` with the base URL of the Orchestration Cluster as it will be reachable from your users’ browsers.
 For local deployment, this is `http://localhost:8080`.
+
+:::caution Two Entra-specific settings required
+By default, the Orchestration Cluster calls the OIDC userinfo endpoint after authentication to augment token claims. Entra's userinfo endpoint is hosted on Microsoft Graph (`graph.microsoft.com/oidc/userinfo`), not on the authorization server, and requires a Graph API access token rather than the OIDC access token Camunda holds — the call fails. Setting `CAMUNDA_SECURITY_AUTHENTICATION_OIDC_USER_INFO_ENABLED` to `false` tells the Orchestration Cluster to rely on claims already present in the token instead, which is also Microsoft's own recommendation since the ID token is a superset of what userinfo returns. Neither setting has a dedicated Helm value — both map to Spring Boot properties (`camunda.security.authentication.oidc.user-info-enabled` and `server.max-http-request-header-size`) passed through `orchestration.env`.
+
+Microsoft's authorization codes are longer than those issued by most other providers. Combined with session cookies from an existing session, the total HTTP header size can exceed Tomcat's 8 KB default, causing a raw HTTP 400 (a plain Tomcat error page, not a Camunda error) before Spring Security ever processes the request. `SERVER_MAX_HTTP_REQUEST_HEADER_SIZE` raises this to 64 KB. See [Request header is too large](./troubleshooting-oidc.md#request-header-is-too-large) if you hit this after deploying.
+:::
 
 `usernameClaim` defines which claim in the access token identifies the user.
 `clientIdClaim` defines which claim identifies the calling client.
@@ -270,13 +286,15 @@ identityPostgresql:
     existingSecret: "camunda-credentials"
     secretKeys:
       adminPasswordKey: "identity-postgresql-admin-password"
-      userPasswordKey: "identity-postgresql-admin-password"
+      userPasswordKey: "identity-postgresql-user-password"
 ```
 
 Replace `<IDENTITY_URL>` with the base URL of Management Identity as it will be reachable from your users' browser. For local deployment, use `http://localhost:8084`.
 
 - `initialClaimName` defines which claim in the access token identifies the initial administrative user.
 - `initialClaimValue` defines the value of that claim that grants administrative access to Management Identity.
+
+`preferred_username` (the user's UPN) is readable and self-documenting, which makes it easy to work with during initial setup. The alternative, `oid` (the user's Entra Object ID), is always present in tokens without any optional claim configuration and doesn't change if the user's email address changes — which makes it the more stable choice for production, since `initialClaimValue` is set only on first startup and can't be updated via Helm afterward.
 
 :::danger
 Once configured, the initial claim name and value cannot be changed using environment variables or Helm values.
@@ -444,6 +462,11 @@ orchestration:
         connectors:
           clients:
             - "<oc-app-id>"
+  env:
+    - name: CAMUNDA_SECURITY_AUTHENTICATION_OIDC_USER_INFO_ENABLED
+      value: "false"
+    - name: SERVER_MAX_HTTP_REQUEST_HEADER_SIZE
+      value: "65536"
 
 connectors:
   security:
@@ -465,7 +488,7 @@ identityPostgresql:
     existingSecret: "camunda-credentials"
     secretKeys:
       adminPasswordKey: "identity-postgresql-admin-password"
-      userPasswordKey: "identity-postgresql-admin-password"
+      userPasswordKey: "identity-postgresql-user-password"
 
 optimize:
   enabled: true
@@ -523,6 +546,22 @@ For example:
 - Orchestration Cluster: `http://localhost:8080` (redirects you to Entra for login)
 - Management Identity: `http://localhost:8084`
 - Console: `http://localhost:8087`
+
+## Troubleshooting
+
+For issues common to any OIDC provider (invalid redirect URI, audience mismatch, missing claims, pods not starting), see [Troubleshoot OIDC authentication](./troubleshooting-oidc.md). The following are specific to Microsoft Entra:
+
+**`AADSTS700016: Application not found in the directory`**
+The `clientId` in your Helm values doesn't match a registered application in your tenant. Verify each `clientId` exactly matches the **Application (client) ID** on the app registration's **Overview** page, and that the app is registered in the tenant identified by your `<tenant id>`.
+
+**`AADSTS50011: Redirect URI mismatch`**
+The redirect URI Camunda sent doesn't match any URI registered for that app. Verify `redirectUrl` in your Helm config exactly matches the redirect URI configured in Entra, including the path suffix (`/auth/login-callback`, `/sso-callback`, and so on).
+
+**`401` with `jwt issuer invalid` or `"The iss claim is not valid"`**
+The app registration is issuing v1.0 tokens (issuer `https://sts.windows.net/...`) instead of v2.0 tokens (issuer `https://login.microsoftonline.com/.../v2.0`). Confirm `api.requestedAccessTokenVersion` is set to `2` in the app's manifest (see [Create applications in Entra](#create-applications-in-entra)). This applies to all app registrations, including single-page applications.
+
+**Service-to-service `401` with `clientId claim could not be found`**
+If Connectors or another machine-to-machine caller gets this error, verify `clientIdClaim: azp` is set for the Orchestration Cluster. The bare-GUID scope format (`<oc-app-id>/.default`) causes Entra to issue v2.0 tokens, which carry the calling client's ID in `azp` rather than the `appid` claim used by v1.0 tokens.
 
 ## Grant access to components
 

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/ping-identity.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/ping-identity.md
@@ -1,0 +1,145 @@
+---
+id: ping-identity
+sidebar_label: Ping Identity
+title: Connect Camunda to Ping Identity (PingFederate or PingOne)
+description: Learn how to configure Camunda 8 Self-Managed to authenticate with PingFederate or PingOne Advanced Identity Cloud.
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+This guide covers connecting Camunda 8 Self-Managed to PingFederate or PingOne Advanced Identity Cloud. Where the two products differ, both variants are noted.
+
+:::info
+This page covers only what's specific to Ping. For the shared setup steps — creating secrets, configuring each Camunda component through Helm, and identifying token claims — see [Generic OIDC provider](./generic-oidc-provider.md). Complete that guide's steps alongside this page's Ping-specific steps.
+:::
+
+## Prerequisites
+
+In addition to the [prerequisites for any OIDC provider](./generic-oidc-provider.md#prerequisites), you'll need:
+
+- Administrator access to your Ping environment with permission to create OAuth/OIDC applications.
+- Your authorization server's discovery document URL:
+  - **PingFederate:** `https://<pingfederate-host>/.well-known/openid-configuration`
+  - **PingOne:** `https://auth.pingone.com/<environment-id>/as/.well-known/openid-configuration`
+
+## Create OAuth/OIDC applications in Ping
+
+The [generic OIDC provider guide](./generic-oidc-provider.md#create-oidc-clients) lists the six clients Camunda needs. Create each one as follows.
+
+<Tabs groupId="ping-product" queryString>
+<TabItem value="pingfederate" label="PingFederate" default>
+
+For each confidential client (Management Identity, Optimize, Orchestration Cluster, Web Modeler API):
+
+1. Go to **Applications → OAuth Clients → Create Client**.
+2. Set a descriptive **Client ID** (for example, `camunda-identity`).
+3. Under **Client Authentication**, select **Client Secret** and generate a secret. Record the value.
+4. Under **Redirect URIs**, add the component's redirect URI from the [redirect URI table](./generic-oidc-provider.md#redirect-uri-table). Skip this for Web Modeler API, which uses client credentials only.
+5. Under **Grant Types**, select **Authorization Code** (skip for Web Modeler API; select **Client Credentials** instead).
+6. Under **Scopes Allowed**, add `openid`, `profile`, `email`, `offline_access`.
+7. Save the client.
+
+For the two public clients (Web Modeler UI, Console), create a client the same way but without a client secret, using whichever public/PKCE client type your PingFederate version supports.
+
+</TabItem>
+<TabItem value="pingone" label="PingOne">
+
+For each confidential client:
+
+1. Go to **Connections → Applications → Add Application → OIDC Web App**.
+2. Set the application name and save.
+3. Under **Configuration**, set the redirect URI from the [redirect URI table](./generic-oidc-provider.md#redirect-uri-table).
+4. Under **Resources**, grant the `openid`, `profile`, and `email` scopes.
+5. Under **Configuration → Token Endpoint Auth Method**, select **Client Secret Post** or **Client Secret Basic**.
+6. Note the **Client ID** and **Client Secret** from the **Configuration** tab.
+
+For Web Modeler API, add a **Worker** (machine-to-machine) application instead, and note its client ID and secret.
+
+For the two public clients, add an application using PingOne's public/native client type.
+
+</TabItem>
+</Tabs>
+
+## Determine whether you need separate signing keys
+
+PingFederate deployments commonly sign access tokens with a different key than ID tokens — this is a standard enterprise PingFederate pattern, not an edge case. Confirm which case you're in before deploying:
+
+<Tabs groupId="ping-product" queryString>
+<TabItem value="pingfederate" label="PingFederate" default>
+
+Go to **Authorization Server → Token Settings**, and compare the signing certificate under **JWT Access Token** against the one under **OpenID Connect Policy Management**. If they match, your deployment uses a single key and you can skip the dual-key configuration below. If they differ (or you're unsure), assume dual keys.
+
+To find the access token JWKS endpoint, go to **Security → Certificate & Key Management → Runtime Keys** — the key set is published at `https://<pingfederate-host>/pf/JWKS`. Compare this against the `jwks_uri` in your discovery document; if the URLs differ, you have two distinct key sets.
+
+</TabItem>
+<TabItem value="pingone" label="PingOne">
+
+Go to **Connections → Applications → your app → Configuration → Token Management**. If a custom access token signing key is configured separately from the OIDC settings, note its JWKS URL — this is your access token JWKS endpoint, distinct from the ID token JWKS in the discovery document.
+
+</TabItem>
+</Tabs>
+
+If your two JWKS URLs differ, follow [Handle separate access token and ID token signing keys](./generic-oidc-provider.md#handle-separate-access-token-and-id-token-signing-keys) using the access token JWKS URL you found above.
+
+## Configure Camunda components
+
+Follow [Configure Camunda components](./generic-oidc-provider.md#configure-camunda-components) using the endpoint URLs from your discovery document. A few Ping-specific notes:
+
+- Set `global.identity.auth.type` to `"GENERIC"`.
+- Ping's `client_id` claim in access tokens identifies the calling client for both PingFederate and PingOne — the `clientIdClaim` default already matches this, so you typically don't need to override it. Confirm by decoding a real client-credentials token (see [JWT token claims reference](./jwt-token-claims.md)).
+- `sub` is a stable, unique per-user identifier and a safe default for `initialClaimName`. Decode a test token first to confirm which user-identifying claims your Ping deployment actually populates — see [Identify token claims](./generic-oidc-provider.md#identify-token-claims).
+
+### Audience configuration requires Ping-side setup
+
+Unlike some providers, Ping doesn't automatically populate the `aud` claim with the requesting client's ID — this needs explicit setup in Ping before the `audience` values in your Helm config will validate correctly.
+
+<Tabs groupId="ping-product" queryString>
+<TabItem value="pingfederate" label="PingFederate" default>
+
+In PingFederate, the `aud` claim comes from an Access Token Manager's **Audience Claim Value** field — a single static string that does not template from the requesting client (`${client_id}` is taken literally, not resolved). A shared Access Token Manager therefore can't produce a different `aud` per client.
+
+To get "audience = own client ID" for each of the six Camunda components, create one Access Token Manager per component, each with **Audience Claim Value** hardcoded to that component's client ID, and point each OAuth client's default Access Token Manager at its own. Without this, tokens validate but either have no `aud` claim at all, or the wrong one if a shared Access Token Manager is reused — and Camunda's audience check fails either way.
+
+</TabItem>
+<TabItem value="pingone" label="PingOne">
+
+Confirm your PingOne resource/scope configuration issues an `aud` claim matching each component's client ID, and adjust the `audience` values in your Helm config to match what you find in a decoded token.
+
+</TabItem>
+</Tabs>
+
+## Assign users
+
+<Tabs groupId="ping-product" queryString>
+<TabItem value="pingfederate" label="PingFederate" default>
+
+User access is controlled by access policies. Ensure your PingFederate access policy permits your admin user to authenticate to the Camunda Identity and Camunda Orchestration Cluster clients before first startup.
+
+</TabItem>
+<TabItem value="pingone" label="PingOne">
+
+In the PingOne admin console, open each application, and under **Access**, ensure the admin user's population or the relevant group is assigned. Confirm the user is in the **Active** state.
+
+</TabItem>
+</Tabs>
+
+## Troubleshooting
+
+For issues common to any OIDC provider, see [Troubleshoot OIDC authentication](./troubleshooting-oidc.md). The following are specific to Ping:
+
+**`invalid_client` during code exchange**
+Ping returned an error exchanging the authorization code for tokens. Verify the client authentication method configured in Ping (**Client Secret Post** vs. **Client Secret Basic**) matches what Camunda sends. PingFederate defaults to **Client Secret Basic** — check your client configuration if you changed it.
+
+**`aud` claim mismatch, or missing entirely**
+See [Audience configuration requires Ping-side setup](#audience-configuration-requires-ping-side-setup) above — this is the most common cause with PingFederate specifically, since a shared Access Token Manager can't produce a per-client audience.
+
+**Token signature validation fails on API calls, but interactive login succeeds**
+The access token and ID token are signed with different keys. See [Determine whether you need separate signing keys](#determine-whether-you-need-separate-signing-keys) above.
+
+**PingFederate: `error=server_error, error_description=There are no authentication methods available for OAuth on the authorization redirect`**
+This means PingFederate has no IdP adapter registered as an authentication source for the OAuth authorization server — check **System → OAuth Settings → Authorization Server → IdP Adapter Mapping**, and confirm the same adapter is also listed under **Authentication Policies → Default Authentication Sources**. A client-credentials grant works regardless, since it doesn't need one; only authorization-code login redirects are affected.
+
+:::note
+Customers evaluating this guide almost always already have a working PingFederate authentication policy — this is basic PingFederate setup unrelated to Camunda, so it's unlikely to come up in practice. It's included here because it was encountered once during testing against a from-scratch PingFederate instance and wasn't fully resolved; if you hit it, it may be specific to your PingFederate version or build.
+:::

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/troubleshooting-oidc.md
@@ -125,15 +125,19 @@ By default, Tomcat rejects requests whose headers exceed this limit (typically 8
 
 Increase the maximum allowed HTTP request header size for the Identity service.
 
-1. Configure the Spring Boot property `server.max-http-request-header-size` (via the `SERVER_MAXHTTPREQUESTHEADERSIZE` environment variable) to a value higher than the default, for example 40KB.
+1. Configure the Spring Boot property `server.max-http-request-header-size` (via the `SERVER_MAX_HTTP_REQUEST_HEADER_SIZE` environment variable) to a value higher than the default, for example 40KB.
 
 2. If you are using the Helm chart, set this environment variable on the Identity deployment in your `values.yaml`, similar to other Identity environment variables:
 
    ```yaml
    identity:
      env:
-       - name: SERVER_MAXHTTPREQUESTHEADERSIZE
+       - name: SERVER_MAX_HTTP_REQUEST_HEADER_SIZE
          value: "40KB"
    ```
+
+:::note
+This same issue can also affect the Orchestration Cluster if its session cookies and authorization code grow large enough (for example, with Microsoft Entra ID). If Operate or Tasklist login fails with the same symptom, set `SERVER_MAX_HTTP_REQUEST_HEADER_SIZE` under `orchestration.env` instead.
+:::
 
 3. Upgrade or redeploy the release so the new environment variable takes effect.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1906,6 +1906,7 @@ module.exports = {
                       },
                       items: [
                         "self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra",
+                        "self-managed/deployment/helm/configure/authentication-and-authorization/ping-identity",
                         "self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider",
                         "self-managed/deployment/helm/configure/authentication-and-authorization/external-keycloak",
                         "self-managed/deployment/helm/configure/authentication-and-authorization/external-idp-via-internal-keycloak",


### PR DESCRIPTION
https://github.com/camunda/camunda-docs/issues/9522

## Summary

Adds a Ping Identity playbook and brings the existing Microsoft Entra and external Keycloak guides in line with it, closing PR 2 of #9522 (per-IdP playbooks). All Helm keys and Spring Boot properties referenced below were independently verified against the `camunda-platform-helm` chart source (14.5.0–14.8.2) and `camunda/camunda`, not just the source drafts.

## Changes

**New:**
- `ping-identity.md` — PingFederate/PingOne playbook: app registration walkthrough, dual signing-key (access token vs. ID token) detection, audience/Access Token Manager setup, Ping-specific troubleshooting. Scoped to only what's Ping-specific; defers to `generic-oidc-provider.md` for shared setup steps. Added to the sidebar and category index.

**Updated:**
- `microsoft-entra.md` — `preferred_username` corrected from "optional" to required (explains the silent-403 failure mode if omitted), added `userInfoEnabled`/HTTP header-size gotchas with Helm examples, new Entra-specific troubleshooting section, `oid` vs `preferred_username` guidance for `initialClaimValue`
- `external-keycloak.md` — added troubleshooting entries (admin API connectivity check, expected first-boot pod restart, realm-exists-but-clients-missing, demo user password behavior), noted the nested vs. deprecated-flat secret form
- `generic-oidc-provider.md` — new "Handle separate access token and ID token signing keys" section covering `additionalJwkSetUris`, since this isn't Ping-specific and other providers can hit it too
- `jwt-token-claims.md` — added a Ping row to the provider claim-patterns table
- `index.md` — added Ping to the reference list

## Bug fixes in already-published content

Found while cross-referencing the drafts against real chart source — unrelated to this PR's scope but fixed along the way:

- `troubleshooting-oidc.md`: `SERVER_MAXHTTPREQUESTHEADERSIZE` → `SERVER_MAX_HTTP_REQUEST_HEADER_SIZE` (missing underscores meant Spring Boot's relaxed binding would never have picked this up)
- `external-keycloak.md`: same bug class, `IDENTITY_CLIENTID` → `IDENTITY_CLIENT_ID`
- `microsoft-entra.md`: `identityPostgresql.auth.secretKeys.userPasswordKey` was copy-pasted to point at the *admin* password secret key instead of the user one (appeared twice)

## Deliberately not carried over from the source drafts

Verification showed these were incorrect, so they were left out rather than merged in:

- Keycloak 16/WildFly `/auth` context-path branch — dead content; only Keycloak 26.x is currently supported
- Claim that `KEYCLOAK_REALM`/`IDENTITY_CLIENTID` env vars are redundant — the chart templates indicate `KEYCLOAK_REALM` is still load-bearing for custom-realm setups
- `identityPostgresql` requirement for external Keycloak — not needed when Keycloak is the provider (Identity's state lives in Keycloak itself); confirmed via the chart's own values.yaml comment
- Entra's `accessTokenAcceptedVersion` top-level manifest step — that's the deprecated Azure AD Graph manifest schema; the existing page's `api.requestedAccessTokenVersion` is correct for the current Microsoft Graph manifest format

## Follow-ups (not blocking, but worth tracking)

- **Open architecture question from Steve**: whether a "generic OIDC provider" page can ever be more than a list of provider-specific exceptions, given how much each provider's implementation actually differs. This PR keeps `generic-oidc-provider.md` as a shared base with thin provider-specific delta pages (Entra, Ping) rather than fully self-contained playbooks per provider. Worth a decision before Okta (and whatever else comes out of Steve's `#ask-identity`-style thread) gets drafted, since it determines that page's shape too.
- Okta, OneLogin, and Google Cloud Identity/Workspace are explicitly out of scope for this PR, but could be included if we want.
