### PR TITLE
docs: document the UpdateJobPriority gRPC RPC

### DIFF
--- a/docs/apis-tools/zeebe-api/gateway-service.md
+++ b/docs/apis-tools/zeebe-api/gateway-service.md
@@ -1560,3 +1560,48 @@ Returned if:
 Returned if:
 
 - The job is not active.
+
+## `UpdateJobPriority` RPC
+
+Updates the priority of a job.
+
+### Input: `UpdateJobPriorityRequest`
+
+```protobuf
+message UpdateJobPriorityRequest {
+  // the unique job identifier, as obtained from ActivateJobsResponse
+  int64 jobKey = 1;
+  // the new priority value for the job
+  optional int32 priority = 2;
+  // a reference key chosen by the user and will be part of all records resulted from this operation
+  optional uint64 operationReference = 3;
+}
+```
+
+### Output: `UpdateJobPriorityResponse`
+
+```protobuf
+message UpdateJobPriorityResponse {
+}
+```
+
+### Errors
+
+#### GRPC_STATUS_NOT_FOUND
+
+Returned if:
+
+- No job exists with the given key.
+- No job was found with the given key for the tenants the user is authorized to work with.
+
+#### GRPC_STATUS_INVALID_ARGUMENT
+
+Returned if:
+
+- Priority is not provided.
+
+#### GRPC_STATUS_INVALID_STATE
+
+Returned if:
+
+- The job is in a terminal state.


### PR DESCRIPTION
## Description

`gateway.proto` on `camunda/camunda@main` has an `UpdateJobPriority` RPC that was never documented in `docs/apis-tools/zeebe-api/gateway-service.md`. This adds it, following the same structure as the other `UpdateJob*` RPCs on the page.

This RPC hasn't shipped in a GA release yet — it's only present in `8.10.0` alpha tags so far (latest GA is `8.9.17`), so it belongs in `/docs` ("Next"), not `/versioned_docs`.

[korthout/Document-job-lease-concept](https://github.com/camunda/camunda-docs/pull/9709) is stacked on top of this branch — it adds a `leaseToken` field to this RPC (and 7 others) as part of documenting the job lease concept.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
