### PR TITLE
docs(helm): document stable pod labels for Web Modeler anti-affinity rules

### DIFF
--- a/docs/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/docs/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -48,14 +48,16 @@ camundaHub:
 
 Apply the same pattern to `camundaHub.websockets`. If you're upgrading from 8.9, [move existing `webModeler.*` overrides to `camundaHub.*`](/self-managed/upgrade/helm/890-to-8100.md#consolidate-console-and-web-modeler-into-camunda-hub).
 
-The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, because their values can change between chart versions.
 
-Keep the following in mind when configuring Pod anti-affinity:
+For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+
+Consider the following when you configure Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
 - Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
 - A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
-- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+- Avoid inter-Pod affinity and anti-affinity for clusters larger than several hundred nodes because they add substantial scheduler processing.
 
 ## Spread Orchestration Cluster pods across availability zones
 

--- a/docs/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/docs/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -48,6 +48,8 @@ camundaHub:
 
 Apply the same pattern to `camundaHub.websockets`. If you're upgrading from 8.9, [move existing `webModeler.*` overrides to `camundaHub.*`](/self-managed/upgrade/helm/890-to-8100.md#consolidate-console-and-web-modeler-into-camunda-hub).
 
+The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+
 Keep the following in mind when configuring Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.

--- a/docs/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/docs/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -15,18 +15,51 @@ Each of the following components supports `nodeSelector`, `tolerations`, and `af
 - `identity`
 - `optimize`
 - `connectors`
-- `webModeler.restapi`
-- `webModeler.websockets`
+- `camundaHub.restapi`
+- `camundaHub.websockets`
 
 `global.nodeSelector` applies a node selector to all components that don't set their own.
 
 By default, the chart configures a hard `podAntiAffinity` rule for the Orchestration Cluster so that no two broker pods are scheduled on the same node.
 
+## Spread Camunda Hub pods across availability zones
+
+Use a stable Pod label you control to spread Camunda Hub replicas without depending on labels managed by the Helm chart.
+
+Set the same label key and value in `podLabels` and `affinity`:
+
+```yaml
+camundaHub:
+  enabled: true
+  restapi:
+    replicas: 2
+    podLabels:
+      scheduling.example.com/affinity-group: camunda-hub-restapi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  scheduling.example.com/affinity-group: camunda-hub-restapi
+              topologyKey: topology.kubernetes.io/zone
+```
+
+Apply the same pattern to `camundaHub.websockets`. If you're upgrading from 8.9, [move existing `webModeler.*` overrides to `camundaHub.*`](/self-managed/upgrade/helm/890-to-8100.md#consolidate-console-and-web-modeler-into-camunda-hub).
+
+Keep the following in mind when configuring Pod anti-affinity:
+
+- Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
+- Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
+- A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
+- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+
 ## Spread Orchestration Cluster pods across availability zones
 
 The default `podAntiAffinity` rule ensures broker pods run on distinct nodes, but does not ensure those nodes are in different zones: if the cluster has more nodes than brokers, all brokers can still be scheduled into a single availability zone. Because broker persistent volumes are bound to a single zone on most cloud providers, a zonal outage can then take down the whole Orchestration Cluster.
 
-With `orchestration.topologySpreadConstraints`, you can spread broker pods across zones. The value is a list of [Kubernetes topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) applied to the Orchestration Cluster StatefulSet pods, and it is empty by default. Those pods run the Zeebe broker and gateway in the same process, so this value covers both. It does not affect separately deployed components such as Identity, Optimize, Connectors, or Web Modeler, which have no equivalent topology spread value in the current chart version — use their `affinity` values instead.
+With `orchestration.topologySpreadConstraints`, you can spread broker pods across zones. The value is a list of [Kubernetes topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) applied to the Orchestration Cluster StatefulSet pods, and it is empty by default. Those pods run the Zeebe broker and gateway in the same process, so this value covers both. It does not affect separately deployed components such as Identity, Optimize, Connectors, or Camunda Hub, which have no equivalent topology spread value in the current chart version — use their `affinity` values instead.
 
 ```yaml
 orchestration:

--- a/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
@@ -441,6 +441,8 @@ webModeler:
 
 Apply the same pattern to `webModeler.webapp` and `webModeler.websockets`.
 
+The same `podLabels` and `affinity` pairing applies to every component that exposes these values, including `zeebe`, `zeebeGateway`, `operate`, `tasklist`, `optimize`, `identity`, `connectors`, and `console`. Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For Zeebe, overriding `zeebe.affinity` replaces the default hard `podAntiAffinity` rule that keeps broker pods on distinct nodes.
+
 Keep the following in mind when configuring Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.

--- a/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
@@ -413,7 +413,7 @@ The following resources and configuration options are important to keep in mind 
           mountPath: /mount
   ```
 
-- It is recommended to set a memory and resource quota for your namespace. Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/) to do so. Namespace-Level Quotas apply limits to all workloads within a namespace. It ensures aggregate resource consumption by all pods in the namespace do not exceed your desired resource limits.
+- Set a memory and resource quota for your namespace. See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/) for configuration details. Namespace-Level Quotas apply limits to all workloads within a namespace. It ensures aggregate resource consumption by all pods in the namespace do not exceed your desired resource limits.
 
 #### Spread Web Modeler pods across availability zones
 
@@ -443,12 +443,12 @@ Apply the same pattern to `webModeler.webapp` and `webModeler.websockets`.
 
 The same `podLabels` and `affinity` pairing applies to every component that exposes these values, including `zeebe`, `zeebeGateway`, `operate`, `tasklist`, `optimize`, `identity`, `connectors`, and `console`. Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For Zeebe, overriding `zeebe.affinity` replaces the default hard `podAntiAffinity` rule that keeps broker pods on distinct nodes.
 
-Keep the following in mind when configuring Pod anti-affinity:
+Consider the following when you configure Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
 - Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
 - A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
-- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+- Avoid inter-Pod affinity and anti-affinity for clusters larger than several hundred nodes because they add substantial scheduler processing.
 
 ### Security
 

--- a/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
+++ b/versioned_docs/version-8.7/self-managed/operational-guides/production-guide/helm-chart-production-guide.md
@@ -415,6 +415,39 @@ The following resources and configuration options are important to keep in mind 
 
 - It is recommended to set a memory and resource quota for your namespace. Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/) to do so. Namespace-Level Quotas apply limits to all workloads within a namespace. It ensures aggregate resource consumption by all pods in the namespace do not exceed your desired resource limits.
 
+#### Spread Web Modeler pods across availability zones
+
+Use a stable Pod label you control to spread Web Modeler replicas without depending on labels managed by the Helm chart.
+
+Set the same label key and value in `podLabels` and `affinity`:
+
+```yaml
+webModeler:
+  enabled: true
+  restapi:
+    replicas: 2
+    podLabels:
+      scheduling.example.com/affinity-group: web-modeler-restapi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  scheduling.example.com/affinity-group: web-modeler-restapi
+              topologyKey: topology.kubernetes.io/zone
+```
+
+Apply the same pattern to `webModeler.webapp` and `webModeler.websockets`.
+
+Keep the following in mind when configuring Pod anti-affinity:
+
+- Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
+- Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
+- A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
+- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+
 ### Security
 
 The following resources and configuration options are important to keep in mind regarding security:

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -24,6 +24,39 @@ Each of the following components supports `nodeSelector`, `tolerations`, and `af
 
 By default, the chart configures a hard `podAntiAffinity` rule for the Orchestration Cluster so that no two broker pods are scheduled on the same node.
 
+## Spread Web Modeler pods across availability zones
+
+Use a stable Pod label you control to spread Web Modeler replicas without depending on labels managed by the Helm chart.
+
+Set the same label key and value in `podLabels` and `affinity`:
+
+```yaml
+webModeler:
+  enabled: true
+  restapi:
+    replicas: 2
+    podLabels:
+      scheduling.example.com/affinity-group: web-modeler-restapi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  scheduling.example.com/affinity-group: web-modeler-restapi
+              topologyKey: topology.kubernetes.io/zone
+```
+
+Apply the same pattern to `webModeler.webapp` and `webModeler.websockets`.
+
+Keep the following in mind when configuring Pod anti-affinity:
+
+- Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
+- Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
+- A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
+- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+
 ## Spread Orchestration Cluster pods across availability zones
 
 The default `podAntiAffinity` rule ensures broker pods run on distinct nodes, but does not ensure those nodes are in different zones: if the cluster has more nodes than brokers, all brokers can still be scheduled into a single availability zone. Because broker persistent volumes are bound to a single zone on most cloud providers, a zonal outage can then take down the whole Orchestration Cluster.

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -50,14 +50,16 @@ webModeler:
 
 Apply the same pattern to `webModeler.webapp` and `webModeler.websockets`.
 
-The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, because their values can change between chart versions.
 
-Keep the following in mind when configuring Pod anti-affinity:
+For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+
+Consider the following when you configure Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
 - Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
 - A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
-- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+- Avoid inter-Pod affinity and anti-affinity for clusters larger than several hundred nodes because they add substantial scheduler processing.
 
 ## Spread Orchestration Cluster pods across availability zones
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -50,6 +50,8 @@ webModeler:
 
 Apply the same pattern to `webModeler.webapp` and `webModeler.websockets`.
 
+The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+
 Keep the following in mind when configuring Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -49,6 +49,8 @@ webModeler:
 
 Apply the same pattern to `webModeler.websockets`.
 
+The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+
 Keep the following in mind when configuring Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -23,6 +23,39 @@ Each of the following components supports `nodeSelector`, `tolerations`, and `af
 
 By default, the chart configures a hard `podAntiAffinity` rule for the Orchestration Cluster so that no two broker pods are scheduled on the same node.
 
+## Spread Web Modeler pods across availability zones
+
+Use a stable Pod label you control to spread Web Modeler replicas without depending on labels managed by the Helm chart.
+
+Set the same label key and value in `podLabels` and `affinity`:
+
+```yaml
+webModeler:
+  enabled: true
+  restapi:
+    replicas: 2
+    podLabels:
+      scheduling.example.com/affinity-group: web-modeler-restapi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  scheduling.example.com/affinity-group: web-modeler-restapi
+              topologyKey: topology.kubernetes.io/zone
+```
+
+Apply the same pattern to `webModeler.websockets`.
+
+Keep the following in mind when configuring Pod anti-affinity:
+
+- Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
+- Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
+- A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
+- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+
 ## Spread Orchestration Cluster pods across availability zones
 
 The default `podAntiAffinity` rule ensures broker pods run on distinct nodes, but does not ensure those nodes are in different zones: if the cluster has more nodes than brokers, all brokers can still be scheduled into a single availability zone. Because broker persistent volumes are bound to a single zone on most cloud providers, a zonal outage can then take down the whole Orchestration Cluster.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/pod-scheduling.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/pod-scheduling.md
@@ -49,14 +49,16 @@ webModeler:
 
 Apply the same pattern to `webModeler.websockets`.
 
-The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, whose values can change between chart versions. For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+The same `podLabels` and `affinity` pairing applies to every component listed in [Configure scheduling values](#configure-scheduling-values). Prefer a label you own over chart-managed labels such as `app.kubernetes.io/component`, because their values can change between chart versions.
 
-Keep the following in mind when configuring Pod anti-affinity:
+For the Orchestration Cluster, overriding `orchestration.affinity` replaces the default hard `podAntiAffinity` rule. To spread broker pods across zones, use [`orchestration.topologySpreadConstraints`](#spread-orchestration-cluster-pods-across-availability-zones) instead.
+
+Consider the following when you configure Pod anti-affinity:
 
 - Use a label key with a DNS prefix you control. If multiple Helm releases share a namespace, choose a label value unique to each component and release because Pod affinity selectors use the current namespace by default.
 - Ensure every eligible node has the label named by `topologyKey`. Managed cloud clusters normally set `topology.kubernetes.io/zone`.
 - A preferred rule is best effort and can colocate Pods when no better placement is available. A required rule can leave Pods `Pending` or stall rolling updates when the cluster lacks capacity in enough topology domains.
-- Inter-Pod affinity and anti-affinity add substantial scheduler processing and are not recommended for clusters larger than several hundred nodes.
+- Avoid inter-Pod affinity and anti-affinity for clusters larger than several hundred nodes because they add substantial scheduler processing.
 
 ## Spread Orchestration Cluster pods across availability zones
 


### PR DESCRIPTION
## Description

Document the existing pattern for upgrade-stable Web Modeler and Camunda Hub pod anti-affinity selectors across the Next, 8.9, 8.8, and 8.7 documentation.

The examples pair a user-owned Pod label with the same affinity selector, avoiding dependencies on Helm chart-managed labels. The guidance also covers namespace scope, topology labels, preferred versus required rules, and scheduler cost. The Next page now uses the current `camundaHub.*` values and links to the existing 8.9-to-8.10 migration guidance.

The guidance additionally states that the same `podLabels` and `affinity` pairing applies to every affinity-capable component, warns against selecting on chart-managed labels such as `app.kubernetes.io/component`, and notes that overriding the Orchestration Cluster (8.7: Zeebe) affinity replaces the default hard `podAntiAffinity` rule.

Related feature request: camunda/camunda-platform-helm#5876  
Closes camunda/camunda-platform-helm#6932  
Companion chart PR: https://github.com/camunda/camunda-platform-helm/pull/6931

Local build and validation commands were not run; CI is the validation authority for this PR.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->

