### PR TITLE
dx(search): Use new v3 index

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -689,7 +689,7 @@ module.exports = {
       // These keys are for our new standalone algolia instance!
       apiKey: "68db7725a8410eace68419c29385ad1e",
       appId: "6KYF3VMCXZ",
-      indexName: "camunda-v2",
+      indexName: "camunda-v3",
       placeholder: "Search Camunda 8 docs",
     },
     languageTabs: [


### PR DESCRIPTION
## Description

Use new algolia index.

This is step 3 in the process of [swapping our search crawler/index](https://github.com/camunda/camunda-docs/issues/9649).

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label) -- No security concern label (used dx)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
