### PR TITLE
docs(connectors): add Orchestration Cluster API connector page

### DIFF
--- a/docs/components/connectors/out-of-the-box-connectors/orchestration-cluster-api.md
+++ b/docs/components/connectors/out-of-the-box-connectors/orchestration-cluster-api.md
@@ -1,0 +1,169 @@
+---
+id: orchestration-cluster-api
+title: Camunda Orchestration Cluster API connector
+sidebar_label: Orchestration Cluster API
+description: Query process, decision, user task, and audit data from the Camunda 8 Orchestration Cluster REST API (v2).
+---
+
+The **Orchestration Cluster API connector** allows you to query data from the [Camunda 8 Orchestration Cluster REST API (v2)](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md)
+in your BPMN process. This connector is compatible with both Camunda 8 SaaS and Camunda 8 Self-Managed deployments.
+
+:::note
+This connector replaces the deprecated Camunda Operate connector, which was compatible with Camunda 8.8 and earlier.
+:::
+
+This connector is read-only by design. It only issues `GET` and `POST /search` requests; no state-changing operations (create, update, delete, cancel, migrate, modify, resolve, etc.) are exposed. If you need to trigger state-changing calls against the Orchestration Cluster API, use the [REST connector](../protocol/rest.md) instead.
+
+## Prerequisites
+
+To use the **Orchestration Cluster API connector**, you need an active Camunda 8.9 or later cluster. This connector is compatible with both Camunda 8 SaaS and Camunda 8 Self-Managed.
+
+You also need OAuth 2.0 client credentials with permission to call the Orchestration Cluster API. Follow the links below to learn more about API client configuration.
+
+- [API client configuration in Camunda 8 SaaS](/components/hub/organization/manage-clusters/manage-api-clients.md).
+- Authentication with a Self-Managed deployment.
+
+:::note
+Basic authentication (username and password) is not supported. Only OAuth 2.0 client credentials are accepted.
+:::
+
+:::note
+Use Camunda secrets to store credentials so you don't expose sensitive information directly from the process. See [managing secrets](/components/hub/organization/manage-clusters/manage-secrets.md) to learn more.
+:::
+
+## Create an Orchestration Cluster API connector task
+
+import ConnectorTask from '../../../components/react-components/connector-task.md'
+
+<ConnectorTask/>
+
+## Enter your cluster information
+
+Choose between **Camunda SaaS** and **Camunda Self-managed** depending on your Camunda 8 installation type. The input fields will update accordingly.
+
+### SaaS clusters
+
+If you are using a SaaS cluster, you will be required to provide your **Region** and **Cluster ID**. You will see these values when you [create an API client](/components/hub/organization/manage-clusters/manage-api-clients.md#create-a-client) for your cluster.
+
+### Self-Managed clusters
+
+If you are using a Self-Managed cluster, you need to provide two URLs:
+
+- URL of your OAuth token endpoint
+- Base URL of the Orchestration Cluster REST API (must end with `/v2`)
+
+If you are testing this connector on your local machine with the Camunda 8 Docker Compose setup, set the following URLs:
+
+- OAuth Token endpoint: `http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token`
+- Base URL: `http://localhost:8080/v2`
+
+## Configure authentication
+
+For both SaaS and Self-Managed clusters, you need to provide **Client ID** and **Client secret**.
+You will see these values when you [create an API client](/components/hub/organization/manage-clusters/manage-api-clients.md#create-a-client) for your cluster.
+
+For Self-Managed clusters, you can additionally specify:
+
+- **Audience**: The OAuth audience expected by your identity provider. Leave empty unless your identity provider requires a specific value.
+- **Scopes**: Space-separated OAuth 2.0 scopes. Required by some identity providers, for example Microsoft Entra ID, which requires `api://<client-id>/.default`.
+
+## Choose endpoint and operation
+
+In the **Entity** dropdown list, select the Orchestration Cluster API v2 entity you want to query. The following entities are available:
+
+- Process instances
+- Process definitions
+- Element instances
+- Incidents
+- Variables
+- User tasks
+- Jobs
+- Decision instances
+- Decision definitions
+- Decision requirements
+- Batch operations
+- Batch operation items
+- Message subscriptions
+- Correlated message subscriptions
+- Audit logs
+- Authorizations
+- Groups
+- Roles
+- Tenants
+- Mapping rules
+
+In the **Operation** dropdown list, select one of the supported operations: **Search** or **Get by key**.
+
+:::note Search-only entities
+**Batch operation items**, **Message subscriptions**, and **Correlated message subscriptions** only support the **Search** operation; **Get by key** is not available for these entities.
+:::
+
+Refer to the [Orchestration Cluster API REST documentation](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-overview.md) for the full list of endpoints, filter fields, and response shapes per entity.
+
+## Configure operation parameters
+
+For **Get by key**, you must provide a single input, **Key / ID**: the numeric key (for example `processInstanceKey`, `incidentKey`, `userTaskKey`) or string identifier (for example `groupId`, `roleId`, `tenantId`) of the entity you want to retrieve.
+
+For **Search**, the following search parameters can be configured:
+
+- **Filter**: A FEEL context with per-entity filter fields. For example, the following filter returns active process instances for the `order-process` process definition:
+
+  `{state: "ACTIVE", processDefinitionId: "order-process"}`
+
+  Filters also support advanced operators (`$eq`, `$neq`, `$gt`, `$gte`, `$lt`, `$lte`, `$like`, `$in`, `$notIn`, `$exists`, `$or`). See [advanced search filters](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md#advanced-search-filters) for details.
+
+- **Sort**: A list of sort objects. For example, the following sorts results by start date in ascending order:
+
+  `[{field: "startDate", order: "ASC"}]`
+
+- **Limit**: The maximum number of results to return per page. Defaults to `100`; the maximum is `10000`. Leave empty to use the server default.
+- **Page after (forward cursor)**: Pass the `page.endCursor` value from the previous response to fetch the next page.
+- **Page before (backward cursor)**: Pass the `page.startCursor` value from the previous response to fetch the previous page.
+- **Page from (offset)**: Zero-based index of the first result, for offset-based pagination.
+
+**Page after**, **Page before**, and **Page from** are mutually exclusive. See [pagination](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-data-fetching.md#page) for more details.
+
+## Handle the API response
+
+You can use an output mapping to map the response:
+
+1. Use **Result variable** to store the response in a process variable.
+2. Use **Result expression** to map fields from the response into process variables. By default, this connector sets the result expression to `={orchestrationClusterResponse: response.body}`.
+
+Response example for a **Search** operation on process instances:
+
+```
+{
+    "status": 200,
+    "headers": {
+      # response headers
+    },
+    "body": {
+        "items": [
+            {
+                "processInstanceKey": "2251799814052469",
+                "processDefinitionId": "order-process",
+                "processDefinitionKey": "2251799814052467",
+                "processDefinitionVersion": 1,
+                "startDate": "2023-03-21T08:25:04.499+0000",
+                "endDate": "2023-03-21T08:25:12.093+0000",
+                "state": "COMPLETED"
+            },
+            {
+                "processInstanceKey": "2251799814052613",
+                "processDefinitionId": "order-process",
+                "processDefinitionKey": "2251799814052610",
+                "processDefinitionVersion": 2,
+                "startDate": "2023-03-21T08:27:49.784+0000",
+                "endDate": "2023-03-21T08:27:58.838+0000",
+                "state": "COMPLETED"
+            }
+        ],
+        "page": {
+            "totalItems": 55,
+            "startCursor": "jfenj8vhekgj98uzfafhu7",
+            "endCursor": "negbkjeh84tzh4gk0kwegj"
+        }
+    }
+}
+```

--- a/docs/components/connectors/out-of-the-box-connectors/orchestration-cluster-api.md
+++ b/docs/components/connectors/out-of-the-box-connectors/orchestration-cluster-api.md
@@ -20,12 +20,10 @@ To use the **Orchestration Cluster API connector**, you need an active Camunda 8
 
 You also need OAuth 2.0 client credentials with permission to call the Orchestration Cluster API. Follow the links below to learn more about API client configuration.
 
-- [API client configuration in Camunda 8 SaaS](/components/hub/organization/manage-clusters/manage-api-clients.md).
-- Authentication with a Self-Managed deployment.
+- [API client configuration in Camunda 8 SaaS](/components/hub/organization/manage-clusters/manage-api-clients.md)
+- [Token-based authentication in Camunda 8 Self-Managed](/apis-tools/orchestration-cluster-api-rest/orchestration-cluster-api-rest-authentication.md#using-a-token-oidcjwt)
 
-:::note
 Basic authentication (username and password) is not supported. Only OAuth 2.0 client credentials are accepted.
-:::
 
 :::note
 Use Camunda secrets to store credentials so you don't expose sensitive information directly from the process. See [managing secrets](/components/hub/organization/manage-clusters/manage-secrets.md) to learn more.
@@ -132,38 +130,38 @@ You can use an output mapping to map the response:
 
 Response example for a **Search** operation on process instances:
 
-```
+```json
 {
-    "status": 200,
-    "headers": {
-      # response headers
-    },
-    "body": {
-        "items": [
-            {
-                "processInstanceKey": "2251799814052469",
-                "processDefinitionId": "order-process",
-                "processDefinitionKey": "2251799814052467",
-                "processDefinitionVersion": 1,
-                "startDate": "2023-03-21T08:25:04.499+0000",
-                "endDate": "2023-03-21T08:25:12.093+0000",
-                "state": "COMPLETED"
-            },
-            {
-                "processInstanceKey": "2251799814052613",
-                "processDefinitionId": "order-process",
-                "processDefinitionKey": "2251799814052610",
-                "processDefinitionVersion": 2,
-                "startDate": "2023-03-21T08:27:49.784+0000",
-                "endDate": "2023-03-21T08:27:58.838+0000",
-                "state": "COMPLETED"
-            }
-        ],
-        "page": {
-            "totalItems": 55,
-            "startCursor": "jfenj8vhekgj98uzfafhu7",
-            "endCursor": "negbkjeh84tzh4gk0kwegj"
-        }
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "items": [
+      {
+        "processInstanceKey": "2251799814052469",
+        "processDefinitionId": "order-process",
+        "processDefinitionKey": "2251799814052467",
+        "processDefinitionVersion": 1,
+        "startDate": "2023-03-21T08:25:04.499+0000",
+        "endDate": "2023-03-21T08:25:12.093+0000",
+        "state": "COMPLETED"
+      },
+      {
+        "processInstanceKey": "2251799814052613",
+        "processDefinitionId": "order-process",
+        "processDefinitionKey": "2251799814052610",
+        "processDefinitionVersion": 2,
+        "startDate": "2023-03-21T08:27:49.784+0000",
+        "endDate": "2023-03-21T08:27:58.838+0000",
+        "state": "COMPLETED"
+      }
+    ],
+    "page": {
+      "totalItems": 55,
+      "startCursor": "jfenj8vhekgj98uzfafhu7",
+      "endCursor": "negbkjeh84tzh4gk0kwegj"
     }
+  }
 }
 ```

--- a/docs/components/connectors/react-components/_connectors-table.js
+++ b/docs/components/connectors/react-components/_connectors-table.js
@@ -377,6 +377,14 @@ const SearchableTable = () => {
       image: OpenaiImg,
     },
     {
+      name: "Camunda Orchestration Cluster API",
+      description:
+        "Query process, decision, and audit data from the Orchestration Cluster API.",
+      type: "Outbound",
+      link: "../orchestration-cluster-api/",
+      image: CamundaImg,
+    },
+    {
       name: "Polling",
       description:
         "Poll an endpoint at regular intervals, enabling periodic data fetching.",

--- a/docs/components/connectors/react-components/_connectors-table.js
+++ b/docs/components/connectors/react-components/_connectors-table.js
@@ -377,9 +377,9 @@ const SearchableTable = () => {
       image: OpenaiImg,
     },
     {
-      name: "Camunda Orchestration Cluster API",
+      name: "Orchestration Cluster API",
       description:
-        "Query process, decision, and audit data from the Orchestration Cluster API.",
+        "Query process, decision, user task, and audit data from the Orchestration Cluster API.",
       type: "Outbound",
       link: "../orchestration-cluster-api/",
       image: CamundaImg,

--- a/sidebars.js
+++ b/sidebars.js
@@ -1130,6 +1130,7 @@ module.exports = {
               ],
             },
             "components/connectors/out-of-the-box-connectors/openai",
+            "components/connectors/out-of-the-box-connectors/orchestration-cluster-api",
             "components/connectors/out-of-the-box-connectors/rabbitmq",
             "components/connectors/protocol/rest",
             "components/connectors/out-of-the-box-connectors/salesforce",


### PR DESCRIPTION
## Description

Adds the missing out-of-the-box connector page for the **Orchestration Cluster API connector**, which replaced the deprecated [Operate connector](https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/operate/) in 8.10.

The Operate page and its built-in connectors table entry had already been removed from `/docs`, but no replacement page was ever added for its successor, so the connector was undocumented. This PR:

- Adds `docs/components/connectors/out-of-the-box-connectors/orchestration-cluster-api.md`, following the same structure as the old Operate connector page (prerequisites, cluster/auth setup, endpoint & operation selection, parameters, response handling), sourced from the connector's [README](https://github.com/camunda/connectors/tree/main/connectors/orchestration) and [element template](https://github.com/camunda/connectors/blob/main/connectors/orchestration/element-templates/orchestration-connector.json).
- Registers the page in `sidebars.js`.
- Adds an entry for it in the built-in connectors table (`_connectors-table.js`).

Closes camunda/connectors#8425

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] I included my new page in the sidebar file(s).
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
