### PR TITLE
docs: document Optimize's object-variable-flattening default change for 8.10

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -441,6 +441,29 @@ This default does not apply to existing clusters. Existing clusters show data fi
 </div>
 </div>
 
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Optimize Self-Managed no longer flattens object variables by default
+
+Starting with Camunda 8.10, Self-Managed Optimize no longer imports object variable values by default. Object variables are no longer flattened into per-property fields, and their raw values are no longer stored. This significantly reduces Optimize storage and CPU usage, and aligns Self-Managed with the default Camunda 8 SaaS has used for years.
+
+This change is **Self-Managed only**; SaaS is unaffected, as it already runs with this behavior disabled.
+
+- Object-heavy processes previously measured 5.9-48.8x more Optimize variable storage on Self-Managed than SaaS for identical workloads.
+- If you rely on object variable properties in reports, filters, or Raw Data Reports, opt in by setting `zeebe.includeObjectVariableValue: true` (environment variable `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE=true`).
+- Optimize logs a `WARN` on startup whenever object variable values are not being imported, whether that's because you left the setting unconfigured or set it explicitly, with the one-line opt-in.
+
+**Action:** Decide whether your Self-Managed deployment needs flattened object variables. If it does, set `zeebe.includeObjectVariableValue: true` before upgrading to 8.10.
+
+<p className="link-arrow">[Object variables configuration](/self-managed/components/optimize/configuration/object-variables.md)</p>
+
+</div>
+</div>
+
 ## Deployment
 
 <div className="release-announcement-row">

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -455,7 +455,7 @@ This change is **Self-Managed only**; SaaS is unaffected, as it already runs wit
 
 - Object-heavy processes previously measured 5.9-48.8x more Optimize variable storage on Self-Managed than SaaS for identical workloads.
 - If you rely on object variable properties in reports, filters, or Raw Data Reports, opt in by setting `zeebe.includeObjectVariableValue: true` (environment variable `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE=true`).
-- Optimize logs a `WARN` on startup whenever object variable values are not being imported, whether that's because you left the setting unconfigured or set it explicitly, with the one-line opt-in.
+- Optimize logs a `WARN` on startup whenever object variable values are not being imported. The message includes the opt-in setting.
 
 **Action:** Decide whether your Self-Managed deployment needs flattened object variables. If it does, set `zeebe.includeObjectVariableValue: true` before upgrading to 8.10.
 

--- a/docs/self-managed/components/optimize/configuration/object-variables.md
+++ b/docs/self-managed/components/optimize/configuration/object-variables.md
@@ -13,11 +13,11 @@ Complex object variables can be imported into Optimize and thereafter be used in
 
 For example, an object variable called `user` with the properties `firstName` and `lastName` will result in two flattened variables: `user.firstName` and `user.lastName`. These variables can be used within reports and filters.
 
-Additionally, to the flattened properties, Optimize also imports the entire raw value of the object variable. In the above example, this would result in a variable called `user` with value `{"firstName": "John", "lastName": "Smith"}`. This raw object variable can be inspected in Raw Data Reports but is not supported in other report types or filters.
+In addition to the flattened properties, Optimize also imports the entire raw value of the object variable. In the example above, this creates a variable called `user` with the value `{"firstName": "John", "lastName": "Smith"}`. You can inspect this raw object variable in Raw Data Reports, but other report types and filters do not support it.
 
 ## List variables
 
-Optimize also supports object variables which are JSON serialized lists of primitive types, for example a list of strings or numbers. Note that for Camunda 7 and external variables, the `type` of list variables must still be set to `Object`. During import, Optimize also evaluate how many entries are in a given list and persists this in an additional `_listSize` variable.
+Optimize also supports object variables that are JSON-serialized lists of primitive types, such as a list of strings or numbers. For Camunda 7 and external variables, the `type` of list variables must still be set to `Object`. During import, Optimize evaluates the number of entries in each list and persists it in an additional `_listSize` variable.
 
 For example, a list variable with the name `users` and the values `["John Smith", "Jane Smith"]` will result in two imported variables: one `users` variable with the two given values, and one variable called `users._listSize` with value `2`. Both can be used in reports and filters.
 

--- a/docs/self-managed/components/optimize/configuration/object-variables.md
+++ b/docs/self-managed/components/optimize/configuration/object-variables.md
@@ -29,10 +29,12 @@ The value of list properties within objects as well as variables which are lists
 
 ## Optimize configuration
 
-The import of object variable values is enabled by default and can be disabled using the `zeebe.includeObjectVariableValue` configuration. Alternatively, this can be set using the `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE` environment variable.
+As of Camunda 8.10, the import of object variable values is disabled by default. It can be enabled using the `zeebe.includeObjectVariableValue` configuration. Alternatively, this can be set using the `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE` environment variable.
 
 When enabled, each flattened property and the raw object itself are stored as separate variables. As a result, object-heavy processes can significantly increase Optimize's storage and CPU usage.
 See [Impact of Optimize](/components/best-practices/architecture/sizing-your-environment.md#impact-of-optimize) for sizing guidance.
+
+When disabled (the default), Optimize logs a `WARN` on startup as a reminder, and object variables are neither flattened nor stored.
 
 Depending on where the imported object variables originate, the following configuration is required to ensure that your system produces object variable data that Optimize can import correctly:
 

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -281,3 +281,24 @@ This applies to new indices created after upgrading. Existing indices are not af
 
 - **Single-node clusters:** Set `number-of-replicas: 0` explicitly in your exporter configuration to avoid yellow cluster health. On a single node, replicas cannot be assigned and remain unassigned, which causes the cluster to report yellow health and may trigger monitoring alerts.
 - **Multi-node clusters:** No action required. The new default improves fault tolerance. Note that each replica stores a full copy of the shard data, so enabling replicas increases disk usage for new indices.
+
+## Optimize
+
+### Default objectVariable inclusion changed
+
+This is a breaking change for Self-Managed. In 8.10, the default value of `zeebe.includeObjectVariableValue` changed from `true` to `false`. Optimize no longer flattens object variables into per-property fields or stores their raw value by default. See the [8.10 breaking change announcement](/reference/announcements-release-notes/8100/8100-announcements.md#optimize-self-managed-no-longer-flattens-object-variables-by-default) for the full rationale.
+
+| Setting                            | 8.9    | 8.10    |
+| ---------------------------------- | ------ | ------- |
+| `zeebe.includeObjectVariableValue` | `true` | `false` |
+
+**Action:** If your reports, filters, or Raw Data Reports rely on flattened object variable properties, set `zeebe.includeObjectVariableValue: true` (environment variable `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE=true`) before upgrading:
+
+```yaml
+zeebe:
+  includeObjectVariableValue: true
+```
+
+Optimize logs a `WARN` on startup whenever object variable values are not being imported, as a reminder.
+
+<p className="link-arrow">[Object variables configuration](/self-managed/components/optimize/configuration/object-variables.md)</p>

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -299,6 +299,6 @@ zeebe:
   includeObjectVariableValue: true
 ```
 
-Optimize logs a `WARN` on startup whenever object variable values are not being imported, as a reminder.
+Optimize logs a `WARN` on startup whenever object variable values are not being imported. The message includes the opt-in setting.
 
 <p className="link-arrow">[Object variables configuration](/self-managed/components/optimize/configuration/object-variables.md)</p>


### PR DESCRIPTION
Documents Optimize's `zeebe.includeObjectVariableValue` default flipping from `true` to `false` for Self-Managed in 8.10 (camunda/camunda#60587): a breaking-change announcement entry, an upgrade-guide entry, and a fix to the config reference page that stated the old default.

Closes camunda/camunda#60585.