### PR TITLE
dx(search): update reference document

### DIFF
--- a/.algolia/crawler.config.js
+++ b/.algolia/crawler.config.js
@@ -13,7 +13,7 @@ new Crawler({
   discoveryPatterns: ["https://docs.camunda.io/**"],
   actions: [
     {
-      indexName: "camunda-v2",
+      indexName: "camunda-v3",
       pathsToMatch: ["https://docs.camunda.io/**"],
       recordExtractor: ({ $, helpers, url }) => {
         // Extracting the breadcrumb titles for better accessibility.
@@ -26,11 +26,8 @@ new Crawler({
           [navbarTitle, ...pageBreadcrumbTitles].join(" / ") || "Documentation";
 
         // Page rank.
-        // Use the page rank from the Docusaurus frontmatter if available, if not
-        // calculate it based on the URL depth.
-
-        // Extracting the page rank from a meta tag (it's set by the Docusaurus pages frontmatter).
-        const pageRank = $("meta[name='docsearch:page_rank']").attr("content");
+        // Extracting the page rank from a meta tag (it's set in Docusaurus).
+        const pageRank = $("meta[name='docsearch:page_rank']").text();
         // Set default page rank based on the number of slashes (ignore trailing slash).
         // Set pageRank as inverse of depth, fewer slashes = higher rank.
         const path = new URL(url).pathname.replace(/\/$/, "");
@@ -61,7 +58,7 @@ new Crawler({
   ],
   safetyChecks: { beforeIndexPublishing: { maxLostRecordsPercentage: 30 } },
   initialIndexSettings: {
-    "camunda-v2": {
+    "camunda-v3": {
       attributesForFaceting: [
         "type",
         "lang",
@@ -92,12 +89,15 @@ new Crawler({
       ],
       distinct: true,
       attributeForDistinct: "url",
-      customRanking: ["desc(weight.level)", "asc(weight.position)"],
+      customRanking: [
+        "desc(weight.pageRank)",
+        "desc(weight.level)",
+        "asc(weight.position)",
+      ],
       ranking: [
         "words",
         "filters",
         "typo",
-        "desc(weight.pageRank)",
         "attribute",
         "proximity",
         "exact",


### PR DESCRIPTION
## Description

Update the reference document with the latest crawler config. The next step in the process of https://github.com/camunda/camunda-docs/issues/9649.

Important to note, the file changed in this PR is only for reference, it has no material impact on the crawler. The crawler actually used to update our search index is determined by Vault secrets. However, I've also updated the Vault secrets, so the next time we deploy production, the new crawler will be used.