### PR TITLE
docs: verify Spring Boot 4.1.x compatibility for camunda-spring-boot-4-starter on 8.7

### DIFF
--- a/docs/reference/announcements-release-notes/870/870-release-notes.md
+++ b/docs/reference/announcements-release-notes/870/870-release-notes.md
@@ -13,6 +13,12 @@ keywords:
 
 These release notes identify the new features included in 8.7, including [alpha feature releases](/components/early-access/alpha/alpha-features.md).
 
+## 8.7.38
+
+### Spring Zeebe SDK - Spring Boot 4.1 support
+
+As the [Spring Boot OSS support](https://spring.io/projects/spring-boot#support) for the bundled Spring Boot 4.0.x will end in December 2026, [Spring Boot 4.1.x compatibility](../../../../versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/getting-started.md#version-compatibility) is verified from the `8.7.38` patch onward. Spring Boot 4.0.x remains the default bundled version.
+
 ## 8.7.17
 
 ### Spring Zeebe SDK - Spring-Boot 3.5 support

--- a/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/getting-started.md
+++ b/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/getting-started.md
@@ -22,7 +22,9 @@ For more information, visit [announcements](/reference/announcements-release-not
 | 8.7.x (< 8.7.17)         | `spring-boot-starter-camunda-sdk` | ≥ 17 | 8.7.x           | 3.4.x                       |                                   |
 | >= 8.7.17                | `spring-boot-starter-camunda-sdk` | ≥ 17 | 8.7.x           | 3.4.x                       | 3.5.x                             |
 | >= 8.7.24                | `camunda-spring-boot-3-starter`   | ≥ 17 | 8.7.x           | 3.4.x                       | 3.5.x                             |
-| >= 8.7.24                | `camunda-spring-boot-4-starter`   | ≥ 17 | 8.7.x           | 4.0.x                       |                                   |
+| >= 8.7.24                | `camunda-spring-boot-4-starter`   | ≥ 17 | 8.7.x           | 4.0.x                       | 4.1.x ¹                           |
+
+¹ Spring Boot 4.1.x compatibility is verified from patch 8.7.38 onward.
 
 ### Spring Boot 4.0 support
 
@@ -41,6 +43,10 @@ You should use this as a drop-in replacement for the default `spring-boot-starte
 :::note
 There is also a new `camunda-spring-boot-3-starter` module, which is an alias for `spring-boot-starter-camunda-sdk` in the 8.7 release. Use `camunda-spring-boot-3-starter` if you want to stay on Spring Boot 3.5 when eventuallyt upgrading to Camunda 8.8 or newer, where the default `camunda-spring-boot-starter` module will be based on Spring Boot 4.0.
 :::
+
+### Spring Boot 4.1 support
+
+The `camunda-spring-boot-4-starter` bundles Spring Boot 4.0.x by default. [Spring Boot 4.1.x compatibility](#version-compatibility) is verified from the `8.7.38` patch onward.
 
 ## Add the Spring Zeebe SDK to your project
 

--- a/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-release-notes.md
+++ b/versioned_docs/version-8.7/reference/announcements-release-notes/870/870-release-notes.md
@@ -13,6 +13,12 @@ keywords:
 
 These release notes identify the new features included in 8.7, including [alpha feature releases](/components/early-access/alpha/alpha-features.md).
 
+## 8.7.38
+
+### Spring Zeebe SDK - Spring Boot 4.1 support
+
+As the [Spring Boot OSS support](https://spring.io/projects/spring-boot#support) for the bundled Spring Boot 4.0.x will end in December 2026, [Spring Boot 4.1.x compatibility](../../../apis-tools/spring-zeebe-sdk/getting-started.md#version-compatibility) is verified from the `8.7.38` patch onward. Spring Boot 4.0.x remains the default bundled version.
+
 ## 8.7.24
 
 ### Spring Zeebe SDK - Spring Boot 4.0 support

--- a/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-release-notes.md
+++ b/versioned_docs/version-8.8/reference/announcements-release-notes/870/870-release-notes.md
@@ -13,6 +13,12 @@ keywords:
 
 These release notes identify the new features included in 8.7, including [alpha feature releases](/components/early-access/alpha/alpha-features.md).
 
+## 8.7.38
+
+### Spring Zeebe SDK - Spring Boot 4.1 support
+
+As the [Spring Boot OSS support](https://spring.io/projects/spring-boot#support) for the bundled Spring Boot 4.0.x will end in December 2026, [Spring Boot 4.1.x compatibility](../../../../version-8.7/apis-tools/spring-zeebe-sdk/getting-started.md#version-compatibility) is verified from the `8.7.38` patch onward. Spring Boot 4.0.x remains the default bundled version.
+
 ## 8.7.17
 
 ### Spring Zeebe SDK - Spring Boot 3.5 support

--- a/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-release-notes.md
+++ b/versioned_docs/version-8.9/reference/announcements-release-notes/870/870-release-notes.md
@@ -13,6 +13,12 @@ keywords:
 
 These release notes identify the new features included in 8.7, including [alpha feature releases](/components/early-access/alpha/alpha-features.md).
 
+## 8.7.38
+
+### Spring Zeebe SDK - Spring Boot 4.1 support
+
+As the [Spring Boot OSS support](https://spring.io/projects/spring-boot#support) for the bundled Spring Boot 4.0.x will end in December 2026, [Spring Boot 4.1.x compatibility](/versioned_docs/version-8.7/apis-tools/spring-zeebe-sdk/getting-started.md#version-compatibility) is verified from the `8.7.38` patch onward. Spring Boot 4.0.x remains the default bundled version.
+
 ## 8.7.17
 
 ### Spring Zeebe SDK - Spring-Boot 3.5 support


### PR DESCRIPTION
## Description

Adds Spring Boot 4.1.x to the 8.7 version-compatibility table for `camunda-spring-boot-4-starter`, mirroring the 8.8/8.9 equivalents (camunda-docs#9300 et al).

8.7 was originally excluded from this coverage because Spring Boot 4.0's OSS support runs through December 2026, past 8.7's end of standard maintenance (13 October 2026). An Extended Support Period agreement now extends Camunda's obligation past that date, which is why 8.7 needs this too (camunda/camunda#60069).

**Depends on** camunda/camunda#60121 (adds the CI axis proving this on 8.7) merging first, and on patch `8.7.38` shipping — this PR references verification "from patch 8.7.38 onward." Marked as draft + `hold` until both land; do not merge before then.

Also mirrors the same entry into the 8.8, 8.9, and unversioned `docs/` copies of the 8.7 release notes page for consistency across duplicated copies.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [x] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

## Related issues

relates to camunda/camunda#60069
