### PR TITLE
docs(optimize): document the 8.10 Optimize authentication model change

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -580,11 +580,9 @@ Web Modeler change 1 description.
 
 #### Optimize authentication moves to the Camunda Security Library
 
-Starting with Camunda 8.10, Optimize authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack: a standard session cookie replaces the self-signed JWT cookie, session state moves server-side into a new Optimize index, and the login `id_token`'s issuer and audience are now validated (Camunda 8.9 did not validate these).
+Starting with Camunda 8.10, Optimize authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack: a standard session cookie replaces the self-signed JWT cookie, session state moves server-side into a new Optimize index, and the login `id_token`'s issuer and audience are validated against your configuration.
 
-A deployment with a mismatched issuer or audience that happened to work on 8.9 fails to log in on 8.10. This is the most likely upgrade breakage for OIDC deployments.
-
-**Action:** Before upgrading, confirm `camunda.security.authentication.oidc.issuer-uri` and `camunda.security.authentication.oidc.audiences` match what your IdP puts in the `id_token`. See [Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md) for the full authentication model change and API-consumer behavior changes (CSRF, bearer tokens on the internal API).
+**Action:** Confirm `camunda.security.authentication.oidc.issuer-uri` and `camunda.security.authentication.oidc.audiences` match what your IdP puts in the `id_token`. See [Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md) for the full authentication model change and API-consumer behavior changes (CSRF, bearer tokens on the internal API).
 
 <p className="link-arrow">[Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md)</p>
 

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -569,3 +569,56 @@ Web Modeler change 1 description.
 
 </div>
 </div> -->
+
+## Optimize
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
+#### Optimize authentication moves to the Camunda Security Library
+
+Starting with Camunda 8.10, Optimize authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack: a standard session cookie replaces the self-signed JWT cookie, session state moves server-side into a new Optimize index, and the login `id_token`'s issuer and audience are now validated (Camunda 8.9 did not validate these).
+
+A deployment with a mismatched issuer or audience that happened to work on 8.9 fails to log in on 8.10. This is the most likely upgrade breakage for OIDC deployments.
+
+**Action:** Before upgrading, confirm `camunda.security.authentication.oidc.issuer-uri` and `camunda.security.authentication.oidc.audiences` match what your IdP puts in the `id_token`. See [Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md) for the full authentication model change and API-consumer behavior changes (CSRF, bearer tokens on the internal API).
+
+<p className="link-arrow">[Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--deprecated">Deprecated</span>
+</div>
+<div className="release-announcement-content">
+
+#### Legacy Optimize security configuration keys deprecated
+
+With the move to CSL, the Optimize security configuration keys used through 8.9 (`CAMUNDA_OPTIMIZE_IDENTITY_*`, `CAMUNDA_OPTIMIZE_AUTH0_*`, and related keys) are deprecated in favor of `camunda.security.*`. A compatibility bridge maps recognized legacy keys automatically and logs a deprecation warning naming the replacement. The legacy keys are removed in Camunda 8.11.
+
+**Action:** Migrate to the `camunda.security.*` keys before upgrading to 8.11. See [legacy configuration keys](/self-managed/upgrade/components/890-to-8100.md#legacy-security-configuration-keys-are-deprecated) for the full mapping and the precedence rules the bridge applies.
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--deprecated">Deprecated</span>
+</div>
+<div className="release-announcement-content">
+
+#### `optimize.security.csl.enabled=false` fallback is temporary
+
+If CSL causes a regression in your 8.10 deployment, `optimize.security.csl.enabled=false` temporarily restores the 8.9 security stack. This fallback, the legacy security stack it restores, and the legacy configuration keys are all removed in Camunda 8.11.
+
+**Action:** Treat this as a temporary escape hatch, not a supported long-term mode. If you rely on it in 8.10, migrate to CSL before upgrading to 8.11.
+
+<p className="link-arrow">[Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md#fall-back-to-the-89-security-stack)</p>
+
+</div>
+</div>

--- a/docs/reference/announcements-release-notes/8100/8100-release-notes.md
+++ b/docs/reference/announcements-release-notes/8100/8100-release-notes.md
@@ -128,6 +128,20 @@ In Self-Managed, you can now hide the **Add user** button on the Web Modeler **C
 
 <p class="link-arrow">[Feature flag reference](/self-managed/components/hub/configuration/properties.md#hide-invite-member-button)</p>
 
+### Optimize
+
+#### Optimize authentication moves to the Camunda Security Library
+
+<!-- https://github.com/camunda/camunda/issues/58600 -->
+
+<div class="release"><span class="badge badge--long" title="This feature affects Self-Managed">Self-Managed</span><span class="badge badge--medium" title="This feature affects Optimize">Optimize</span></div>
+
+Optimize now authenticates through the Camunda Security Library (CSL), the same session-based OIDC login the Orchestration Cluster uses, replacing its own stateless JWT-cookie stack. A standard session cookie replaces the self-signed JWT cookie, and the login `id_token`'s issuer and audience are now validated.
+
+See the [release announcement](/reference/announcements-release-notes/8100/8100-announcements.md#optimize-authentication-moves-to-the-camunda-security-library) for the upgrade action required, and [Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md) for the full authentication model change.
+
+<p class="link-arrow">[Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md)</p>
+
 ### Orchestration Cluster
 
 #### Elasticsearch 9.x and OpenSearch 3.x support

--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -40,13 +40,27 @@ Changes for 8.10 will be added here as the 8.10 documentation is updated.
 
 :::
 
-## Optimize data filters in Console
+## Optimize
+
+### Data filters in Console
 
 On SaaS, you can now configure Optimize export filters directly in Console cluster settings. No Helm values or configuration files required. Use the **Data filters** section in cluster settings to control which process definitions (by `bpmnProcessId`) and variable names reach Optimize.
 
 New SaaS clusters include a default `business_` variable include filter, which limits Optimize to variables whose names start with `business_`. This reduces Elasticsearch storage and shard usage significantly. Existing clusters are unaffected and can opt in with one click.
 
 <p class="link-arrow">[Configure Optimize data filters](/components/hub/organization/manage-clusters/settings.md#data-filters)</p>
+
+### Authentication moves to the Camunda Security Library
+
+Optimize now authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack. A standard session cookie replaces the self-signed JWT cookie, session state moves server-side into a new Optimize index, and Optimize now validates the login `id_token`'s issuer and audience, which it did not in 8.9.
+
+:::warning Check your OIDC configuration before upgrading
+A mismatched issuer or audience that happened to work on 8.9 fails to log in on 8.10. This is the most likely upgrade breakage for OIDC deployments running Optimize.
+:::
+
+The legacy `CAMUNDA_OPTIMIZE_IDENTITY_*` and `CAMUNDA_OPTIMIZE_AUTH0_*` configuration keys are deprecated in favor of `camunda.security.*` and removed in 8.11, along with the legacy security stack and its `optimize.security.csl.enabled=false` fallback.
+
+<p class="link-arrow">[Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md)</p>
 
 ## Web Modeler data
 

--- a/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
+++ b/docs/reference/announcements-release-notes/8100/whats-new-in-810.md
@@ -52,11 +52,7 @@ New SaaS clusters include a default `business_` variable include filter, which l
 
 ### Authentication moves to the Camunda Security Library
 
-Optimize now authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack. A standard session cookie replaces the self-signed JWT cookie, session state moves server-side into a new Optimize index, and Optimize now validates the login `id_token`'s issuer and audience, which it did not in 8.9.
-
-:::warning Check your OIDC configuration before upgrading
-A mismatched issuer or audience that happened to work on 8.9 fails to log in on 8.10. This is the most likely upgrade breakage for OIDC deployments running Optimize.
-:::
+Optimize now authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack. A standard session cookie replaces the self-signed JWT cookie, session state moves server-side into a new Optimize index, and Optimize validates the login `id_token`'s issuer and audience against your configuration.
 
 The legacy `CAMUNDA_OPTIMIZE_IDENTITY_*` and `CAMUNDA_OPTIMIZE_AUTH0_*` configuration keys are deprecated in favor of `camunda.security.*` and removed in 8.11, along with the legacy security stack and its `optimize.security.csl.enabled=false` fallback.
 

--- a/docs/self-managed/components/optimize/configuration/security-instructions.md
+++ b/docs/self-managed/components/optimize/configuration/security-instructions.md
@@ -11,6 +11,8 @@ This page provides an overview of how to secure a Camunda Optimize installation.
 
 This guide also identifies areas where we consider security issues to be relevant for the Camunda Optimize product and list those in the subsequent sections. Compliance for those areas is ensured based on common industry best practices and influenced by security requirements of standards like OWASP Top 10 and others.
 
+For how Optimize authenticates users and API requests, see [Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md).
+
 <Tabs groupId="security" queryString values={
 [
 {label: 'Optimize', value: 'optimize' },

--- a/docs/self-managed/components/optimize/configuration/system-configuration.md
+++ b/docs/self-managed/components/optimize/configuration/system-configuration.md
@@ -83,6 +83,10 @@ security:
 
 These values control mechanisms of Optimize related security, e.g. security headers and authentication.
 
+:::note
+`security.auth.token.secret` and `security.responseHeaders.X-XSS-Protection` apply to Optimize's legacy security stack. In Camunda 8.10, that stack is only active if you set `optimize.security.csl.enabled=false`. With the default (CSL enabled), both have no effect, and `security.responseHeaders.HSTS.max-age` is replaced by `camunda.security.http-headers.hsts.max-age-in-seconds`. See [legacy configuration keys](/self-managed/upgrade/components/890-to-8100.md#legacy-security-configuration-keys-are-deprecated) for the full mapping.
+:::
+
 | YAML path                                        | Environment variable                                    | Default value   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | ------------------------------------------------ | ------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 |                                                  |
@@ -112,6 +116,10 @@ This section focuses on common properties related to the External REST API of Op
 mandatory to configure one of the values below if the External REST API is to be used. If neither is
 configured an error will be thrown and all requests to the External API will get rejected. If both are configured then
 the `jwtSetUri` will take precedence and the `accessToken` will be ignored.
+
+:::note
+These properties apply to Optimize's legacy security stack. In Camunda 8.10, that stack is only active if you set `optimize.security.csl.enabled=false`. With the default (CSL enabled), `api.jwtSetUri` and `api.audience` are replaced by `camunda.security.authentication.oidc.jwk-set-uri` and `camunda.security.authentication.oidc.audiences`, and `api.accessToken` has no effect. See [legacy configuration keys](/self-managed/upgrade/components/890-to-8100.md#legacy-security-configuration-keys-are-deprecated) for the full mapping.
+:::
 
 | YAML path       | Environment variable                                  | Default value | Description                                                                                                                                    |
 | --------------- | ----------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/self-managed/concepts/authentication/authentication-to-management-components.md
+++ b/docs/self-managed/concepts/authentication/authentication-to-management-components.md
@@ -8,7 +8,11 @@ description: "Learn about authentication methods for management and modeling com
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Authentication to the Camunda 8 management and modeling components and their resources is managed by [Management Identity](/self-managed/components/management-identity/overview.md). This includes components such as Web Modeler, Console, and [Optimize](/self-managed/components/optimize/overview.md).
+Authentication to the Camunda 8 management and modeling components and their resources is managed by [Management Identity](/self-managed/components/management-identity/overview.md). This includes components such as Web Modeler and Console.
+
+:::note
+Through Camunda 8.9, [Optimize](/self-managed/components/optimize/overview.md) also authenticated through Management Identity. Starting with Camunda 8.10, Optimize authenticates directly against your OIDC provider through the Camunda Security Library. See [Optimize authentication in Self-Managed](authentication-to-optimize.md).
+:::
 
 ## About Management Identity authentication
 

--- a/docs/self-managed/concepts/authentication/authentication-to-optimize.md
+++ b/docs/self-managed/concepts/authentication/authentication-to-optimize.md
@@ -1,0 +1,97 @@
+---
+id: authentication-to-optimize
+title: Optimize authentication in Self-Managed
+sidebar_label: "Optimize authentication"
+description: "Learn how Optimize authenticates users and API requests in Self-Managed, and what changes when upgrading from Camunda 8.9 to 8.10."
+---
+
+## About Optimize authentication
+
+[Optimize](/self-managed/components/optimize/overview.md) authenticates against an external OIDC identity provider (IdP). Optimize doesn't offer Basic authentication as a login method.
+
+Starting with Camunda 8.10, Optimize authenticates through the Camunda Security Library (CSL): the same session-based OIDC login the [Orchestration Cluster](authentication-to-orchestration-cluster.md) uses. Through 8.9, Optimize used its own stateless, self-signed JWT cookie instead. See [ADR-0038](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md) for the design decision behind this change.
+
+:::tip Recommendation
+If you've already configured [OIDC for the Orchestration Cluster](authentication-to-orchestration-cluster.md#oidc), use the same identity provider for Optimize. This gives your users a single login experience across both components.
+:::
+
+## Configure OIDC for Optimize
+
+Set the following properties, shared with the rest of the Camunda Security Library:
+
+- `camunda.security.authentication.oidc.issuer-uri`
+- `camunda.security.authentication.oidc.client-id`
+- `camunda.security.authentication.oidc.client-secret`
+- `camunda.security.authentication.oidc.audiences`
+
+See the [OIDC configuration properties reference](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camundasecurityauthenticationoidc) for the full list and defaults.
+
+:::note
+If you deploy with the Camunda Helm chart, you don't need to set these directly. The chart continues to read the same `global.identity.auth.optimize.*` values you already use, and renders them into the properties above for you.
+:::
+
+## Session cookie replaces the legacy JWT cookie
+
+In 8.10, a standard session cookie replaces Optimize's self-signed JWT cookie, and session state moves from the cookie itself into a session store on the same Elasticsearch or OpenSearch cluster Optimize already uses.
+
+|                 | Optimize 8.9                                                                   | Optimize 8.10                                                                                           |
+| --------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Session carrier | Self-signed JWT split across `X-Optimize-Authorization[_n]` cookies when large | Standard session cookie; no cookie splitting                                                            |
+| Session state   | Stateless; revocation checked against a terminated-session list                | Session document stored server-side, in a new Optimize index (Elasticsearch and OpenSearch)             |
+| Login           | Identity SDK / Auth0 login code inside Optimize                                | Spring `oauth2Login` against your configured OIDC provider                                              |
+| Logout          | Cookie cleared; session ID added to the terminated-session list                | `POST /logout` clears the server-side session and calls your IdP's end-session endpoint                 |
+| Load balancing  | Affinity-free                                                                  | Affinity-free; sessions live in the shared Elasticsearch or OpenSearch store, not in application memory |
+
+The new session index is created automatically by the same schema manager that creates Optimize's other indices, using the same Elasticsearch or OpenSearch credentials. You don't need to provision it manually, run a migration, or grant additional privileges.
+
+Because the session cookie format changes, an active 8.9 session isn't valid after the upgrade. Your users log in again the first time they open Optimize on 8.10.
+
+## API-consumer behavior changes
+
+### CSRF protection on cookie-authenticated requests
+
+Optimize uses the same CSRF mechanism as the Orchestration Cluster: after login, Optimize sets a `X-CSRF-TOKEN` cookie, and state-changing requests (POST, PUT, PATCH, DELETE) that authenticate with the session cookie must echo that value in an `X-CSRF-TOKEN` request header. See [CSRF protection](/self-managed/components/orchestration-cluster/core-settings/configuration/csrf-protection.md) for the full mechanism.
+
+Requests that authenticate with a bearer token only, without a session cookie, are exempt from this check, so scripted API clients that don't use the session cookie are unaffected.
+
+### Bearer tokens now work against the internal API
+
+Optimize's internal API is the set of endpoints its own UI calls, such as `/api/dashboard/**`, `/api/report/**`, and `/api/collection/**`. Through 8.9, only the public API (`/api/public/**`) and ingestion endpoints accepted bearer tokens; the internal API required the session cookie. In 8.10, Optimize also accepts bearer tokens on the internal API.
+
+The token's `aud` claim must be listed in `camunda.security.authentication.oidc.audiences`.
+
+:::note
+The internal API is not a supported public contract. Its shape can change between Camunda releases, even patch releases.
+:::
+
+`/api/authentication/**` is unchanged and still serves the login callback.
+
+### Stricter OIDC id_token validation
+
+Camunda 8.10 validates the login `id_token`'s issuer and audience, which Camunda 8.9 did not. This is the most likely source of upgrade breakage for OIDC deployments: a deployment with a mismatched issuer or audience that happened to work on 8.9 fails to log in on 8.10.
+
+Before upgrading, confirm that:
+
+- `camunda.security.authentication.oidc.issuer-uri` matches the issuer your IdP puts in the `id_token`.
+- `camunda.security.authentication.oidc.audiences` contains every value your IdP puts in the audience claim for the Optimize application, including whatever the legacy `CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE` and `CAMUNDA_OPTIMIZE_API_AUDIENCE` variables previously covered. The same list validates both the login `id_token` and any bearer token sent to Optimize, so it must also include the audience of any other application that calls Optimize on a user's behalf. For example, if Camunda Hub is enabled, its client API audience must be included, or the requests it forwards to Optimize on the signed-in user's behalf are rejected. See [legacy configuration keys](/self-managed/upgrade/components/890-to-8100.md#legacy-security-configuration-keys-are-deprecated) for the full mapping.
+
+## Legacy configuration keys are deprecated
+
+The Optimize security configuration keys used through 8.9 (`CAMUNDA_OPTIMIZE_IDENTITY_*`, `CAMUNDA_OPTIMIZE_AUTH0_*`, and related keys) are deprecated in favor of `camunda.security.*`. A compatibility bridge maps recognized legacy keys automatically and logs a deprecation warning naming the replacement.
+
+If you're deploying Camunda 8.10 for the first time, none of this applies to you: configure the `camunda.security.*` properties above and skip this section and the next one.
+
+See [Upgrade Camunda components from 8.9 to 8.10](/self-managed/upgrade/components/890-to-8100.md#legacy-security-configuration-keys-are-deprecated) for the full key mapping, precedence rules, and the keys that no longer have any effect.
+
+## Fall back to the 8.9 security stack
+
+If CSL causes a regression in your deployment, you can temporarily revert Optimize to the 8.9 security stack:
+
+```yaml
+optimize:
+  security:
+    csl:
+      enabled: false
+```
+
+Treat this as a temporary escape hatch, not a supported long-term mode. `optimize.security.csl.enabled=false`, the legacy security stack it restores, and the legacy configuration keys are all removed in Camunda 8.11. If you rely on this fallback in 8.10, migrate to CSL before upgrading to 8.11.

--- a/docs/self-managed/concepts/authentication/authentication-to-optimize.md
+++ b/docs/self-managed/concepts/authentication/authentication-to-optimize.md
@@ -66,11 +66,9 @@ The internal API is not a supported public contract. Its shape can change betwee
 
 `/api/authentication/**` is unchanged and still serves the login callback.
 
-### Stricter OIDC id_token validation
+### OIDC id_token validation
 
-Camunda 8.10 validates the login `id_token`'s issuer and audience, which Camunda 8.9 did not. This is the most likely source of upgrade breakage for OIDC deployments: a deployment with a mismatched issuer or audience that happened to work on 8.9 fails to log in on 8.10.
-
-Before upgrading, confirm that:
+Optimize validates the login `id_token`'s issuer and audience against your configuration. Confirm that:
 
 - `camunda.security.authentication.oidc.issuer-uri` matches the issuer your IdP puts in the `id_token`.
 - `camunda.security.authentication.oidc.audiences` contains every value your IdP puts in the audience claim for the Optimize application, including whatever the legacy `CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE` and `CAMUNDA_OPTIMIZE_API_AUDIENCE` variables previously covered. The same list validates both the login `id_token` and any bearer token sent to Optimize, so it must also include the audience of any other application that calls Optimize on a user's behalf. For example, if Camunda Hub is enabled, its client API audience must be included, or the requests it forwards to Optimize on the signed-in user's behalf are rejected. See [legacy configuration keys](/self-managed/upgrade/components/890-to-8100.md#legacy-security-configuration-keys-are-deprecated) for the full mapping.

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -302,3 +302,47 @@ zeebe:
 Optimize logs a `WARN` on startup whenever object variable values are not being imported. The message includes the opt-in setting.
 
 <p className="link-arrow">[Object variables configuration](/self-managed/components/optimize/configuration/object-variables.md)</p>
+
+In 8.10, Optimize authenticates through the Camunda Security Library (CSL) instead of its own stateless JWT-cookie stack. For the full picture of what changes, including the new session model and API-consumer behavior changes, see [Optimize authentication in Self-Managed](/self-managed/concepts/authentication/authentication-to-optimize.md). The following two sections cover the configuration key changes only.
+
+### Legacy security configuration keys are deprecated
+
+The following legacy keys are deprecated in favor of `camunda.security.*`. They remain supported through 8.10 and are removed in 8.11, along with the legacy security stack.
+
+A compatibility bridge maps each recognized legacy key to its replacement automatically and logs a deprecation warning naming the replacement, so existing deployments keep working unchanged through 8.10.
+
+| Legacy key                                                | Replacement                                                                                    |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL`                    | `camunda.security.authentication.oidc.issuer-uri`                                              |
+| `CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID`                      | `camunda.security.authentication.oidc.client-id`                                               |
+| `CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET`                  | `camunda.security.authentication.oidc.client-secret`                                           |
+| `CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE`                      | `camunda.security.authentication.oidc.audiences`                                               |
+| `CAMUNDA_OPTIMIZE_AUTH0_CLIENTID`                         | `camunda.security.authentication.oidc.client-id`                                               |
+| `CAMUNDA_OPTIMIZE_AUTH0_CLIENTSECRET`                     | `camunda.security.authentication.oidc.client-secret`                                           |
+| `CAMUNDA_OPTIMIZE_AUTH0_DOMAIN`                           | `camunda.security.authentication.oidc.issuer-uri` (issuer is derived from the Auth0 domain)    |
+| `CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION`                     | `camunda.security.saas.*`                                                                      |
+| `CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE`                        | `camunda.security.authentication.oidc.audiences`                                               |
+| `CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID`                       | `camunda.security.saas.*` (also derives the redirect URI `?uuid` and the servlet context path) |
+| `CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_AUTH0_AUDIENCE`            | `camunda.security.authentication.oidc.audiences`                                               |
+| `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`   | `camunda.security.authentication.oidc.jwk-set-uri`                                             |
+| `CAMUNDA_OPTIMIZE_API_AUDIENCE`                           | `camunda.security.authentication.oidc.audiences`                                               |
+| `CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE` | `camunda.security.http-headers.hsts.max-age-in-seconds` (a negative value disables the header) |
+
+Two behaviors of the bridge are easy to get wrong:
+
+- **Precedence:** The bridge registers values it derives from legacy keys at the lowest precedence. If you also set the `camunda.security.*` property explicitly, your explicit value always wins over the value the bridge would have derived from the legacy key.
+- **`audiences` replaces, not merges:** If you set `camunda.security.authentication.oidc.audiences` yourself, that list replaces everything the bridge would have derived from `CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE` and `CAMUNDA_OPTIMIZE_API_AUDIENCE`. Include every audience you still need in your explicit list; the bridge does not add its derived values on top.
+
+**Action:** Migrate to the `camunda.security.*` keys before upgrading to 8.11, when the legacy keys and the legacy security stack are both removed.
+
+### Obsolete keys have no effect under CSL
+
+The following keys no longer have any effect under CSL. Optimize still accepts them without failing startup, logs why each no longer applies, and ignores them:
+
+| Key                                                       | Why it no longer applies                                                |
+| --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `CAMUNDA_OPTIMIZE_SECURITY_AUTH_TOKEN_SECRET`             | Optimize no longer issues self-signed tokens.                           |
+| `CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_MAX_SIZE`          | The session cookie is no longer split across multiple cookies.          |
+| `CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED` | `SameSite` is now set automatically on the session cookie.              |
+| `OPTIMIZE_API_ACCESS_TOKEN`                               | The static shared API token is removed; use OIDC bearer tokens instead. |
+| `security.responseHeaders.X-XSS-Protection`               | The deprecated `X-XSS-Protection` header is no longer emitted.          |

--- a/sidebars.js
+++ b/sidebars.js
@@ -2125,6 +2125,7 @@ module.exports = {
           Authentication: [
             "self-managed/concepts/authentication/authentication-to-orchestration-cluster",
             "self-managed/concepts/authentication/authentication-to-management-components",
+            "self-managed/concepts/authentication/authentication-to-optimize",
           ],
         },
         {


### PR DESCRIPTION
## Description

Documents the Camunda 8.10 change where Optimize moves from its own stateless JWT-cookie security stack to the Camunda Security Library (CSL) — the same session-based OIDC chain the Orchestration Cluster runs. Closes camunda/camunda#58600.

Adds:

- A new concept page, [Optimize authentication in Self-Managed](self-managed/concepts/authentication/authentication-to-optimize.md), covering the session-cookie model, CSRF, bearer tokens on the internal API, stricter OIDC `id_token` validation (the most likely upgrade breakage), and the temporary `optimize.security.csl.enabled=false` fallback with its 8.11 removal timeline.
- The legacy-to-`camunda.security.*` config key mapping, precedence rules, and obsolete-key list in the 8.9→8.10 component upgrade guide.
- 8.10 release notes, release announcements, and what's-new entries for the change, all cross-linked.
- A fix to `system-configuration.md`, which still documented `api.accessToken` and related legacy keys as fully live with no mention that they're obsolete under CSL — a real contradiction this PR surfaces and resolves.
- A correction to the Management Identity authentication page, which listed Optimize as one of its components; that's no longer accurate in 8.10.

This was reviewed locally by two persona-based passes (an 8.9→8.10 upgrader and a first-time 8.10 deployer) before opening, which is where the config-reference contradiction and several structural/discoverability issues were caught and fixed.

**Known open item:** the Helm chart side of this (`camunda-platform-helm#6883`) is still an open draft PR. The new concept page notes that Helm users keep using their existing `global.identity.auth.optimize.*` values unchanged, worded as current design intent rather than a merged guarantee — worth a follow-up check once that PR lands.

## When should this change go live?

- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.

- [x] I included my new page in the sidebar file(s).

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
