### PR TITLE
docs(self-managed): apply the readiness check partial to 8.8

### DIFF
--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-check.md
@@ -1,0 +1,20 @@
+import DeploymentReadinessDownload from './\_deployment-readiness-download.md'
+
+The script polls the namespace until every pod is `Running` with all of its containers ready. If the deployment stalls, it reports the containers that are not ready, with their restart count, waiting reason, last termination reason, and exit code, together with recent warning events, so you can see what is blocking it.
+
+{props.download && <DeploymentReadinessDownload />}
+
+Configure it with the following environment variables:
+
+| Variable                            | Default   | Purpose                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CAMUNDA_NAMESPACE`                 | `camunda` | Namespace to watch                                               |
+| `DEPLOYMENT_READY_TIMEOUT_SECONDS`  | `1800`    | Wall-clock budget in seconds. Set it to `0` to wait indefinitely |
+| `DEPLOYMENT_READY_INTERVAL_SECONDS` | `5`       | Delay in seconds between two polls                               |
+
+<details>
+<summary>See the check-deployment-ready.sh script</summary>
+```bash reference
+https://github.com/camunda/camunda-deployment-references/blob/stable/8.8/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+```
+</details>

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-download.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/_partials/_deployment-readiness-download.md
@@ -1,0 +1,9 @@
+Download the script and run it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/camunda/camunda-deployment-references/stable/8.8/generic/kubernetes/single-region/procedure/check-deployment-ready.sh -o check-deployment-ready.sh
+chmod +x check-deployment-ready.sh
+./check-deployment-ready.sh
+```
+
+Review the script before you run it.

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/eks-helm.md
@@ -8,6 +8,7 @@ description: "Set up the Camunda 8 environment with Helm and an optional Ingress
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import DeploymentReadinessCheck from '../../\_partials/\_deployment-readiness-check.md'
 
 This guide provides a comprehensive walkthrough for installing the Camunda 8 Helm chart on your existing AWS Kubernetes EKS cluster. It also includes instructions for setting up optional DNS configurations and other optional AWS-managed services, such as OpenSearch and PostgreSQL.
 
@@ -452,11 +453,9 @@ This guide uses `helm upgrade --install` as it runs install on initial deploymen
 
 :::
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.8/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
+<DeploymentReadinessCheck download />
 
 <details>
 <summary>Understand how each component interacts with IRSA</summary>

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/azure/microsoft-aks/aks-helm.md
@@ -6,6 +6,7 @@ description: "Set up your Camunda 8 environment with Helm on Azure Kubernetes Se
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import DeploymentReadinessCheck from '../../\_partials/\_deployment-readiness-check.md'
 
 This guide provides a comprehensive walkthrough for installing the Camunda 8 Helm chart on your existing Azure Kubernetes Service (AKS) cluster, and confirmation it is working as intended.
 
@@ -371,11 +372,9 @@ This guide uses `helm upgrade --install` as it runs install on initial deploymen
 
 :::
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.8/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
+<DeploymentReadinessCheck download />
 
 ## Verify connectivity to Camunda 8
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/kind.md
@@ -7,6 +7,7 @@ description: "Deploy Camunda 8 Self-Managed on a local Kubernetes cluster using 
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import DeploymentReadinessCheck from './\_partials/\_deployment-readiness-check.md'
 
 With this guide, you'll deploy Camunda 8 Self-Managed to a local Kubernetes cluster using [kind (Kubernetes in Docker)](https://kind.sigs.k8s.io/). The setup is optimized for learning, development, and testing, with reduced resource requirements suitable for a personal machine.
 
@@ -303,11 +304,10 @@ You can also use the deployment readiness check script from the root directory o
 
 ```bash
 export CAMUNDA_NAMESPACE=camunda
+./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
 
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.8/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
+<DeploymentReadinessCheck />
 
 Finally, verify the Helm release:
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/kind.md
@@ -300,11 +300,11 @@ kubectl get pods -n camunda -w
 
 Wait until all pods show `Running` status. This may take 5–10 minutes depending on your internet connection and system resources.
 
-You can also use the deployment readiness check script from the root directory of the `camunda-deployment-references` repository. This script requires [jq](https://jqlang.github.io/jq/) to be installed:
+You can also use the deployment readiness check script, run from the reference architecture directory `get-your-copy.sh` left you in. This script requires [jq](https://jqlang.github.io/jq/) to be installed:
 
 ```bash
 export CAMUNDA_NAMESPACE=camunda
-./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+../../../generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
 
 <DeploymentReadinessCheck />

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/cloud-providers/openshift/redhat-openshift.md
@@ -8,6 +8,7 @@ description: "Deploy Camunda 8 Self-Managed on Red Hat OpenShift"
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DeploymentReadinessCheck from '../\_partials/\_deployment-readiness-check.md'
 
 Red Hat OpenShift, a Kubernetes distribution maintained by [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift), provides options for both managed and on-premises hosting.
 
@@ -329,11 +330,9 @@ This guide uses `helm upgrade --install` as it runs install on initial deploymen
 
 :::
 
-You can track the progress of the installation using the following command:
+You can track the progress of the installation with the deployment readiness check script, which requires [jq](https://jqlang.github.io/jq/) to be installed.
 
-```bash reference
-https://github.com/camunda/camunda-deployment-references/blob/stable/8.8/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-```
+<DeploymentReadinessCheck download />
 
 ## Verify connectivity to Camunda 8
 


### PR DESCRIPTION
## Description

`stable/8.8` now carries the reworked `check-deployment-ready.sh` (camunda/camunda-deployment-references#3132 and #3142), which grew from 14 to **177 lines**. Four 8.8 guides embed that file verbatim with ` ```bash reference `, so they currently render a wall of defensive bash in the middle of a "track the progress of the installation" step, and they document none of the three environment variables the script now accepts.

This is the same problem #9542 fixed for `docs` and `versioned_docs/version-8.9`. Backporting the code without the documentation recreated it for 8.8.

Affected pages, all four:

- `kind.md`
- `openshift/redhat-openshift.md`
- `azure/microsoft-aks/aks-helm.md`
- `amazon/amazon-eks/eks-helm.md`

## Change

Decline the two partials introduced by #9542 into `versioned_docs/version-8.8/.../cloud-providers/_partials/`, re-pinned from `stable/8.9` to `stable/8.8`:

- `_deployment-readiness-check.md`: what the script does, a table of `CAMUNDA_NAMESPACE`, `DEPLOYMENT_READY_TIMEOUT_SECONDS` and `DEPLOYMENT_READY_INTERVAL_SECONDS`, and the source collapsed into a `details` block.
- `_deployment-readiness-download.md`: the `curl` fetch, rendered only when the importing page passes `download`.

The Kind guide hands the reader a local copy of the reference architecture through `get-your-copy.sh`, so it shows the invocation directly and omits the download. The EKS, AKS, and OpenShift guides never instruct a clone and treat embedded scripts as copy-paste material, so they opt in.

## Validation

- `npm run build` completes. The broken-anchor warnings it emits are pre-existing and unrelated.
- `prettier` reports no formatting issue on the six files.
- Rendered HTML checked per page rather than by eye:

  | Page | curl block | env var table | pinned branch |
  | --- | --- | --- | --- |
  | `8.8/kind` | absent | present | `stable/8.8` |
  | `8.8/eks-helm` | present | present | `stable/8.8` |

- The raw URL used by the download block returns HTTP 200 on `stable/8.8`.
- No page is left with a bare embed. The only remaining reference to the script path in `kind.md` is the invocation line itself.

## Scope

`versioned_docs/version-8.8` only. `docs` and `versioned_docs/version-8.9` were handled by #9542, and `versioned_docs/version-8.7` has no Kind guide and still points at the original short script on `stable/8.7`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
