### PR TITLE
docs: align Optimize /api/readyz auth header behavior with 8.10 implementation

### DIFF
--- a/docs/apis-tools/optimize-api/health-readiness.md
+++ b/docs/apis-tools/optimize-api/health-readiness.md
@@ -7,7 +7,7 @@ description: "The REST API to check the readiness of Optimize."
 The purpose of Health-Readiness REST API is to return information indicating whether Optimize is ready to be used.
 
 :::note
-The Health-Readiness REST API does not require an [`Authorization` header](./optimize-api-authentication.md), and rejects requests that include one.
+The Health-Readiness REST API does not require an [`Authorization` header](./optimize-api-authentication.md). If a request includes one, the header is ignored.
 :::
 
 ## Method & HTTP target resource

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -320,6 +320,23 @@ With Camunda 8.10, the Console Self-Managed API and the Web Modeler API are depr
 </div>
 </div>
 
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Optimize `GET /api/readyz` no longer rejects requests that carry an `Authorization` header
+
+Starting with Camunda 8.10.0-alpha5, the Optimize [health readiness endpoint](/apis-tools/optimize-api/health-readiness.md) (`GET /api/readyz`) ignores an `Authorization` header instead of rejecting the request. Previously, a request that included the header was rejected with a client error status code. It now returns the readiness status (`200` or `503`), as it does for a request without the header.
+
+This aligns the endpoint with the other public endpoints of the Orchestration Cluster, which also accept and ignore a superfluous `Authorization` header.
+
+**Action:** No action is required for Kubernetes readiness and liveness probes, as these do not send an `Authorization` header. If you have a client or monitoring check that relies on the endpoint rejecting requests that carry an `Authorization` header, update it to expect the readiness status instead.
+
+</div>
+</div>
+
 ## Connectors
 
 <div className="release-announcement-row">


### PR DESCRIPTION
## Description

Since the Camunda Security Library became Optimize's default security stack in 8.10 (camunda/camunda#60190), `GET /api/readyz` no longer rejects requests that carry an `Authorization` header — the header is ignored and the endpoint returns the readiness status. The docs still promise rejection, so a QA regression test caught the mismatch: camunda/camunda#60703.

We are fixing the docs rather than the code:

- The rejection was never an explicit design decision. It was an emergent property of the legacy filter chain layout, and it only got documented retrospectively when the docs team came across it (camunda/camunda-docs#1737).
- Every other public, unauthenticated endpoint in the Orchestration Cluster tolerates a superfluous `Authorization` header. Keeping the rejection would leave Optimize as the sole exception.
- The Optimize team confirmed they see no need to keep the behavior.

Changes:

- `docs/apis-tools/optimize-api/health-readiness.md`: the header is ignored instead of rejected.
- `docs/reference/announcements-release-notes/8100/8100-announcements.md`: new **Breaking change** entry under *APIs & tools*, flagged as breaking even though practical impact is expected to be nil — Kubernetes readiness and liveness probes, including the Helm chart's, never send an `Authorization` header.

Only `/docs` (8.10, unreleased) is touched. The existing note stays accurate for 8.7, 8.8, and 8.9, where the legacy chain is still in place, so no backport is intended.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
