### PR TITLE
docs(api): add agent definition get and search REST API reference

### DIFF
--- a/api/camunda/v2/agent-definitions.yaml
+++ b/api/camunda/v2/agent-definitions.yaml
@@ -1,0 +1,278 @@
+paths:
+  /agent-definitions/search:
+    post:
+      tags:
+        - Agent definition
+      operationId: searchAgentDefinitions
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Search agent definitions
+      description: |-
+
+
+        [[REQUIRED_PERMISSIONS:eyJwZXJtaXNzaW9ucyI6W3sicmVzb3VyY2VUeXBlIjoiUFJPQ0VTU19ERUZJTklUSU9OIiwicGVybWlzc2lvblR5cGUiOiJSRUFEX1BST0NFU1NfREVGSU5JVElPTiJ9XSwiZW5mb3JjZW1lbnQiOiJmaWx0ZXIifQ]]
+
+        [[ADDED_IN_VERSION:8.10]]
+
+        [[CONSISTENCY:EVENTUAL]]
+
+        Search for agent definitions based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentDefinitionSearchQuery"
+      responses:
+        "200":
+          description: The agent definition search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentDefinitionSearchQueryResult"
+        "400":
+          $ref: "common-responses.yaml#/components/responses/InvalidData"
+        "401":
+          $ref: "common-responses.yaml#/components/responses/Unauthorized"
+        "403":
+          $ref: "common-responses.yaml#/components/responses/Forbidden"
+        "500":
+          $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.10"
+  /agent-definitions/{agentDefinitionKey}:
+    get:
+      tags:
+        - Agent definition
+      operationId: getAgentDefinition
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get agent definition
+      description: |-
+
+
+        [[REQUIRED_PERMISSIONS:eyJwZXJtaXNzaW9ucyI6W3sicmVzb3VyY2VUeXBlIjoiUFJPQ0VTU19ERUZJTklUSU9OIiwicGVybWlzc2lvblR5cGUiOiJSRUFEX1BST0NFU1NfREVGSU5JVElPTiJ9XX0]]
+
+        [[ADDED_IN_VERSION:8.10]]
+
+        [[CONSISTENCY:EVENTUAL]]
+
+        Returns an agent definition by key.
+      parameters:
+        - name: agentDefinitionKey
+          in: path
+          required: true
+          description: The assigned key of the agent definition, which acts as a unique identifier for this agent definition.
+          schema:
+            type: string
+            format: string<AgentDefinitionKey>
+            example: "2251799813691958"
+            description: System-generated key for an agent definition.
+      responses:
+        "200":
+          description: The agent definition is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentDefinitionResult"
+        "400":
+          $ref: "common-responses.yaml#/components/responses/InvalidData"
+        "401":
+          $ref: "common-responses.yaml#/components/responses/Unauthorized"
+        "403":
+          $ref: "common-responses.yaml#/components/responses/Forbidden"
+        "404":
+          description: |
+            The agent definition with the given key was not found. More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.10"
+components:
+  schemas:
+    AgentDefinitionSearchQuerySortRequest:
+      type: object
+      required:
+        - field
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - agentDefinitionKey
+            - agentType
+            - name
+            - elementId
+            - processDefinitionId
+            - processDefinitionKey
+            - processDefinitionVersion
+            - processDefinitionVersionTag
+            - tenantId
+        order:
+          $ref: "search-models.yaml#/components/schemas/SortOrderEnum"
+    AgentDefinitionSearchQuery:
+      description: Agent definition search request.
+      type: object
+      allOf:
+        - $ref: "search-models.yaml#/components/schemas/SearchQueryRequest"
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionSearchQuerySortRequest"
+        filter:
+          description: The agent definition search filters.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionFilter"
+    AgentDefinitionFilter:
+      description: Agent definition search filter.
+      type: object
+      properties:
+        agentDefinitionKey:
+          description: The unique key of the agent definition.
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/AgentDefinitionKeyFilterProperty"
+        agentType:
+          description: The kind of agent this agent definition describes.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionTypeFilterProperty"
+        name:
+          description: The human-readable name of the process element that owns the agent definition.
+          allOf:
+            - $ref: "filters.yaml#/components/schemas/StringFilterProperty"
+        elementId:
+          description: The BPMN element ID of the process element that owns the agent definition.
+          allOf:
+            - $ref: "identifiers.yaml#/components/schemas/ElementIdFilterProperty"
+        processDefinitionId:
+          description: The BPMN process ID of the process definition that owns the agent definition.
+          allOf:
+            - $ref: "identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty"
+        processDefinitionKey:
+          description: The key of the process definition that owns the agent definition.
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty"
+        processDefinitionVersion:
+          description: The version of the process definition that owns the agent definition.
+          allOf:
+            - $ref: "filters.yaml#/components/schemas/IntegerFilterProperty"
+        processDefinitionVersionTag:
+          description: The version tag of the process definition that owns the agent definition.
+          allOf:
+            - $ref: "filters.yaml#/components/schemas/StringFilterProperty"
+        tenantId:
+          description: The tenant ID of the agent definition.
+          allOf:
+            - $ref: "filters.yaml#/components/schemas/StringFilterProperty"
+    AgentDefinitionSearchQueryResult:
+      description: Agent definition search response.
+      type: object
+      required:
+        - items
+      allOf:
+        - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching agent definitions.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionResult"
+    AgentDefinitionResult:
+      description: An agent definition, created at deploy time for the process element it belongs to.
+      type: object
+      required:
+        - agentDefinitionKey
+        - agentType
+        - name
+        - elementId
+        - processDefinitionId
+        - processDefinitionKey
+        - processDefinitionVersion
+        - processDefinitionVersionTag
+        - tenantId
+      properties:
+        agentDefinitionKey:
+          description: |
+            The unique key for this agent definition. Unique across process definition versions.
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/AgentDefinitionKey"
+        agentType:
+          $ref: "#/components/schemas/AgentDefinitionTypeEnum"
+        name:
+          description: |
+            The human-readable name of the process element that owns the agent definition. Falls
+            back to elementId when the element has no BPMN name configured.
+          type: string
+        elementId:
+          description: The BPMN element ID of the process element that owns the agent definition.
+          allOf:
+            - $ref: "identifiers.yaml#/components/schemas/ElementId"
+        processDefinitionId:
+          description: The BPMN process ID of the process definition that owns the agent definition.
+          allOf:
+            - $ref: "identifiers.yaml#/components/schemas/ProcessDefinitionId"
+        processDefinitionKey:
+          description: The key of the process definition that owns the agent definition.
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/ProcessDefinitionKey"
+        processDefinitionVersion:
+          type: integer
+          format: int32
+          description: The version of the process definition that owns the agent definition.
+        processDefinitionVersionTag:
+          type: string
+          nullable: true
+          description: The version tag of the process definition that owns the agent definition.
+        tenantId:
+          description: The tenant ID of this agent definition.
+          allOf:
+            - $ref: "identifiers.yaml#/components/schemas/TenantId"
+    AgentDefinitionTypeEnum:
+      description: The kind of agent an agent definition describes.
+      type: string
+      enum:
+        - AI_AGENT_SUB_PROCESS
+        - AI_AGENT_TASK
+        - EXTERNAL_AGENT
+    AgentDefinitionTypeFilterProperty:
+      description: AgentDefinitionTypeEnum property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionTypeEnum"
+        - $ref: "#/components/schemas/AdvancedAgentDefinitionTypeFilter"
+    AdvancedAgentDefinitionTypeFilter:
+      title: Advanced filter
+      description: Advanced AgentDefinitionTypeEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionTypeEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionTypeEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionTypeEnum"
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionTypeEnum"
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"

--- a/api/camunda/v2/camunda-openapi.yaml
+++ b/api/camunda/v2/camunda-openapi.yaml
@@ -42,6 +42,7 @@ servers:
         description: The schema of the Orchestration Cluster REST API server.
 tags:
   - name: Ad-hoc sub-process
+  - name: Agent definition
   - name: Agent instance
   - name: Audit Log
   - name: Authentication
@@ -81,6 +82,10 @@ tags:
   - name: User task
   - name: Variable
 paths:
+  /agent-definitions/{agentDefinitionKey}:
+    $ref: "agent-definitions.yaml#/paths/~1agent-definitions~1{agentDefinitionKey}"
+  /agent-definitions/search:
+    $ref: "agent-definitions.yaml#/paths/~1agent-definitions~1search"
   /agent-instances:
     $ref: "agent-instances.yaml#/paths/~1agent-instances"
   /agent-instances/{agentInstanceKey}:

--- a/api/camunda/v2/keys.yaml
+++ b/api/camunda/v2/keys.yaml
@@ -115,6 +115,13 @@ components:
       type: integer
       format: int64
       minimum: 1
+    AgentDefinitionKey:
+      description: System-generated key for an agent definition.
+      format: AgentDefinitionKey
+      example: "2251799813691958"
+      type: string
+      allOf:
+        - $ref: "#/components/schemas/LongKey"
     AgentInstanceKey:
       description: System-generated key for an agent instance.
       format: AgentInstanceKey
@@ -484,6 +491,41 @@ components:
           addedInVersion: "8.9"
         - propertyName: $notIn
           addedInVersion: "8.9"
+    AgentDefinitionKeyFilterProperty:
+      description: AgentDefinitionKey property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionKey"
+        - $ref: "#/components/schemas/AdvancedAgentDefinitionKeyFilter"
+    AdvancedAgentDefinitionKeyFilter:
+      title: Advanced filter
+      description: Advanced AgentDefinitionKey filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionKey"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentDefinitionKey"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionKey"
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentDefinitionKey"
     AgentInstanceKeyFilterProperty:
       description: AgentInstanceKey property with full advanced search capabilities.
       oneOf:

--- a/docs/apis-tools/orchestration-cluster-api-rest/specifications/get-agent-definition.api.mdx
+++ b/docs/apis-tools/orchestration-cluster-api-rest/specifications/get-agent-definition.api.mdx
@@ -1,0 +1,469 @@
+---
+id: get-agent-definition
+title: "Get agent definition"
+sidebar_label: "Get agent definition"
+hide_title: true
+hide_table_of_contents: true
+api: eJztWutu2zoSfhVC50/b9S1p0ybBYgE3cXKctkmOL0lOkyClJNpmI5E+JGXXNQzsQ+wT7pPsDCnZsi2nt8VifxhoEYsih8OZbz4OxZl6hva1d3jr1ftMGBKyHhfccCm8+5Inh0xRfGiG3qHXZ8Z2Ol70KXmaBYniZgIipp7PqGKqnpgBPN7PStBCNQ/mDSAyZDpQfGhHH3p34k7c3rYaf3Sbrcbxw2Wj9aHZbjcvztuHbHI2/nhzZujN+Vd6fZAEk+br65cgLb766r+8mvy5e9VlN2+j5mfJuydnl3/UrjrdnYNGq/vxrPMYddvdg4smH/Pg9GriX0dfg91o5EetveC0yy/4WbvVPWnc7Lxtd2rnJ92d816rcXXa7u6dXTWiyw4/O7i5qd3fO/3qx8egXPP84arRQuUO9ys785dHoGyz3WmcH/152LhqnHe69ffuXYuZRAlNqCB0xbjEn5BHNqmAAYdU0ZgZprQ1oYAHMAxdNvQ7NoGuHE02pGDMkqfYXwlXDPxiVMJW7doZMEK15n3BQpyIyB4x2LaiR4mMBzwYEBoY0BP+kUTwvxJGeAgdeY8zRXpSwViu1waj9joYsJh6h1PPTIaouDaKiz68gWExNfOWv9fXVvQP6MW+0HgY4cDd3b2dNwcH+zsvXx/sHOzte6trak+0YXEZxCAo03WhcgX2rXgzBJtieiiFZhoV3K3V8E+BoVadA2vVSRAwrXtJFE2Iso5kIS44kMJAd5REh8OIBzY+qp81ipvm7LE8T31dxxIJFLMLodg8jOSEGB6z1OCMDJVEHQiLWIxDuSE+i6Toa2Ik6pKaXPqfWWCWMHFbDCDb2MFRJQc0cIATDgEOUHQTLkYVtzpZa81XAGHHCZtedSgCA8xH7YT3tidQjOHOQwU6FzosxWjm/2Jwkq7rRQMlwYiZMXNuHjmtdOUOlaZRdNGzIfgrsMvhfh3w38L7aghtUukjYz4jDdHnggE4tUxU4Mzx7IyOKEGMEM0UpxH/ivgCPFuZzwsmMdxYfd7DINQR4yZrK1jCDGg9h6NC/zxyESLjOPMU0Z8b4zNdKdCIiSS2O1LzoX4KhPrQ7r59uGxdHDXabXg9b+7U2+/guXHTabTO6+9dq7dZfVS4gbJnKfoLlR8kMRVliMyQ+hEj2DFjz9WANAOIXDkGii/i1go5AQfqO+HT4BEilsxDDUiXCTsmkzQAFwlJ3l5+OHczAs30eD+BYHboXLbRLB+3hauwkjLpzeOfXMETGMRJYhmyqGz7A8q487nIhC8FQyNHM2v+nsdEPTB8BMnEw07t9aPUfg6eCwEWgUVUtdkQ2bLXDZHD5M/boulWXiC0RHpKxlagNVaFXAjYUHioccR6f+20gCwq3REweuEh0Qy2oiWLXhaS9WbbCjYu0yCQiTBlKXxJVQhdymOpHnuRHOdMXSS52OgbGTqXcvxXLb2ZjBf2Wp/wabs9Qcz7r9+8Ovh/JObCRRT7KNuWFykahwymz1TeKND0cnct40JPppvkL3jzCaUwIShIHQVkXUi+m3PbTCs4vPyaZvNkpBDG7u2cNjbkwAs0LEAUJNrImKkyeHvEA1Zo2/VcO12Lm3cJtp1M0c1AmXcBIMw27oItppPIQH6MfV5tyonBmiPQKyQhNRQTYiENGQFsn0qCYRB4Lf7bN5Nhcul6giEN5RFxGSyGQ5YYwHYiyG3r5IgcvNp7c/9sYMxQH1ar4/G4onpBmYXcSFWRql+FR/yP/Z5XCCgPfBnTCeTKhIahXTONyCLTJHrIAjB3gHtyihyrDNp1abctTKyNS5+ddeEAZKhJtHUvLsWe0qBNgMvX8luTZkwbj0pwkl4DSp10W80MIxMYsK6zHdOj6FY4OfoyMYd+RMXjEq1lFgxloCsBjRMR0gqXVTrk1dFupZZ5r4widdWnYRmXzbTxFmBa131VWZ3EMVV59l/Sc6HPWxqS1mKC1I4/yVK/dzqXxImA1Clki3NBqsDS3ID6khdDPMSYaLon+sU9va7VZnNnfnu9kO18GYKtbQCsLhogHEu7laO05eWnS89wOSG3oMKZ9HVH2iwIdjd9TwIqMPAAykOqNABwlsPXN5AE7utBLIgC8nGYwi8Ja8CSisPutbKSZdUBLtXPoGmVOkVRZp5w0uA+djbMiGanmGhSjJEIkmTtGIbQBOYGrRyt4DHZKkkje1wYQGpuv5ZMvevr63J90Zktk85KzoxqbIlrS1xb4toS148Q18t1HjiRyuchKGDDds5haZoE+aAcP/m1cMs3W77Z8s2Wbwr55tV33lKMOWiFc/f5iAn7lWFMHQP1JIC2Qj4sbKrtZ6T5qY67z4/Z/QjxZThxEb1lrC1jbRlry1jfz1h7Rd+QwHroZYXxyZQCl8kgSBQEGt44R/PPdZluKR63OdOWgbYMtGWgH2EgePmlDMHIwjIX5VF23eFhkY4VDWxi7/ntJ/pHvLIqGlDyRjRKWDYQb1tiZgYyrXzySq7yBjS0mVg5d2lXna5XLswwfJkaZXU9iQKPe1PHWjMIlelAajM7nA6lMjNYtVVAcbz3sEjF147dsuCLZEAj21yEUnyRv6y+UDAV+M6B5yhKNNAxaTXaHXIK/h/TibuagemXp9mv7dcKZ8Cu3yG9ftkkbuV2gjxPZ1MgXRRO4Tr/6CS21icrRGujCGfCfDnaHM7p3HYmfHadoMX9OMlAfnbdQfVzBWybRWAfi1IuetJ2TNFavAJQHr09R2qtspPuewB6HJ4WgR05Ik0vFFkahg5JGeP24RSQ+JVAxtWUd+d/udbAAt5sLUDBdkhhMAY62v0V4tMeJyjJ5twngdO2gqVsv/1GjqQYYTQD3l3LbwSLKYiNGuAS3MrxRdt6pawh9ksESzks54fzjyQ9zqIQjiNBwIZYHDJJx9or9DsBO0iCF/0wwkl+hqqm/EA+1Y86zavGpxL5ZPmBwS8qQmh3T3jKuYMdOUrlgxSs5xLDxMD23crKwQiNAP8ar9Ut0IAJJRoimq9DD+RYuGMSX2zq1o3WIB1L/0zFYGSYeL46nw3oiIPGeFeYItTaAis6wH4cKRNVvhPQ48ULIOAXL5B/F5E1ZAI9hKbDQQAeyF7+/c9/kfbxO00WV99YWXAn1vXD2kLkbBiVdpZK26RFMZsJwVrL8xXficz87kgYRBzPmahyhUAw2KinPo8gtLJaKlSklNoQTMXAAUVWJMtGzDzrsiDI64CWWQHa37s3JL0jJjuV2o+g3o+kX40pF9V0Cl09qn/onh/Xy++bR43zdqMMEivmi7EROwTajKnI6XHKzNphe5WspossdVvDOk9pDey1VUhYuEDSsR6bprtmWpCY3zVh3GFBxR9Qudv6br3pFJiVdVU0m2EzRJjCOuP7xU7pajC4xt+wUfdopFfrBfKuetZKc+3n5H9WIVtom7QR2C+Xd8BPl50UWMXWdribr1waU7cklxOxVpK6lMacNjrQly5vZiv7n5VeqB54w/boyEcmZrO5tgafbc3B7D+WhR17
+sidebar_class_name: "get api-method"
+info_path: docs/apis-tools/orchestration-cluster-api-rest/specifications/orchestration-cluster-api
+custom_edit_url: null
+hide_send_button: true
+---
+
+import MarkerRequiredPermissions from "@site/src/mdx/MarkerRequiredPermissions";
+
+import MarkerAddedInVersion from "@site/src/mdx/MarkerAddedInVersion";
+
+import MarkerEventuallyConsistentExtension from "@site/src/mdx/MarkerEventuallyConsistentExtension";
+
+import MethodEndpoint from "@theme/ApiExplorer/MethodEndpoint";
+import ParamsDetails from "@theme/ParamsDetails";
+import RequestSchema from "@theme/RequestSchema";
+import StatusCodes from "@theme/StatusCodes";
+import OperationTabs from "@theme/OperationTabs";
+import TabItem from "@theme/TabItem";
+import Heading from "@theme/Heading";
+import Translate from "@docusaurus/Translate";
+
+<Heading as={"h1"} className={"openapi__heading"}>
+  {"Get agent definition"} <MarkerAddedInVersion version="8.10" />
+</Heading>
+
+<MethodEndpoint
+  method={"get"}
+  path={"/agent-definitions/{agentDefinitionKey}"}
+  context={"endpoint"}
+></MethodEndpoint>
+
+<MarkerEventuallyConsistentExtension />
+
+Returns an agent definition by key.
+
+<MarkerRequiredPermissions
+  permissions={[
+    {
+      resourceType: "PROCESS_DEFINITION",
+      permissionType: "READ_PROCESS_DEFINITION",
+    },
+  ]}
+/>
+
+<Heading id={"request"} as={"h2"} className={"openapi-tabs__heading"}>
+  <Translate id="theme.openapi.request.title">Request</Translate>
+</Heading>
+
+<ParamsDetails
+  parameters={[
+    {
+      name: "agentDefinitionKey",
+      in: "path",
+      required: true,
+      description:
+        "The assigned key of the agent definition, which acts as a unique identifier for this agent definition.",
+      schema: {
+        type: "string",
+        format: "string<AgentDefinitionKey>",
+        example: "2251799813691958",
+        description: "System-generated key for an agent definition.",
+      },
+    },
+  ]}
+></ParamsDetails>
+
+<RequestSchema title={"Body"} body={undefined}></RequestSchema>
+
+<StatusCodes
+  id={undefined}
+  label={undefined}
+  responses={{
+    "200": {
+      description: "The agent definition is successfully returned.",
+      content: {
+        "application/json": {
+          schema: {
+            description:
+              "An agent definition, created at deploy time for the process element it belongs to.",
+            type: "object",
+            required: [
+              "agentDefinitionKey",
+              "agentType",
+              "name",
+              "elementId",
+              "processDefinitionId",
+              "processDefinitionKey",
+              "processDefinitionVersion",
+              "processDefinitionVersionTag",
+              "tenantId",
+            ],
+            properties: {
+              agentDefinitionKey: {
+                description:
+                  "The unique key for this agent definition. Unique across process definition versions.\n",
+                allOf: [
+                  {
+                    description:
+                      "System-generated key for an agent definition.",
+                    format: "AgentDefinitionKey",
+                    example: "2251799813691958",
+                    type: "string",
+                    allOf: [
+                      {
+                        description:
+                          "Zeebe Engine resource key (Java long serialized as string)",
+                        type: "string",
+                        title: "LongKey",
+                      },
+                    ],
+                    title: "AgentDefinitionKey",
+                  },
+                ],
+              },
+              agentType: {
+                description: "The kind of agent an agent definition describes.",
+                type: "string",
+                enum: [
+                  "AI_AGENT_SUB_PROCESS",
+                  "AI_AGENT_TASK",
+                  "EXTERNAL_AGENT",
+                ],
+                title: "AgentDefinitionTypeEnum",
+              },
+              name: {
+                description:
+                  "The human-readable name of the process element that owns the agent definition. Falls\nback to elementId when the element has no BPMN name configured.\n",
+                type: "string",
+              },
+              elementId: {
+                description:
+                  "The BPMN element ID of the process element that owns the agent definition.",
+                allOf: [
+                  {
+                    description: "The model-defined id of an element.",
+                    format: "ElementId",
+                    type: "string",
+                    example: "Activity_106kosb",
+                    title: "ElementId",
+                  },
+                ],
+              },
+              processDefinitionId: {
+                description:
+                  "The BPMN process ID of the process definition that owns the agent definition.",
+                allOf: [
+                  {
+                    description:
+                      "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                    format: "ProcessDefinitionId",
+                    type: "string",
+                    example: "new-account-onboarding-workflow",
+                    title: "ProcessDefinitionId",
+                  },
+                ],
+              },
+              processDefinitionKey: {
+                description:
+                  "The key of the process definition that owns the agent definition.",
+                allOf: [
+                  {
+                    description:
+                      "System-generated key for a deployed process definition.",
+                    format: "ProcessDefinitionKey",
+                    example: "2251799813686749",
+                    type: "string",
+                    allOf: [
+                      {
+                        description:
+                          "Zeebe Engine resource key (Java long serialized as string)",
+                        type: "string",
+                        title: "LongKey",
+                      },
+                    ],
+                    title: "ProcessDefinitionKey",
+                  },
+                ],
+              },
+              processDefinitionVersion: {
+                type: "integer",
+                format: "int32",
+                description:
+                  "The version of the process definition that owns the agent definition.",
+              },
+              processDefinitionVersionTag: {
+                type: "string",
+                nullable: true,
+                description:
+                  "The version tag of the process definition that owns the agent definition.",
+              },
+              tenantId: {
+                description: "The tenant ID of this agent definition.",
+                allOf: [
+                  {
+                    example: "customer-service",
+                    description: "The unique identifier of the tenant.",
+                    format: "TenantId",
+                    type: "string",
+                    title: "TenantId",
+                  },
+                ],
+              },
+            },
+            title: "AgentDefinitionResult",
+          },
+        },
+      },
+    },
+    "400": {
+      description: "The provided data is not valid.",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "401": {
+      description: "The request lacks valid authentication credentials.",
+      headers: { "WWW-Authenticate": { schema: { type: "string" } } },
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "403": {
+      description: "Forbidden. The request is not allowed.",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "404": {
+      description:
+        "The agent definition with the given key was not found. More details are provided in the response body.\n",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "500": {
+      description: "An internal error occurred while processing the request.",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+  }}
+></StatusCodes>

--- a/docs/apis-tools/orchestration-cluster-api-rest/specifications/search-agent-definitions.api.mdx
+++ b/docs/apis-tools/orchestration-cluster-api-rest/specifications/search-agent-definitions.api.mdx
@@ -1,0 +1,1522 @@
+---
+id: search-agent-definitions
+title: "Search agent definitions"
+sidebar_label: "Search agent definitions"
+hide_title: true
+hide_table_of_contents: true
+api: eJztPdtWG7myv6LVsx8y2b6R2wReznLAyTaTAPEFsgOsIHfLWKHd7S2pMQ7La52POF94vuRUSX2zW7YhBwaY+CHBrdalbqoqlaqla0fRc+lsHTv1cxYo4rE+D7jiYeCclpxwxATFh6bnbDmSUeEOdL2dtJp0SvDCjQRXE+jm2ulBLSbqkRrA4+m0BCVUcjctgG49Jl3BR3qULeckOAmOj1uNz91mq7Hz7aDR+tRst5v7e+0tNtkdf/2yq+iXvR/0aDNyJ803Ry+ht+Hhj97Lw8m/Xxx22Zd3fvN7yLvvdw8+1w473Y3NRqv7dbdz4Xfb3c39Jh9z98PhpHfk/3Bf+Jc9v/Xa/dDl+3y33eq+b3zZeNfu1Pbedzf2+q3G4Yd29/XuYcM/6PDdzS/tMf969HrYe7n7/evRht8LPmO7IT26qn390uT9z6enBvz6zg7A3tz7dthoIexbbysbteTlNuDSbHcae9v/3mocNvY63fpH866tSUr6oSB0jv6SAN2YR8KAnPNLFhAgmWKC0wpQXLD/REyqd6EHRL/Wj1wwYFKf+pKVHDcMFHSH7+ho5HNXc7H6XSLFrx3pDtiQ4q9ZVszLADEsJ/FwOLKajBjUDHvfmavgmfr+fl8zfv7NSKD4KM4kDjQC/IoDHtBzHmjYZtDLOl1dnWzTgESSkbDfl0yVDdVGWc1nfREOqz4fcvU72W8RkFUZCks92oceqz0G3GDkn8S0KJFepEgQKtIL1QCBCwO2AGPFlY8FH7FlYYACSfQARZp0BowM6RUfRkMSRMMeE4AaAWyHkqgQeKEiERAegGQwC2c4cP6cCSgAPIZUmaKXLxycd30a+VCyUauVnCEwGcaAJ/htxtNvarXpFKftIuz27XQuoIdkt2PHA49dzSAlFRUqljYenBNsezOcUixq09LjoehyCm7nJRD6HFOxlJJaMItodUHoFaB2xgLPdHlGLqkfMU0+/Wok2CUPIwlYyRHoFIb49pmCOY2vA3alcGCcPFgFUJHL5h8SEgaLpxBSjCYqAogmJnEfUKbpl5ILMX3zKqOoVAK4DM/sig5HmiZHP5qTvU7j5X7n4tWnzqcX+zvu1aedXS9HtkaCpjM9fUzMvt30mWF+j7oXq7hvFNIS9uvJ83MCkL6+pRCY+fowYtDO0H38gnCag1tT6DMSCOwYa5kREYWptVJWYV4iAHMLvm0oJX3OfG/GlsboUCHoBB41/th4Xj4zH+LY0b04hXFNsZXQZlzU5AhFb1KxcTlAyhw7dNaD/JMhXLqwgy1KTkCH+If5bAiFTc9MCZdJmbWyl5q+CsWHTMh0allfdShCCD4T1QOiWIXCs2ldxFa/QtEZDzjOpBhtnFGC+VShWkeCLKNCvb0NTzsN+HOaE6m4PJUH6HcfR2tgs7ykzPnhOcHBNqnwQIs+9632AzGZ9zqTeWzaLNUDi5xF09TmK85ZtaIYWEGMAg64kAs2wfmrLECvhHJmFBKDMSFjrgDcyPcJ9S5p4ALbYhxcOqI97nOE1erzpexMjdMVdRXoG9CszvwK5xOWMqlhN/qZYW1/sgzw9kTCVC0D+LgGA9CQAHqhEFgJkGqpIsYzGvbFi9cbf2xuvt14+WZzY/P1W4uILgLpK2M9RhoBmCoUdBlGwjWMebZLLynxQ3DdJCoen/8AiKkkps/fLYOkzjI0QhjzqtKCwlQvJdMKCb9i2Z6nePrewv6byuc/2H+KArk9YO6F1HyAGQZ4JmJkrGl4yT0YVTN5zdxbMdf5R7CC4ADYmuR3S3J2xaWSC6nOjb4FP08ggVLFaZrlplAvDH1GAwf75MGq/tJ+hrFipEGq22cZKpd5MGv+LuOvnlGhat6eGwE6xGt23DE7pstrvNdW6SDmhZmemU9sdYwuOCzFgU+GnGrAZdGdM616bLUnl0GDI6K7+UQcpSIpLCI2S4iFPnnzW/1DY6/zrd199+2gtb/daLfhdVrcqbf/hOfGl06jtVf/aEqdxXxNKHlH3kvKmMfgwjwVst+3X/F06PA3MvZPgugPbIGfDI18fsFyEal09FuRbIZU2GM8c/UuWzQahQKdkDH3PRfjre6ACrAsTIA8CraFtZ6Ts+dnW2mHP5gISxgbhP8EGUa+4uCB5BpWdJP/yjXRlSUAn6+nITiyjOsCO8AfASTpSIMGqgfjwdKnclCKNZNUaAm2yNnJyfMz6CrveQCSxmtwljoXSGybd6GjbFapGURDGpQFox7tASpYMSeNGD8jcWwOyqgi4TiQtw7MtDWbH5WP8VM22gyeM8m5HdEb9vUON8hzaM/3eP9GfpaQd2c0i/0+aSM0h85fruDnx7duNM1Jx1q73oV2ndnI0SS0qdRsx8KqV98dfNpLNWdz5+51aiMZ/1Gp1eW+8zD0mF/W+AFs3LgrQUKMmdBAI7chtHgLse4qfgl66dtG7c1FKHt5BNIOfnJBlhH4sSzBHo58f8XC6iGxe9KW6tGQ8hEsgh4Q87XxvdulTUpem/W15QgstsOJ1S3a4dzq+OdN8UERmCdilJtmgljIUcryivScqpD9wJ/AjJLYolhfGvqBFELhyA8nGFSHh0gyQH5m4lnItXQKBmxcpq4bRoEqh0EvBAGEKuVxKC76fjjO0cfW809afxtPH4Mf8Itw7L4djl+GjH8jz+ZX4NkDu1C/ConXvtrd+moWQt/Ia1uYCJjLALxfV+3vkCSYzbAirZbPtCUZF2/f/PFq0zIPHzzjworEXXl5jz9pcM3sB04hXDPg7+darrm9jNuPNr1wzZz5ZENbnRt5YslnM1Zv7NK8vBePrGm+vZpzwm7tfy35hOshMgVicMgzDcTvD7HBv5Aid77lv3Sk+7AS55ZP4j4IBspBoCQGxA2HIyq4BMn8f4J/riyJMzNjJVy5w0F9C34fw/HdY+fbsMuNdA+4/dUJHIuBmdWcsR66jbLEDwmX6ktFz+9FZ67zqdb5VE/N4V7nU/2qYcKb5VOl32NbNap5m9vAXavLtbpcq8u1uvw11eXisyGSjpbVyZ0fYTjrJCfGaD6+qNVud4CEOQIGpenOzyIzYNk0U/4MEyO1p8tOKMtX1+eTFU48WXlqGQ/MCgJ/014YmUNAZmggV0GqQkX9pga35Ayo/BQK1smX5Q74wQBVegxSAdxcT0Vm4bv4+Bst06jktbIrHhZjXx+9eYXqrghgccc48JDLMGnGAwZDCHNOUQZdckwR9AWzBM+2A8mAaeJF+nwiqYN75gA2WSFHA6ihRATzb6YP/N6V+HphCpQPPNCqnvEDXIXr0+zQnxRfgz40PM+v1rGNYLEWSTSLVdfnOWGdDvGRSPEpTPDrnCmVUHrhaUvEnOUEcHEDzZk59OksPlcnTlgMZIRd5c4qCsBhwW90nC1Nn6dzZlMmxLcno/XUsiIJ9alpd0rBR3L0mf24KHOmlNGNzoI62fuC6liWP5vMnsIRlTeP19eLnx6WQPMwHbunKg7aE8WHht+27yK4AmWBkXM8v2uVUn0Kh0zdwYlIhlaWL/9hQpha1BUhENESa4ojUtIou/W5KTc/N+VWBzM8wq9u/5qPP8l7YKA8CdDvRbOeTjV0C4ySTnpCRyAITWK2HhGcxj4/j2Ayz5jibCX30J9aPfDXKY8q1/1XyBB8HKlq623vVRkoyzaxV28L38c29+rNonnM533S+9pMum2E1eZmzEhDJkRuJFU4ZKIM3L7kLrPSNvZjuAd9cvDTRYKLGXdGbDsJoIsFJa2yNNDR0n66M71ZLCSrDdVfLQqCpLEpjyqKy0s8LxwWL9xbEgCBRsDj4T9XBkIwIxFrAtkV5T4x/i5OnsSNwNwCctx6v002X73+4/TZQKmR3KpWx+NxRfTdMvO4CkUlFOdVeMR/WO/3CgHgBTr4EwxWUc/T6MPSOfNLiRwxF5jjogWP5UwDg1yYsc322IZxtg2h9fpZRVILA6KC64U4CmYJZsT+1Ty7U5GIBC/GxUm31UwkapItvHMwO/nTVnXMZqvn0+BiRgkmFPRCV1ZcOowCj1Z4WKUjXr18Uakl3Ctjl7Lao15ZJEeupnK1KupZJzIaDqnI24oZODN43lGPtLIBYjr+pE77V6dzQEwX4Gh5LFtFxADMjP1q5pBj85Qcc/ymhseux8xcjS/4RlcjoLWJl80hDSI8DLXhx95m0Y9RzyLDxwDCbtiTnVD7TBhsOsWgqz6oH/qkQoIATnPytUKSgH19mAuBRVUZmRpRNSgIVij4OZ/HZBZ0EJfqd4C0Sg2g2Gde98STe8fQMFE0G3ZFE8sY8TGUbDQMoRGMDVC5ycUITANJfb24GIAjD8YCuzs6OirXs8psVukUgvtrxbVWXGvFtVZct1NcL4t64H0oetwDAPS0TXVY7CaB9xiO2dpRWuubtb5Z65tb6pvXthVZPdCp1gLnJxMCWBa6OqMDA4/cT5fKCWy53aC1BlproLUGWmugm2ogeHlVhsnIvDIPypdJqNHB2/9016BN9B6bDo9dYLjY1qDk6J3upCFGOodMDUK8dXEUSp1WRfH+RKeqA3DlXMS8anahccYycamXejBUJIDJzrVRVFOYHdcD6Ge6dY1ZDlNAVI8pOIYZtXDia6PQkvnmhy71B2Z0yzYRvMjvDe0LzJJS5rpIsu1HEtMrWo12h3wAlo/pxERC06uLkmHe1t7WrCNg1Rv0Xj9oEoO5HiCvmpMhUENYhzCVbzuI/kQgufOyjV0kF3VlN1+mEhyPrUfSySS6EpSYH+8Tud496iD4ubsyF3eBdbRgoj1qZVdBNhJJTq6IOk7vbLLvh8dXHOk7hxCp7KYg21a0bcs2txO6aL/SbDXmtmSynTvbhpd1Z+sGuzf2zRnbbsbiLYLailB9Luacxs1ze5JJtlh8IdkG3gCGaq0fam4m9ydaxQwkDKdkqkFqlY3YHwFlhM1jMm4bAxdvsrAYHDPdE0t4ztUg6lXccFiN7WH6l0sJ0uJMC4oTBBxNC7SBitrvAb1pPrsjyZhviWug1WmPv/1GtsPgErUsqCFT8hvR59ObvB2XootlrjnFqVOWoJNLBLe3tS320qWgFlJJgMFspHRyrGmrtxVPArDsEYpMkp1FnunEYiPt5Ky+3WkeNs5K5EzrbQa/MBPsrG6ecAPxBDwlP+6f6TtVeTCKFLhVSUoMjO6DkpL6KlGdFkeDEAnhp3jIQTgOTHoRz5wtzUZNkI42y0wMgcgwcIpdjw3oJcekIamThlJa4C430I+jKUOQTwKo8fw5GMbnz9EuZupvxALkEJIOGylMMyX/+9//Q9o7f0qSbQfibutJUISP9CZ6pw1axZVDIbUzKZj2UAHXcorxSZCQ3+zSuz7HXR8EuUJAY2nVbHLiJ0l+CQJSimkIpGJxKt48FcksERPOGu8U/G2G2UlFaf9o3pB4MpKNSu02Ut/zw151SHlQjYeQ1e36p+7eTr38sbnd2Gs3ytBjRV2ZC9PQ5A5pkIMjvqe3kAA1b1WusxXE+l7jn7jXOLZ4ChynKnifXCddajZfxx5QnNlVnmVC7AOBCTN+zLFzfY3DdIU/nWKxztHD+6czt8dcTx0HyHP+2bbhYDnOE0s8s0LuMia/mxZ1rVeW1s17dAf77Q46APHlzZgYAaWCohXD/7ccNM0jgxtU0GVgVWhwHmkL45g+UVTprKsw513ks55Bq+YgBPLoGp3wggVAolKMisJnvYE6/T97zU69
+sidebar_class_name: "post api-method"
+info_path: docs/apis-tools/orchestration-cluster-api-rest/specifications/orchestration-cluster-api
+custom_edit_url: null
+hide_send_button: true
+---
+
+import MarkerRequiredPermissions from "@site/src/mdx/MarkerRequiredPermissions";
+
+import MarkerAddedInVersion from "@site/src/mdx/MarkerAddedInVersion";
+
+import MarkerEventuallyConsistentExtension from "@site/src/mdx/MarkerEventuallyConsistentExtension";
+
+import MethodEndpoint from "@theme/ApiExplorer/MethodEndpoint";
+import ParamsDetails from "@theme/ParamsDetails";
+import RequestSchema from "@theme/RequestSchema";
+import StatusCodes from "@theme/StatusCodes";
+import OperationTabs from "@theme/OperationTabs";
+import TabItem from "@theme/TabItem";
+import Heading from "@theme/Heading";
+import Translate from "@docusaurus/Translate";
+
+<Heading as={"h1"} className={"openapi__heading"}>
+  {"Search agent definitions"} <MarkerAddedInVersion version="8.10" />
+</Heading>
+
+<MethodEndpoint
+  method={"post"}
+  path={"/agent-definitions/search"}
+  context={"endpoint"}
+></MethodEndpoint>
+
+<MarkerEventuallyConsistentExtension />
+
+Search for agent definitions based on given criteria.
+
+<MarkerRequiredPermissions
+  permissions={[
+    {
+      resourceType: "PROCESS_DEFINITION",
+      permissionType: "READ_PROCESS_DEFINITION",
+    },
+  ]}
+  enforcement={"filter"}
+/>
+
+<Heading id={"request"} as={"h2"} className={"openapi-tabs__heading"}>
+  <Translate id="theme.openapi.request.title">Request</Translate>
+</Heading>
+
+<ParamsDetails parameters={undefined}></ParamsDetails>
+
+<RequestSchema
+  title={"Body"}
+  body={{
+    required: false,
+    content: {
+      "application/json": {
+        schema: {
+          description: "Agent definition search request.",
+          type: "object",
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                page: {
+                  description: "Pagination criteria.",
+                  allOf: [
+                    {
+                      description:
+                        "Pagination criteria. Can use offset-based pagination (from/limit) OR cursor-based pagination (after/before + limit), but not both.",
+                      oneOf: [
+                        {
+                          type: "object",
+                          title: "Limit-based pagination",
+                          properties: {
+                            limit: {
+                              description:
+                                "The maximum number of items to return in one request.",
+                              type: "integer",
+                              format: "int32",
+                              default: 100,
+                              minimum: 1,
+                              maximum: 10000,
+                            },
+                          },
+                        },
+                        {
+                          type: "object",
+                          title: "Offset-based pagination",
+                          properties: {
+                            from: {
+                              description:
+                                "The index of items to start searching from.",
+                              type: "integer",
+                              format: "int32",
+                              minimum: 0,
+                            },
+                            limit: {
+                              description:
+                                "The maximum number of items to return in one request.",
+                              type: "integer",
+                              format: "int32",
+                              default: 100,
+                              minimum: 1,
+                            },
+                          },
+                        },
+                        {
+                          type: "object",
+                          title: "Cursor-based forward pagination",
+                          properties: {
+                            after: {
+                              description:
+                                "Use the `endCursor` value from the previous response to fetch the next page of results.",
+                              allOf: [
+                                {
+                                  description:
+                                    "The end cursor in a search query result set.",
+                                  format: "base64",
+                                  type: "string",
+                                  example: "WzIyNTE3OTk4MTM2ODcxMDJd",
+                                  title: "EndCursor",
+                                },
+                              ],
+                            },
+                            limit: {
+                              description:
+                                "The maximum number of items to return in one request.",
+                              type: "integer",
+                              format: "int32",
+                              default: 100,
+                              minimum: 1,
+                              maximum: 10000,
+                            },
+                          },
+                        },
+                        {
+                          type: "object",
+                          title: "Cursor-based backward pagination",
+                          properties: {
+                            before: {
+                              description:
+                                "Use the `startCursor` value from the previous response to fetch the previous page of results.",
+                              allOf: [
+                                {
+                                  description:
+                                    "The start cursor in a search query result set.",
+                                  format: "base64",
+                                  type: "string",
+                                  example: "WzIyNTE3OTk4MTM2ODcxMDJd",
+                                  title: "StartCursor",
+                                },
+                              ],
+                            },
+                            limit: {
+                              description:
+                                "The maximum number of items to return in one request.",
+                              type: "integer",
+                              format: "int32",
+                              default: 100,
+                              minimum: 1,
+                              maximum: 10000,
+                            },
+                          },
+                        },
+                      ],
+                      title: "SearchQueryPageRequest",
+                    },
+                  ],
+                },
+              },
+              title: "SearchQueryRequest",
+            },
+          ],
+          properties: {
+            sort: {
+              description: "Sort field criteria.",
+              type: "array",
+              items: {
+                type: "object",
+                required: ["field"],
+                properties: {
+                  field: {
+                    description: "The field to sort by.",
+                    type: "string",
+                    enum: [
+                      "agentDefinitionKey",
+                      "agentType",
+                      "name",
+                      "elementId",
+                      "processDefinitionId",
+                      "processDefinitionKey",
+                      "processDefinitionVersion",
+                      "processDefinitionVersionTag",
+                      "tenantId",
+                    ],
+                  },
+                  order: {
+                    description:
+                      "The order in which to sort the related field.",
+                    type: "string",
+                    enum: ["ASC", "DESC"],
+                    default: "ASC",
+                    title: "SortOrderEnum",
+                  },
+                },
+                title: "AgentDefinitionSearchQuerySortRequest",
+              },
+            },
+            filter: {
+              description: "The agent definition search filters.",
+              allOf: [
+                {
+                  description: "Agent definition search filter.",
+                  type: "object",
+                  properties: {
+                    agentDefinitionKey: {
+                      description: "The unique key of the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "AgentDefinitionKey property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                              allOf: [
+                                {
+                                  description:
+                                    "System-generated key for an agent definition.",
+                                  format: "AgentDefinitionKey",
+                                  example: "2251799813691958",
+                                  type: "string",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "Zeebe Engine resource key (Java long serialized as string)",
+                                      type: "string",
+                                      title: "LongKey",
+                                    },
+                                  ],
+                                  title: "AgentDefinitionKey",
+                                },
+                              ],
+                            },
+                            {
+                              title: "Advanced filter",
+                              description:
+                                "Advanced AgentDefinitionKey filter.",
+                              type: "object",
+                              properties: {
+                                $eq: {
+                                  description:
+                                    "Checks for equality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "System-generated key for an agent definition.",
+                                      format: "AgentDefinitionKey",
+                                      example: "2251799813691958",
+                                      type: "string",
+                                      allOf: [
+                                        {
+                                          description:
+                                            "Zeebe Engine resource key (Java long serialized as string)",
+                                          type: "string",
+                                          title: "LongKey",
+                                        },
+                                      ],
+                                      title: "AgentDefinitionKey",
+                                    },
+                                  ],
+                                },
+                                $neq: {
+                                  description:
+                                    "Checks for inequality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "System-generated key for an agent definition.",
+                                      format: "AgentDefinitionKey",
+                                      example: "2251799813691958",
+                                      type: "string",
+                                      allOf: [
+                                        {
+                                          description:
+                                            "Zeebe Engine resource key (Java long serialized as string)",
+                                          type: "string",
+                                          title: "LongKey",
+                                        },
+                                      ],
+                                      title: "AgentDefinitionKey",
+                                    },
+                                  ],
+                                },
+                                $exists: {
+                                  description:
+                                    "Checks if the current property exists.",
+                                  type: "boolean",
+                                },
+                                $in: {
+                                  description:
+                                    "Checks if the property matches any of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "System-generated key for an agent definition.",
+                                    format: "AgentDefinitionKey",
+                                    example: "2251799813691958",
+                                    type: "string",
+                                    allOf: [
+                                      {
+                                        description:
+                                          "Zeebe Engine resource key (Java long serialized as string)",
+                                        type: "string",
+                                        title: "LongKey",
+                                      },
+                                    ],
+                                    title: "AgentDefinitionKey",
+                                  },
+                                },
+                                $notIn: {
+                                  description:
+                                    "Checks if the property matches none of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "System-generated key for an agent definition.",
+                                    format: "AgentDefinitionKey",
+                                    example: "2251799813691958",
+                                    type: "string",
+                                    allOf: [
+                                      {
+                                        description:
+                                          "Zeebe Engine resource key (Java long serialized as string)",
+                                        type: "string",
+                                        title: "LongKey",
+                                      },
+                                    ],
+                                    title: "AgentDefinitionKey",
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                          title: "AgentDefinitionKeyFilterProperty",
+                        },
+                      ],
+                    },
+                    agentType: {
+                      description:
+                        "The kind of agent this agent definition describes.",
+                      allOf: [
+                        {
+                          description:
+                            "AgentDefinitionTypeEnum property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                              allOf: [
+                                {
+                                  description:
+                                    "The kind of agent an agent definition describes.",
+                                  type: "string",
+                                  enum: [
+                                    "AI_AGENT_SUB_PROCESS",
+                                    "AI_AGENT_TASK",
+                                    "EXTERNAL_AGENT",
+                                  ],
+                                  title: "AgentDefinitionTypeEnum",
+                                },
+                              ],
+                            },
+                            {
+                              title: "Advanced filter",
+                              description:
+                                "Advanced AgentDefinitionTypeEnum filter.",
+                              type: "object",
+                              properties: {
+                                $eq: {
+                                  description:
+                                    "Checks for equality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "The kind of agent an agent definition describes.",
+                                      type: "string",
+                                      enum: [
+                                        "AI_AGENT_SUB_PROCESS",
+                                        "AI_AGENT_TASK",
+                                        "EXTERNAL_AGENT",
+                                      ],
+                                      title: "AgentDefinitionTypeEnum",
+                                    },
+                                  ],
+                                },
+                                $neq: {
+                                  description:
+                                    "Checks for inequality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "The kind of agent an agent definition describes.",
+                                      type: "string",
+                                      enum: [
+                                        "AI_AGENT_SUB_PROCESS",
+                                        "AI_AGENT_TASK",
+                                        "EXTERNAL_AGENT",
+                                      ],
+                                      title: "AgentDefinitionTypeEnum",
+                                    },
+                                  ],
+                                },
+                                $exists: {
+                                  description:
+                                    "Checks if the current property exists.",
+                                  type: "boolean",
+                                },
+                                $in: {
+                                  description:
+                                    "Checks if the property matches any of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "The kind of agent an agent definition describes.",
+                                    type: "string",
+                                    enum: [
+                                      "AI_AGENT_SUB_PROCESS",
+                                      "AI_AGENT_TASK",
+                                      "EXTERNAL_AGENT",
+                                    ],
+                                    title: "AgentDefinitionTypeEnum",
+                                  },
+                                },
+                                $notIn: {
+                                  description:
+                                    "Checks if the property matches none of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "The kind of agent an agent definition describes.",
+                                    type: "string",
+                                    enum: [
+                                      "AI_AGENT_SUB_PROCESS",
+                                      "AI_AGENT_TASK",
+                                      "EXTERNAL_AGENT",
+                                    ],
+                                    title: "AgentDefinitionTypeEnum",
+                                  },
+                                },
+                                $like: {
+                                  type: "string",
+                                  description:
+                                    "Checks if the property matches the provided like value.\n\nSupported wildcard characters are:\n\n* `*`: matches zero, one, or multiple characters.\n* `?`: matches one, single character.\n\nWildcard characters can be escaped with backslash, for instance: `\\*`.\n",
+                                  title: "LikeFilter",
+                                },
+                              },
+                            },
+                          ],
+                          title: "AgentDefinitionTypeFilterProperty",
+                        },
+                      ],
+                    },
+                    name: {
+                      description:
+                        "The human-readable name of the process element that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "String property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                            },
+                            {
+                              title: "Advanced filter",
+                              description: "Advanced string filter.",
+                              allOf: [
+                                {
+                                  title: "Advanced filter",
+                                  description: "Basic advanced string filter.",
+                                  type: "object",
+                                  properties: {
+                                    $eq: {
+                                      description:
+                                        "Checks for equality with the provided value.",
+                                      type: "string",
+                                    },
+                                    $neq: {
+                                      description:
+                                        "Checks for inequality with the provided value.",
+                                      type: "string",
+                                    },
+                                    $exists: {
+                                      description:
+                                        "Checks if the current property exists.",
+                                      type: "boolean",
+                                    },
+                                    $in: {
+                                      description:
+                                        "Checks if the property matches any of the provided values.",
+                                      type: "array",
+                                      items: { type: "string" },
+                                    },
+                                    $notIn: {
+                                      description:
+                                        "Checks if the property matches none of the provided values.",
+                                      type: "array",
+                                      items: { type: "string" },
+                                    },
+                                  },
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    $like: {
+                                      type: "string",
+                                      description:
+                                        "Checks if the property matches the provided like value.\n\nSupported wildcard characters are:\n\n* `*`: matches zero, one, or multiple characters.\n* `?`: matches one, single character.\n\nWildcard characters can be escaped with backslash, for instance: `\\*`.\n",
+                                      title: "LikeFilter",
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                          title: "StringFilterProperty",
+                        },
+                      ],
+                    },
+                    elementId: {
+                      description:
+                        "The BPMN element ID of the process element that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "ElementId property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                              allOf: [
+                                {
+                                  description:
+                                    "The model-defined id of an element.",
+                                  format: "ElementId",
+                                  type: "string",
+                                  example: "Activity_106kosb",
+                                  title: "ElementId",
+                                },
+                              ],
+                            },
+                            {
+                              title: "Advanced filter",
+                              description: "Advanced ElementId filter.",
+                              type: "object",
+                              properties: {
+                                $eq: {
+                                  description:
+                                    "Checks for equality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "The model-defined id of an element.",
+                                      format: "ElementId",
+                                      type: "string",
+                                      example: "Activity_106kosb",
+                                      title: "ElementId",
+                                    },
+                                  ],
+                                },
+                                $neq: {
+                                  description:
+                                    "Checks for inequality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "The model-defined id of an element.",
+                                      format: "ElementId",
+                                      type: "string",
+                                      example: "Activity_106kosb",
+                                      title: "ElementId",
+                                    },
+                                  ],
+                                },
+                                $exists: {
+                                  description:
+                                    "Checks if the current property exists.",
+                                  type: "boolean",
+                                },
+                                $in: {
+                                  description:
+                                    "Checks if the property matches any of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "The model-defined id of an element.",
+                                    format: "ElementId",
+                                    type: "string",
+                                    example: "Activity_106kosb",
+                                    title: "ElementId",
+                                  },
+                                },
+                                $notIn: {
+                                  description:
+                                    "Checks if the property matches none of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "The model-defined id of an element.",
+                                    format: "ElementId",
+                                    type: "string",
+                                    example: "Activity_106kosb",
+                                    title: "ElementId",
+                                  },
+                                },
+                                $like: {
+                                  type: "string",
+                                  description:
+                                    "Checks if the property matches the provided like value.\n\nSupported wildcard characters are:\n\n* `*`: matches zero, one, or multiple characters.\n* `?`: matches one, single character.\n\nWildcard characters can be escaped with backslash, for instance: `\\*`.\n",
+                                  title: "LikeFilter",
+                                },
+                              },
+                            },
+                          ],
+                          title: "ElementIdFilterProperty",
+                        },
+                      ],
+                    },
+                    processDefinitionId: {
+                      description:
+                        "The BPMN process ID of the process definition that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "ProcessDefinitionId property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                              allOf: [
+                                {
+                                  description:
+                                    "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                                  format: "ProcessDefinitionId",
+                                  type: "string",
+                                  example: "new-account-onboarding-workflow",
+                                  title: "ProcessDefinitionId",
+                                },
+                              ],
+                            },
+                            {
+                              title: "Advanced filter",
+                              description:
+                                "Advanced ProcessDefinitionId filter.",
+                              type: "object",
+                              properties: {
+                                $eq: {
+                                  description:
+                                    "Checks for equality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                                      format: "ProcessDefinitionId",
+                                      type: "string",
+                                      example:
+                                        "new-account-onboarding-workflow",
+                                      title: "ProcessDefinitionId",
+                                    },
+                                  ],
+                                },
+                                $neq: {
+                                  description:
+                                    "Checks for inequality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                                      format: "ProcessDefinitionId",
+                                      type: "string",
+                                      example:
+                                        "new-account-onboarding-workflow",
+                                      title: "ProcessDefinitionId",
+                                    },
+                                  ],
+                                },
+                                $exists: {
+                                  description:
+                                    "Checks if the current property exists.",
+                                  type: "boolean",
+                                },
+                                $in: {
+                                  description:
+                                    "Checks if the property matches any of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                                    format: "ProcessDefinitionId",
+                                    type: "string",
+                                    example: "new-account-onboarding-workflow",
+                                    title: "ProcessDefinitionId",
+                                  },
+                                },
+                                $notIn: {
+                                  description:
+                                    "Checks if the property matches none of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                                    format: "ProcessDefinitionId",
+                                    type: "string",
+                                    example: "new-account-onboarding-workflow",
+                                    title: "ProcessDefinitionId",
+                                  },
+                                },
+                                $like: {
+                                  type: "string",
+                                  description:
+                                    "Checks if the property matches the provided like value.\n\nSupported wildcard characters are:\n\n* `*`: matches zero, one, or multiple characters.\n* `?`: matches one, single character.\n\nWildcard characters can be escaped with backslash, for instance: `\\*`.\n",
+                                  title: "LikeFilter",
+                                },
+                              },
+                            },
+                          ],
+                          title: "ProcessDefinitionIdFilterProperty",
+                        },
+                      ],
+                    },
+                    processDefinitionKey: {
+                      description:
+                        "The key of the process definition that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "ProcessDefinitionKey property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                              allOf: [
+                                {
+                                  description:
+                                    "System-generated key for a deployed process definition.",
+                                  format: "ProcessDefinitionKey",
+                                  example: "2251799813686749",
+                                  type: "string",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "Zeebe Engine resource key (Java long serialized as string)",
+                                      type: "string",
+                                      title: "LongKey",
+                                    },
+                                  ],
+                                  title: "ProcessDefinitionKey",
+                                },
+                              ],
+                            },
+                            {
+                              title: "Advanced filter",
+                              description:
+                                "Advanced ProcessDefinitionKey filter.",
+                              type: "object",
+                              properties: {
+                                $eq: {
+                                  description:
+                                    "Checks for equality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "System-generated key for a deployed process definition.",
+                                      format: "ProcessDefinitionKey",
+                                      example: "2251799813686749",
+                                      type: "string",
+                                      allOf: [
+                                        {
+                                          description:
+                                            "Zeebe Engine resource key (Java long serialized as string)",
+                                          type: "string",
+                                          title: "LongKey",
+                                        },
+                                      ],
+                                      title: "ProcessDefinitionKey",
+                                    },
+                                  ],
+                                },
+                                $neq: {
+                                  description:
+                                    "Checks for inequality with the provided value.",
+                                  allOf: [
+                                    {
+                                      description:
+                                        "System-generated key for a deployed process definition.",
+                                      format: "ProcessDefinitionKey",
+                                      example: "2251799813686749",
+                                      type: "string",
+                                      allOf: [
+                                        {
+                                          description:
+                                            "Zeebe Engine resource key (Java long serialized as string)",
+                                          type: "string",
+                                          title: "LongKey",
+                                        },
+                                      ],
+                                      title: "ProcessDefinitionKey",
+                                    },
+                                  ],
+                                },
+                                $exists: {
+                                  description:
+                                    "Checks if the current property exists.",
+                                  type: "boolean",
+                                },
+                                $in: {
+                                  description:
+                                    "Checks if the property matches any of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "System-generated key for a deployed process definition.",
+                                    format: "ProcessDefinitionKey",
+                                    example: "2251799813686749",
+                                    type: "string",
+                                    allOf: [
+                                      {
+                                        description:
+                                          "Zeebe Engine resource key (Java long serialized as string)",
+                                        type: "string",
+                                        title: "LongKey",
+                                      },
+                                    ],
+                                    title: "ProcessDefinitionKey",
+                                  },
+                                },
+                                $notIn: {
+                                  description:
+                                    "Checks if the property matches none of the provided values.",
+                                  type: "array",
+                                  items: {
+                                    description:
+                                      "System-generated key for a deployed process definition.",
+                                    format: "ProcessDefinitionKey",
+                                    example: "2251799813686749",
+                                    type: "string",
+                                    allOf: [
+                                      {
+                                        description:
+                                          "Zeebe Engine resource key (Java long serialized as string)",
+                                        type: "string",
+                                        title: "LongKey",
+                                      },
+                                    ],
+                                    title: "ProcessDefinitionKey",
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                          title: "ProcessDefinitionKeyFilterProperty",
+                        },
+                      ],
+                    },
+                    processDefinitionVersion: {
+                      description:
+                        "The version of the process definition that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "Integer property with advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "integer",
+                              format: "int32",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                            },
+                            {
+                              title: "Advanced filter",
+                              description: "Advanced integer (int32) filter.",
+                              type: "object",
+                              properties: {
+                                $eq: {
+                                  description:
+                                    "Checks for equality with the provided value.",
+                                  type: "integer",
+                                  format: "int32",
+                                },
+                                $neq: {
+                                  description:
+                                    "Checks for inequality with the provided value.",
+                                  type: "integer",
+                                  format: "int32",
+                                },
+                                $exists: {
+                                  description:
+                                    "Checks if the current property exists.",
+                                  type: "boolean",
+                                },
+                                $gt: {
+                                  description:
+                                    "Greater than comparison with the provided value.",
+                                  type: "integer",
+                                  format: "int32",
+                                },
+                                $gte: {
+                                  description:
+                                    "Greater than or equal comparison with the provided value.",
+                                  type: "integer",
+                                  format: "int32",
+                                },
+                                $lt: {
+                                  description:
+                                    "Lower than comparison with the provided value.",
+                                  type: "integer",
+                                  format: "int32",
+                                },
+                                $lte: {
+                                  description:
+                                    "Lower than or equal comparison with the provided value.",
+                                  type: "integer",
+                                  format: "int32",
+                                },
+                                $in: {
+                                  description:
+                                    "Checks if the property matches any of the provided values.",
+                                  type: "array",
+                                  items: { type: "integer", format: "int32" },
+                                },
+                              },
+                            },
+                          ],
+                          title: "IntegerFilterProperty",
+                        },
+                      ],
+                    },
+                    processDefinitionVersionTag: {
+                      description:
+                        "The version tag of the process definition that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "String property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                            },
+                            {
+                              title: "Advanced filter",
+                              description: "Advanced string filter.",
+                              allOf: [
+                                {
+                                  title: "Advanced filter",
+                                  description: "Basic advanced string filter.",
+                                  type: "object",
+                                  properties: {
+                                    $eq: {
+                                      description:
+                                        "Checks for equality with the provided value.",
+                                      type: "string",
+                                    },
+                                    $neq: {
+                                      description:
+                                        "Checks for inequality with the provided value.",
+                                      type: "string",
+                                    },
+                                    $exists: {
+                                      description:
+                                        "Checks if the current property exists.",
+                                      type: "boolean",
+                                    },
+                                    $in: {
+                                      description:
+                                        "Checks if the property matches any of the provided values.",
+                                      type: "array",
+                                      items: { type: "string" },
+                                    },
+                                    $notIn: {
+                                      description:
+                                        "Checks if the property matches none of the provided values.",
+                                      type: "array",
+                                      items: { type: "string" },
+                                    },
+                                  },
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    $like: {
+                                      type: "string",
+                                      description:
+                                        "Checks if the property matches the provided like value.\n\nSupported wildcard characters are:\n\n* `*`: matches zero, one, or multiple characters.\n* `?`: matches one, single character.\n\nWildcard characters can be escaped with backslash, for instance: `\\*`.\n",
+                                      title: "LikeFilter",
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                          title: "StringFilterProperty",
+                        },
+                      ],
+                    },
+                    tenantId: {
+                      description: "The tenant ID of the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "String property with full advanced search capabilities.",
+                          oneOf: [
+                            {
+                              type: "string",
+                              title: "Exact match",
+                              description: "Matches the value exactly.",
+                            },
+                            {
+                              title: "Advanced filter",
+                              description: "Advanced string filter.",
+                              allOf: [
+                                {
+                                  title: "Advanced filter",
+                                  description: "Basic advanced string filter.",
+                                  type: "object",
+                                  properties: {
+                                    $eq: {
+                                      description:
+                                        "Checks for equality with the provided value.",
+                                      type: "string",
+                                    },
+                                    $neq: {
+                                      description:
+                                        "Checks for inequality with the provided value.",
+                                      type: "string",
+                                    },
+                                    $exists: {
+                                      description:
+                                        "Checks if the current property exists.",
+                                      type: "boolean",
+                                    },
+                                    $in: {
+                                      description:
+                                        "Checks if the property matches any of the provided values.",
+                                      type: "array",
+                                      items: { type: "string" },
+                                    },
+                                    $notIn: {
+                                      description:
+                                        "Checks if the property matches none of the provided values.",
+                                      type: "array",
+                                      items: { type: "string" },
+                                    },
+                                  },
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    $like: {
+                                      type: "string",
+                                      description:
+                                        "Checks if the property matches the provided like value.\n\nSupported wildcard characters are:\n\n* `*`: matches zero, one, or multiple characters.\n* `?`: matches one, single character.\n\nWildcard characters can be escaped with backslash, for instance: `\\*`.\n",
+                                      title: "LikeFilter",
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                          title: "StringFilterProperty",
+                        },
+                      ],
+                    },
+                  },
+                  title: "AgentDefinitionFilter",
+                },
+              ],
+            },
+          },
+          title: "AgentDefinitionSearchQuery",
+        },
+      },
+    },
+  }}
+></RequestSchema>
+
+<StatusCodes
+  id={undefined}
+  label={undefined}
+  responses={{
+    "200": {
+      description: "The agent definition search result.",
+      content: {
+        "application/json": {
+          schema: {
+            description: "Agent definition search response.",
+            type: "object",
+            required: ["items"],
+            allOf: [
+              {
+                type: "object",
+                required: ["page"],
+                properties: {
+                  page: {
+                    description:
+                      "Pagination information about the search results.",
+                    type: "object",
+                    required: [
+                      "totalItems",
+                      "hasMoreTotalItems",
+                      "startCursor",
+                      "endCursor",
+                    ],
+                    properties: {
+                      totalItems: {
+                        description: "Total items matching the criteria.",
+                        type: "integer",
+                        format: "int64",
+                      },
+                      hasMoreTotalItems: {
+                        description:
+                          "Indicates whether the `totalItems` value has been capped due to system limits. When true, `totalItems` is a lower bound and the actual number of matching items is greater than the reported value.\n",
+                        type: "boolean",
+                      },
+                      startCursor: {
+                        description:
+                          "The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.",
+                        nullable: true,
+                        allOf: [
+                          {
+                            description:
+                              "The start cursor in a search query result set.",
+                            format: "base64",
+                            type: "string",
+                            example: "WzIyNTE3OTk4MTM2ODcxMDJd",
+                            title: "StartCursor",
+                          },
+                        ],
+                      },
+                      endCursor: {
+                        description:
+                          "The cursor value for getting the next page of results. Use this in the `after` field of an ensuing request.",
+                        nullable: true,
+                        allOf: [
+                          {
+                            description:
+                              "The end cursor in a search query result set.",
+                            format: "base64",
+                            type: "string",
+                            example: "WzIyNTE3OTk4MTM2ODcxMDJd",
+                            title: "EndCursor",
+                          },
+                        ],
+                      },
+                    },
+                    title: "SearchQueryPageResponse",
+                  },
+                },
+                title: "SearchQueryResponse",
+              },
+            ],
+            properties: {
+              items: {
+                description: "The matching agent definitions.",
+                type: "array",
+                items: {
+                  description:
+                    "An agent definition, created at deploy time for the process element it belongs to.",
+                  type: "object",
+                  required: [
+                    "agentDefinitionKey",
+                    "agentType",
+                    "name",
+                    "elementId",
+                    "processDefinitionId",
+                    "processDefinitionKey",
+                    "processDefinitionVersion",
+                    "processDefinitionVersionTag",
+                    "tenantId",
+                  ],
+                  properties: {
+                    agentDefinitionKey: {
+                      description:
+                        "The unique key for this agent definition. Unique across process definition versions.\n",
+                      allOf: [
+                        {
+                          description:
+                            "System-generated key for an agent definition.",
+                          format: "AgentDefinitionKey",
+                          example: "2251799813691958",
+                          type: "string",
+                          allOf: [
+                            {
+                              description:
+                                "Zeebe Engine resource key (Java long serialized as string)",
+                              type: "string",
+                              title: "LongKey",
+                            },
+                          ],
+                          title: "AgentDefinitionKey",
+                        },
+                      ],
+                    },
+                    agentType: {
+                      description:
+                        "The kind of agent an agent definition describes.",
+                      type: "string",
+                      enum: [
+                        "AI_AGENT_SUB_PROCESS",
+                        "AI_AGENT_TASK",
+                        "EXTERNAL_AGENT",
+                      ],
+                      title: "AgentDefinitionTypeEnum",
+                    },
+                    name: {
+                      description:
+                        "The human-readable name of the process element that owns the agent definition. Falls\nback to elementId when the element has no BPMN name configured.\n",
+                      type: "string",
+                    },
+                    elementId: {
+                      description:
+                        "The BPMN element ID of the process element that owns the agent definition.",
+                      allOf: [
+                        {
+                          description: "The model-defined id of an element.",
+                          format: "ElementId",
+                          type: "string",
+                          example: "Activity_106kosb",
+                          title: "ElementId",
+                        },
+                      ],
+                    },
+                    processDefinitionId: {
+                      description:
+                        "The BPMN process ID of the process definition that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "Id of a process definition, from the model. Only ids of process definitions that are deployed are useful.",
+                          format: "ProcessDefinitionId",
+                          type: "string",
+                          example: "new-account-onboarding-workflow",
+                          title: "ProcessDefinitionId",
+                        },
+                      ],
+                    },
+                    processDefinitionKey: {
+                      description:
+                        "The key of the process definition that owns the agent definition.",
+                      allOf: [
+                        {
+                          description:
+                            "System-generated key for a deployed process definition.",
+                          format: "ProcessDefinitionKey",
+                          example: "2251799813686749",
+                          type: "string",
+                          allOf: [
+                            {
+                              description:
+                                "Zeebe Engine resource key (Java long serialized as string)",
+                              type: "string",
+                              title: "LongKey",
+                            },
+                          ],
+                          title: "ProcessDefinitionKey",
+                        },
+                      ],
+                    },
+                    processDefinitionVersion: {
+                      type: "integer",
+                      format: "int32",
+                      description:
+                        "The version of the process definition that owns the agent definition.",
+                    },
+                    processDefinitionVersionTag: {
+                      type: "string",
+                      nullable: true,
+                      description:
+                        "The version tag of the process definition that owns the agent definition.",
+                    },
+                    tenantId: {
+                      description: "The tenant ID of this agent definition.",
+                      allOf: [
+                        {
+                          example: "customer-service",
+                          description: "The unique identifier of the tenant.",
+                          format: "TenantId",
+                          type: "string",
+                          title: "TenantId",
+                        },
+                      ],
+                    },
+                  },
+                  title: "AgentDefinitionResult",
+                },
+              },
+            },
+            title: "AgentDefinitionSearchQueryResult",
+          },
+        },
+      },
+    },
+    "400": {
+      description: "The provided data is not valid.",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "401": {
+      description: "The request lacks valid authentication credentials.",
+      headers: { "WWW-Authenticate": { schema: { type: "string" } } },
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "403": {
+      description: "Forbidden. The request is not allowed.",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+    "500": {
+      description: "An internal error occurred while processing the request.",
+      content: {
+        "application/problem+json": {
+          schema: {
+            description:
+              "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
+            type: "object",
+            required: ["type", "title", "status", "detail", "instance"],
+            properties: {
+              type: {
+                type: "string",
+                format: "uri",
+                description: "A URI identifying the problem type.",
+                default: "about:blank",
+                example:
+                  "https://docs.camunda.io/api/v2.0/problem-types/bad-request",
+              },
+              title: {
+                type: "string",
+                description: "A summary of the problem type.",
+                example: "Bad Request",
+              },
+              status: {
+                type: "integer",
+                format: "int32",
+                description: "The HTTP status code for this problem.",
+                example: 400,
+                minimum: 400,
+                maximum: 600,
+              },
+              detail: {
+                type: "string",
+                description: "An explanation of the problem in more detail.",
+                example:
+                  "Request property [maxJobsToActivates] cannot be parsed",
+              },
+              instance: {
+                type: "string",
+                format: "uri-reference",
+                description:
+                  "A URI path identifying the origin of the problem.",
+                example: "/v2/jobs/activation",
+              },
+            },
+            title: "ProblemDetail",
+          },
+        },
+      },
+    },
+  }}
+></StatusCodes>

--- a/docs/apis-tools/orchestration-cluster-api-rest/specifications/sidebar.ts
+++ b/docs/apis-tools/orchestration-cluster-api-rest/specifications/sidebar.ts
@@ -20,6 +20,24 @@ const sidebar: SidebarsConfig = {
     },
     {
       type: "category",
+      label: "Agent definition",
+      items: [
+        {
+          type: "doc",
+          id: "apis-tools/orchestration-cluster-api-rest/specifications/get-agent-definition",
+          label: "Get agent definition",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "apis-tools/orchestration-cluster-api-rest/specifications/search-agent-definitions",
+          label: "Search agent definitions",
+          className: "api-method post",
+        },
+      ],
+    },
+    {
+      type: "category",
       label: "Agent instance",
       items: [
         {

--- a/docs/components/agentic-orchestration/agent-definitions-and-instances.md
+++ b/docs/components/agentic-orchestration/agent-definitions-and-instances.md
@@ -27,7 +27,7 @@ This reuse is what allows an agent to hold a multi-turn conversation across a lo
 
 ## Agent definitions
 
-An AI agent definition is a first-class, queryable resource that Camunda creates when you deploy a process containing one or more agents.
+An AI agent definition is a first-class, queryable resource that Camunda creates when you deploy a process containing one or more agents. Use the [Agent Definition API](/apis-tools/orchestration-cluster-api-rest/specifications/get-agent-definition.api.mdx) to get an agent definition by key, or the [search endpoint](/apis-tools/orchestration-cluster-api-rest/specifications/search-agent-definitions.api.mdx) to list agent definitions filtered by any of their properties.
 
 Camunda creates one agent definition per agent element in a deployed process, analogous to how a [DRD](/reference/glossary.md#drd-decision-requirements-diagram) deployment creates one decision definition per decision. An agent definition is a **structural descriptor** of the agent, not a store of its runtime configuration.
 
@@ -129,7 +129,7 @@ The following data is available for an agent instance in Operate:
 | Model                | The LLM the agent is running against.                                                                                                                                                                                |
 | System prompt        | The system prompt the agent was configured with.                                                                                                                                                                     |
 | Tool definitions     | The [tools](/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-tool-definitions.md) available to the agent, resolved from the agent's ad-hoc sub-process.                                           |
-| Conversation history | The decision trail of the agent execution: initial configuration, user prompts, assistant messages, the tools the agent selected with its reasoning, and tool calls with their inputs and results.                                          |
+| Conversation history | The decision trail of the agent execution: initial configuration, user prompts, assistant messages, the tools the agent selected with its reasoning, and tool calls with their inputs and results.                   |
 
 #### Agent states
 


### PR DESCRIPTION
## Description

Syncs the `AgentDefinition` REST API contract added in [camunda/camunda#59804](https://github.com/camunda/camunda/pull/59804) into the "next" (unreleased) REST API reference, added in 8.10:

- `GET /agent-definitions/{agentDefinitionKey}` — get an agent definition by key.
- `POST /agent-definitions/search` — search agent definitions, filterable and sortable by all 9 properties (`agentDefinitionKey`, `agentType`, `name`, `elementId`, `processDefinitionId`, `processDefinitionKey`, `processDefinitionVersion`, `processDefinitionVersionTag`, `tenantId`).

Changes:

- Vendored the new `agent-definitions.yaml` spec file and the corresponding `AgentDefinitionKey` type/filter into `keys.yaml`, and registered the new tag/paths in `camunda-openapi.yaml`, mirroring the upstream contract.
- Regenerated the API reference, adding `get-agent-definition.api.mdx` and `search-agent-definitions.api.mdx` and their sidebar entries.
- Linked the new API pages from [Agent definitions and instances](https://github.com/camunda/camunda-docs/blob/main/docs/components/agentic-orchestration/agent-definitions-and-instances.md), which already described this resource conceptually.

Closes #9503 

## When should this change go live?

- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
