### PR TITLE
docs(app-integrations): document Physical Tenant support and fix the removed auth.audience setting

### DIFF
--- a/docs/components/camunda-integrations/ms-teams/ms-teams-installation.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-installation.md
@@ -373,6 +373,10 @@ The `urls.tasklist` field supports two formats:
 
 :::
 
+:::note
+On Camunda 8.10, a cluster can host several [Physical Tenants](/self-managed/concepts/physical-tenants/index.md). To serve them from one App Integrations deployment, add a `physicalTenants` array to the cluster. See [App Integrations and Physical Tenants](/self-managed/concepts/physical-tenants/app-integrations.md).
+:::
+
 ### Stage values
 
 The `stage` field controls the environment label.
@@ -427,54 +431,58 @@ docker run -d \
 
 Below is a reference of each section in the `config.yaml` file.
 
-| Section           | Field                               | Description                                                                                                                                         |
-| :---------------- | :---------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `serverPort`      | —                                   | The port the backend server listens on inside the container (default: `8080`).                                                                      |
-| `stage`           | —                                   | Environment stage: `local`, `dev`, `int`, or `prod`.                                                                                                |
-| **auth**          |                                     | Authentication configuration for connecting to your Camunda platform. See [Auth configuration](#auth-configuration).                                |
-|                   | `kind`                              | Identity provider variant: `keycloak` (default) or `entra`. Determines how OIDC endpoints are resolved.                                             |
-|                   | `m2m.clientId` / `m2m.clientSecret` | Machine-to-machine OAuth2 credentials for backend services.                                                                                         |
-|                   | `spa.clientId` / `spa.clientSecret` | Single Page Application OAuth2 credentials for frontend.                                                                                            |
-|                   | `issuer`                            | The OAuth2/OIDC issuer URL. Required for Keycloak; auto-derived for Entra.                                                                          |
-|                   | `audiences.zeebe`                   | _(Required)_ The audience of the Orchestration Cluster API. Typically `camunda-platform` on Keycloak.                                               |
-|                   | `audiences.app_integrations`        | _(Optional)_ The audience App Integrations accepts on its own inbound API, used when the exporter authenticates with OAuth instead of an API key.   |
-|                   | `entra.tenantId`                    | _(Entra only, required)_ The Entra tenant ID.                                                                                                       |
-|                   | `entra.tokenUrl`                    | _(Entra only, optional)_ Token endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                              |
-|                   | `entra.jwksUrl`                     | _(Entra only, optional)_ JWKS endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                             |
-|                   | `entra.scope`                       | _(Entra only, optional)_ OAuth2 scope. Defaults to `openid profile offline_access <auth.audiences.zeebe>/.default`.                                 |
-|                   | `entra.usernameClaim`               | _(Entra only, optional)_ ID token claim for the user's email. Default: `preferred_username`.                                                        |
-| **db**            |                                     | PostgreSQL database connection settings.                                                                                                            |
-|                   | `username`                          | Database username.                                                                                                                                  |
-|                   | `password`                          | Database password.                                                                                                                                  |
-|                   | `database`                          | Database name.                                                                                                                                      |
-|                   | `host`                              | Database hostname (as reachable from the container).                                                                                                |
-|                   | `loginType`                         | Authentication type (`password` for username/password auth).                                                                                        |
-|                   | `encryptionKey`                     | 32-character key used for encrypting sensitive data.                                                                                                |
-| **teams**         |                                     | Microsoft Teams integration settings.                                                                                                               |
-|                   | `clientId`                          | Azure AD app client ID.                                                                                                                             |
-|                   | `appId`                             | Teams app ID.                                                                                                                                       |
-|                   | `appPassword`                       | Azure AD app password (client secret).                                                                                                              |
-|                   | `tenantId`                          | Azure AD tenant ID.                                                                                                                                 |
-|                   | `tabEndpoint`                       | Public URL endpoint for the Teams tab.                                                                                                              |
-|                   | `multitenant`                       | Enable multi-tenant mode (default: `true`). See [note on multitenant](#notes).                                                                      |
-|                   | `serviceUrl`                        | Bot Framework service URL (default: `https://smba.trafficmanager.net/teams`). See [note on serviceUrl](#notes).                                     |
-| **session**       |                                     | Session management configuration.                                                                                                                   |
-|                   | `secure`                            | Set to `true` for HTTPS environments.                                                                                                               |
-|                   | `secret`                            | A random secret string for signing session cookies.                                                                                                 |
-| **frontendUrl**   | —                                   | Public URL where the frontend is accessible.                                                                                                        |
-| **backendUrl**    | —                                   | Public URL where the backend is accessible.                                                                                                         |
-| **flavor**        | —                                   | Deployment flavor (must be `self-managed`).                                                                                                         |
-| **organisation**  | `name`                              | Display name for your organization.                                                                                                                 |
-| **clusters**      | —                                   | Array of Camunda cluster configurations.                                                                                                            |
-|                   | `uuid`                              | Unique identifier for the cluster.                                                                                                                  |
-|                   | `name`                              | Display name for the cluster.                                                                                                                       |
-|                   | `urls.orchestration`                | Zeebe/Orchestration API URL.                                                                                                                        |
-|                   | `urls.tasklist`                     | Tasklist URL (string) or object with `base` and `task`. See note below.                                                                             |
-|                   | `urls.tasklist.base`                | _(Object format only)_ Root Tasklist URL.                                                                                                           |
-|                   | `urls.tasklist.task`                | _(Object format only)_ URL template for deep-linking to a specific task. Must contain `:userTaskKey` placeholder.                                   |
-|                   | `urls.operate`                      | Operate URL.                                                                                                                                        |
-|                   | `exporter.apiKey`                   | API key for the exporter. Must match the key configured in the [orchestration cluster Helm chart](#step-3-configure-the-app-integrations-exporter). |
-| **subscriptions** | —                                   | Subscription configuration (empty object `{}` for Self-Managed).                                                                                    |
+| Section           | Field                               | Description                                                                                                                                                     |
+| :---------------- | :---------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serverPort`      | —                                   | The port the backend server listens on inside the container (default: `8080`).                                                                                  |
+| `stage`           | —                                   | Environment stage: `local`, `dev`, `int`, or `prod`.                                                                                                            |
+| **auth**          |                                     | Authentication configuration for connecting to your Camunda platform. See [Auth configuration](#auth-configuration).                                            |
+|                   | `kind`                              | Identity provider variant: `keycloak` (default) or `entra`. Determines how OIDC endpoints are resolved.                                                         |
+|                   | `m2m.clientId` / `m2m.clientSecret` | Machine-to-machine OAuth2 credentials for backend services.                                                                                                     |
+|                   | `spa.clientId` / `spa.clientSecret` | Single Page Application OAuth2 credentials for frontend.                                                                                                        |
+|                   | `issuer`                            | The OAuth2/OIDC issuer URL. Required for Keycloak; auto-derived for Entra.                                                                                      |
+|                   | `audiences.zeebe`                   | _(Required)_ The audience of the Orchestration Cluster API. Typically `camunda-platform` on Keycloak.                                                           |
+|                   | `audiences.app_integrations`        | _(Optional)_ The audience App Integrations accepts on its own inbound API, used when the exporter authenticates with OAuth instead of an API key.               |
+|                   | `entra.tenantId`                    | _(Entra only, required)_ The Entra tenant ID.                                                                                                                   |
+|                   | `entra.tokenUrl`                    | _(Entra only, optional)_ Token endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                                          |
+|                   | `entra.jwksUrl`                     | _(Entra only, optional)_ JWKS endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                                         |
+|                   | `entra.scope`                       | _(Entra only, optional)_ OAuth2 scope. Defaults to `openid profile offline_access <auth.audiences.zeebe>/.default`.                                             |
+|                   | `entra.usernameClaim`               | _(Entra only, optional)_ ID token claim for the user's email. Default: `preferred_username`.                                                                    |
+| **db**            |                                     | PostgreSQL database connection settings.                                                                                                                        |
+|                   | `username`                          | Database username.                                                                                                                                              |
+|                   | `password`                          | Database password.                                                                                                                                              |
+|                   | `database`                          | Database name.                                                                                                                                                  |
+|                   | `host`                              | Database hostname (as reachable from the container).                                                                                                            |
+|                   | `loginType`                         | Authentication type (`password` for username/password auth).                                                                                                    |
+|                   | `encryptionKey`                     | 32-character key used for encrypting sensitive data.                                                                                                            |
+| **teams**         |                                     | Microsoft Teams integration settings.                                                                                                                           |
+|                   | `clientId`                          | Azure AD app client ID.                                                                                                                                         |
+|                   | `appId`                             | Teams app ID.                                                                                                                                                   |
+|                   | `appPassword`                       | Azure AD app password (client secret).                                                                                                                          |
+|                   | `tenantId`                          | Azure AD tenant ID.                                                                                                                                             |
+|                   | `tabEndpoint`                       | Public URL endpoint for the Teams tab.                                                                                                                          |
+|                   | `multitenant`                       | Enable multi-tenant mode (default: `true`). See [note on multitenant](#notes).                                                                                  |
+|                   | `serviceUrl`                        | Bot Framework service URL (default: `https://smba.trafficmanager.net/teams`). See [note on serviceUrl](#notes).                                                 |
+| **session**       |                                     | Session management configuration.                                                                                                                               |
+|                   | `secure`                            | Set to `true` for HTTPS environments.                                                                                                                           |
+|                   | `secret`                            | A random secret string for signing session cookies.                                                                                                             |
+| **frontendUrl**   | —                                   | Public URL where the frontend is accessible.                                                                                                                    |
+| **backendUrl**    | —                                   | Public URL where the backend is accessible.                                                                                                                     |
+| **flavor**        | —                                   | Deployment flavor (must be `self-managed`).                                                                                                                     |
+| **organisation**  | `name`                              | Display name for your organization.                                                                                                                             |
+| **clusters**      | —                                   | Array of Camunda cluster configurations.                                                                                                                        |
+|                   | `uuid`                              | Unique identifier for the cluster.                                                                                                                              |
+|                   | `name`                              | Display name for the cluster.                                                                                                                                   |
+|                   | `urls.orchestration`                | Zeebe/Orchestration API URL.                                                                                                                                    |
+|                   | `urls.tasklist`                     | Tasklist URL (string) or object with `base` and `task`. See note below.                                                                                         |
+|                   | `urls.tasklist.base`                | _(Object format only)_ Root Tasklist URL.                                                                                                                       |
+|                   | `urls.tasklist.task`                | _(Object format only)_ URL template for deep-linking to a specific task. Must contain `:userTaskKey` placeholder.                                               |
+|                   | `urls.operate`                      | Operate URL.                                                                                                                                                    |
+|                   | `exporter.apiKey`                   | API key for the exporter. Must match the key configured in the [orchestration cluster Helm chart](#step-3-configure-the-app-integrations-exporter).             |
+|                   | `connector.apiKey`                  | _(Optional)_ Separate API key for the App Integrations connector endpoints. Rotates independently of `exporter.apiKey`.                                         |
+|                   | `auth.audiences.zeebe`              | _(Optional)_ Overrides the deployment-wide `auth.audiences.zeebe` for this cluster.                                                                             |
+|                   | `physicalTenants`                   | _(Optional)_ Physical Tenants hosted on this cluster. See [App Integrations and Physical Tenants](/self-managed/concepts/physical-tenants/app-integrations.md). |
+|                   | `exposeDefaultTenant`               | _(Optional)_ Offer the `default` tenant alongside the configured Physical Tenants (default: `false`). No effect unless `physicalTenants` is set.                |
+| **subscriptions** | —                                   | Subscription configuration (empty object `{}` for Self-Managed).                                                                                                |
 
 ### Notes
 

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-installation.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-installation.md
@@ -298,7 +298,7 @@ In your deployment, mount the secrets as environment variables on the container 
 
 Replace the placeholder values with your actual settings.
 
-- Use the credentials from [Step 1](#step-1-create-applications-in-camunda-identity) and the Teams configuration from [Step 2](#step-2-set-up-the-microsoft-teams-app-cli).
+- Use the credentials from [Step 1](#step-1-create-applications-in-camunda-identity) and the Teams configuration from [Step 2](#step-2-set-up-the-microsoft-teams-camunda-app-using-cli).
 - The `exporter.apiKey` must match the API key configured in the Orchestration Cluster Helm chart in [Step 3](#step-3-configure-the-app-integrations-exporter).
 - For production deployments, replace sensitive values with environment variable references as described in [Secret management](#secret-management).
 - See [Auth configuration](#auth-configuration) for the full `auth` block reference.

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-installation.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-installation.md
@@ -177,6 +177,12 @@ Create a `config.yaml` file with your configuration settings. This file will be 
 
 The `auth` block must be configured to match the identity provider used in your environment. The `auth.kind` field selects the provider variant, which determines how OIDC discovery, token endpoints, and audience/issuer values are resolved.
 
+Audiences are configured under `auth.audiences`. On Self-Managed, set `auth.audiences.zeebe` to the audience of your Orchestration Cluster API; App Integrations also uses it as the identity audience when requesting tokens. `auth.audiences.global` applies to SaaS only and should be omitted.
+
+:::warning
+The singular `auth.audience` field was removed. A configuration that still uses it is rejected at startup with `auth.audience has been removed; use auth.audiences.{global,zeebe,app_integrations}`.
+:::
+
 <Tabs groupId="identity-provider" defaultValue="keycloak" values={[
 { label: 'Keycloak', value: 'keycloak' },
 { label: 'Entra', value: 'entra' },
@@ -186,15 +192,16 @@ The `auth` block must be configured to match the identity provider used in your 
 
 Set `auth.kind` to `"keycloak"` for Keycloak-based Camunda Self-Managed installations.
 
-| Field                   | Required | Description                                                                                      |
-| :---------------------- | :------- | :----------------------------------------------------------------------------------------------- |
-| `auth.kind`             | Yes      | Set to `keycloak`.                                                                               |
-| `auth.issuer`           | Yes      | The Keycloak realm URL. For example, `https://<your-camunda-host>/auth/realms/camunda-platform`. |
-| `auth.audience`         | Yes      | Typically `camunda-platform`.                                                                    |
-| `auth.m2m.clientId`     | Yes      | M2M client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                    |
-| `auth.m2m.clientSecret` | Yes      | M2M client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                |
-| `auth.spa.clientId`     | Yes      | SPA client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                    |
-| `auth.spa.clientSecret` | Yes      | SPA client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                |
+| Field                             | Required | Description                                                                                                                            |
+| :-------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth.kind`                       | Yes      | Set to `keycloak`.                                                                                                                     |
+| `auth.issuer`                     | Yes      | The Keycloak realm URL. For example, `https://<your-camunda-host>/auth/realms/camunda-platform`.                                       |
+| `auth.audiences.zeebe`            | Yes      | The audience of the Orchestration Cluster API. Typically `camunda-platform`.                                                           |
+| `auth.audiences.app_integrations` | No       | The audience App Integrations accepts on its own inbound API. Required if the exporter authenticates with OAuth instead of an API key. |
+| `auth.m2m.clientId`               | Yes      | M2M client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                                                          |
+| `auth.m2m.clientSecret`           | Yes      | M2M client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                                                      |
+| `auth.spa.clientId`               | Yes      | SPA client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                                                          |
+| `auth.spa.clientSecret`           | Yes      | SPA client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                                                      |
 
 Example:
 
@@ -208,7 +215,8 @@ auth:
     clientId: <your-spa-client-id>
     clientSecret: <your-spa-client-secret>
   issuer: https://<your-camunda-host>/auth/realms/camunda-platform
-  audience: camunda-platform
+  audiences:
+    zeebe: camunda-platform
 ```
 
 </TabItem>
@@ -217,20 +225,21 @@ auth:
 
 Set `auth.kind` to `"entra"` for Microsoft Entra ID (formerly Azure AD) based setups.
 
-| Field                      | Required | Description                                                                                                              |
-| :------------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------- |
-| `auth.kind`                | Yes      | Set to `entra`.                                                                                                          |
-| `auth.issuer`              | No       | Derived automatically as `https://login.microsoftonline.com/<tenantId>/v2.0`. Override only if using a custom authority. |
-| `auth.audience`            | No       | Defaults to `auth.spa.clientId`. Override only if using a different audience.                                            |
-| `auth.m2m.clientId`        | Yes      | Entra App Registration client ID for the M2M application.                                                                |
-| `auth.m2m.clientSecret`    | Yes      | Entra App Registration client secret for the M2M application.                                                            |
-| `auth.spa.clientId`        | Yes      | Entra App Registration client ID for the SPA application.                                                                |
-| `auth.spa.clientSecret`    | Yes      | Entra App Registration client secret for the SPA application.                                                            |
-| `auth.entra.tenantId`      | Yes      | The Entra tenant ID.                                                                                                     |
-| `auth.entra.tokenUrl`      | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                                            |
-| `auth.entra.jwksUrl`       | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                                          |
-| `auth.entra.scope`         | No       | Defaults to `openid profile offline_access <spa.clientId>/.default`.                                                     |
-| `auth.entra.usernameClaim` | No       | The ID token claim used to resolve the user's email. Default: `preferred_username`.                                      |
+| Field                             | Required | Description                                                                                                                            |
+| :-------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth.kind`                       | Yes      | Set to `entra`.                                                                                                                        |
+| `auth.issuer`                     | No       | Derived automatically as `https://login.microsoftonline.com/<tenantId>/v2.0`. Override only if using a custom authority.               |
+| `auth.audiences.zeebe`            | Yes      | The audience of the Orchestration Cluster API. In Entra setups this is usually the Application ID URI of the M2M app registration.     |
+| `auth.audiences.app_integrations` | No       | The audience App Integrations accepts on its own inbound API. Required if the exporter authenticates with OAuth instead of an API key. |
+| `auth.m2m.clientId`               | Yes      | Entra App Registration client ID for the M2M application.                                                                              |
+| `auth.m2m.clientSecret`           | Yes      | Entra App Registration client secret for the M2M application.                                                                          |
+| `auth.spa.clientId`               | Yes      | Entra App Registration client ID for the SPA application.                                                                              |
+| `auth.spa.clientSecret`           | Yes      | Entra App Registration client secret for the SPA application.                                                                          |
+| `auth.entra.tenantId`             | Yes      | The Entra tenant ID.                                                                                                                   |
+| `auth.entra.tokenUrl`             | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                                                          |
+| `auth.entra.jwksUrl`              | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                                                        |
+| `auth.entra.scope`                | No       | Defaults to `openid profile offline_access <auth.audiences.zeebe>/.default`.                                                           |
+| `auth.entra.usernameClaim`        | No       | The ID token claim used to resolve the user's email. Default: `preferred_username`.                                                    |
 
 Example:
 
@@ -243,6 +252,8 @@ auth:
   spa:
     clientId: <your-entra-spa-client-id>
     clientSecret: <your-entra-spa-client-secret>
+  audiences:
+    zeebe: <your-orchestration-cluster-audience>
   entra:
     tenantId: <your-entra-tenant-id>
 ```
@@ -306,7 +317,8 @@ auth:
     clientId: <your-spa-client-id>
     clientSecret: <your-spa-client-secret>
   issuer: https://<your-camunda-host>/auth/realms/camunda-platform
-  audience: camunda-platform
+  audiences:
+    zeebe: camunda-platform
 
 db:
   username: <your-postgres-username>
@@ -424,11 +436,12 @@ Below is a reference of each section in the `config.yaml` file.
 |                   | `m2m.clientId` / `m2m.clientSecret` | Machine-to-machine OAuth2 credentials for backend services.                                                                                         |
 |                   | `spa.clientId` / `spa.clientSecret` | Single Page Application OAuth2 credentials for frontend.                                                                                            |
 |                   | `issuer`                            | The OAuth2/OIDC issuer URL. Required for Keycloak; auto-derived for Entra.                                                                          |
-|                   | `audience`                          | The OAuth2 audience. Required for Keycloak (typically `camunda-platform`); defaults to `spa.clientId` for Entra.                                    |
+|                   | `audiences.zeebe`                   | _(Required)_ The audience of the Orchestration Cluster API. Typically `camunda-platform` on Keycloak.                                               |
+|                   | `audiences.app_integrations`        | _(Optional)_ The audience App Integrations accepts on its own inbound API, used when the exporter authenticates with OAuth instead of an API key.   |
 |                   | `entra.tenantId`                    | _(Entra only, required)_ The Entra tenant ID.                                                                                                       |
 |                   | `entra.tokenUrl`                    | _(Entra only, optional)_ Token endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                              |
 |                   | `entra.jwksUrl`                     | _(Entra only, optional)_ JWKS endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                             |
-|                   | `entra.scope`                       | _(Entra only, optional)_ OAuth2 scope. Defaults to `openid profile offline_access <spa.clientId>/.default`.                                         |
+|                   | `entra.scope`                       | _(Entra only, optional)_ OAuth2 scope. Defaults to `openid profile offline_access <auth.audiences.zeebe>/.default`.                                 |
 |                   | `entra.usernameClaim`               | _(Entra only, optional)_ ID token claim for the user's email. Default: `preferred_username`.                                                        |
 | **db**            |                                     | PostgreSQL database connection settings.                                                                                                            |
 |                   | `username`                          | Database username.                                                                                                                                  |

--- a/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
+++ b/docs/components/camunda-integrations/ms-teams/ms-teams-notifications.md
@@ -57,20 +57,21 @@ You manage notification rules from the Notification rules page in the Camunda fo
 
 A rule triggers a notification only when a user task matches all configured filters.
 
-| Field              | Required | Description                                                                                                                                                                                  |
-| :----------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Organization       | Yes      | The Camunda organization the rule applies to. Auto-selected if you only have access to one.                                                                                                  |
-| Cluster            | Yes      | The cluster within the organization. Auto-selected if only one cluster is available.                                                                                                         |
-| Process definition | No       | Limit the rule to user tasks from a single process. Leave empty (**All processes (no filter)**) to match user tasks from every process in the cluster.                                       |
-| User tasks         | No       | One or more specific user task elements within the selected process. Pick them visually on the BPMN diagram. Only available after you select a process. Leave empty to match all user tasks. |
-| Candidate users    | No       | Comma-separated list of user identifiers. Matches tasks assigned to any of these users.                                                                                                      |
-| Candidate groups   | No       | Comma-separated list of group identifiers. Matches tasks assigned to any of these groups.                                                                                                    |
+| Field              | Required | Description                                                                                                                                                                                                                                                                                                  |
+| :----------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Organization       | Yes      | The Camunda organization the rule applies to. Auto-selected if you only have access to one.                                                                                                                                                                                                                  |
+| Cluster            | Yes      | The cluster within the organization. Auto-selected if only one cluster is available. On a Self-Managed deployment with [Physical Tenants](/self-managed/concepts/physical-tenants/app-integrations.md), each cluster and tenant pair is listed as its own entry, and the rule is bound to the pair you pick. |
+| Process definition | No       | Limit the rule to user tasks from a single process. Leave empty (**All processes (no filter)**) to match user tasks from every process in the cluster.                                                                                                                                                       |
+| User tasks         | No       | One or more specific user task elements within the selected process. Pick them visually on the BPMN diagram. Only available after you select a process. Leave empty to match all user tasks.                                                                                                                 |
+| Candidate users    | No       | Comma-separated list of user identifiers. Matches tasks assigned to any of these users.                                                                                                                                                                                                                      |
+| Candidate groups   | No       | Comma-separated list of group identifiers. Matches tasks assigned to any of these groups.                                                                                                                                                                                                                    |
 
 ### Match semantics
 
 - Empty filters match all user tasks in the selected cluster. A rule with no filters matches every user task in the selected cluster: the broadest possible subscription.
 - Adding filters narrows the match. Filters combine with AND across fields and OR within each list. For example, a rule with `candidateGroups = "finance, hr"` and a selected process matches tasks from that process that have either `finance` or `hr` as a candidate group.
 - Multiple matching rules deduplicate. If several rules match the same user task event, the recipient still receives only one notification per event.
+- The cluster and Physical Tenant are matched exactly and cannot be left empty. A rule created for one Physical Tenant never receives another tenant's user tasks, so a cluster split into Physical Tenants needs its rules recreated per tenant.
 
 :::tip
 Start broad and narrow down. If you are not sure which filters you need, create a rule with no filters first, observe the notifications you receive, and then refine.

--- a/docs/self-managed/concepts/physical-tenants/app-integrations.md
+++ b/docs/self-managed/concepts/physical-tenants/app-integrations.md
@@ -1,0 +1,184 @@
+---
+id: app-integrations
+title: "App Integrations and Physical Tenants"
+sidebar_label: "App Integrations"
+description: "Configure one App Integrations deployment to serve several Physical Tenants, with per-tenant web apps, audiences, and notification routing."
+---
+
+A single App Integrations deployment can serve every Physical Tenant of an orchestration cluster. Each tenant gets its own API endpoint, web app links, and notification rules, while the backend, its database, and the Microsoft Teams app registration stay shared.
+
+:::note
+Physical Tenant support in App Integrations is available in Camunda 8.10 Self-Managed only. It is not available on SaaS.
+:::
+
+:::note Related pages
+
+- **[Physical Tenant isolation model](/self-managed/concepts/physical-tenants/index.md)** — How Physical Tenants isolate execution and storage
+- **[Authentication and authorization](/self-managed/concepts/physical-tenants/authentication-authorization.md)** — Identity deployment models and token routing
+- **[Microsoft Teams installation](/components/camunda-integrations/ms-teams/ms-teams-installation.md)** — The full `config.yaml` reference
+  :::
+
+## Terminology
+
+Three different concepts on this page use the word "tenant". Keep them apart:
+
+| Term                   | Identifier         | What it is                                                                                           |
+| :--------------------- | :----------------- | :--------------------------------------------------------------------------------------------------- |
+| **Physical Tenant**    | `physicalTenantId` | An isolated execution unit inside one orchestration cluster. This is what the page describes.        |
+| **Logical Tenant**     | `tenantId`         | Camunda's multi-tenancy within a single Physical Tenant. App Integrations does not route on it.      |
+| Microsoft Entra tenant | `teams.tenantId`   | The Entra directory hosting the Teams app registration. Unrelated to Camunda tenancy of either kind. |
+
+## How App Integrations resolves the Physical Tenant
+
+App Integrations resolves a tenant independently on each of its three paths.
+
+```mermaid
+graph TD
+    subgraph ai["App Integrations deployment (shared)"]
+        be["Backend"]
+        db[("Database\nusers, notification rules")]
+        bot["Microsoft Teams app\nand bot registration"]
+    end
+
+    subgraph cluster["Orchestration cluster"]
+        td["default\ncluster URLs"]
+        ta["tenanta\n/physical-tenants/tenanta"]
+        tb["tenantb\n/physical-tenants/tenantb"]
+    end
+
+    be --- db
+    be --- bot
+    be -->|"API calls per tenant"| td
+    be --> ta
+    be --> tb
+    ta -->|"exporter events"| be
+    tb --> be
+```
+
+**Outbound API calls** are issued against the tenant's own orchestration URL, derived as `<cluster-url>/physical-tenants/<physicalTenantId>` unless the tenant configures an explicit one. The `default` tenant uses the cluster URL unchanged.
+
+**Inbound exporter events** carry their tenant in the `X-Physical-Tenant-Id` header. When the header is absent, App Integrations falls back to the tenant whose `exporter.apiKey` authenticated the request, and finally to `default`. See [event routing](#event-routing-and-notifications).
+
+**User context** is the `(organization, cluster, Physical Tenant)` triple stored per user. It determines which tenant a chat command reads from, and which tenant a new notification rule is scoped to.
+
+## Configuration
+
+Declare the tenants of a cluster in the `physicalTenants` array of your `config.yaml`:
+
+```yaml
+flavor: self-managed
+
+clusters:
+  - uuid: <unique-cluster-uuid>
+    name: <cluster-display-name>
+    urls:
+      orchestration: https://<your-camunda-host>
+      tasklist: https://<your-camunda-host>/tasklist
+      operate: https://<your-camunda-host>/operate
+    exporter:
+      apiKey: <cluster-exporter-api-key>
+    physicalTenants:
+      - id: tenanta
+        name: Tenant A
+        urls:
+          tasklist: https://<your-camunda-host>/physical-tenants/tenanta/tasklist
+          operate: https://<your-camunda-host>/physical-tenants/tenanta/operate
+      - id: tenantb
+        name: Tenant B
+        exporter:
+          apiKey: <tenant-b-exporter-api-key>
+        auth:
+          audiences:
+            zeebe: <tenant-b-audience>
+        urls:
+          tasklist: https://<your-camunda-host>/physical-tenants/tenantb/tasklist
+          operate: https://<your-camunda-host>/physical-tenants/tenantb/operate
+```
+
+| Field                                | Required | Description                                                                                                                                                                                                         |
+| :----------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`                                 | Yes      | The `physicalTenantId`, matching the tenant configured on the orchestration cluster.                                                                                                                                |
+| `name`                               | Yes      | Display name shown in the Teams cluster selector.                                                                                                                                                                   |
+| `urls.tasklist`                      | Yes      | The tenant's Tasklist URL. Accepts a plain URL or the `{ base, task }` object described in the [installation guide](/components/camunda-integrations/ms-teams/ms-teams-installation.md#example-configuration-file). |
+| `urls.operate`                       | Yes      | The tenant's Operate URL.                                                                                                                                                                                           |
+| `urls.orchestration`                 | No       | Overrides the tenant's API base URL. Defaults to `<cluster orchestration URL>/physical-tenants/<id>`. Specify it without the `/v2` suffix, as at cluster level.                                                     |
+| `exporter.apiKey`                    | No       | Identifies this tenant on an inbound exporter request that carries no `X-Physical-Tenant-Id` header.                                                                                                                |
+| `connector.apiKey`                   | No       | A separate key for the App Integrations connector endpoints. Rotates independently of `exporter.apiKey`.                                                                                                            |
+| `auth.audiences.zeebe`               | No       | Overrides the audience requested for this tenant's API calls. See [authentication](#authentication).                                                                                                                |
+| `exposeDefaultTenant` _(on cluster)_ | No       | Whether the `default` tenant is selectable alongside the configured ones. Defaults to `false`.                                                                                                                      |
+
+Note that `urls.tasklist` and `urls.operate` are required on every tenant: a tenant never inherits the cluster's web app URLs, because those point at the cluster's own `default` tenant.
+
+### The default tenant
+
+The `default` Physical Tenant represents the cluster itself and always uses the cluster's own URLs, never a `/physical-tenants/default/…` path.
+
+- **No `physicalTenants` configured** — App Integrations synthesizes a single `default` tenant that takes the cluster's name and URLs. This is the behavior of every cluster configured before 8.10, and it needs no migration.
+- **`physicalTenants` configured** — only the tenants you declare are offered. The `default` tenant is hidden, so users cannot accidentally read from the cluster-wide endpoint.
+- **`physicalTenants` configured with `exposeDefaultTenant: true`** — the `default` tenant is added at the top of the list, in addition to the configured tenants.
+
+## Authentication
+
+App Integrations defines **one** identity provider for the whole deployment: a single `auth.issuer` and `auth.kind`, and one M2M/SPA client pair. Tenants are distinguished by **audience**, configured per tenant under `auth.audiences.zeebe`.
+
+This implements [Model B: single IdP, multiple role-level clients](./authentication-authorization.md#model-b-single-idp-multiple-role-level-clients). [Model C](./authentication-authorization.md#model-c-multiple-idps-advanced), a separate identity provider per Physical Tenant, is **not supported** — App Integrations cannot hold more than one issuer.
+
+The audience for an outbound call is resolved in this order, first match wins:
+
+1. `clusters[].physicalTenants[].auth.audiences.zeebe`
+2. `clusters[].auth.audiences.zeebe`
+3. `auth.audiences.zeebe` (the deployment-wide value)
+
+Only the resource audience can be overridden per tenant. `auth.audiences.global` and `auth.audiences.app_integrations` are deployment-wide and are rejected inside a per-cluster or per-tenant `auth` block.
+
+:::note
+The shapes differ from the orchestration cluster's own configuration: Camunda's identity provider takes a list of allowed audiences, whereas App Integrations sends a single audience string per tenant. The value you set here must be one of the audiences the tenant's client registration accepts.
+:::
+
+User sign-in is deployment-wide. A user links their Camunda identity once, not per Physical Tenant, so the OIDC redirect URIs registered for App Integrations are not tenant-scoped. See [IdP redirect URI registration](./authentication-authorization.md#idp-redirect-uri-registration).
+
+## Event routing and notifications
+
+Each tenant's exporter posts its events to the same App Integrations endpoint. The tenant is resolved per request:
+
+1. **The `X-Physical-Tenant-Id` header**, if present. It must name a tenant configured for that cluster, or the request is rejected with `400 Invalid X-Physical-Tenant-Id header`.
+2. **The authenticating API key**, if it is a tenant's `exporter.apiKey`.
+3. **`default`**, otherwise.
+
+:::warning
+A request authenticated with the **cluster-level** `exporter.apiKey` never resolves to a named tenant, because the cluster key is matched before the per-tenant keys. If such a request omits the header, its events are attributed to `default` and silently match no rule on a cluster whose `default` tenant is hidden. Give every tenant its own `exporter.apiKey`, send the header, or both.
+:::
+
+Notification rules are scoped to the `(organization, cluster, Physical Tenant)` triple, and the tenant is matched on exact equality. Unlike the process and element filters, it has no wildcard: a rule scoped to `default` never receives a named tenant's events.
+
+## User experience in Microsoft Teams
+
+A Physical Tenant is not a separate selector. The Teams cluster picker lists one row per `(cluster, tenant)` pair, and choosing a row sets both at once:
+
+- A row for the `default` tenant is labeled with the **cluster's** name.
+- A row for a named tenant is labeled with the **tenant's** name.
+- The cluster's health and support status is appended to every one of its rows.
+- When exactly one pair is available, it is selected automatically.
+
+Users switch tenants the same way they switch clusters, and all task lists, process starts, and deep links follow the selected pair.
+
+## Migrate an existing cluster
+
+Adding `physicalTenants` to a cluster that already runs App Integrations changes which tenant its traffic is attributed to. Plan for the following:
+
+1. **Existing notification rules stop matching.** Rules created before the change are scoped to `default`. Once events arrive tagged with a named tenant, those rules no longer match and deliver nothing. Recreate them per tenant.
+2. **Users must reselect their cluster.** A stored context pointing at a tenant that is no longer offered is not migrated.
+3. **The `default` tenant disappears from the picker** unless you set `exposeDefaultTenant: true`.
+4. **Give each tenant's exporter its own credentials.** Configure a per-tenant `exporter.apiKey`, and confirm the exporter sends `X-Physical-Tenant-Id`.
+
+To keep the cluster-wide view available during a migration, set `exposeDefaultTenant: true` and remove it once every rule has been recreated.
+
+## Known limitations in 8.10
+
+- A separate identity provider per Physical Tenant ([Model C](./authentication-authorization.md#model-c-multiple-idps-advanced)) is not supported.
+- Identity linking and sign-in are deployment-wide, not per tenant.
+- Cluster health and version are reported per cluster, not per Physical Tenant.
+- The App Integrations connector's message endpoint is not tenant-scoped: a form referenced by the connector is always fetched from the cluster's `default` tenant, using the cluster-level audience. On a deployment with per-tenant audiences, that lookup can fail, and the connector falls back to the message's plain text.
+- Physical Tenants are a Self-Managed feature; App Integrations on SaaS is single-tenant.
+
+<p class="link-arrow">[Physical Tenant isolation model](./index.md)</p>

--- a/docs/self-managed/concepts/physical-tenants/app-integrations.md
+++ b/docs/self-managed/concepts/physical-tenants/app-integrations.md
@@ -30,7 +30,7 @@ Three different concepts on this page use the word "tenant". Keep them apart:
 
 ## How App Integrations resolves the Physical Tenant
 
-App Integrations resolves a tenant independently on each of its three paths.
+App Integrations resolves a tenant independently on each of its four paths.
 
 ```mermaid
 graph TD
@@ -58,6 +58,8 @@ graph TD
 **Outbound API calls** are issued against the tenant's own orchestration URL, derived as `<cluster-url>/physical-tenants/<physicalTenantId>` unless the tenant configures an explicit one. The `default` tenant uses the cluster URL unchanged.
 
 **Inbound exporter events** carry their tenant in the `X-Physical-Tenant-Id` header. When the header is absent, App Integrations falls back to the tenant whose `exporter.apiKey` authenticated the request, and finally to `default`. See [event routing](#event-routing-and-notifications).
+
+**Inbound connector calls** carry the same header. The App Integrations connector reads the tenant from the job it is executing, so a linked form is fetched from that tenant's orchestration endpoint. See [connector calls](#connector-calls).
 
 **User context** is the `(organization, cluster, Physical Tenant)` triple stored per user. It determines which tenant a chat command reads from, and which tenant a new notification rule is scoped to.
 
@@ -151,6 +153,16 @@ A request authenticated with the **cluster-level** `exporter.apiKey` never resol
 
 Notification rules are scoped to the `(organization, cluster, Physical Tenant)` triple, and the tenant is matched on exact equality. Unlike the process and element filters, it has no wildcard: a rule scoped to `default` never receives a named tenant's events.
 
+## Connector calls
+
+The App Integrations connector posts to the same deployment, and its tenant is resolved the same way as an exporter event's: the `X-Physical-Tenant-Id` header first, then the tenant whose `connector.apiKey` authenticated the request, then `default`.
+
+The connector reads the tenant from the job it is executing and sends it on every call, so there is nothing to configure on the connector task or in the process model. What matters is that the connector runtime knows its own tenant. Set `physical-tenant-id` on each client entry, as described in [Connectors runtime](./connectors-runtime.md#how-the-runtime-identifies-the-physical-tenant). A client without it produces jobs that carry no tenant, so the connector omits the header and the call resolves to `default`.
+
+Because the tenant reaches the backend, a form referenced by the connector is fetched from that tenant's own orchestration endpoint using that tenant's audience, and notification rule matching is scoped to the same tenant.
+
+A call naming a tenant that is not configured for the cluster is rejected with `400 Invalid X-Physical-Tenant-Id header` rather than delivered to `default`. Keep the tenant IDs in `physicalTenants` and the runtime's `physical-tenant-id` values in sync.
+
 ## User experience in Microsoft Teams
 
 A Physical Tenant is not a separate selector. The Teams cluster picker lists one row per `(cluster, tenant)` pair, and choosing a row sets both at once:
@@ -178,7 +190,6 @@ To keep the cluster-wide view available during a migration, set `exposeDefaultTe
 - A separate identity provider per Physical Tenant ([Model C](./authentication-authorization.md#model-c-multiple-idps-advanced)) is not supported.
 - Identity linking and sign-in are deployment-wide, not per tenant.
 - Cluster health and version are reported per cluster, not per Physical Tenant.
-- The App Integrations connector's message endpoint is not tenant-scoped: a form referenced by the connector is always fetched from the cluster's `default` tenant, using the cluster-level audience. On a deployment with per-tenant audiences, that lookup can fail, and the connector falls back to the message's plain text.
 - Physical Tenants are a Self-Managed feature; App Integrations on SaaS is single-tenant.
 
 <p class="link-arrow">[Physical Tenant isolation model](./index.md)</p>

--- a/docs/self-managed/concepts/physical-tenants/index.md
+++ b/docs/self-managed/concepts/physical-tenants/index.md
@@ -98,6 +98,8 @@ description: "Add tenants, apply configuration changes, and manage tenant availa
 
 Learn how Operate, Tasklist, and Optimize behave per Physical Tenant, including URL navigation, data scoping, and session behavior, in [web apps](./web-apps.md).
 
+To serve several Physical Tenants from one App Integrations deployment, including per-tenant audiences and notification routing for Microsoft Teams, see [App Integrations](./app-integrations.md).
+
 ## What is not isolated in 8.10
 
 - Gateways are shared between tenants, so a saturated gateway can still affect multiple tenants.

--- a/sidebars.js
+++ b/sidebars.js
@@ -2270,6 +2270,7 @@ module.exports = {
                 "self-managed/concepts/physical-tenants/configuration-reference",
                 "self-managed/concepts/physical-tenants/provisioning-and-lifecycle",
                 "self-managed/concepts/physical-tenants/connectors-runtime",
+                "self-managed/concepts/physical-tenants/app-integrations",
               ],
             },
           ],

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-installation.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-installation.md
@@ -298,7 +298,7 @@ In your deployment, mount the secrets as environment variables on the container 
 
 Replace the placeholder values with your actual settings.
 
-- Use the credentials from [Step 1](#step-1-create-applications-in-camunda-identity) and the Teams configuration from [Step 2](#step-2-set-up-the-microsoft-teams-app-cli).
+- Use the credentials from [Step 1](#step-1-create-applications-in-camunda-identity) and the Teams configuration from [Step 2](#step-2-set-up-the-microsoft-teams-camunda-app-using-cli).
 - The `exporter.apiKey` must match the API key configured in the Orchestration Cluster Helm chart in [Step 3](#step-3-configure-the-app-integrations-exporter).
 - For production deployments, replace sensitive values with environment variable references as described in [Secret management](#secret-management).
 - See [Auth configuration](#auth-configuration) for the full `auth` block reference.

--- a/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-installation.md
+++ b/versioned_docs/version-8.9/components/camunda-integrations/ms-teams/ms-teams-installation.md
@@ -177,6 +177,12 @@ Create a `config.yaml` file with your configuration settings. This file will be 
 
 The `auth` block must be configured to match the identity provider used in your environment. The `auth.kind` field selects the provider variant, which determines how OIDC discovery, token endpoints, and audience/issuer values are resolved.
 
+Audiences are configured under `auth.audiences`. On Self-Managed, set `auth.audiences.zeebe` to the audience of your Orchestration Cluster API; App Integrations also uses it as the identity audience when requesting tokens. `auth.audiences.global` applies to SaaS only and should be omitted.
+
+:::warning
+The singular `auth.audience` field was removed. A configuration that still uses it is rejected at startup with `auth.audience has been removed; use auth.audiences.{global,zeebe,app_integrations}`.
+:::
+
 <Tabs groupId="identity-provider" defaultValue="keycloak" values={[
 { label: 'Keycloak', value: 'keycloak' },
 { label: 'Entra', value: 'entra' },
@@ -186,15 +192,16 @@ The `auth` block must be configured to match the identity provider used in your 
 
 Set `auth.kind` to `"keycloak"` for Keycloak-based Camunda Self-Managed installations.
 
-| Field                   | Required | Description                                                                                      |
-| :---------------------- | :------- | :----------------------------------------------------------------------------------------------- |
-| `auth.kind`             | Yes      | Set to `keycloak`.                                                                               |
-| `auth.issuer`           | Yes      | The Keycloak realm URL. For example, `https://<your-camunda-host>/auth/realms/camunda-platform`. |
-| `auth.audience`         | Yes      | Typically `camunda-platform`.                                                                    |
-| `auth.m2m.clientId`     | Yes      | M2M client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                    |
-| `auth.m2m.clientSecret` | Yes      | M2M client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                |
-| `auth.spa.clientId`     | Yes      | SPA client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                    |
-| `auth.spa.clientSecret` | Yes      | SPA client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                |
+| Field                             | Required | Description                                                                                                                            |
+| :-------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth.kind`                       | Yes      | Set to `keycloak`.                                                                                                                     |
+| `auth.issuer`                     | Yes      | The Keycloak realm URL. For example, `https://<your-camunda-host>/auth/realms/camunda-platform`.                                       |
+| `auth.audiences.zeebe`            | Yes      | The audience of the Orchestration Cluster API. Typically `camunda-platform`.                                                           |
+| `auth.audiences.app_integrations` | No       | The audience App Integrations accepts on its own inbound API. Required if the exporter authenticates with OAuth instead of an API key. |
+| `auth.m2m.clientId`               | Yes      | M2M client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                                                          |
+| `auth.m2m.clientSecret`           | Yes      | M2M client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                                                      |
+| `auth.spa.clientId`               | Yes      | SPA client ID from [Step 1](#step-1-create-applications-in-camunda-identity).                                                          |
+| `auth.spa.clientSecret`           | Yes      | SPA client secret from [Step 1](#step-1-create-applications-in-camunda-identity).                                                      |
 
 Example:
 
@@ -208,7 +215,8 @@ auth:
     clientId: <your-spa-client-id>
     clientSecret: <your-spa-client-secret>
   issuer: https://<your-camunda-host>/auth/realms/camunda-platform
-  audience: camunda-platform
+  audiences:
+    zeebe: camunda-platform
 ```
 
 </TabItem>
@@ -217,20 +225,21 @@ auth:
 
 Set `auth.kind` to `"entra"` for Microsoft Entra ID (formerly Azure AD) based setups.
 
-| Field                      | Required | Description                                                                                                              |
-| :------------------------- | :------- | :----------------------------------------------------------------------------------------------------------------------- |
-| `auth.kind`                | Yes      | Set to `entra`.                                                                                                          |
-| `auth.issuer`              | No       | Derived automatically as `https://login.microsoftonline.com/<tenantId>/v2.0`. Override only if using a custom authority. |
-| `auth.audience`            | No       | Defaults to `auth.spa.clientId`. Override only if using a different audience.                                            |
-| `auth.m2m.clientId`        | Yes      | Entra App Registration client ID for the M2M application.                                                                |
-| `auth.m2m.clientSecret`    | Yes      | Entra App Registration client secret for the M2M application.                                                            |
-| `auth.spa.clientId`        | Yes      | Entra App Registration client ID for the SPA application.                                                                |
-| `auth.spa.clientSecret`    | Yes      | Entra App Registration client secret for the SPA application.                                                            |
-| `auth.entra.tenantId`      | Yes      | The Entra tenant ID.                                                                                                     |
-| `auth.entra.tokenUrl`      | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                                            |
-| `auth.entra.jwksUrl`       | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                                          |
-| `auth.entra.scope`         | No       | Defaults to `openid profile offline_access <spa.clientId>/.default`.                                                     |
-| `auth.entra.usernameClaim` | No       | The ID token claim used to resolve the user's email. Default: `preferred_username`.                                      |
+| Field                             | Required | Description                                                                                                                            |
+| :-------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth.kind`                       | Yes      | Set to `entra`.                                                                                                                        |
+| `auth.issuer`                     | No       | Derived automatically as `https://login.microsoftonline.com/<tenantId>/v2.0`. Override only if using a custom authority.               |
+| `auth.audiences.zeebe`            | Yes      | The audience of the Orchestration Cluster API. In Entra setups this is usually the Application ID URI of the M2M app registration.     |
+| `auth.audiences.app_integrations` | No       | The audience App Integrations accepts on its own inbound API. Required if the exporter authenticates with OAuth instead of an API key. |
+| `auth.m2m.clientId`               | Yes      | Entra App Registration client ID for the M2M application.                                                                              |
+| `auth.m2m.clientSecret`           | Yes      | Entra App Registration client secret for the M2M application.                                                                          |
+| `auth.spa.clientId`               | Yes      | Entra App Registration client ID for the SPA application.                                                                              |
+| `auth.spa.clientSecret`           | Yes      | Entra App Registration client secret for the SPA application.                                                                          |
+| `auth.entra.tenantId`             | Yes      | The Entra tenant ID.                                                                                                                   |
+| `auth.entra.tokenUrl`             | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                                                          |
+| `auth.entra.jwksUrl`              | No       | Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                                                        |
+| `auth.entra.scope`                | No       | Defaults to `openid profile offline_access <auth.audiences.zeebe>/.default`.                                                           |
+| `auth.entra.usernameClaim`        | No       | The ID token claim used to resolve the user's email. Default: `preferred_username`.                                                    |
 
 Example:
 
@@ -243,6 +252,8 @@ auth:
   spa:
     clientId: <your-entra-spa-client-id>
     clientSecret: <your-entra-spa-client-secret>
+  audiences:
+    zeebe: <your-orchestration-cluster-audience>
   entra:
     tenantId: <your-entra-tenant-id>
 ```
@@ -306,7 +317,8 @@ auth:
     clientId: <your-spa-client-id>
     clientSecret: <your-spa-client-secret>
   issuer: https://<your-camunda-host>/auth/realms/camunda-platform
-  audience: camunda-platform
+  audiences:
+    zeebe: camunda-platform
 
 db:
   username: <your-postgres-username>
@@ -424,11 +436,12 @@ Below is a reference of each section in the `config.yaml` file.
 |                   | `m2m.clientId` / `m2m.clientSecret` | Machine-to-machine OAuth2 credentials for backend services.                                                                                         |
 |                   | `spa.clientId` / `spa.clientSecret` | Single Page Application OAuth2 credentials for frontend.                                                                                            |
 |                   | `issuer`                            | The OAuth2/OIDC issuer URL. Required for Keycloak; auto-derived for Entra.                                                                          |
-|                   | `audience`                          | The OAuth2 audience. Required for Keycloak (typically `camunda-platform`); defaults to `spa.clientId` for Entra.                                    |
+|                   | `audiences.zeebe`                   | _(Required)_ The audience of the Orchestration Cluster API. Typically `camunda-platform` on Keycloak.                                               |
+|                   | `audiences.app_integrations`        | _(Optional)_ The audience App Integrations accepts on its own inbound API, used when the exporter authenticates with OAuth instead of an API key.   |
 |                   | `entra.tenantId`                    | _(Entra only, required)_ The Entra tenant ID.                                                                                                       |
 |                   | `entra.tokenUrl`                    | _(Entra only, optional)_ Token endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token`.                              |
 |                   | `entra.jwksUrl`                     | _(Entra only, optional)_ JWKS endpoint. Defaults to `https://login.microsoftonline.com/<tenantId>/discovery/v2.0/keys`.                             |
-|                   | `entra.scope`                       | _(Entra only, optional)_ OAuth2 scope. Defaults to `openid profile offline_access <spa.clientId>/.default`.                                         |
+|                   | `entra.scope`                       | _(Entra only, optional)_ OAuth2 scope. Defaults to `openid profile offline_access <auth.audiences.zeebe>/.default`.                                 |
 |                   | `entra.usernameClaim`               | _(Entra only, optional)_ ID token claim for the user's email. Default: `preferred_username`.                                                        |
 | **db**            |                                     | PostgreSQL database connection settings.                                                                                                            |
 |                   | `username`                          | Database username.                                                                                                                                  |


### PR DESCRIPTION
## Description

Documents Physical Tenant support in App Integrations, and corrects two errors in the published Microsoft Teams installation guide.

A single App Integrations deployment can serve every Physical Tenant of a Self-Managed orchestration cluster in 8.10. Each tenant gets its own API endpoint, Operate and Tasklist links, and notification rules, while the backend, its database, and the Teams app registration stay shared. The new page covers how a tenant is identified on each path, how to configure one, how per-tenant isolation is achieved through audiences, and what changes for an existing cluster that adopts tenants — most importantly that notification rules do not carry over and must be recreated per tenant.

It also states plainly what is not supported: a separate identity provider per Physical Tenant. App Integrations holds one identity provider for the whole deployment and distinguishes tenants by audience, which is Model B in the identity deployment models.

Two fixes to already-released 8.9 content, both backported:

- The installation guide documents an `auth.audience` setting that no longer exists. It was replaced by `auth.audiences`, and the application now refuses to start if the old key is present — so an operator following the published page today produces a configuration that cannot boot.
- A broken in-page link to Step 2.

Stacked on #9598 and should merge after it.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

The `auth.audience` correction is urgent for 8.9. The Physical Tenants page targets the 8.10 minor.

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file. — not applicable, no page was renamed or removed.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
