### PR TITLE
Add test for Hub API spec bundling with RefParser

### DIFF
--- a/hacks/postman/sync-hub-api.spec.js
+++ b/hacks/postman/sync-hub-api.spec.js
@@ -4,24 +4,68 @@
 // sync-hub-api.js. That script only runs from the `update-postman` workflow,
 // which triggers on release-tag pushes, not on pull requests — so a breaking
 // bump to this dependency would otherwise reach production undetected.
+//
+// The package ships ESM-only. Jest's own module pipeline can't `require()` it
+// (no Babel config transforms node_modules here), even though plain Node can
+// via its native require(esm) interop — the same way sync-hub-api.js loads
+// it. So this test shells out to a real `node` process instead of importing
+// the package directly, to exercise the exact runtime path production uses.
 
-const RefParser = require("@apidevtools/json-schema-ref-parser");
+const { execFileSync } = require("child_process");
 const path = require("path");
 
 const SPECS = {
-  hubsm: path.join(__dirname, "..", "..", "api", "hubsm", "v2", "camunda-openapi.yaml"),
-  hubsaas: path.join(__dirname, "..", "..", "api", "hubsaas", "v2", "camunda-openapi.yaml"),
+  hubsm: path.join(
+    __dirname,
+    "..",
+    "..",
+    "api",
+    "hubsm",
+    "v2",
+    "camunda-openapi.yaml"
+  ),
+  hubsaas: path.join(
+    __dirname,
+    "..",
+    "..",
+    "api",
+    "hubsaas",
+    "v2",
+    "camunda-openapi.yaml"
+  ),
 };
+
+// Mirrors the `RefParser.bundle(specPath)` call in convertHubApiSpec().
+const BUNDLE_SNIPPET = `
+  const RefParser = require("@apidevtools/json-schema-ref-parser");
+  RefParser.bundle(process.argv[1])
+    .then((spec) => {
+      console.log(JSON.stringify({
+        openapi: spec.openapi,
+        title: spec.info && spec.info.title,
+        pathCount: Object.keys(spec.paths || {}).length,
+      }));
+    })
+    .catch((err) => {
+      console.error(err.stack || String(err));
+      process.exit(1);
+    });
+`;
 
 describe("RefParser.bundle on the Hub API specs", () => {
   it.each(Object.entries(SPECS))(
     "bundles the %s spec without throwing",
-    async (_target, specPath) => {
-      const spec = await RefParser.bundle(specPath);
+    (_target, specPath) => {
+      const output = execFileSync(
+        process.execPath,
+        ["-e", BUNDLE_SNIPPET, specPath],
+        { encoding: "utf8" }
+      );
+      const spec = JSON.parse(output);
 
       expect(spec.openapi).toMatch(/^3\./);
-      expect(spec.info?.title).toEqual(expect.any(String));
-      expect(Object.keys(spec.paths || {}).length).toBeGreaterThan(0);
+      expect(spec.title).toEqual(expect.any(String));
+      expect(spec.pathCount).toBeGreaterThan(0);
     }
   );
 });

--- a/hacks/postman/sync-hub-api.spec.js
+++ b/hacks/postman/sync-hub-api.spec.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+// Guards the `@apidevtools/json-schema-ref-parser` dependency used by
+// sync-hub-api.js. That script only runs from the `update-postman` workflow,
+// which triggers on release-tag pushes, not on pull requests — so a breaking
+// bump to this dependency would otherwise reach production undetected.
+
+const RefParser = require("@apidevtools/json-schema-ref-parser");
+const path = require("path");
+
+const SPECS = {
+  hubsm: path.join(__dirname, "..", "..", "api", "hubsm", "v2", "camunda-openapi.yaml"),
+  hubsaas: path.join(__dirname, "..", "..", "api", "hubsaas", "v2", "camunda-openapi.yaml"),
+};
+
+describe("RefParser.bundle on the Hub API specs", () => {
+  it.each(Object.entries(SPECS))(
+    "bundles the %s spec without throwing",
+    async (_target, specPath) => {
+      const spec = await RefParser.bundle(specPath);
+
+      expect(spec.openapi).toMatch(/^3\./);
+      expect(spec.info?.title).toEqual(expect.any(String));
+      expect(Object.keys(spec.paths || {}).length).toBeGreaterThan(0);
+    }
+  );
+});


### PR DESCRIPTION
## Description

This PR adds a test that guards against breaking changes to the `@apidevtools/json-schema-ref-parser` dependency used by the `sync-hub-api.js` script.

The `sync-hub-api.js` script runs only from the `update-postman` workflow on release-tag pushes, not on pull requests. Without this test, a breaking bump to the `json-schema-ref-parser` dependency could reach production undetected.

The test shells out to a real `node` process to exercise the exact runtime path that production uses, since the package ships ESM-only and Jest's module pipeline cannot directly require it in the test environment.

## When should this change go live?

- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up
- [x] My changes are for **an upcoming minor release** and are in the appropriate directory

## Test Plan

The added test (`sync-hub-api.spec.js`) validates that `RefParser.bundle()` can successfully process both the `hubsm` and `hubsaas` OpenAPI specifications without throwing errors. The test verifies that the bundled specs contain expected properties (OpenAPI version, title, and paths).

https://claude.ai/code/session_016UZGCRa9bMN8DwjMJGpY6S