### PR TITLE
PushFeedback Aug 17 2026

### DIFF
--- a/docs/components/hub/workspace/modeler/idp/idp-unstructured-extraction.md
+++ b/docs/components/hub/workspace/modeler/idp/idp-unstructured-extraction.md
@@ -82,6 +82,8 @@ Add an extraction field for each piece of data you want to extract from your doc
 
 :::note
 You can edit and delete extraction fields at any time. Click the three vertical dots next to the field to open the Options menu.
+
+There's currently no way to reorder existing fields directly; delete and re-add them in the order you want instead. Extraction fields and prompts are stored as part of the document extraction template in Web Modeler, not in the BPMN file, so they can't be edited outside Web Modeler (for example, in an external source control tool).
 :::
 
 ### Extract data and save as test case {#extract-data}
@@ -212,6 +214,10 @@ You can restore a version to revert to a previous snapshot of a document extract
 1. In the sidebar **Versions** list, hover over the version you want to restore.
 1. Select the three vertical dots to open the actions menu.
 1. Select **Restore as latest**.
+
+:::note
+You can't edit a previous version directly. To make changes based on an older version, restore it as the latest version first, then edit it.
+:::
 
 ### Update a version
 

--- a/docs/components/modeler/bpmn/events.md
+++ b/docs/components/modeler/bpmn/events.md
@@ -26,13 +26,13 @@ Not all the events are supported yet. For a complete overview of supported event
 
 ## Events in general
 
-Events in BPMN can be **thrown** (i.e. sent), or **caught** (i.e. received), respectively referred to as **throw** or **catch** events (e.g. `message throw event`, `timer catch event`).
+Events in BPMN can be **thrown** (i.e. sent) or **caught** (i.e. received), respectively referred to as **throw** or **catch** events (e.g. `message throw event`, `timer catch event`). The distinction is about which side of the event the process is on: a throw event is something the process itself actively does as part of its own execution (for example, sending a message or raising an escalation); a catch event is something the process passively waits for, coming from outside the process (for example, a message arriving, or a timer elapsing).
 
 Additionally, a distinction is made between start, intermediate, and end events:
 
-- **Start events** (catch events, as they can only react to something) are used to denote the beginning of a process or subprocess.
-- **End events** (throw events, as they indicate something has happened) are used to denote the end of a particular sequence flow.
-- **Intermediate events** can be used to indicate that something has happened (i.e. intermediate throw events), or to wait and react to certain events (i.e. intermediate catch events).
+- **Start events** (always catch events) react to something external to begin the process or subprocess — a process can't start itself.
+- **End events** (always throw events) are the process's own final action, such as sending a message or signaling that an error occurred, and denote the end of a particular sequence flow.
+- **Intermediate events** can go either way: an intermediate throw event performs an action as part of the process's execution, while an intermediate catch event pauses the process and waits to react to something external.
 
 Intermediate catch events can be inserted into your process in two different contexts: normal flow, or attached to an activity, and are called boundary events.
 

--- a/docs/guides/getting-started-agentic-orchestration.md
+++ b/docs/guides/getting-started-agentic-orchestration.md
@@ -59,10 +59,10 @@ In this guide, you can try the following use cases:
 | :----------------------- | :-------------------------------------------------------------------------------- | :----------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SaaS                     | [Camunda-provided LLM](/components/agentic-orchestration/camunda-provided-llm.md) | Camunda-managed model (for example, Claude Sonnet 4.6) | <p><ul><li> Camunda 8 SaaS trial or enterprise organization.</li><li><p> Camunda-provided LLM available in your organization. No additional LLM provider credentials are required to run this guide.</p></li></ul></p>                                                                                                                                                     |
 | Cloud (customer-managed) | AWS Bedrock                                                                       | Claude Sonnet 4                                        | <p><ul><li> An AWS account with permissions for the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html).</li><li><p> Anthropic Claude foundation models using the AWS console. See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for details.</p></li></ul></p> |
-| Local                    | Ollama                                                                            | GPT-OSS:20b                                            | <p><ul><li> [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) running locally.</li><li><p> Ollama and GPT-OSS:20b installed. See [Set up Ollama](#set-up-ollama) for details.</p></li></ul></p>                                                                                                                                                      |
+| Local                    | Ollama                                                                            | GPT-OSS:20b (any Ollama-supported model works)         | <p><ul><li> [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) running locally.</li><li><p> Ollama and a model installed. See [set up Ollama](#set-up-ollama) for details.</p></li></ul></p>                                                                                                                                                          |
 
-:::important
-Running LLMs locally requires substantial disk space and memory. GPT-OSS:20b requires more than 20GB of RAM to function and 14GB of free disk space to download.
+:::tip Choose a lighter model if needed
+This guide uses GPT-OSS:20b as an example, but any model supported by Ollama works with the AI Agent connector. GPT-OSS:20b requires more than 20GB of RAM and 14GB of free disk space, which may be more than needed for this guide. Consider a smaller model (for example, `llama3.2` or `qwen2.5`) if your machine has limited resources.
 :::
 
 ## Step 1: Install the model blueprint
@@ -204,7 +204,7 @@ Configure your local LLM with Ollama.
 1. **Download and install**: Follow [Ollama's documentation](https://docs.ollama.com/quickstart) for details.
 1. **Confirm installation**: Check the installed version in a terminal or command prompt by running `ollama --version`.
 1. **Start the local server**: Start it using the application, or run `ollama serve` in a terminal or command prompt.
-1. **Pull the GPT-OSS:20b model**: If it isn't installed by default, run `ollama pull gpt-oss:20b` in a terminal or command prompt to download the model.
+1. **Pull a model**: This guide uses GPT-OSS:20b as an example. Run `ollama pull gpt-oss:20b` in a terminal or command prompt to download it. Any [model supported by Ollama](https://ollama.com/search) works with the AI Agent connector; substitute a smaller model (for example, `ollama pull llama3.2`) if you prefer a lighter download.
 1. **Test**: Ollama serves an API at `http://localhost:11434` by default. To test it, open that URL in a browser or run this command in your terminal:
 
 ```
@@ -225,7 +225,7 @@ The example blueprint downloaded in step one is preconfigured to use AWS Bedrock
 
 **Model**
 
-1. Enter `gpt-oss:20b` in the **Model** field. This field is case-sensitive, so be sure to enter it in all lowercase.
+1. Enter `gpt-oss:20b` in the **Model** field, or the name of whichever model you pulled instead. This field is case-sensitive, so be sure to enter it in all lowercase.
 
 </TabItem>
 </Tabs>
@@ -264,6 +264,7 @@ Because the AI agent in this example is an ad-hoc sub-process, you can't use Pla
 <TabItem value="self-managed">
 
 1. Deploy the process model to your local Camunda 8 environment using [Desktop Modeler](/components/modeler/desktop-modeler/index.md).
+1. Deploy the start event's linked form. Open the form in Desktop Modeler and click **Deploy**. [Linked forms are not deployed automatically with the process](/components/modeler/forms/utilizing-forms.md#deploy-a-linked-form) — skipping this step causes Tasklist to fail with "We were not able to load the form" when you try to start the process.
 1. Open Tasklist in your browser at http://localhost:8080/tasklist.
 1. On the **Processes** tab, find the `AI Agent Chat With Tools` process and click **Start process**.
 1. In the start form, add a prompt for the AI agent. For example, enter "Tell me a joke" in the **How can I help you today?** field, and click **Start process**.

--- a/docs/guides/getting-started-agentic-orchestration.md
+++ b/docs/guides/getting-started-agentic-orchestration.md
@@ -264,7 +264,7 @@ Because the AI agent in this example is an ad-hoc sub-process, you can't use Pla
 <TabItem value="self-managed">
 
 1. Deploy the process model to your local Camunda 8 environment using [Desktop Modeler](/components/modeler/desktop-modeler/index.md).
-1. Deploy the start event's linked form. Open the form in Desktop Modeler and click **Deploy**. [Linked forms are not deployed automatically with the process](/components/modeler/forms/utilizing-forms.md#deploy-a-linked-form) — skipping this step causes Tasklist to fail with "We were not able to load the form" when you try to start the process.
+1. Deploy the start event's linked form. Open the form in Desktop Modeler and click **Deploy**. [Linked forms are not deployed automatically with the process](/components/modeler/forms/utilizing-forms.md#deploy-a-linked-form). Skipping this step causes Tasklist to fail with "We were not able to load the form" when you try to start the process.
 1. Open Tasklist in your browser at http://localhost:8080/tasklist.
 1. On the **Processes** tab, find the `AI Agent Chat With Tools` process and click **Start process**.
 1. In the start form, add a prompt for the AI agent. For example, enter "Tell me a joke" in the **How can I help you today?** field, and click **Start process**.

--- a/docs/guides/getting-started-hello-world.md
+++ b/docs/guides/getting-started-hello-world.md
@@ -87,7 +87,7 @@ Data needs to sync to Operate, so your process instance may not be visible immed
 
 ### Watch the timer
 
-Your process instance pauses at the **Countdown T-10** task for 10 seconds. Open the instance in Operate and watch the token move through the countdown in real time.
+Your process instance pauses at the **Countdown T-10** task for 10 seconds. Open the instance in Operate and watch the [token](/reference/glossary.md#token-process-instance) — the marker showing the current point of execution — move through the countdown in real time.
 
 ### Inspect variables
 

--- a/versioned_docs/version-8.7/components/modeler/bpmn/bpmn-primer.md
+++ b/versioned_docs/version-8.7/components/modeler/bpmn/bpmn-primer.md
@@ -216,6 +216,10 @@ When the event is triggered, the subprocess is interrupted, regardless which of 
 
 Refer to the [subprocesses](subprocesses.md) section on which types of subprocesses are currently supported and how to use them.
 
+:::note
+Swim lanes (pools and lanes) are only available at the top-level process or collaboration level. They cannot be added inside a subprocess. This is a constraint of the BPMN 2.0 specification.
+:::
+
 ## Additional resources
 
 - [BPMN specification](http://www.bpmn.org/)

--- a/versioned_docs/version-8.7/components/modeler/web-modeler/idp/idp-unstructured-extraction.md
+++ b/versioned_docs/version-8.7/components/modeler/web-modeler/idp/idp-unstructured-extraction.md
@@ -80,6 +80,8 @@ Add an extraction field for each piece of data you want to extract from your doc
 
 :::note
 You can edit and delete extraction fields at any time. Click the three vertical dots next to the field to open the Options menu.
+
+There's currently no way to reorder existing fields directly; delete and re-add them in the order you want instead. Extraction fields and prompts are stored as part of the document extraction template in Web Modeler, not in the BPMN file, so they can't be edited outside Web Modeler (for example, in an external source control tool).
 :::
 
 ### Extract data and save as test case {#extract-data}
@@ -185,6 +187,10 @@ You can restore a version to revert to a previous snapshot of a document extract
 1. In the sidebar **Versions** list, hover over the version you want to restore.
 1. Select the three vertical dots to open the actions menu.
 1. Select **Restore as latest**.
+
+:::note
+You can't edit a previous version directly. To make changes based on an older version, restore it as the latest version first, then edit it.
+:::
 
 ### Rename a version
 

--- a/versioned_docs/version-8.8/components/modeler/bpmn/bpmn-primer.md
+++ b/versioned_docs/version-8.8/components/modeler/bpmn/bpmn-primer.md
@@ -216,6 +216,10 @@ When the event is triggered, the subprocess is interrupted, regardless which of 
 
 Refer to the [subprocesses](subprocesses.md) section on which types of subprocesses are currently supported and how to use them.
 
+:::note
+Swim lanes (pools and lanes) are only available at the top-level process or collaboration level. They cannot be added inside a subprocess. This is a constraint of the BPMN 2.0 specification.
+:::
+
 ## Additional resources
 
 - [BPMN specification](http://www.bpmn.org/)

--- a/versioned_docs/version-8.8/components/modeler/bpmn/events.md
+++ b/versioned_docs/version-8.8/components/modeler/bpmn/events.md
@@ -26,13 +26,13 @@ Not all the events are supported yet. For a complete overview of supported event
 
 ## Events in general
 
-Events in BPMN can be **thrown** (i.e. sent), or **caught** (i.e. received), respectively referred to as **throw** or **catch** events (e.g. `message throw event`, `timer catch event`).
+Events in BPMN can be **thrown** (i.e. sent) or **caught** (i.e. received), respectively referred to as **throw** or **catch** events (e.g. `message throw event`, `timer catch event`). The distinction is about which side of the event the process is on: a throw event is something the process itself actively does as part of its own execution (for example, sending a message or raising an escalation); a catch event is something the process passively waits for, coming from outside the process (for example, a message arriving, or a timer elapsing).
 
 Additionally, a distinction is made between start, intermediate, and end events:
 
-- **Start events** (catch events, as they can only react to something) are used to denote the beginning of a process or subprocess.
-- **End events** (throw events, as they indicate something has happened) are used to denote the end of a particular sequence flow.
-- **Intermediate events** can be used to indicate that something has happened (i.e. intermediate throw events), or to wait and react to certain events (i.e. intermediate catch events).
+- **Start events** (always catch events) react to something external to begin the process or subprocess — a process can't start itself.
+- **End events** (always throw events) are the process's own final action, such as sending a message or signaling that an error occurred, and denote the end of a particular sequence flow.
+- **Intermediate events** can go either way: an intermediate throw event performs an action as part of the process's execution, while an intermediate catch event pauses the process and waits to react to something external.
 
 Intermediate catch events can be inserted into your process in two different contexts: normal flow, or attached to an activity, and are called boundary events.
 

--- a/versioned_docs/version-8.8/components/modeler/web-modeler/idp/idp-unstructured-extraction.md
+++ b/versioned_docs/version-8.8/components/modeler/web-modeler/idp/idp-unstructured-extraction.md
@@ -81,6 +81,8 @@ Add an extraction field for each piece of data you want to extract from your doc
 
 :::note
 You can edit and delete extraction fields at any time. Click the three vertical dots next to the field to open the Options menu.
+
+There's currently no way to reorder existing fields directly; delete and re-add them in the order you want instead. Extraction fields and prompts are stored as part of the document extraction template in Web Modeler, not in the BPMN file, so they can't be edited outside Web Modeler (for example, in an external source control tool).
 :::
 
 ### Extract data and save as test case {#extract-data}
@@ -195,6 +197,10 @@ You can restore a version to revert to a previous snapshot of a document extract
 1. In the sidebar **Versions** list, hover over the version you want to restore.
 1. Select the three vertical dots to open the actions menu.
 1. Select **Restore as latest**.
+
+:::note
+You can't edit a previous version directly. To make changes based on an older version, restore it as the latest version first, then edit it.
+:::
 
 ### Update a version
 

--- a/versioned_docs/version-8.8/guides/getting-started-agentic-orchestration.md
+++ b/versioned_docs/version-8.8/guides/getting-started-agentic-orchestration.md
@@ -55,14 +55,14 @@ Frontier models are billed per token. That works well for complex reasoning, but
 
 In this guide, you can try the following use cases:
 
-| Setup                    | Model provider                                                                    | Model used                                             | Prerequisites                                                                                                                                                                                                                                                                                                                                                              |
-| :----------------------- | :-------------------------------------------------------------------------------- | :----------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SaaS                     | [Camunda-provided LLM](/components/agentic-orchestration/camunda-provided-llm.md) | Camunda-managed model (for example, Claude Sonnet 4.6) | <p><ul><li> Camunda 8 SaaS trial or enterprise organization.</li><li><p> Camunda-provided LLM available in your organization. No additional LLM provider credentials are required to run this guide.</p></li></ul></p>                                                                                                                                                     |
-| Cloud (customer-managed) | AWS Bedrock                                                                       | Claude Sonnet 4                                        | <p><ul><li> An AWS account with permissions for the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html).</li><li><p> Anthropic Claude foundation models using the AWS console. See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for details.</p></li></ul></p> |
-| Local                    | Ollama                                                                            | GPT-OSS:20b                                            | <p><ul><li> [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) running locally.</li><li><p> Ollama and GPT-OSS:20b installed. See [Set up Ollama](#set-up-ollama) for details.</p></li></ul></p>                                                                                                                                                      |
+| Setup                    | Model provider                                                                    | Model used                                              | Prerequisites                                                                                                                                                                                                                                                                                                                                                              |
+| :----------------------- | :-------------------------------------------------------------------------------- | :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SaaS                     | [Camunda-provided LLM](/components/agentic-orchestration/camunda-provided-llm.md) | Camunda-managed model (for example, Claude Sonnet 4.6)  | <p><ul><li> Camunda 8 SaaS trial or enterprise organization.</li><li><p> Camunda-provided LLM available in your organization. No additional LLM provider credentials are required to run this guide.</p></li></ul></p>                                                                                                                                                     |
+| Cloud (customer-managed) | AWS Bedrock                                                                       | Claude Sonnet 4                                         | <p><ul><li> An AWS account with permissions for the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html).</li><li><p> Anthropic Claude foundation models using the AWS console. See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for details.</p></li></ul></p> |
+| Local                    | Ollama                                                                            | GPT-OSS:20b (example: any Ollama-supported model works) | <p><ul><li> [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) running locally.</li><li><p> Ollama and a model installed. See [set up Ollama](#set-up-ollama) for details.</p></li></ul></p>                                                                                                                                                          |
 
-:::important
-Running LLMs locally requires substantial disk space and memory. GPT-OSS:20b requires more than 20GB of RAM to function and 14GB of free disk space to download.
+:::tip Choose a lighter model if needed
+This guide uses GPT-OSS:20b as an example, but any model supported by Ollama works with the AI Agent connector. GPT-OSS:20b requires more than 20GB of RAM and 14GB of free disk space, which may be more than needed for this guide. Consider a smaller model (for example, `llama3.2` or `qwen2.5`) if your machine has limited resources.
 :::
 
 ## Step 1: Install the model blueprint
@@ -204,7 +204,7 @@ Configure your local LLM with Ollama.
 1. **Download and install**: Follow [Ollama's documentation](https://docs.ollama.com/quickstart) for details.
 1. **Confirm installation**: Check the installed version in a terminal or command prompt by running `ollama --version`.
 1. **Start the local server**: Start it using the application, or run `ollama serve` in a terminal or command prompt.
-1. **Pull the GPT-OSS:20b model**: If it isn't installed by default, run `ollama pull gpt-oss:20b` in a terminal or command prompt to download the model.
+1. **Pull a model**: This guide uses GPT-OSS:20b as an example. Run `ollama pull gpt-oss:20b` in a terminal or command prompt to download it. Any [model supported by Ollama](https://ollama.com/search) works with the AI Agent connector; substitute a smaller model (for example, `ollama pull llama3.2`) if you prefer a lighter download.
 1. **Test**: Ollama serves an API at `http://localhost:11434` by default. To test it, open that URL in a browser or run this command in your terminal:
 
 ```
@@ -225,7 +225,7 @@ The example blueprint downloaded in step one is preconfigured to use AWS Bedrock
 
 **Model**
 
-1. Enter `gpt-oss:20b` in the **Model** field. This field is case-sensitive, so be sure to enter it in all lowercase.
+1. Enter `gpt-oss:20b` in the **Model** field, or the name of whichever model you pulled instead. This field is case-sensitive, so be sure to enter it in all lowercase.
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-8.9/components/modeler/bpmn/bpmn-primer.md
+++ b/versioned_docs/version-8.9/components/modeler/bpmn/bpmn-primer.md
@@ -216,6 +216,10 @@ When the event is triggered, the subprocess is interrupted, regardless which of 
 
 Refer to the [subprocesses](subprocesses.md) section on which types of subprocesses are currently supported and how to use them.
 
+:::note
+Swim lanes (pools and lanes) are only available at the top-level process or collaboration level. They cannot be added inside a subprocess. This is a constraint of the BPMN 2.0 specification.
+:::
+
 ## Additional resources
 
 - [BPMN specification](http://www.bpmn.org/)

--- a/versioned_docs/version-8.9/components/modeler/bpmn/events.md
+++ b/versioned_docs/version-8.9/components/modeler/bpmn/events.md
@@ -26,13 +26,13 @@ Not all the events are supported yet. For a complete overview of supported event
 
 ## Events in general
 
-Events in BPMN can be **thrown** (i.e. sent), or **caught** (i.e. received), respectively referred to as **throw** or **catch** events (e.g. `message throw event`, `timer catch event`).
+Events in BPMN can be **thrown** (i.e. sent) or **caught** (i.e. received), respectively referred to as **throw** or **catch** events (e.g. `message throw event`, `timer catch event`). The distinction is about which side of the event the process is on: a throw event is something the process itself actively does as part of its own execution (for example, sending a message or raising an escalation); a catch event is something the process passively waits for, coming from outside the process (for example, a message arriving, or a timer elapsing).
 
 Additionally, a distinction is made between start, intermediate, and end events:
 
-- **Start events** (catch events, as they can only react to something) are used to denote the beginning of a process or subprocess.
-- **End events** (throw events, as they indicate something has happened) are used to denote the end of a particular sequence flow.
-- **Intermediate events** can be used to indicate that something has happened (i.e. intermediate throw events), or to wait and react to certain events (i.e. intermediate catch events).
+- **Start events** (always catch events) react to something external to begin the process or subprocess — a process can't start itself.
+- **End events** (always throw events) are the process's own final action, such as sending a message or signaling that an error occurred, and denote the end of a particular sequence flow.
+- **Intermediate events** can go either way: an intermediate throw event performs an action as part of the process's execution, while an intermediate catch event pauses the process and waits to react to something external.
 
 Intermediate catch events can be inserted into your process in two different contexts: normal flow, or attached to an activity, and are called boundary events.
 

--- a/versioned_docs/version-8.9/components/modeler/web-modeler/idp/idp-unstructured-extraction.md
+++ b/versioned_docs/version-8.9/components/modeler/web-modeler/idp/idp-unstructured-extraction.md
@@ -81,6 +81,8 @@ Add an extraction field for each piece of data you want to extract from your doc
 
 :::note
 You can edit and delete extraction fields at any time. Click the three vertical dots next to the field to open the Options menu.
+
+There's currently no way to reorder existing fields directly; delete and re-add them in the order you want instead. Extraction fields and prompts are stored as part of the document extraction template in Web Modeler, not in the BPMN file, so they can't be edited outside Web Modeler (for example, in an external source control tool).
 :::
 
 ### Extract data and save as test case {#extract-data}
@@ -195,6 +197,10 @@ You can restore a version to revert to a previous snapshot of a document extract
 1. In the sidebar **Versions** list, hover over the version you want to restore.
 1. Select the three vertical dots to open the actions menu.
 1. Select **Restore as latest**.
+
+:::note
+You can't edit a previous version directly. To make changes based on an older version, restore it as the latest version first, then edit it.
+:::
 
 ### Update a version
 

--- a/versioned_docs/version-8.9/guides/getting-started-agentic-orchestration.md
+++ b/versioned_docs/version-8.9/guides/getting-started-agentic-orchestration.md
@@ -55,14 +55,14 @@ Frontier models are billed per token. That works well for complex reasoning, but
 
 In this guide, you can try the following use cases:
 
-| Setup                    | Model provider                                                                    | Model used                                             | Prerequisites                                                                                                                                                                                                                                                                                                                                                              |
-| :----------------------- | :-------------------------------------------------------------------------------- | :----------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SaaS                     | [Camunda-provided LLM](/components/agentic-orchestration/camunda-provided-llm.md) | Camunda-managed model (for example, Claude Sonnet 4.6) | <p><ul><li> Camunda 8 SaaS trial or enterprise organization.</li><li><p> Camunda-provided LLM available in your organization. No additional LLM provider credentials are required to run this guide.</p></li></ul></p>                                                                                                                                                     |
-| Cloud (customer-managed) | AWS Bedrock                                                                       | Claude Sonnet 4                                        | <p><ul><li> An AWS account with permissions for the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html).</li><li><p> Anthropic Claude foundation models using the AWS console. See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for details.</p></li></ul></p> |
-| Local                    | Ollama                                                                            | GPT-OSS:20b                                            | <p><ul><li> [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) running locally.</li><li><p> Ollama and GPT-OSS:20b installed. See [Set up Ollama](#set-up-ollama) for details.</p></li></ul></p>                                                                                                                                                      |
+| Setup                    | Model provider                                                                    | Model used                                              | Prerequisites                                                                                                                                                                                                                                                                                                                                                              |
+| :----------------------- | :-------------------------------------------------------------------------------- | :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SaaS                     | [Camunda-provided LLM](/components/agentic-orchestration/camunda-provided-llm.md) | Camunda-managed model (for example, Claude Sonnet 4.6)  | <p><ul><li> Camunda 8 SaaS trial or enterprise organization.</li><li><p> Camunda-provided LLM available in your organization. No additional LLM provider credentials are required to run this guide.</p></li></ul></p>                                                                                                                                                     |
+| Cloud (customer-managed) | AWS Bedrock                                                                       | Claude Sonnet 4                                         | <p><ul><li> An AWS account with permissions for the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html).</li><li><p> Anthropic Claude foundation models using the AWS console. See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) for details.</p></li></ul></p> |
+| Local                    | Ollama                                                                            | GPT-OSS:20b (example: any Ollama-supported model works) | <p><ul><li> [Camunda 8 Run](/self-managed/quickstart/developer-quickstart/c8run.md) running locally.</li><li><p> Ollama and a model installed. See [set up Ollama](#set-up-ollama) for details.</p></li></ul></p>                                                                                                                                                          |
 
-:::important
-Running LLMs locally requires substantial disk space and memory. GPT-OSS:20b requires more than 20GB of RAM to function and 14GB of free disk space to download.
+:::tip Choose a lighter model if needed
+This guide uses GPT-OSS:20b as an example, but any model supported by Ollama works with the AI Agent connector. GPT-OSS:20b requires more than 20GB of RAM and 14GB of free disk space, which may be more than needed for this guide. Consider a smaller model (for example, `llama3.2` or `qwen2.5`) if your machine has limited resources.
 :::
 
 ## Step 1: Install the model blueprint
@@ -204,7 +204,7 @@ Configure your local LLM with Ollama.
 1. **Download and install**: Follow [Ollama's documentation](https://docs.ollama.com/quickstart) for details.
 1. **Confirm installation**: Check the installed version in a terminal or command prompt by running `ollama --version`.
 1. **Start the local server**: Start it using the application, or run `ollama serve` in a terminal or command prompt.
-1. **Pull the GPT-OSS:20b model**: If it isn't installed by default, run `ollama pull gpt-oss:20b` in a terminal or command prompt to download the model.
+1. **Pull a model**: This guide uses GPT-OSS:20b as an example. Run `ollama pull gpt-oss:20b` in a terminal or command prompt to download it. Any [model supported by Ollama](https://ollama.com/search) works with the AI Agent connector; substitute a smaller model (for example, `ollama pull llama3.2`) if you prefer a lighter download.
 1. **Test**: Ollama serves an API at `http://localhost:11434` by default. To test it, open that URL in a browser or run this command in your terminal:
 
 ```
@@ -225,7 +225,7 @@ The example blueprint downloaded in step one is preconfigured to use AWS Bedrock
 
 **Model**
 
-1. Enter `gpt-oss:20b` in the **Model** field. This field is case-sensitive, so be sure to enter it in all lowercase.
+1. Enter `gpt-oss:20b` in the **Model** field, or the name of whichever model you pulled instead. This field is case-sensitive, so be sure to enter it in all lowercase.
 
 </TabItem>
 </Tabs>
@@ -264,6 +264,7 @@ Because the AI agent in this example is an ad-hoc sub-process, you can't use Pla
 <TabItem value="self-managed">
 
 1. Deploy the process model to your local Camunda 8 environment using [Desktop Modeler](/components/modeler/desktop-modeler/index.md).
+1. Deploy the start event's linked form. Open the form in Desktop Modeler and click **Deploy**. [Linked forms are not deployed automatically with the process](/components/modeler/forms/utilizing-forms.md#deploy-a-linked-form) — skipping this step causes Tasklist to fail with "We were not able to load the form" when you try to start the process.
 1. Open Tasklist in your browser at http://localhost:8080/tasklist.
 1. On the **Processes** tab, find the `AI Agent Chat With Tools` process and click **Start process**.
 1. In the start form, add a prompt for the AI agent. For example, enter "Tell me a joke" in the **How can I help you today?** field, and click **Start process**.

--- a/versioned_docs/version-8.9/guides/getting-started-agentic-orchestration.md
+++ b/versioned_docs/version-8.9/guides/getting-started-agentic-orchestration.md
@@ -264,7 +264,7 @@ Because the AI agent in this example is an ad-hoc sub-process, you can't use Pla
 <TabItem value="self-managed">
 
 1. Deploy the process model to your local Camunda 8 environment using [Desktop Modeler](/components/modeler/desktop-modeler/index.md).
-1. Deploy the start event's linked form. Open the form in Desktop Modeler and click **Deploy**. [Linked forms are not deployed automatically with the process](/components/modeler/forms/utilizing-forms.md#deploy-a-linked-form) — skipping this step causes Tasklist to fail with "We were not able to load the form" when you try to start the process.
+1. Deploy the start event's linked form. Open the form in Desktop Modeler and click **Deploy**. [Linked forms are not deployed automatically with the process](/components/modeler/forms/utilizing-forms.md#deploy-a-linked-form). Skipping this step causes Tasklist to fail with "We were not able to load the form" when you try to start the process.
 1. Open Tasklist in your browser at http://localhost:8080/tasklist.
 1. On the **Processes** tab, find the `AI Agent Chat With Tools` process and click **Start process**.
 1. In the start form, add a prompt for the AI agent. For example, enter "Tell me a joke" in the **How can I help you today?** field, and click **Start process**.

--- a/versioned_docs/version-8.9/guides/getting-started-hello-world.md
+++ b/versioned_docs/version-8.9/guides/getting-started-hello-world.md
@@ -91,7 +91,7 @@ Data needs to sync to Operate, so your process instance may not be visible immed
 
 ### Watch the timer
 
-Your process instance pauses at the **Countdown T-10** task for 10 seconds. Open the instance in Operate and watch the token move through the countdown in real time.
+Your process instance pauses at the **Countdown T-10** task for 10 seconds. Open the instance in Operate and watch the [token](/reference/glossary.md#token-process-instance) — the marker showing the current point of execution — move through the countdown in real time.
 
 ### Inspect variables
 


### PR DESCRIPTION
## Description

Resolves 6 pieces of in-product user feedback across getting-started guides and BPMN/IDP reference docs, backported where the underlying issue applies to older versions.

- **"What's the token?"** - linked the term to its glossary definition in the Hello World guide.
- **Tasklist "Start process" fails/vague error** - root cause: linked forms stopped auto-deploying with the process as of 8.9. Added an explicit form-deploy step to the AI agent guide's Self-Managed flow (8.9 only; 8.8 still auto-deploys).
- **"Docs only mention GPT-OSS:20b"** - clarified any Ollama-supported model works; GPT-OSS:20b is just the walkthrough example, with a lighter-model suggestion for constrained machines.
- **Throw vs. catch event confusion** - reworded the distinction around agency (process acts vs. process waits) instead of repeating "something happened" for both sides.
- **Swim lanes in subprocesses** - the clarifying note already existed in unversioned docs but was missing from all versioned snapshots; backported to 8.7–8.9.
- **IDP unstructured extraction (editing versions, reordering fields, prompts in BPMN)** - added two limitation notes: versions can't be edited in place (restore first), and fields/prompts live in Web Modeler, not the BPMN file.

## PR Checklist

- [x] My changes are for an upcoming minor release and are in the `/docs` directory.
- [x] My changes are for an already released minor and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style
