### PR TITLE
docs(agentic-orchestration): remove em dashes and tag curl blocks in connect-external-agent

### DIFF
--- a/docs/components/agentic-orchestration/connect-external-agent.md
+++ b/docs/components/agentic-orchestration/connect-external-agent.md
@@ -330,4 +330,4 @@ If your agent can't finish, [fail the job](/apis-tools/orchestration-cluster-api
 
 Start a process instance and open it in Operate. Select the agent element on the diagram to see the agent instance data you reported: its state, usage metrics, model, system prompt, tools, and conversation history grouped by loop iteration.
 
-See [monitor your AI agents with Operate](/components/agentic-orchestration/evaluate-agents/monitor-ai-agents.md) for a walkthrough of the agent views.
+See [monitor your AI agents](/components/agentic-orchestration/evaluate-agents/monitor-ai-agents.md) to learn how to inspect and debug AI agents in Operate.

--- a/docs/components/agentic-orchestration/connect-external-agent.md
+++ b/docs/components/agentic-orchestration/connect-external-agent.md
@@ -114,7 +114,7 @@ Element templates configure properties through bindings. If a `zeebe:agentDefini
 
 Activate the job for the agent element with `withLease` set to `true`. The activation response returns a `leaseToken` alongside the `jobKey` and `elementInstanceKey` you need for every later call.
 
-```
+```bash
 curl -L 'http://localhost:8080/v2/jobs/activation' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -133,7 +133,7 @@ A lease is required because the conversation history you report is fenced to a s
 
 Create the agent instance as the first step of handling the job, before your agent makes its first model call. Establish the agent's initial configuration through a `CONFIGURATION` history item included in the same request, and pass the `jobKey` and `jobLease` from the job activation so Camunda can associate the item with this run. The response returns the `agentInstanceKey` that identifies the agent for every later call.
 
-```
+```bash
 curl -L 'http://localhost:8080/v2/agent-instances' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -181,7 +181,7 @@ Only one agent instance can exist per element instance. If the job is retried, t
 
 Update the agent instance whenever the agent moves between phases of its loop. Send the update to `PATCH /agent-instances/{agentInstanceKey}`.
 
-```
+```bash
 curl -L -X PATCH 'http://localhost:8080/v2/agent-instances/4503599627370496' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -195,13 +195,13 @@ curl -L -X PATCH 'http://localhost:8080/v2/agent-instances/4503599627370496' \
 | :------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `elementInstanceKey` | Yes      | The key of the currently active element instance. Camunda validates it against the stored agent instance.                                                                                                     |
 | `status`             | No       | The agent's current state: `TOOL_DISCOVERY`, `THINKING`, `TOOL_CALLING`, or `IDLE`. See [agent states](/components/agentic-orchestration/agent-states-and-metrics.md#agent-states) for what each state means. |
-| `history`            | No       | A batch of conversation history items to append — usage metrics, tool updates, and the conversation itself all flow through this field. See [step 5](#step-5-report-the-conversation-history).                |
+| `history`            | No       | A batch of conversation history items to append. Usage metrics, tool updates, and the conversation itself all flow through this field. See [step 5](#step-5-report-the-conversation-history).                 |
 
 Camunda sets the `Initializing` and `Completed` states itself, so your runtime can't set them.
 
 Report the tools once the agent has resolved them, typically while the agent is in `TOOL_DISCOVERY`, through a `CONFIGURATION` history item rather than a dedicated field:
 
-```
+```bash
 curl -L -X PATCH 'http://localhost:8080/v2/agent-instances/4503599627370496' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -242,7 +242,7 @@ The conversation history is the decision trail Operate displays for the agent: t
 
 Report history items either as a batch on the create or update call, or one at a time with [create agent instance history item](/apis-tools/orchestration-cluster-api-rest/specifications/create-agent-instance-history-item.api.mdx). Batching is the better default, because it keeps every item for a loop iteration in a single request.
 
-```
+```bash
 curl -L -X PATCH 'http://localhost:8080/v2/agent-instances/4503599627370496' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
@@ -289,20 +289,20 @@ curl -L -X PATCH 'http://localhost:8080/v2/agent-instances/4503599627370496' \
 }'
 ```
 
-| Field           | Required | Description                                                                                                                                                                                                                                                                                         |
-| :-------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `historyItemId` | Yes      | An identifier you assign to the item. Camunda uses it to recognize a resubmitted item as a duplicate rather than rejecting it, so reuse the same ID when a retried activation resends an item.                                                                                                      |
-| `loopIteration` | Yes      | The loop iteration the item belongs to, starting at `1`.                                                                                                                                                                                                                                            |
-| `role`          | Yes      | `USER`, `ASSISTANT`, `TOOL_RESULT`, or `CONFIGURATION`.                                                                                                                                                                                                                                             |
-| `content`       | Yes      | The content blocks of the item, each typed as `TEXT`, `DOCUMENT`, or `OBJECT`. Use `TEXT` for natural language and `OBJECT` for structured data. An empty array is valid for a `CONFIGURATION` item, whose data lives in the fields below instead.                                                  |
-| `toolCalls`     | No       | For an `ASSISTANT` item, the tool calls the model dispatched. For a `TOOL_RESULT` item, a single entry referencing the originating tool call through its `toolCallId`. Omit for a `USER` item.                                                                                                      |
-| `metrics`       | No       | The `inputTokens`, `outputTokens`, and `durationMs` of a single model call. Report these on `ASSISTANT` items only — Camunda aggregates them into the agent instance's running totals, so there's no separate counter to increment.                                                                 |
-| `model`         | No       | The LLM model identifier. `CONFIGURATION` items only.                                                                                                                                                                                                                                               |
-| `provider`      | No       | The LLM provider. `CONFIGURATION` items only.                                                                                                                                                                                                                                                       |
-| `systemPrompt`  | No       | The system prompt, as content blocks. `CONFIGURATION` items only. Together with `model` and `provider`, at least one of the `CONFIGURATION` items you send must establish all three — see [step 3](#step-3-create-the-agent-instance). Omit any of the three on a later item to leave it unchanged. |
-| `limits`        | No       | The agent's operational limits. `CONFIGURATION` items only; omit to leave the previously reported limits unchanged.                                                                                                                                                                                 |
-| `tools`         | No       | The complete list of tools available to the agent, replacing any previously reported list. `CONFIGURATION` items only; omit to leave the list unchanged, or send an empty array to clear it.                                                                                                        |
-| `producedAt`    | Yes      | The timestamp from your runtime for when the message was produced.                                                                                                                                                                                                                                  |
+| Field           | Required | Description                                                                                                                                                                                                                                                                                        |
+| :-------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `historyItemId` | Yes      | An identifier you assign to the item. Camunda uses it to recognize a resubmitted item as a duplicate rather than rejecting it, so reuse the same ID when a retried activation resends an item.                                                                                                     |
+| `loopIteration` | Yes      | The loop iteration the item belongs to, starting at `1`.                                                                                                                                                                                                                                           |
+| `role`          | Yes      | `USER`, `ASSISTANT`, `TOOL_RESULT`, or `CONFIGURATION`.                                                                                                                                                                                                                                            |
+| `content`       | Yes      | The content blocks of the item, each typed as `TEXT`, `DOCUMENT`, or `OBJECT`. Use `TEXT` for natural language and `OBJECT` for structured data. An empty array is valid for a `CONFIGURATION` item, whose data lives in the fields below instead.                                                 |
+| `toolCalls`     | No       | For an `ASSISTANT` item, the tool calls the model dispatched. For a `TOOL_RESULT` item, a single entry referencing the originating tool call through its `toolCallId`. Omit for a `USER` item.                                                                                                     |
+| `metrics`       | No       | The `inputTokens`, `outputTokens`, and `durationMs` of a single model call. Report these on `ASSISTANT` items only. Camunda aggregates them into the agent instance's running totals, so there's no separate counter to increment.                                                                 |
+| `model`         | No       | The LLM model identifier. `CONFIGURATION` items only.                                                                                                                                                                                                                                              |
+| `provider`      | No       | The LLM provider. `CONFIGURATION` items only.                                                                                                                                                                                                                                                      |
+| `systemPrompt`  | No       | The system prompt, as content blocks. `CONFIGURATION` items only. Together with `model` and `provider`, at least one of the `CONFIGURATION` items you send must establish all three. See [step 3](#step-3-create-the-agent-instance). Omit any of the three on a later item to leave it unchanged. |
+| `limits`        | No       | The agent's operational limits. `CONFIGURATION` items only; omit to leave the previously reported limits unchanged.                                                                                                                                                                                |
+| `tools`         | No       | The complete list of tools available to the agent, replacing any previously reported list. `CONFIGURATION` items only; omit to leave the list unchanged, or send an empty array to clear it.                                                                                                       |
+| `producedAt`    | Yes      | The timestamp from your runtime for when the message was produced.                                                                                                                                                                                                                                 |
 
 Whenever you send `history`, also send the `jobKey` and `jobLease` from the job activation. Camunda records each item with a `PENDING` commit status and promotes it to `COMMITTED` when the job completes successfully. If the job fails and a later activation supersedes the lease, the items are marked `DISCARDED` instead.
 
@@ -312,7 +312,7 @@ The response echoes one entry per submitted item, in request order, with the `hi
 
 Complete the job with the same lease token you activated it with. Completing the job commits the conversation history and moves the process instance on to the next element.
 
-```
+```bash
 curl -L 'http://localhost:8080/v2/jobs/2251799813685260/completion' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \


### PR DESCRIPTION
## Description

Style-guide cleanup for [Connect an external agent](https://docs.camunda.io/docs/next/components/agentic-orchestration/connect-external-agent/), found during a review requested against the technical writing style guide.

- Removed 3 em dashes (disallowed by the style guide) in the `history`, `metrics`, and `systemPrompt` field descriptions, rephrasing into shorter sentences.
- Added the missing `bash` language tag to all 6 curl code fences, matching the convention used in the sibling Orchestration Cluster REST API docs this page links to.

Also checked for content duplication against `agent-definitions-and-instances.md`, `agent-states-and-metrics.md`, and `ai-agents.md`, and verified all internal links/anchors resolve — no further issues found.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
