### PR TITLE
docs(self-managed): document removed Web Modeler file-download executor properties

### DIFF
--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -271,6 +271,24 @@ DELETE /api/v2/clusters/{clusterId}
 
 Read more about dynamic cluster management in the [Camunda Hub properties reference](/self-managed/components/hub/configuration/properties.md#dynamic-cluster-management).
 
+### File download concurrency configuration
+
+The file-download endpoints (used by Web Modeler features in Camunda Hub) no longer use a bounded executor. Downloads now stream synchronously on the request thread, bounded by a semaphore, which keeps peak memory usage modest. As a result, the following executor tuning properties have been **removed**:
+
+- `camunda.modeler.file-download.executor.core-pool-size`
+- `camunda.modeler.file-download.executor.max-pool-size`
+- `camunda.modeler.file-download.executor.queue-capacity`
+
+These have been replaced by a single property:
+
+- `camunda.modeler.file-download.max-concurrent-downloads` — default `15` (equal to the previous `max-pool-size` of `5` plus `queue-capacity` of `10`)
+
+:::warning
+If any of the removed properties are still set (for example, as environment variables), Camunda Hub **fails to start**. Remove the executor properties and, if you need to tune download concurrency, set `camunda.modeler.file-download.max-concurrent-downloads` instead before upgrading.
+:::
+
+Note the semantics differ slightly from 8.9: previously, at most 5 downloads ran concurrently with up to 10 queued; now, up to 15 downloads stream concurrently.
+
 ## Elasticsearch/OpenSearch Exporter
 
 ### Default replica count changed

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -273,7 +273,7 @@ Read more about dynamic cluster management in the [Camunda Hub properties refere
 
 ### File download concurrency configuration
 
-The file-download endpoints (used by Web Modeler features in Camunda Hub) no longer use a bounded executor. Downloads now stream synchronously on the request thread, bounded by a semaphore, which keeps peak memory usage modest. As a result, the following executor tuning properties have been **removed**:
+The file download endpoints (used by Web Modeler features in Camunda Hub) no longer use a bounded executor. Downloads now stream synchronously on the request thread, bounded by a semaphore, which keeps peak memory usage modest. As a result, the following executor tuning properties have been removed:
 
 - `camunda.modeler.file-download.executor.core-pool-size`
 - `camunda.modeler.file-download.executor.max-pool-size`
@@ -281,11 +281,13 @@ The file-download endpoints (used by Web Modeler features in Camunda Hub) no lon
 
 These have been replaced by a single property:
 
-- `camunda.modeler.file-download.max-concurrent-downloads` — default `15` (equal to the previous `max-pool-size` of `5` plus `queue-capacity` of `10`)
+- `camunda.modeler.file-download.max-concurrent-downloads` — default `15` (equal to the previous defaults: `max-pool-size` `5` plus `queue-capacity` `10`)
 
 :::warning
-If any of the removed properties are still set (for example, as environment variables), Camunda Hub **fails to start**. Remove the executor properties and, if you need to tune download concurrency, set `camunda.modeler.file-download.max-concurrent-downloads` instead before upgrading.
+Camunda Hub fails to start if any of the removed properties are still set (for example, as environment variables).
 :::
+
+Remove the executor properties and, if you need to tune download concurrency, set `camunda.modeler.file-download.max-concurrent-downloads` instead before upgrading.
 
 Note the semantics differ slightly from 8.9: previously, at most 5 downloads ran concurrently with up to 10 queued; now, up to 15 downloads stream concurrently.
 


### PR DESCRIPTION
Documents the removal of the `camunda.modeler.file-download.executor.*` properties and their replacement with `camunda.modeler.file-download.max-concurrent-downloads` in the 8.9 → 8.10 Self-Managed upgrade guide, so operators can update config before upgrading and avoid the fail-fast startup error.

Closes #9646