### PR TITLE
fix(spring-boot-starter): sync properties reference from upstream config metadata

### DIFF
--- a/config-reference/camunda-spring-boot-starter/8.9/spring-configuration-metadata.json
+++ b/config-reference/camunda-spring-boot-starter/8.9/spring-configuration-metadata.json
@@ -238,7 +238,8 @@
       "name": "camunda.client.auth.proactive-token-refresh-threshold",
       "type": "java.time.Duration",
       "description": "The lead time before actual token expiry at which a background refresh is triggered. The token is still considered valid inside this window; this is a policy knob for how early refresh kicks in so callers don't have to block on a synchronous refresh at the cliff edge. Must be strictly larger than the internal expiry grace period.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties",
+      "defaultValue": "PT30S"
     },
     {
       "name": "camunda.client.auth.read-timeout",
@@ -263,31 +264,36 @@
       "name": "camunda.client.auth.token-fetch-backoff-multiplier",
       "type": "java.lang.Double",
       "description": "The multiplier applied to the backoff duration between successive token fetch retry attempts. Must be greater than or equal to 1.0.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties",
+      "defaultValue": 2
     },
     {
       "name": "camunda.client.auth.token-fetch-initial-backoff",
       "type": "java.time.Duration",
       "description": "The initial backoff duration applied between token fetch retry attempts. Subsequent delays grow geometrically by {@link #tokenFetchBackoffMultiplier}.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties",
+      "defaultValue": "PT1S"
     },
     {
       "name": "camunda.client.auth.token-fetch-max-retries",
       "type": "java.lang.Integer",
       "description": "The maximum number of attempts (including the initial one) when fetching a token from the OAuth authorization server. Retries are only attempted on IOException or HTTP status codes configured via {@code tokenFetchRetryableStatusCodes}.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties",
+      "defaultValue": 5
     },
     {
       "name": "camunda.client.auth.token-fetch-non-retryable-cooldown",
       "type": "java.time.Duration",
       "description": "Duration for which token fetches fail fast after the token endpoint returns a non-retryable response. After the cooldown elapses, the next call retries; if it fails again non-retryably, the latch re-arms with a new cooldown. Set to Duration.ZERO to disable the cooldown entirely.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties",
+      "defaultValue": "PT5M"
     },
     {
       "name": "camunda.client.auth.token-fetch-retryable-status-codes",
       "type": "java.util.Set<java.lang.Integer>",
       "description": "The set of HTTP status codes from the token endpoint that should be retried with backoff. Any non-200 status code outside this set trips a non-retryable failure latch that fails fast for the duration of tokenFetchNonRetryableCooldown.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientAuthProperties",
+      "defaultValue": [404, 429, 500, 502, 503, 504]
     },
     {
       "name": "camunda.client.auth.token-url",
@@ -407,7 +413,8 @@
       "name": "camunda.client.keep-alive",
       "type": "java.time.Duration",
       "description": "The time interval between keep-alive messages sent to the gateway.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientProperties",
+      "defaultValue": "PT45S"
     },
     {
       "name": "camunda.client.max-http-connections",
@@ -598,7 +605,8 @@
       "name": "camunda.client.worker.override",
       "type": "java.util.Map<java.lang.String,io.camunda.client.spring.properties.CamundaClientJobWorkerProperties>",
       "description": "Properties for overriding settings of individual job workers registered to the Camunda client. The key of the override is the job type or worker name.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientWorkerProperties"
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientWorkerProperties",
+      "defaultValue": {}
     },
     {
       "name": "management.endpoint.jobworkers.access",

--- a/config-reference/camunda-spring-boot-starter/additional-properties.json
+++ b/config-reference/camunda-spring-boot-starter/additional-properties.json
@@ -1,3 +1,41 @@
 {
-  "properties": []
+  "properties": [
+    {
+      "name": "camunda.client.cluster-variables.variables",
+      "sourceType": "io.camunda.client.spring.properties.ClusterVariableEntry",
+      "placeholderName": "[*]",
+      "properties": [
+        {
+          "name": "camunda.client.cluster-variables.variables[*].name",
+          "type": "java.lang.String",
+          "description": "The name of the cluster variable.",
+          "sourceType": "io.camunda.client.spring.properties.ClusterVariableEntry"
+        },
+        {
+          "name": "camunda.client.cluster-variables.variables[*].value",
+          "type": "java.lang.Object",
+          "description": "The value of the cluster variable.",
+          "sourceType": "io.camunda.client.spring.properties.ClusterVariableEntry"
+        },
+        {
+          "name": "camunda.client.cluster-variables.variables[*].metadata",
+          "type": "java.util.Map<java.lang.String,java.lang.Object>",
+          "description": "The metadata of the cluster variable.",
+          "sourceType": "io.camunda.client.spring.properties.ClusterVariableEntry"
+        },
+        {
+          "name": "camunda.client.cluster-variables.variables[*].kind",
+          "type": "io.camunda.client.api.search.enums.ClusterVariableKind",
+          "description": "The kind of the cluster variable.",
+          "sourceType": "io.camunda.client.spring.properties.ClusterVariableEntry"
+        },
+        {
+          "name": "camunda.client.cluster-variables.variables[*].tenant-id",
+          "type": "java.lang.String",
+          "description": "The tenant ID of the cluster variable.",
+          "sourceType": "io.camunda.client.spring.properties.ClusterVariableEntry"
+        }
+      ]
+    }
+  ]
 }

--- a/config-reference/camunda-spring-boot-starter/spring-configuration-metadata.json
+++ b/config-reference/camunda-spring-boot-starter/spring-configuration-metadata.json
@@ -357,20 +357,14 @@
     {
       "name": "camunda.client.cluster-variables.enabled",
       "type": "java.lang.Boolean",
-      "description": "Indicates if cluster variable processing is enabled. When {@code true}, variables configured via <code>@ClusterVariables<\/code> annotations and via the {@code global}\/{@code tenant} properties are applied at startup. When {@code false}, all cluster variable processing is skipped.",
+      "description": "Indicates if cluster variable processing is enabled. When {@code true}, variables configured via <code>@ClusterVariables<\/code> annotations and via the {@code variables} property are applied at startup. When {@code false}, all cluster variable processing is skipped.",
       "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
       "defaultValue": true
     },
     {
-      "name": "camunda.client.cluster-variables.global",
-      "type": "java.util.Map<java.lang.String,java.lang.Object>",
-      "description": "Globally-scoped cluster variables to set at startup as key-value pairs.",
-      "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties"
-    },
-    {
-      "name": "camunda.client.cluster-variables.tenant",
-      "type": "java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Object>>",
-      "description": "Tenant-scoped cluster variables to set at startup, keyed by tenant ID.",
+      "name": "camunda.client.cluster-variables.variables",
+      "type": "java.util.List<io.camunda.client.spring.properties.ClusterVariableEntry>",
+      "description": "Cluster variables to set at startup. Each entry carries a name, a value and optionally metadata, a kind and a tenant ID. Entries without a tenant ID are globally scoped.",
       "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties"
     },
     {
@@ -628,6 +622,12 @@
       "sourceType": "io.camunda.client.spring.properties.CamundaClientJobWorkerProperties"
     },
     {
+      "name": "camunda.client.worker.defaults.with-lease",
+      "type": "java.lang.Boolean",
+      "description": "Activate the jobs polled by this worker with a lease. When enabled, each activated job is assigned a distinct lease token, fencing the complete, fail, and throw-error commands against a superseded activation of the same job. <p>Only applies to the polling path. If not set, jobs are activated without a lease.",
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientJobWorkerProperties"
+    },
+    {
       "name": "camunda.client.worker.override",
       "type": "java.util.Map<java.lang.String,io.camunda.client.spring.properties.CamundaClientJobWorkerProperties>",
       "description": "Properties for overriding settings of individual job workers registered to the Camunda client. The key of the override is the job type or worker name.",
@@ -673,6 +673,26 @@
       "deprecated": true,
       "deprecation": {
         "replacement": "camunda.client.cloud.cluster-id"
+      }
+    },
+    {
+      "name": "camunda.client.cluster-variables.global",
+      "type": "java.util.Map<java.lang.String,java.lang.Object>",
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
+      "description": "Deprecated globally-scoped cluster variables to set at startup as key-value pairs.",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "camunda.client.cluster-variables.variables"
+      }
+    },
+    {
+      "name": "camunda.client.cluster-variables.tenant",
+      "type": "java.util.Map<java.lang.String,java.lang.Object>",
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
+      "description": "Deprecated tenant-scoped cluster variables to set at startup, keyed by tenant ID.",
+      "deprecated": true,
+      "deprecation": {
+        "replacement": "camunda.client.cluster-variables.variables"
       }
     },
     {

--- a/config-reference/generate-config-reference.js
+++ b/config-reference/generate-config-reference.js
@@ -31,6 +31,10 @@ const typeReplacements = {
   "java.util.Map<java.lang.String,java.lang.Object>": "map[string,object]",
   "java.util.Map<java.lang.String,java.util.Map<java.lang.String,java.lang.Object>>":
     "map[string,map[string,object]]",
+  "java.util.Map": "map[string,object]",
+  "java.lang.Object": "object",
+  "io.camunda.client.api.search.enums.ClusterVariableKind":
+    "enum[json, secretReference]",
 };
 
 const preserveGroups = [];

--- a/docs/apis-tools/camunda-spring-boot-starter/properties-reference.md
+++ b/docs/apis-tools/camunda-spring-boot-starter/properties-reference.md
@@ -215,7 +215,7 @@ Type: <code>string</code>
 
 <td>
 
-The physical tenant ID applied to every outgoing call: sent as the `camunda-physical-tenant` gRPC header, and used to prefix the REST base path for the per-tenant API (see `camunda.client.prefix-physical-tenant-path`) unless disabled — the cluster-scoped REST API (`/cluster/v2/...`) is never prefixed. Leave this unset (`null`) rather than an empty string to target the default physical tenant; the header is then omitted and REST calls target the default physical tenant.
+The physical tenant ID sent as the `camunda-physical-tenant` gRPC header on every outgoing call. When `null` the header is omitted.
 
 Type: <code>string</code>
 
@@ -935,45 +935,13 @@ Properties for setting cluster variables at startup.
 
 <td>
 
-Indicates if cluster variable processing is enabled. When `true`, variables configured via `@ClusterVariables` annotations and via the `global`/`tenant` properties are applied at startup. When `false`, all cluster variable processing is skipped.
+Indicates if cluster variable processing is enabled. When `true`, variables configured via `@ClusterVariables` annotations and via the `variables` property are applied at startup. When `false`, all cluster variable processing is skipped.
 
 Type: <code>boolean</code>
 
 </td>
 <td>
   <code>true</code>
-</td>
-</tr>
-<tr>
-<td>
-  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.global" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_GLOBAL"/><a href="#camundaclientclustervariablesglobal" id="camundaclientclustervariablesglobal" class="hash-link"/>
-</td>
-
-<td>
-
-Globally-scoped cluster variables to set at startup as key-value pairs.
-
-Type: <code>map[string,object]</code>
-
-</td>
-<td>
-  <code>null</code>
-</td>
-</tr>
-<tr>
-<td>
-  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.tenant" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_TENANT"/><a href="#camundaclientclustervariablestenant" id="camundaclientclustervariablestenant" class="hash-link"/>
-</td>
-
-<td>
-
-Tenant-scoped cluster variables to set at startup, keyed by tenant ID.
-
-Type: <code>map[string,map[string,object]]</code>
-
-</td>
-<td>
-  <code>null</code>
 </td>
 </tr>
 </tbody>
@@ -1312,6 +1280,24 @@ Type: <code>string</code>
   <code>null</code>
 </td>
 </tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.worker.defaults.with-lease" env="CAMUNDA_CLIENT_WORKER_DEFAULTS_WITHLEASE"/><a href="#camundaclientworkerdefaultswithlease" id="camundaclientworkerdefaultswithlease" class="hash-link"/>
+</td>
+
+<td>
+
+Activate the jobs polled by this worker with a lease. When enabled, each activated job is assigned a distinct lease token, fencing the complete, fail, and throw-error commands against a superseded activation of the same job.
+
+Only applies to the polling path. If not set, jobs are activated without a lease.
+
+Type: <code>boolean</code>
+
+</td>
+<td>
+  <code>null</code>
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -1358,6 +1344,102 @@ Type: <code>duration</code>
 </td>
 <td>
   <code>&quot;0ms&quot;</code>
+</td>
+</tr>
+</tbody>
+</table>
+
+### `camunda.client.cluster-variables.variables`
+
+Cluster variables to set at startup. Each entry carries a name, a value and optionally metadata, a kind and a tenant ID. Entries without a tenant ID are globally scoped.
+
+<table>
+<thead>
+  <tr>
+    <th>Property</th>
+    <th>Description</th>
+    <th>Default value</th>
+  </tr>
+</thead>
+<tbody>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables[*].name" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES[*]_NAME"/><a href="#camundaclientclustervariablesvariables[*]name" id="camundaclientclustervariablesvariables[*]name" class="hash-link"/>
+</td>
+
+<td>
+
+The name of the cluster variable.
+
+Type: <code>string</code>
+
+</td>
+<td>
+  <code>null</code>
+</td>
+</tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables[*].value" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES[*]_VALUE"/><a href="#camundaclientclustervariablesvariables[*]value" id="camundaclientclustervariablesvariables[*]value" class="hash-link"/>
+</td>
+
+<td>
+
+The value of the cluster variable.
+
+Type: <code>object</code>
+
+</td>
+<td>
+  <code>null</code>
+</td>
+</tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables[*].metadata" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES[*]_METADATA"/><a href="#camundaclientclustervariablesvariables[*]metadata" id="camundaclientclustervariablesvariables[*]metadata" class="hash-link"/>
+</td>
+
+<td>
+
+The metadata of the cluster variable.
+
+Type: <code>map[string,object]</code>
+
+</td>
+<td>
+  <code>null</code>
+</td>
+</tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables[*].kind" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES[*]_KIND"/><a href="#camundaclientclustervariablesvariables[*]kind" id="camundaclientclustervariablesvariables[*]kind" class="hash-link"/>
+</td>
+
+<td>
+
+The kind of the cluster variable.
+
+Type: <code>enum[json, secretReference]</code>
+
+</td>
+<td>
+  <code>null</code>
+</td>
+</tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables[*].tenant-id" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES[*]_TENANTID"/><a href="#camundaclientclustervariablesvariables[*]tenantid" id="camundaclientclustervariablesvariables[*]tenantid" class="hash-link"/>
+</td>
+
+<td>
+
+The tenant ID of the cluster variable.
+
+Type: <code>string</code>
+
+</td>
+<td>
+  <code>null</code>
 </td>
 </tr>
 </tbody>
@@ -1648,6 +1730,24 @@ Type: <code>string</code>
   <code>null</code>
 </td>
 </tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.worker.override.&lt;job-type|worker-name&gt;.with-lease" env="CAMUNDA_CLIENT_WORKER_OVERRIDE_&lt;JOBTYPE|WORKERNAME&gt;_WITHLEASE"/><a href="#camundaclientworkeroverridejobtypeworkernamewithlease" id="camundaclientworkeroverridejobtypeworkernamewithlease" class="hash-link"/>
+</td>
+
+<td>
+
+Activate the jobs polled by this worker with a lease. When enabled, each activated job is assigned a distinct lease token, fencing the complete, fail, and throw-error commands against a superseded activation of the same job.
+
+Only applies to the polling path. If not set, jobs are activated without a lease.
+
+Type: <code>boolean</code>
+
+</td>
+<td>
+  <code>null</code>
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -1754,6 +1854,44 @@ Deprecated properties for connecting the Camunda client to SaaS. These are used 
 </td>
 <td>
   <a href="#camundaclientclouddomain"><Property defaultValue="property" groupId="property-format" property="camunda.client.cloud.domain" env="CAMUNDA_CLIENT_CLOUD_DOMAIN"/></a>
+</td>
+<td>
+N/A
+</td>
+</tr>
+</tbody>
+</table>
+
+### `camunda.client.cluster-variables`
+
+Deprecated properties for setting cluster variables at startup.
+
+<table>
+<thead>
+  <tr>
+    <th>Property</th>
+    <th>Replacement</th>
+    <th>Hint</th>
+  </tr>
+</thead>
+<tbody>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.global" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_GLOBAL"/><a href="#camundaclientclustervariablesglobal" id="camundaclientclustervariablesglobal" class="hash-link"/>
+</td>
+<td>
+  <a href="#camundaclientclustervariablesvariables"><Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES"/></a>
+</td>
+<td>
+N/A
+</td>
+</tr>
+<tr>
+<td>
+  <Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.tenant" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_TENANT"/><a href="#camundaclientclustervariablestenant" id="camundaclientclustervariablestenant" class="hash-link"/>
+</td>
+<td>
+  <a href="#camundaclientclustervariablesvariables"><Property defaultValue="property" groupId="property-format" property="camunda.client.cluster-variables.variables" env="CAMUNDA_CLIENT_CLUSTERVARIABLES_VARIABLES"/></a>
 </td>
 <td>
 N/A

--- a/versioned_docs/version-8.8/apis-tools/camunda-spring-boot-starter/properties-reference.md
+++ b/versioned_docs/version-8.8/apis-tools/camunda-spring-boot-starter/properties-reference.md
@@ -1391,7 +1391,7 @@ Identity is now part of Camunda.
   <Property defaultValue="property" groupId="property-format" property="camunda.client.identity.base-url" env="CAMUNDA_CLIENT_IDENTITY_BASEURL"/><a href="#camundaclientidentitybaseurl" id="camundaclientidentitybaseurl" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 Identity is now part of Camunda.
@@ -1926,7 +1926,7 @@ Deprecated Keycloak-specific properties.
   <Property defaultValue="property" groupId="property-format" property="common.keycloak.realm" env="COMMON_KEYCLOAK_REALM"/><a href="#commonkeycloakrealm" id="commonkeycloakrealm" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 There is no keycloak-specific configuration for Camunda; the issuer is provided as a URL.
@@ -1975,7 +1975,7 @@ Deprecated Zeebe client properties.
   <Property defaultValue="property" groupId="property-format" property="zeebe.client.apply-environment-variable-overrides" env="ZEEBE_CLIENT_APPLYENVIRONMENTVARIABLEOVERRIDES"/><a href="#zeebeclientapplyenvironmentvariableoverrides" id="zeebeclientapplyenvironmentvariableoverrides" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 Only the environment variables belonging to the Spring SDK are applied.
@@ -2194,7 +2194,7 @@ N/A
   <Property defaultValue="property" groupId="property-format" property="zeebe.client.cloud.port" env="ZEEBE_CLIENT_CLOUD_PORT"/><a href="#zeebeclientcloudport" id="zeebeclientcloudport" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 The Zeebe client URL is now configured as HTTP&#x2F;HTTPS URL.
@@ -2341,7 +2341,7 @@ N/A
   <Property defaultValue="property" groupId="property-format" property="zeebe.client.security.plaintext" env="ZEEBE_CLIENT_SECURITY_PLAINTEXT"/><a href="#zeebeclientsecurityplaintext" id="zeebeclientsecurityplaintext" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 plaintext is now determined by the URL protocol (HTTP or HTTPS).

--- a/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/properties-reference.md
+++ b/versioned_docs/version-8.9/apis-tools/camunda-spring-boot-starter/properties-reference.md
@@ -109,7 +109,7 @@ Type: <code>duration</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>&quot;PT45S&quot;</code>
 </td>
 </tr>
 <tr>
@@ -493,7 +493,7 @@ Type: <code>duration</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>&quot;PT30S&quot;</code>
 </td>
 </tr>
 <tr>
@@ -557,7 +557,7 @@ Type: <code>double</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>2</code>
 </td>
 </tr>
 <tr>
@@ -573,7 +573,7 @@ Type: <code>duration</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>&quot;PT1S&quot;</code>
 </td>
 </tr>
 <tr>
@@ -589,7 +589,7 @@ Type: <code>integer</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>5</code>
 </td>
 </tr>
 <tr>
@@ -605,7 +605,7 @@ Type: <code>duration</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>&quot;PT5M&quot;</code>
 </td>
 </tr>
 <tr>
@@ -621,7 +621,7 @@ Type: <code>array[integer]</code>
 
 </td>
 <td>
-  <code>null</code>
+  <code>[404,429,500,502,503,504]</code>
 </td>
 </tr>
 <tr>
@@ -1711,7 +1711,7 @@ Identity is now part of Camunda.
   <Property defaultValue="property" groupId="property-format" property="camunda.client.identity.base-url" env="CAMUNDA_CLIENT_IDENTITY_BASEURL"/><a href="#camundaclientidentitybaseurl" id="camundaclientidentitybaseurl" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 Identity is now part of Camunda.
@@ -2246,7 +2246,7 @@ Deprecated Keycloak-specific properties.
   <Property defaultValue="property" groupId="property-format" property="common.keycloak.realm" env="COMMON_KEYCLOAK_REALM"/><a href="#commonkeycloakrealm" id="commonkeycloakrealm" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 There is no keycloak-specific configuration for Camunda; the issuer is provided as a URL.
@@ -2295,7 +2295,7 @@ Deprecated Zeebe client properties.
   <Property defaultValue="property" groupId="property-format" property="zeebe.client.apply-environment-variable-overrides" env="ZEEBE_CLIENT_APPLYENVIRONMENTVARIABLEOVERRIDES"/><a href="#zeebeclientapplyenvironmentvariableoverrides" id="zeebeclientapplyenvironmentvariableoverrides" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 Only the environment variables belonging to the Spring SDK are applied.
@@ -2514,7 +2514,7 @@ N/A
   <Property defaultValue="property" groupId="property-format" property="zeebe.client.cloud.port" env="ZEEBE_CLIENT_CLOUD_PORT"/><a href="#zeebeclientcloudport" id="zeebeclientcloudport" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 The Zeebe client URL is now configured as HTTP&#x2F;HTTPS URL.
@@ -2661,7 +2661,7 @@ N/A
   <Property defaultValue="property" groupId="property-format" property="zeebe.client.security.plaintext" env="ZEEBE_CLIENT_SECURITY_PLAINTEXT"/><a href="#zeebeclientsecurityplaintext" id="zeebeclientsecurityplaintext" class="hash-link"/>
 </td>
 <td>
-  
+
 </td>
 <td>
 plaintext is now determined by the URL protocol (HTTP or HTTPS).


### PR DESCRIPTION
## Description

The Sync Spring Boot Docs workflow was failing (#9660) because the generator
(`config-reference/generate-config-reference.js`) had no type mapping for
`java.util.Map`, `java.lang.Object`, and
`io.camunda.client.api.search.enums.ClusterVariableKind`, which are new types
introduced in recent `camunda-spring-boot-starter` releases.

This PR adds the missing type mappings and regenerates the properties
reference for the current docs and the `8.8`/`8.9` versioned docs from the
latest upstream Spring configuration metadata.

Related: camunda/camunda#60831, which ports back the required format of the
deprecated properties these docs reference.

Closes #9660.

## When should this change go live?

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
