### PR TITLE
docs(self-managed): run the readiness script from the reference architecture directory

### DIFF
--- a/docs/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/docs/self-managed/deployment/helm/cloud-providers/kind.md
@@ -427,11 +427,11 @@ kubectl get pods -n camunda -w
 
 Wait until all pods show `Running` status. This may take 5–10 minutes depending on your internet connection and system resources.
 
-You can also use the deployment readiness check script from the root directory of the `camunda-deployment-references` repository. This script requires [jq](https://jqlang.github.io/jq/) to be installed:
+You can also use the deployment readiness check script, run from the reference architecture directory `get-your-copy.sh` left you in. This script requires [jq](https://jqlang.github.io/jq/) to be installed:
 
 ```bash
 export CAMUNDA_NAMESPACE=camunda
-./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+../../../generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
 
 <DeploymentReadinessCheck />

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/cloud-providers/kind.md
@@ -427,11 +427,11 @@ kubectl get pods -n camunda -w
 
 Wait until all pods show `Running` status. This may take 5–10 minutes depending on your internet connection and system resources.
 
-You can also use the deployment readiness check script from the root directory of the `camunda-deployment-references` repository. This script requires [jq](https://jqlang.github.io/jq/) to be installed:
+You can also use the deployment readiness check script, run from the reference architecture directory `get-your-copy.sh` left you in. This script requires [jq](https://jqlang.github.io/jq/) to be installed:
 
 ```bash
 export CAMUNDA_NAMESPACE=camunda
-./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+../../../generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 ```
 
 <DeploymentReadinessCheck />


### PR DESCRIPTION
## Problem

#9542 added a direct invocation of the readiness script to the Kind guide:

```bash
export CAMUNDA_NAMESPACE=camunda
./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
```

That path is relative to the repository root, but the reader is not there. `get-your-copy.sh` ends with:

```bash
cd "camunda-deployment-references/local/kubernetes/kind-single-region" || exit 1
echo "You are now in the reference architecture directory $(pwd)."
```

So anyone following the guide gets `No such file or directory`. Every other command on the page is relative to that same directory, for example `./procedure/camunda-deploy-domain.sh` and `./procedure/certs-generate.sh`, which confirms the working directory.

The surrounding sentence claimed the reader was at the "root directory of the `camunda-deployment-references` repository". That wording predates #9542 and was already inaccurate, but it was harmless while the section only embedded the script. Turning it into a runnable command made it wrong.

## Change

Use the same relative path the Makefile uses in its `camunda.wait` target:

```bash
export CAMUNDA_NAMESPACE=camunda
../../../generic/kubernetes/single-region/procedure/check-deployment-ready.sh
```

and describe the directory the reader is actually in.

Applied to `docs` and `versioned_docs/version-8.9`, the two versions where #9542 has already merged. The 8.8 equivalent is fixed in its own pull request, #9657, which has not merged yet.

## How it was found

Reviewing #9657 before asking for eyes on it. The defect was mine, introduced in #9542 and reproduced in #9657.