### PR TITLE
Tenant: Cluster Admin Operations

### DIFF
--- a/docs/components/admin/admin-introduction.md
+++ b/docs/components/admin/admin-introduction.md
@@ -21,6 +21,7 @@ Admin includes the following features:
 | Unified access management                                   | Authentication and authorization are handled consistently across all Orchestration Cluster components and APIs.                                               |
 | Flexible authentication                                     | Admin supports multiple authentication modes, including no authentication, Basic authentication, and OpenID Connect (OIDC), depending on the deployment type. |
 | Tenant management                                           | Multi-tenancy is managed directly within the Orchestration Cluster, allowing for clear separation of resources.                                               |
+| [Cluster admin](cluster-admin.md)                           | A separate, coarse-grained role for cluster-wide operations (status, topology, restore) that span all Physical Tenants.                                       |
 | [Cluster variables](cluster-variables.md)                   | Manage configuration values centrally across your cluster, making them available in FEEL expressions.                                                         |
 | [Global user task listeners](global-user-task-listeners.md) | Configure cluster-wide listeners that react to user task lifecycle events across all processes.                                                               |
 
@@ -31,13 +32,14 @@ For details about authorization concepts, resources, and configuration, see
 
 Depending on your setup, Admin allows you to manage Orchestration Cluster access as follows:
 
-| Entity                             | Description                                                                                                                         | Availability    |
-| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :-------------- |
-| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments |
-| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments |
-| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments |
-| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments |
-| [Tenants](tenant.md)               | Logically isolate data within a single cluster. This is useful for multi-tenancy applications.                                      | All deployments |
+| Entity                             | Description                                                                                                                         | Availability      |
+| :--------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :---------------- |
+| [Users](user.md)                   | Individuals who can access applications and perform actions based on their permissions.                                             | All deployments   |
+| [Groups](group.md)                 | Simplify access management by granting permissions collectively to groups of users.                                                 | All deployments   |
+| [Roles](role.md)                   | Sets of permissions to define what actions can be performed on specific resources. Roles can be assigned to users and groups.       | All deployments   |
+| [Authorizations](authorization.md) | The specific permissions that connect users, groups, or roles with resources and actions (for example, `READ`, `UPDATE`, `DELETE`). | All deployments   |
+| [Tenants](tenant.md)               | Logically isolate data within a single cluster. This is useful for multi-tenancy applications.                                      | All deployments   |
+| [Cluster admin](cluster-admin.md)  | A separate role for cluster-wide operations that span all Physical Tenants, such as status, topology, and restore.                  | Self-Managed only |
 
 :::info Admin in Self-Managed
 For documentation on deploying Admin as part of Camunda 8 Self-Managed, see [Admin in Self-Managed](/self-managed/components/orchestration-cluster/admin/overview.md).

--- a/docs/components/admin/cluster-admin.md
+++ b/docs/components/admin/cluster-admin.md
@@ -1,0 +1,91 @@
+---
+id: cluster-admin
+title: "Cluster admin"
+sidebar_label: "Cluster admin"
+description: "Cluster admin is a coarse-grained role for cluster-wide operations that span all Physical Tenants in an Orchestration Cluster."
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<span class="badge badge--platform">Self-Managed only</span>
+
+Cluster admin is a role for operations that apply to an entire [Orchestration Cluster](../orchestration-cluster.md), rather than a single tenant. It's separate from the [tenant-scoped roles and authorizations](authorization.md) managed elsewhere in Admin, and uses its own credentials.
+
+:::note
+Cluster admin was added in 8.10 alongside [Physical Tenants](/self-managed/concepts/multi-tenancy/physical-tenants.md). It's most relevant in clusters running multiple Physical Tenants, where cluster-wide visibility and recovery operations span tenant boundaries.
+:::
+
+## How cluster admin differs from tenant-scoped access
+
+- Cluster admin is authenticated and authorized separately from Orchestration Cluster user sessions. It does not share credentials, roles, or mapping rules with tenant-scoped users.
+- Cluster admin access does not grant admin rights within any specific Physical Tenant, and no existing role grants cluster admin implicitly. You must configure it explicitly — see [Configure cluster admin access](#configure-cluster-admin-access).
+- Authorization is coarse-grained by design: cluster admin grants access to all cluster-level operations. There are no sub-roles or partial cluster admin grants.
+
+## Cluster-wide operations
+
+Cluster admin protects the following REST operations, all under the `/cluster/v2/...` path prefix:
+
+| Operation                 | Method and path            | Authentication                                                   |
+| ------------------------- | -------------------------- | ---------------------------------------------------------------- |
+| Cluster status            | `GET /cluster/v2/status`   | None — public, for health checks by load balancers and operators |
+| Cluster topology          | `GET /cluster/v2/topology` | Cluster admin                                                    |
+| Change cluster mode       | `PATCH /cluster/v2/mode`   | Cluster admin                                                    |
+| Trigger a cluster restore | `POST /cluster/v2/restore` | Cluster admin                                                    |
+
+All four operations were added in 8.10.
+
+:::note
+These endpoints aren't yet reflected in the [Orchestration Cluster API](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-authentication.md) reference. Full request and response schemas will be available there once the generated reference is updated.
+:::
+
+## Configure cluster admin access
+
+Assign cluster admin access using one of two methods, matching your cluster's authentication method. The two methods are mutually exclusive.
+
+<Tabs groupId="clusterAdminAuth" defaultValue="basic" queryString values={[{label: 'Basic authentication', value: 'basic' }, {label: 'OIDC', value: 'oidc' }]}>
+<TabItem value="basic">
+
+Define one or more cluster admin users directly in configuration:
+
+```yaml
+camunda:
+  security:
+    cluster-admin:
+      basic:
+        users:
+          - name: cluster-operator
+            password: <password>
+```
+
+</TabItem>
+<TabItem value="oidc">
+
+Match cluster admin against a claim in the access token — for example, a specific client, group, or custom claim:
+
+```yaml
+camunda:
+  security:
+    cluster-admin:
+      oidc:
+        clients:
+          - cluster-admin-client
+        groups:
+          - cluster-operators
+        # claims:
+        #   - name: <claim-name>
+        #     value: <claim-value>
+```
+
+</TabItem>
+</Tabs>
+
+:::caution
+Cluster admin is a recent addition to Camunda 8.10. Verify the exact configuration schema against your version's release notes before relying on it in production.
+:::
+
+## Related
+
+- [Physical Tenants authorization model](/self-managed/concepts/physical-tenants/authorization-model.md)
+- [Physical Tenants API routing](/self-managed/concepts/physical-tenants/api-routing.md)
+- [Orchestration Cluster authorizations](../concepts/access-control/authorizations.md)

--- a/docs/self-managed/concepts/physical-tenants/api-routing.md
+++ b/docs/self-managed/concepts/physical-tenants/api-routing.md
@@ -42,7 +42,7 @@ GET /physical-tenants/default/v2/process-definitions/search
 
 ## Cluster-wide endpoints
 
-A cluster-wide endpoint applies to the whole cluster rather than a single Physical Tenant. The cluster-wide topology is exposed under a dedicated `/cluster/v2/...` path prefix, at `/cluster/v2/topology`.
+A cluster-wide endpoint applies to the whole cluster rather than a single Physical Tenant. Cluster-wide operations are exposed under a dedicated `/cluster/v2/...` path prefix — see [Cluster admin](/components/admin/cluster-admin.md) for the full list of operations, their authentication requirements, and how to configure access.
 
 The legacy `/v2/status` endpoint is deprecated. It continues to serve the default Physical Tenant only for backward compatibility. Use `/cluster/v2/status` for overall cluster status or `/physical-tenants/{id}/v2/topology` for per-tenant status.
 

--- a/docs/self-managed/concepts/physical-tenants/authorization-model.md
+++ b/docs/self-managed/concepts/physical-tenants/authorization-model.md
@@ -5,7 +5,7 @@ sidebar_label: "Authorization model"
 description: "Learn how cluster-wide and tenant-local authorization work for Physical Tenants in Camunda 8.10."
 ---
 
-This page describes the authorization model for Physical Tenants in Camunda 8.10 Self-Managed deployments. Authorization is divided into two scopes: **cluster-wide operations**, which affect the entire orchestration cluster, and **tenant-local operations**, which are scoped to a single Physical Tenant. Tenant-local operations are fully available in 8.10. The cluster-admin role and its authentication mechanism became available in 8.10 alpha4, but the cluster-wide operations it protects (topology, backup, restore) are still being wired behind it and are not yet complete.
+This page describes the authorization model for Physical Tenants in Camunda 8.10 Self-Managed deployments. Authorization is divided into two scopes: **cluster-wide operations**, which affect the entire orchestration cluster, and **tenant-local operations**, which are scoped to a single Physical Tenant. Tenant-local operations are fully available in 8.10. The [cluster-admin role](/components/admin/cluster-admin.md) and the cluster-wide operations it protects (status, topology, restore, and cluster mode changes) were added in 8.10.
 
 Two new authorization resource types were added for the per-tenant management APIs introduced alongside Physical Tenants:
 
@@ -21,15 +21,15 @@ The default **admin** role receives all four `BACKUP` permissions and `EXPORTER:
 In Camunda 8.10, the Physical Tenant authorization model is designed around per-engine, per-tenant role and permission management. Key design principles for 8.10:
 
 - **Per-tenant authorization is independently managed.** Each Physical Tenant defines its own roles, permissions, and mapping rules. A change in one tenant's authorization configuration does not affect other tenants.
-- **Cluster-wide governance via Camunda Hub is a future capability.** Cross-tenant administration using Camunda Hub is not available in 8.10. A dedicated cluster-admin role exists starting in 8.10 alpha4, though the cluster-wide operations it will protect are still being wired behind it.
+- **Cluster-wide governance via Camunda Hub is a future capability.** Cross-tenant administration using Camunda Hub is not available in 8.10. A dedicated [cluster-admin role](/components/admin/cluster-admin.md) exists starting in 8.10, covering cluster-wide status, topology, restore, and mode-change operations.
 - **Per-engine IdP fragmentation is not recommended.** Using a different identity provider for each Zeebe/Operate/Tasklist engine (as opposed to a single cluster-level IdP) is explicitly discouraged. See [authentication and authorization](./authentication-authorization.md) for the supported identity deployment models.
 
 ## Cluster-wide operations
 
-Cluster-wide operations affect the entire orchestration cluster rather than a single Physical Tenant. Examples include viewing cluster topology, triggering cluster backups, and modifying Physical Tenant configuration at runtime.
+Cluster-wide operations affect the entire orchestration cluster rather than a single Physical Tenant. Examples include viewing cluster status and topology, triggering a cluster restore, and changing cluster mode.
 
 :::note
-The cluster-admin role and its dedicated security chain are available starting in 8.10 alpha4, exposed under the `/cluster/v2/...` path prefix. However, the cluster-wide operations this role is meant to protect (topology, backup, restore) are still being wired behind that chain and are not yet complete. Check the [8.10 announcements](../../../reference/announcements-release-notes/8100/8100-announcements.md) for updates.
+These operations are protected by the [cluster-admin role](/components/admin/cluster-admin.md) and its dedicated security chain, exposed under the `/cluster/v2/...` path prefix. Cluster-admin was added in 8.10 — see [Cluster admin](/components/admin/cluster-admin.md) for the full list of operations and how to configure access.
 :::
 
 Endpoints served at the standard `/v2/...` paths — including `/v2/topology` — are scoped to a Physical Tenant, not the cluster.
@@ -92,14 +92,6 @@ Because each Physical Tenant is independently authorized, audit logs for tenant-
 
 ## Cluster-admin role
 
-:::note
-The cluster-admin role and its authentication chain are available starting in 8.10 alpha4. The cluster-wide operations listed below are still being wired behind it and are not all complete yet — check the [8.10 announcements](../../../reference/announcements-release-notes/8100/8100-announcements.md) for the current status.
-:::
+The cluster-admin role covers operations that span all Physical Tenants or affect the entire cluster — cluster status, topology, restore, and mode changes. It's resolved separately from tenant-scoped roles, using its own Basic authentication users or OIDC claim matching, and is coarse-grained (no sub-roles).
 
-The cluster-admin role is intended to cover operations that span all Physical Tenants or affect the entire cluster, such as:
-
-- Triggering cluster backups and restores
-- Viewing cluster topology
-- Assigning tenants or modifying Physical Tenant configuration at runtime
-
-Cluster-admin is resolved from JWT token claims using configurable mapping rules, a dedicated cluster-admin configuration, or explicit user assignment for Basic auth — there is no separate persisted cluster-level role binding service. Authorization is coarse-grained: cluster-admin grants access to all cluster-level operations, with no fine-grained sub-roles.
+See [Cluster admin](/components/admin/cluster-admin.md) for the full list of cluster-wide operations and how to configure access.

--- a/docs/self-managed/concepts/physical-tenants/configuration-reference.md
+++ b/docs/self-managed/concepts/physical-tenants/configuration-reference.md
@@ -230,3 +230,4 @@ If YAML and environment variables are used together, use the same normalized ten
 - [Physical Tenant isolation model](./index.md)
 - [Provisioning and lifecycle](./provisioning-and-lifecycle.md)
 - [Multi-tenancy overview](../multi-tenancy/index.md)
+- [Cluster admin](/components/admin/cluster-admin.md) — configure access for cluster-wide operations (status, topology, restore)

--- a/sidebars.js
+++ b/sidebars.js
@@ -678,6 +678,7 @@ module.exports = {
             "components/admin/client",
             "components/admin/mapping-rules",
             "components/admin/tenant",
+            "components/admin/cluster-admin",
             "components/admin/cluster-variables",
             "components/admin/global-user-task-listeners",
             "components/admin/audit-operations",


### PR DESCRIPTION
## Description

Answers Panos/Deepthi's question about whether there's a dedicated docs page for Cluster Admin operations.

Adds `docs/components/admin/cluster-admin.md`, defining the cluster-admin role and the four `/cluster/v2/...` operations it protects (status, topology, mode, restore), including how to configure access via Basic auth or OIDC. Linked from the Admin overview and cross-linked from the Physical Tenants concept docs (`authorization-model.md`, `api-routing.md`, `configuration-reference.md`), which previously described this content in scattered, partially stale terms ("still being wired") - verified against the actual `camunda/camunda` implementation, which is further along than the existing docs suggested.

A few details (exact OIDC claim schema, precise semantics of the mode-change endpoint, GA timeline) are still pending confirmation from engineering - flagged separately in Slack, not blocking this PR.

## PR Checklist

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] I included my new page in the sidebar file(s).
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style
