### PR TITLE
Document the job lease concept

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -61,6 +61,15 @@ message ActivateJobsRequest {
   int64 requestTimeout = 6;
   // a list of IDs of tenants for which to activate jobs
   repeated string tenantIds = 7;
+  // whether to activate the jobs with a lease; when true, each activated job is assigned a
+  // distinct, opaque lease token, returned as ActivatedJob.leaseToken. The lease fences the
+  // complete, fail, and throw-error commands against a superseded activation of the same job
+  // (e.g. after the job timed out or failed and was re-activated by another worker): a command
+  // carrying a stale lease token is rejected rather than racing with the newer activation. Once
+  // a job has been activated with a lease, it is served only to leasing workers of that job
+  // type; a homogeneous fleet per job type is recommended. Defaults to false, which activates
+  // jobs without a lease.
+  bool withLease = 9;
 }
 ```
 
@@ -134,6 +143,9 @@ message ActivatedJob {
   JobKind kind = 15;
   // the listener event type of the job.
   ListenerEventType listenerEventType = 16;
+  // the lease token identifying this activation; unset when the job was activated without a
+  // lease
+  optional string leaseToken = 21;
 }
 ```
 
@@ -247,6 +259,13 @@ message CompleteJobRequest {
   // The result of the completed job as determined by the worker.
   // This functionality is currently supported only by user task listeners
   optional JobResult result = 3;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, the matching token must be supplied to prove the command comes from the
+  // worker that holds the current lease; a command with no token is rejected. A command carrying
+  // a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+  // after the job timed out or failed and was re-activated by another worker). A job that was
+  // activated without a lease requires no token.
+  optional string leaseToken = 4;
 }
 
 message JobResult{
@@ -933,6 +952,13 @@ message FailJobRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 5;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, the matching token must be supplied to prove the command comes from the
+  // worker that holds the current lease; a command with no token is rejected. A command carrying
+  // a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+  // after the job timed out or failed and was re-activated by another worker). A job that was
+  // activated without a lease requires no token.
+  optional string leaseToken = 6;
 }
 ```
 
@@ -1279,6 +1305,13 @@ message StreamActivatedJobsRequest {
   repeated string fetchVariable = 5;
   // a list of identifiers of tenants for which to stream jobs
   repeated string tenantIds = 6;
+  // whether to stream jobs with a lease; when true, each job pushed on this stream is
+  // assigned a distinct, opaque lease token, returned as ActivatedJob.leaseToken. The lease
+  // fences the complete, fail, and throw-error commands against a superseded activation of
+  // the same job (e.g. after the job timed out or failed and was re-activated by another
+  // worker): a command carrying a stale lease token is rejected rather than racing with the
+  // newer activation. Defaults to false, which pushes jobs without a lease.
+  bool withLease = 8;
 }
 ```
 
@@ -1340,6 +1373,9 @@ message ActivatedJob {
   JobKind kind = 15;
   // the listener event type of the job.
   ListenerEventType listenerEventType = 16;
+  // the lease token identifying this activation; unset when the job was activated without a
+  // lease
+  optional string leaseToken = 21;
 }
 ```
 
@@ -1382,6 +1418,13 @@ message ThrowErrorRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 4;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, the matching token must be supplied to prove the command comes from the
+  // worker that holds the current lease; a command with no token is rejected. A command carrying
+  // a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+  // after the job timed out or failed and was re-activated by another worker). A job that was
+  // activated without a lease requires no token.
+  optional string leaseToken = 5;
 }
 ```
 
@@ -1498,6 +1541,15 @@ message UpdateJobRetriesRequest {
   int64 jobKey = 1;
   // the new amount of retries for the job; must be positive
   int32 retries = 2;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, a supplied token is validated to prove the command comes from the worker
+  // that holds the current lease; a command carrying a stale token is rejected, fencing the job
+  // against a superseded activation (e.g. after the job timed out or failed and was re-activated
+  // by another worker). An update without a token always applies, to support operator and bulk
+  // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+  // throw-error, which always require a token for leased jobs. A job that was activated without a
+  // lease requires no token.
+  optional string leaseToken = 4;
 }
 ```
 
@@ -1536,6 +1588,15 @@ message UpdateJobTimeoutRequest {
   int64 jobKey = 1;
   // the duration of the new timeout in ms, starting from the current moment
   int64 timeout = 2;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, a supplied token is validated to prove the command comes from the worker
+  // that holds the current lease; a command carrying a stale token is rejected, fencing the job
+  // against a superseded activation (e.g. after the job timed out or failed and was re-activated
+  // by another worker). An update without a token always applies, to support operator and bulk
+  // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+  // throw-error, which always require a token for leased jobs. A job that was activated without a
+  // lease requires no token.
+  optional string leaseToken = 4;
 }
 ```
 
@@ -1575,6 +1636,15 @@ message UpdateJobPriorityRequest {
   optional int32 priority = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
   optional uint64 operationReference = 3;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, a supplied token is validated to prove the command comes from the worker
+  // that holds the current lease; a command carrying a stale token is rejected, fencing the job
+  // against a superseded activation (e.g. after the job timed out or failed and was re-activated
+  // by another worker). An update without a token always applies, to support operator and bulk
+  // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+  // throw-error, which always require a token for leased jobs. A job that was activated without a
+  // lease requires no token.
+  optional string leaseToken = 4;
 }
 ```
 

--- a/docs/components/agentic-orchestration/connect-external-agent.md
+++ b/docs/components/agentic-orchestration/connect-external-agent.md
@@ -127,7 +127,9 @@ curl -L 'http://localhost:8080/v2/jobs/activation' \
 }'
 ```
 
-A lease is required because the conversation history you report is fenced to a single job activation. Items reported under a superseded lease are discarded instead of committed, so a retried activation can't interleave its history with the previous attempt. See [activate jobs](/apis-tools/orchestration-cluster-api-rest/specifications/activate-jobs.api.mdx) for the full activation response.
+A lease is required because the conversation history you report is fenced to a single job activation. Items reported under a superseded lease are discarded instead of committed, so a retried activation can't interleave its history with the previous attempt.
+
+See [activate jobs](/apis-tools/orchestration-cluster-api-rest/specifications/activate-jobs.api.mdx) for the full activation response, and [job leasing](/components/concepts/job-workers.md#job-leasing) for how the lease is enforced, the permanent lease-only caveat, and fleet guidance.
 
 ## Step 3: Create the agent instance
 

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -5,7 +5,6 @@ description: "Learn more about job workers, a service that can perform a particu
 ---
 
 A [job worker](/reference/glossary.md#job-worker) is a service capable of performing a particular task in a process. Each time that task needs to be performed, it is represented by a [job](/reference/glossary.md#job).
-
 For example, [AI agent](/reference/glossary.md#ai-agent) tool calls use this mechanism. Each activity inside an [ad-hoc sub-process](/reference/glossary.md#ad-hoc-sub-process) acts as a tool and is executed as a job, like any other task in the process.
 
 A job has the following properties:
@@ -443,6 +442,8 @@ sequenceDiagram
     Note over Z: Commits activation 2's update,<br/>discards activation 1's pending update
 ```
 
+See [connect an external agent](../agentic-orchestration/connect-external-agent.md#step-2-activate-the-job-with-a-lease) for a concrete walkthrough of activating a job with a lease and reporting history against it.
+
 ### How job leasing works
 
 To use leasing, request a lease by setting `withLease` to `true` when you activate jobs. Zeebe then returns a `leaseToken` on each activated job. This token identifies that specific activation, not the job itself.
@@ -470,10 +471,10 @@ There is currently no operation to remove a lease from a job. To recover, you ha
 - Use process instance modification to terminate and reactivate the element, which produces a fresh, unleased job.
   :::
 
-This also affects rollbacks. If you roll back a leasing worker deployment to a non-leasing version, any jobs leased in the interim stay permanently unavailable to the rolled-back version.
+This also affects rollbacks. If you roll back a leasing worker deployment to a non-leasing version, any jobs leased in the interim stay permanently unavailable to the rolled-back version. Before rolling back, drain in-flight leased jobs of that type first, so the rolled-back version doesn't start out starved of jobs it can never activate.
 
 :::tip
-Run a homogeneous fleet per job type: either all workers for a type request a lease, or none do. Mixed fleets work, but treat them as a transitional state, such as during a rollout. Keep an eye on the `skipped` jobs metric mentioned above to ensure the fleet is homonogeous.
+Run a homogeneous fleet per job type: either all workers for a type request a lease, or none do. Mixed fleets work, but treat them as a transitional state, such as during a rollout. Keep an eye on the `skipped` jobs metric mentioned above to ensure the fleet is homogeneous.
 :::
 
 ### Example

--- a/docs/components/concepts/job-workers.md
+++ b/docs/components/concepts/job-workers.md
@@ -183,6 +183,8 @@ On the broker side, whenever a job is made activate-able (e.g. a service task is
 The RNG used to randomly pick streams and clients provides a good uniform distribution for the same underlying set, which is a cheap way of evenly distributing the load _as long as the stream set remains stable_.
 :::
 
+Job leasing also applies to streaming: a leased job only matches streams opened with a lease request, and streams opened without one only match unleased jobs. See [job leasing](#job-leasing) for details.
+
 To help visualize the process in general, here is a sequence diagram which shows a single worker opening a job stream for jobs of type "foo" against a cluster consisting of a single gateway and a single broker. It receives some jobs, and when it closes, one job that was pushed asynchronously is returned to the broker:
 
 ![Sample Sequence Diagram](assets/job-push-sequence.png)
@@ -372,3 +374,149 @@ When a BPMN element is activated and creates a job:
 - **Inherited**: Jobs inherit the complete tag set from their process instance.
 
 For detailed information about tag formats, validation rules, limits, and additional use cases, see [process instance creation tags](/components/concepts/process-instance-creation.md#tags).
+
+## Job leasing
+
+A job lease is an opt-in, opaque token that fences a specific activation of a job. It lets a worker prove its activation is still current when it interacts with Camunda.
+
+For example, consider a job worker that performs a credit check on a loan application and completes the job with its decision: approve or reject. Worker A activates the job and is on its way to approving, but a new negative evaluation appears on the applicant before it completes, and the job's deadline passes. Zeebe reassigns the job to worker B, which sees the new evaluation and decides to reject instead. Without a lease, Zeebe only checks that the job is still activated, not which activation the completion came from, so if worker A's stale approval reaches Zeebe first, it wins: funds get disbursed on outdated information, and worker B's correct rejection is discarded.
+
+```mermaid
+sequenceDiagram
+    participant A as Worker A
+    participant Z as Zeebe
+    participant B as Worker B
+
+    A->>Z: Activate job
+    Z-->>A: job
+    Note over A: Deciding: approve
+    Z->>Z: Job times out, reassigned
+    B->>Z: Activate job
+    Z-->>B: job
+    Note over B: Sees new record, decides: reject
+    A->>Z: Complete job (approve)
+    Z-->>A: Accepted
+    B->>Z: Complete job (reject)
+    Z-->>B: Rejected: job already completed
+```
+
+With leasing, worker A's completion carries its own activation's token, which becomes stale the moment worker B's activation supersedes it, so Zeebe rejects it regardless of arrival order. The outcome flips: instead of whichever completion arrives first, the most up-to-date activation's completion wins.
+
+```mermaid
+sequenceDiagram
+    participant A as Worker A
+    participant Z as Zeebe
+    participant B as Worker B
+
+    A->>Z: Activate job (withLease)
+    Z-->>A: Job with leaseToken A
+    Note over A: Deciding: approve
+    Z->>Z: Job times out, reassigned
+    B->>Z: Activate job (withLease)
+    Z-->>B: Job with leaseToken B
+    Note over B: Sees new record, decides: reject
+    A->>Z: Complete job (leaseToken A)
+    Z-->>A: Rejected: INVALID_STATE, stale lease
+    B->>Z: Complete job (leaseToken B)
+    Z-->>B: Accepted
+```
+
+Camunda's own [agentic orchestration](../agentic-orchestration/agentic-orchestration-overview.md) builds on this same guarantee for visibility into [agent instance](../agentic-orchestration/agent-definitions-and-instances.md#agent-instances)'s conversation. Before completing, an agent worker separately reports its reasoning as an [agent instance update](../../apis-tools/orchestration-cluster-api-rest/specifications/update-agent-instance.api.mdx), tied to its lease token. If a later activation supersedes it and completes instead, Zeebe discards the superseded activation's pending update and commits the winning one's, so a retry's contradicting reasoning never gets mixed with the activation that actually gets acted on.
+
+```mermaid
+sequenceDiagram
+    participant A1 as Activation 1
+    participant Z as Zeebe
+    participant A2 as Activation 2
+
+    A1->>Z: Activate job (withLease)
+    Z-->>A1: Job with leaseToken 1
+    A1->>Z: Update agent instance (leaseToken 1)
+    Z-->>A1: Update pending
+    Z->>Z: Job times out, reassigned
+    A2->>Z: Activate job (withLease)
+    Z-->>A2: Job with leaseToken 2
+    A2->>Z: Update agent instance (leaseToken 2)
+    Z-->>A2: Update pending
+    A2->>Z: Complete job (leaseToken 2)
+    Z-->>A2: Accepted
+    Note over Z: Commits activation 2's update,<br/>discards activation 1's pending update
+```
+
+### How job leasing works
+
+To use leasing, request a lease by setting `withLease` to `true` when you activate jobs. Zeebe then returns a `leaseToken` on each activated job. This token identifies that specific activation, not the job itself.
+
+Pass the matching lease token back when you complete, fail, or throw an error on the job. You can also include it when you update the job timeout, retries, or priority, to verify the activation is still current before the update applies.
+
+### Enforcement and rejections
+
+Complete, fail, and throw-error commands on a leased job require the matching lease token. If the token is missing or doesn't match, Zeebe rejects the command with `INVALID_STATE`.
+
+Updating a job's timeout, retries, or priority never requires a lease token, but Zeebe validates one if you supply it. This keeps operator and bulk updates of leased jobs possible without requiring a lease.
+
+A lease-mismatch rejection means another activation of the same job has already superseded yours, for example after the job timed out and was reassigned. Treat this as expected, not as an error: don't retry the command, and log it at debug level rather than as an error.
+
+### Leasing is permanent for a job
+
+Once a job has been leased by any worker, Zeebe never again serves that job to a non-leasing worker of the same type. A non-leasing poll or stream silently skips the job.
+
+The affected process instances may appear stuck with no incident indicating the problem if all leasing workers are stopped. Zeebe exposes a `skipped` action on the `zeebe.job.events.total` metric as the operator signal that a non-leasing worker attempted to activate the leased job.
+
+:::note
+There is currently no operation to remove a lease from a job. To recover, you have two options:
+
+- Redeploy any worker for the job type with `withLease` set to `true`, to drain the leased jobs.
+- Use process instance modification to terminate and reactivate the element, which produces a fresh, unleased job.
+  :::
+
+This also affects rollbacks. If you roll back a leasing worker deployment to a non-leasing version, any jobs leased in the interim stay permanently unavailable to the rolled-back version.
+
+:::tip
+Run a homogeneous fleet per job type: either all workers for a type request a lease, or none do. Mixed fleets work, but treat them as a transitional state, such as during a rollout. Keep an eye on the `skipped` jobs metric mentioned above to ensure the fleet is homonogeous.
+:::
+
+### Example
+
+The following example activates jobs with a lease and completes the job using the matching lease token.
+
+```java
+client
+    .newWorker()
+    .jobType("process-payment")
+    .handler(
+        (jobClient, job) -> {
+            // process the job ...
+
+            jobClient
+                // highlight-start
+                .newCompleteCommand(job.getKey())
+                .withLeaseToken(job.getLeaseToken())
+                // highlight-end
+                .send();
+        })
+    // highlight-start
+    .withLease(true)
+    // highlight-end
+    .open();
+```
+
+When you build a command from the activated job itself, the client carries the job's lease token for you automatically:
+
+```java
+client
+    .newWorker()
+    .jobType("process-payment")
+    .handler(
+        (jobClient, job) -> {
+            // process the job ...
+
+            // highlight-start
+            jobClient.newCompleteCommand(job).send();
+            // highlight-end
+        })
+    // highlight-start
+    .withLease(true)
+    // highlight-end
+    .open();
+```

--- a/docs/components/hub/index.md
+++ b/docs/components/hub/index.md
@@ -34,7 +34,7 @@ image: DocsIcon,
 description: "Create, monitor, and assign clusters for seamless execution across all rollout stages.",
 },
 {
-link: "./organization/manage-users/manage-users",
+link: "./organization/manage-users",
 title: "Manage users",
 image: DocsIcon,
 description: "Manage the users, user groups, and roles in your organization.",

--- a/docs/components/hub/organization/index.md
+++ b/docs/components/hub/organization/index.md
@@ -50,7 +50,7 @@ Manage the users, user groups, and roles in your organization:
 
 <AoGrid ao={[
 {
-link: "./manage-users/manage-users",
+link: "./manage-users",
 title: "Manage users",
 image: DocsIcon,
 description: "Manage users in your organization.",

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -320,11 +320,13 @@ Optimize logs a `WARN` on startup whenever object variable values are not being 
 
 ### Job leasing during the rolling upgrade
 
-8.10 introduces [job leasing](/components/concepts/job-workers.md#job-leasing). While the rolling upgrade from 8.9 is in progress, jobs from partitions still running 8.9 return a `null` `leaseToken`, even when activated with `withLease` set to `true`, because 8.9 brokers don't support leasing yet.
+Camunda 8.10 introduces [job leasing](/components/concepts/job-workers.md#job-leasing).
+During a rolling upgrade from 8.9, jobs on partitions that are still running 8.9 return a `null` `leaseToken`, even when activated with `withLease` set to `true`, because 8.9 brokers do not support job leasing.
 
-If your worker requires the lease to process a job safely, treat a `null` `leaseToken` as not yet supported on that partition: fail the job with a retry backoff, and set retries back to the job's current value so the fail doesn't burn through them while the upgrade is in progress. The lease becomes available once that job's partition leader upgrades to 8.10, and the retry converges.
+If your worker requires the lease to process a job safely, treat a `null` `leaseToken` as not yet supported on that partition: fail the job with a retry backoff, and set retries back to the job's current value so the fail doesn't burn through them while the upgrade is in progress.
+The lease becomes available after that job's partition leader is upgraded to 8.10, and the retry converges.
 
-Over REST, a partition still on 8.9 rejects the unknown `withLease` field with a `400` error instead of returning `null`. Once the whole cluster has upgraded to 8.10, this handling is no longer needed.
+When using the REST API, a partition still running 8.9 rejects the unknown `withLease` field with a `400` error instead of returning `null`. This handling is no longer required after the entire cluster has been upgraded to 8.10.
 
 ```java
 final JobHandler paymentJobHandler =

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -326,7 +326,7 @@ During a rolling upgrade from 8.9, jobs on partitions that are still running 8.9
 If your worker requires the lease to process a job safely, treat a `null` `leaseToken` as not yet supported on that partition: fail the job with a retry backoff, and set retries back to the job's current value so the fail doesn't burn through them while the upgrade is in progress.
 The lease becomes available after that job's partition leader is upgraded to 8.10, and the retry converges.
 
-When using the REST API, a partition still running 8.9 rejects the unknown `withLease` field with a `400` error instead of returning `null`. This handling is no longer required after the entire cluster has been upgraded to 8.10.
+When using the REST API, a gateway instance still running 8.9 rejects the unknown `withLease` field with a `400` error instead of returning `null`. This handling is no longer required after every gateway in the cluster has been upgraded to 8.10.
 
 ```java
 final JobHandler paymentJobHandler =

--- a/docs/self-managed/upgrade/components/890-to-8100.md
+++ b/docs/self-managed/upgrade/components/890-to-8100.md
@@ -315,3 +315,44 @@ zeebe:
 Optimize logs a `WARN` on startup whenever object variable values are not being imported. The message includes the opt-in setting.
 
 <p className="link-arrow">[Object variables configuration](/self-managed/components/optimize/configuration/object-variables.md)</p>
+
+## Zeebe
+
+### Job leasing during the rolling upgrade
+
+8.10 introduces [job leasing](/components/concepts/job-workers.md#job-leasing). While the rolling upgrade from 8.9 is in progress, jobs from partitions still running 8.9 return a `null` `leaseToken`, even when activated with `withLease` set to `true`, because 8.9 brokers don't support leasing yet.
+
+If your worker requires the lease to process a job safely, treat a `null` `leaseToken` as not yet supported on that partition: fail the job with a retry backoff, and set retries back to the job's current value so the fail doesn't burn through them while the upgrade is in progress. The lease becomes available once that job's partition leader upgrades to 8.10, and the retry converges.
+
+Over REST, a partition still on 8.9 rejects the unknown `withLease` field with a `400` error instead of returning `null`. Once the whole cluster has upgraded to 8.10, this handling is no longer needed.
+
+```java
+final JobHandler paymentJobHandler =
+    (jobClient, job) -> {
+        final String leaseToken = job.getLeaseToken();
+
+        if (leaseToken == null) {
+            // This partition hasn't upgraded to 8.10 yet. Fail with retries
+            // preserved so the job converges once the upgrade completes,
+            // instead of being burned into an incident.
+            jobClient
+                .newFailCommand(job)
+                .retries(job.getRetries())
+                .retryBackoff(Duration.ofSeconds(30))
+                .errorMessage("Lease required but not returned; retrying until the partition upgrades to 8.10")
+                .send();
+            return;
+        }
+
+        // process the job
+
+        jobClient.newCompleteCommand(job).send();
+    };
+
+client
+    .newWorker()
+    .jobType("process-payment")
+    .handler(paymentJobHandler)
+    .withLease(true)
+    .open();
+```


### PR DESCRIPTION
## Description

Documents the job lease concept, introduced in https://github.com/camunda/camunda/issues/54840.

- Adds a new **Job leasing** section to `docs/components/concepts/job-workers.md`, covering: what a lease is, how to request and pass one, enforcement and rejection handling, the permanent lease-only caveat (including the rollback scenario), fleet guidance, and how to check lease support during a rolling upgrade.
- Cross-links the new section from the existing **Job streaming** section.
- Syncs the proto snippets in `docs/apis-tools/zeebe-api/gateway-service.md` with the `withLease`/`leaseToken` fields already present in `gateway.proto` on `camunda/camunda@main`, across the 8 affected RPCs (`StreamActivatedJobs`, `ActivateJobs`, `CompleteJob`, `FailJob`, `ThrowError`, `UpdateJobRetries`, `UpdateJobTimeout`, `UpdateJobPriority`).

This PR is stacked on top of [#9710](https://github.com/camunda/camunda-docs/pull/9710), which documents the `UpdateJobPriority` RPC itself (previously undocumented, unrelated to leasing). Merge #9710 first.

Out of scope: the REST API spec pages already document `withLease`/`leaseToken` (auto-generated).

closes https://github.com/camunda/camunda/issues/56097

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
