### PR TITLE
Tenants Issue 11: minor provisioning and lifecycle updates

### DIFF
--- a/docs/self-managed/concepts/physical-tenants/provisioning-and-lifecycle.md
+++ b/docs/self-managed/concepts/physical-tenants/provisioning-and-lifecycle.md
@@ -26,11 +26,15 @@ To add a tenant:
 3. Ensure required storage and identity configuration is valid.
 4. Apply the change through a rolling restart.
 
+You can add multiple new Physical Tenants in the same configuration change and rolling restart — there is no requirement to add them one at a time.
+
 ### Rolling restart expectations
+
+Existing Physical Tenants keep running during a rolling restart to add a new tenant. Any interference they experience is the normal interference of a rolling restart itself, not something caused specifically by the new tenant's addition.
 
 During a rolling restart for tenant provisioning:
 
-- Existing tenant traffic should continue according to your rollout strategy.
+- Existing tenants continue processing requests throughout the restart, subject to your normal rollout strategy.
 - New tenant availability starts after updated components are running and ready.
 - Startup validation failures block readiness for affected components.
 
@@ -48,11 +52,17 @@ If tenant scope is omitted in compatibility paths, requests resolve to the defau
 
 For 8.10:
 
-- Disabling a Physical Tenant is not supported.
+- Disabling and re-enabling a Physical Tenant is supported, but only through configuration — there is no dedicated API for it.
 - Renaming a Physical Tenant is not supported.
 - Deleting a Physical Tenant is not supported.
 
-If you remove a Physical Tenant from configuration, the cluster will no longer process requests for that tenant. The API returns `404 Not Found` for requests scoped to a removed tenant. No data is deleted. You can reactivate the tenant by restoring its configuration.
+A Physical Tenant's enabled state follows its configuration directly:
+
+- **Present in configuration** — the tenant is enabled.
+- **Removed from configuration** — the tenant is disabled. The cluster stops processing requests for that tenant, and the API returns `404 Not Found` for requests scoped to it. No data is deleted.
+- **Re-added to configuration** — the tenant is re-enabled with its existing data. Nothing needs to be re-created.
+
+Each of these transitions takes effect through the same rolling restart used for any other configuration change.
 
 ## Out of scope for 8.10
 


### PR DESCRIPTION
## Description

Closes #8897 (Tenant Issue 11: Provisioning and Lifecycle Operations).

Updates `provisioning-and-lifecycle.md` with the engineering answers Deepthi provided on the issue:

- Fixes contradiction: it said disabling a Physical Tenant is "not supported," then described exactly how to do it via config removal two sentences later. Reworded to state clearly that disable/re-enable is supported in 8.10, config-only, no dedicated API - present in config = enabled, removed = disabled (no data loss), re-added = re-enabled with existing data.
- Adds that multiple new Physical Tenants can be added in the same config change and rolling restart - no one-at-a-time requirement.
- Firms up the rolling-restart language: existing tenants keep running during a restart to add a new tenant; any interference is normal restart interference, not something the new tenant causes.

## When should this change go live?

- [x] This is part of a scheduled **alpha or minor**. (add `alpha` or `minor` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) — @deepthidevaki, who answered the open engineering questions this PR resolves
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

