### PR TITLE
docs(hub): document process application versioning and file versioning UI changes

### DIFF
--- a/docs/components/hub/workspace/manage-projects/git-sync.md
+++ b/docs/components/hub/workspace/manage-projects/git-sync.md
@@ -310,7 +310,7 @@ Organization owners/administrators, workspace administrators, and editors can sy
 
 In the case of a merge conflict, select between your local Camunda Hub changes and the changes in the remote repository to continue.
 
-Once the pull is complete and any merge conflicts are resolved, Camunda Hub will push its changes. The newly created version is now accessible via the **View version** button in the success notification.
+Once the pull is complete and any merge conflicts are resolved, Camunda Hub will push its changes. The newly created snapshot is now accessible via the **View snapshot** button in the success notification.
 
 ## Manage existing configurations
 

--- a/docs/components/hub/workspace/manage-projects/git-sync.md
+++ b/docs/components/hub/workspace/manage-projects/git-sync.md
@@ -305,7 +305,7 @@ Once successful, your project will display a new **Sync with Bitbucket** button.
 Organization owners/administrators, workspace administrators, and editors can sync their version of Camunda Hub with the connected repository at any time.
 
 1. In your connected project, click **Sync with _GitProvider_** button.
-2. Enter a [version number](./project-versioning.md#create-a-version) to create a new version for your project. The new version will be created prior to pushing your changes to the central repository.
+2. Enter a [snapshot tag](./project-versioning.md#create-a-snapshot) to create a new snapshot for your project. The new snapshot will be created prior to pushing your changes to the central repository.
 3. Click **Synchronize**.
 
 In the case of a merge conflict, select between your local Camunda Hub changes and the changes in the remote repository to continue.

--- a/docs/components/hub/workspace/manage-projects/manage-projects.md
+++ b/docs/components/hub/workspace/manage-projects/manage-projects.md
@@ -51,9 +51,9 @@ description: "Validate your project in development before deploying it to your t
 },
 {
 link: "./project-versioning",
-title: "Manage and review project versions",
+title: "Manage and review project snapshots",
 image: DocsIcon,
-description: "Create and review distinct versions for the entire project.",
+description: "Create and review distinct snapshots for the entire project.",
 },
 {
 link: "./deploy-project",

--- a/docs/components/hub/workspace/manage-projects/project-versioning.md
+++ b/docs/components/hub/workspace/manage-projects/project-versioning.md
@@ -49,7 +49,7 @@ From here, you can perform the following actions on a project snapshot:
 | **Restore as latest** | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
 | **Edit details**      | Edit the snapshot tag and description.                                                          |
 | **Download**          | Download the project as a zip file.                                                             |
-| **Copy to**           | Create a new project with the files from the snapshot.                                          |
+| **Copy**              | Create a new project with the files from the snapshot.                                          |
 | **Edit review**       | Update the [review](#request-a-review) status of the snapshot.                                  |
 | **Delete**            | Delete the project snapshot.                                                                    |
 
@@ -74,7 +74,7 @@ The comparison lists every file present in either snapshot, with a status badge 
 | **Moved**     | The file changed location. A move summary is shown under its name. |
 | **Unchanged** | The file content is identical in both snapshots.                   |
 
-A file gets only one status badge, in this order of priority: **New**, then **Removed**, then **Modified**, then **Moved**, then **Unchanged**. For example, a file that was both moved and had its content changed shows as **Modified**, since the content change is the more significant one — but its move summary is still shown under its name.
+A file gets only one status badge, in this order of priority: **New**, then **Removed**, then **Modified**, then **Moved**, then **Unchanged**. For example, a file that was both moved and had its content changed shows as **Modified**, since the content change is the more significant one. Its move summary is still shown under its name.
 
 For each file in the list, you can:
 
@@ -88,7 +88,7 @@ Restoring a snapshot reverts the entire project to its state at the time the sna
 
 - Moving and renaming files and folders to their snapshot state.
 - Soft-deleting files that were created after the snapshot.
-- Restoring file instances that were deleted after the snapshot was created (the old file histories will not exist since the file was deleted).
+- Restoring file instances that were deleted after the snapshot was created.
 - Updating all file content to match the snapshot.
 
 To restore a snapshot:
@@ -103,13 +103,13 @@ The project state changes to match the snapshot, and the snapshots timeline is r
 A project snapshot restore is a single bulk operation, not a series of individual [file restores](/components/hub/workspace/modeler/modeling/versions.md#restore-a-version). It affects the project, its files, and any element templates differently:
 
 - **The project snapshot itself**: if the project's live state has drifted from its most recent snapshot, a safety snapshot is created first to capture that state before restoring. If nothing has changed since the last snapshot, no safety snapshot is created.
-- **Files that still exist in the project**: for each file that is still present (in its original location or elsewhere in the project), Web Modeler moves and renames it back into place, then restores its content the same way as an individual file restore — a safety autosave entry captures the file's state just before the restore (only if it differs from the file's last saved entry), followed by a new "(restored)" entry with the snapshot's content.
+- **Files that still exist in the project**: for each file that is still present (in its original location or elsewhere in the project), Web Modeler moves and renames it back into place, then restores its content the same way as an individual file restore. A safety autosave entry captures the file's state just before the restore (only if it differs from the file's last saved entry), followed by a new "(restored)" entry with the snapshot's content.
 - **Files that were moved out of the project or permanently deleted**: since there's no existing file to restore into, Web Modeler creates a new file from the snapshot's content directly. This new file has no autosave step and no prior version history, since none of its own history exists yet.
 - **Files that exist now but weren't part of the snapshot**: these are soft-deleted so the project matches the snapshot's file set.
 - **Element templates**: element templates are handled differently depending on their state at the time of restore:
   - If a template is still in the project, its content is reset in place, and it's moved back to its recorded location. This does **not** publish a new numbered template version the way [restoring an element template directly](/components/hub/workspace/modeler/element-templates/manage-element-templates.md#versioning-element-templates) does.
   - If a template was soft- or permanently deleted since the snapshot was created, the entire restore fails rather than recreating the template.
-  - If a template is still live but was moved out of the project, it's skipped — restoring it in place would conflict with whoever now manages it in its new location. Any BPMN element still referencing the template keeps a broken reference; this is an accepted trade-off.
+  - If a template is still live but was moved out of the project, it's skipped. Restoring it in place would conflict with whoever now manages it in its new location. Any BPMN element still referencing the template keeps a broken reference; this is an accepted trade-off.
   - If a template was added to the project after the snapshot was created, it's left in place rather than removed. Unlike other new files, it can't be safely reverted or removed, since it has its own independent versioning.
 
 ## Request a review
@@ -118,7 +118,7 @@ A project snapshot restore is a single bulk operation, not a series of individua
 2. Reviewers can view the changes, comment, request changes, or approve the project snapshot.
 3. After a user has submitted their review, the project snapshot is marked as reviewed and the review status is shown in the snapshots timeline.
    1. Any user with edit permissions can go back and edit the review at any point in time to update the assessment.
-4. If the reviewer has marked the snapshot with "changes requested", you can address the feedback by performing the requested changes, creating a new snapshot, and requesting a review for the new snapshot.
+4. If the reviewer has marked the snapshot as **Changes requested**, you can address the feedback by performing the requested changes, creating a new snapshot, and requesting a review for the new snapshot.
 
 This review capability is most useful for reviews on a business level.
 For technical reviews, you may instead [sync your Git repository](git-sync.md) to put changes into a technical context with related code changes.

--- a/docs/components/hub/workspace/manage-projects/project-versioning.md
+++ b/docs/components/hub/workspace/manage-projects/project-versioning.md
@@ -1,67 +1,126 @@
 ---
 id: project-versioning
-title: Manage and review project versions
-description: Create distinct versions for the entire project.
+title: Manage and review project snapshots
+description: Create distinct snapshots for the entire project.
 ---
 
-Create distinct versions for the entire project.
+Create distinct snapshots for the entire project.
 
 ## About
 
-Use versioning to save a single snapshot of all the project files in one action. This helps you track a project throughout its development lifecycle and ensures the correct version is referenced.
+Use snapshots to save a single capture of all the project files in one action. This helps you track a project throughout its development lifecycle and ensures the correct state is referenced.
 
-In this context, a [version](/reference/glossary.md#version) is a Camunda Hub project snapshot, not a deployed process definition version.
+In this context, a [snapshot](/reference/glossary.md#snapshot-project) is a Camunda Hub project snapshot, not a deployed process definition version.
 
-## Create a version
+## Create a snapshot
 
-To create a project version:
+To create a project snapshot:
 
 1. In your workspace, open a project.
-2. On the right side of the project view, under **Versions**, click **Create version**.
-3. Enter a **Version tag** in the version creation modal.
+2. On the right side of the project view, under **Snapshots**, click **Create snapshot**.
+3. Enter a **Snapshot tag** in the snapshot creation modal.
 4. Click **Create**.
 
-## View all versions
+## View all snapshots
 
-To view all versions:
+To view all snapshots:
 
 1. In your workspace, open a project.
-2. On the right side of the project view, under **Versions**, click **Show full list**.
+2. On the right side of the project view, under **Snapshots**, click **Show full list**.
 3. At the top of the modeling view, use the file navigation header buttons to switch between files and view their content.
 
-See [manage file versions](/components/hub/workspace/modeler/modeling/versions.md) to learn about more features like comparing and restoring versions.
+The side panel has two sub-tabs:
 
-## Manage a project version
+- **Snapshots**: the timeline of all project snapshots.
+- **Compare**: the comparison of the two snapshots you selected.
 
-To manage a project version:
+See [manage file versions](/components/hub/workspace/modeler/modeling/versions.md) to learn about more features like comparing and restoring individual file versions.
+
+## Manage a project snapshot
+
+To manage a project snapshot:
 
 1. In your workspace, open a project.
-2. On the right side of the project view, under **Versions**, open the vertical ellipsis menu.
+2. On the right side of the project view, under **Snapshots**, open the vertical ellipsis menu.
 
-From here, you can perform the following actions on a project version:
+From here, you can perform the following actions on a project snapshot:
 
-| Action                | Description                                                                                     |
-| :-------------------- | :---------------------------------------------------------------------------------------------- |
-| **View details**      | Open the version details page to review the contents of all files in the version.               |
-| **Restore as latest** | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
-| **Edit**              | Edit the project version.                                                                       |
-| **Deploy**            | Deploy the project version, especially after it has been [reviewed](#request-a-review).         |
-| **Download**          | Download the project as a zip file.                                                             |
-| **Copy to**           | Create a new project with the files from the version.                                           |
-| **Delete**            | Delete the project version.                                                                     |
+| Action           | Description                                                                                     |
+| :--------------- | :---------------------------------------------------------------------------------------------- |
+| **View details** | Open the snapshot details page to review the contents of all files in the snapshot.             |
+| **Restore**      | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
+| **Edit details** | Edit the snapshot tag and description.                                                          |
+| **Deploy**       | Deploy the project snapshot, especially after it has been [reviewed](#request-a-review).        |
+| **Download**     | Download the project as a zip file.                                                             |
+| **Copy to**      | Create a new project with the files from the snapshot.                                          |
+| **Edit review**  | Update the [review](#request-a-review) status of the snapshot.                                  |
+| **Delete**       | Delete the project snapshot.                                                                    |
+
+## Compare snapshots
+
+You can compare any two project snapshots, including snapshots that are not next to each other in the timeline.
+
+1. In the **Snapshots** sub-tab, select the checkbox of the first snapshot you want to compare.
+1. Select the checkbox of the second snapshot you want to compare.
+
+The side panel switches to the **Compare** sub-tab and shows the older snapshot against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL, so you can share or bookmark a specific comparison.
+
+The comparison lists every file present in either snapshot, with a status badge per file:
+
+| Status        | Meaning                                                            |
+| ------------- | ------------------------------------------------------------------ |
+| **New**       | The file exists in the newer snapshot only.                        |
+| **Removed**   | The file exists in the older snapshot only.                        |
+| **Modified**  | The file content differs between the two snapshots.                |
+| **Moved**     | The file changed location. A move summary is shown under its name. |
+| **Unchanged** | The file content is identical in both snapshots.                   |
+
+A file gets only one status badge, in this order of priority: **New**, then **Removed**, then **Modified**, then **Moved**, then **Unchanged**. For example, a file that was both moved and had its content changed shows as **Modified**, since the content change is the more significant one — but its move summary is still shown under its name.
+
+For each file in the list, you can:
+
+- Expand the row to view an inline diff of the file.
+- Select **Open file editor** to open the file.
+- Select **Open file history** to open the [version history](/components/hub/workspace/modeler/modeling/versions.md) of the file.
+
+## Restore a snapshot
+
+Restoring a snapshot reverts the entire project to its state at the time the snapshot was created. This includes:
+
+- Moving and renaming files and folders to their snapshot state.
+- Soft-deleting files that were created after the snapshot.
+- Restoring file instances that were deleted after the snapshot was created (the old file histories will not exist since the file was deleted).
+- Updating all file content to match the snapshot.
+
+To restore a snapshot:
+
+1. In the **Snapshots** sub-tab, open the actions menu of the snapshot you want to restore.
+1. Select **Restore**.
+
+The project state changes to match the snapshot, and the snapshots timeline is refreshed.
+
+### What happens during a project snapshot restore
+
+A project snapshot restore is a single bulk operation, not a series of individual [file restores](/components/hub/workspace/modeler/modeling/versions.md#restore-a-version). It affects the project, its files, and any element templates differently:
+
+- **The project snapshot itself**: if the project's live state has drifted from its most recent snapshot, a safety snapshot is created first to capture that state before restoring. If nothing has changed since the last snapshot, no safety snapshot is created.
+- **Files that still exist in the project**: for each file that is still present (in its original location or elsewhere in the project), Web Modeler moves and renames it back into place, then restores its content the same way as an individual file restore — a safety autosave entry captures the file's state just before the restore (only if it differs from the file's last saved entry), followed by a new "(restored)" entry with the snapshot's content.
+- **Files that were moved out of the project or permanently deleted**: since there's no existing file to restore into, Web Modeler creates a new file from the snapshot's content directly. This new file has no autosave step and no prior version history, since none of its own history exists yet.
+- **Files that exist now but weren't part of the snapshot**: these are soft-deleted so the project matches the snapshot's file set.
+- **Element templates**: an element template that's still present in the project has its content reset in place, but this does **not** publish a new numbered template version the way [restoring an element template directly](/components/hub/workspace/modeler/element-templates/manage-element-templates.md#versioning-element-templates) does. If the element template that was part of the snapshot can no longer be found in the project, it's skipped — Web Modeler doesn't recreate deleted element templates as part of a project snapshot restore.
 
 ## Request a review
 
-1. Request a review for the newest version of the project from the version history page of the project. Collaborators with edit permission in your project will see a notification on the process diagram page once you have requested a review. Reviews cannot be performed by the user who created the project version unless the user is an organization administrator.
-2. Reviewers can view the changes, comment, request changes, or approve the project version.
-3. After a user has submitted their review, the project version is marked as reviewed and the review status is shown in the version history.
+1. Request a review for the newest snapshot of the project from the snapshots page of the project. Collaborators with edit permission in your project will see a notification on the process diagram page once you have requested a review. Reviews cannot be performed by the user who created the project snapshot unless the user is an organization administrator.
+2. Reviewers can view the changes, comment, request changes, or approve the project snapshot.
+3. After a user has submitted their review, the project snapshot is marked as reviewed and the review status is shown in the snapshots timeline.
    1. Any user with edit permissions can go back and edit the review at any point in time to update the assessment.
-4. If the reviewer has marked the version with "changes requested", you can address the feedback by performing the requested changes, creating a new version, and requesting a review for the new version.
+4. If the reviewer has marked the snapshot with "changes requested", you can address the feedback by performing the requested changes, creating a new snapshot, and requesting a review for the new snapshot.
 
 This review capability is most useful for reviews on a business level.
 For technical reviews, you may instead [sync your Git repository](git-sync.md) to put changes into a technical context with related code changes.
 
-After the review is complete, you can promote the versioned project to the next stage(s) of the [deployment pipeline](./deploy-project.md). For example, promote to your testing cluster/stage, then to staging, and finally to production.
+After the review is complete, you can promote the project snapshot to the next stage(s) of the [deployment pipeline](./deploy-project.md). For example, promote to your testing cluster/stage, then to staging, and finally to production.
 
 :::info
 If you want to use your own deployment pipeline after the review is complete, you can [sync your Git repository](git-sync.md) at this point to deploy and promote the project through your own pipeline.

--- a/docs/components/hub/workspace/manage-projects/project-versioning.md
+++ b/docs/components/hub/workspace/manage-projects/project-versioning.md
@@ -31,7 +31,7 @@ To view all snapshots:
 
 The side panel has two sub-tabs:
 
-- **Snapshots**: the timeline of all project snapshots.
+- **Versions**: the timeline of all project snapshots.
 - **Compare**: the comparison of the two snapshots you selected.
 
 See [manage file versions](/components/hub/workspace/modeler/modeling/versions.md) to learn about more features like comparing and restoring individual file versions.
@@ -50,17 +50,18 @@ From here, you can perform the following actions on a project snapshot:
 | **View details** | Open the snapshot details page to review the contents of all files in the snapshot.             |
 | **Restore**      | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
 | **Edit details** | Edit the snapshot tag and description.                                                          |
-| **Deploy**       | Deploy the project snapshot, especially after it has been [reviewed](#request-a-review).        |
 | **Download**     | Download the project as a zip file.                                                             |
 | **Copy to**      | Create a new project with the files from the snapshot.                                          |
 | **Edit review**  | Update the [review](#request-a-review) status of the snapshot.                                  |
 | **Delete**       | Delete the project snapshot.                                                                    |
 
+You can also deploy a project snapshot from the project's main deployment flow after it has been [reviewed](#request-a-review). A dedicated **Deploy** action in this menu is planned as a follow-up.
+
 ## Compare snapshots
 
 You can compare any two project snapshots, including snapshots that are not next to each other in the timeline.
 
-1. In the **Snapshots** sub-tab, select the checkbox of the first snapshot you want to compare.
+1. In the **Versions** sub-tab, select the checkbox of the first snapshot you want to compare.
 1. Select the checkbox of the second snapshot you want to compare.
 
 The side panel switches to the **Compare** sub-tab and shows the older snapshot against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL, so you can share or bookmark a specific comparison.
@@ -94,7 +95,7 @@ Restoring a snapshot reverts the entire project to its state at the time the sna
 
 To restore a snapshot:
 
-1. In the **Snapshots** sub-tab, open the actions menu of the snapshot you want to restore.
+1. In the **Versions** sub-tab, open the actions menu of the snapshot you want to restore.
 1. Select **Restore**.
 
 The project state changes to match the snapshot, and the snapshots timeline is refreshed.

--- a/docs/components/hub/workspace/manage-projects/project-versioning.md
+++ b/docs/components/hub/workspace/manage-projects/project-versioning.md
@@ -17,20 +17,23 @@ In this context, a [snapshot](/reference/glossary.md#snapshot-project) is a Camu
 To create a project snapshot:
 
 1. In your workspace, open a project.
-2. On the right side of the project view, under **Snapshots**, click **Create snapshot**.
+2. On the right side of the project view, under **Project snapshots**, click **Create snapshot**.
 3. Enter a **Snapshot tag** in the snapshot creation modal.
 4. Click **Create**.
 
 ## View all snapshots
 
-To view all snapshots, select **Snapshots** in the breadcrumb path at the top of a project or file within it.
+To view all snapshots:
+
+1. In your workspace, open a project.
+2. On the right side of the project view, under **Project snapshots**, click **Show full list**. This opens the **Snapshots** page.
 
 The page lists every file in the project with its status, file version, last changed date, and creator, so you can review changes at a glance without opening the comparison view.
 
 The side panel has two tabs:
 
-- **Snapshots**: the timeline of all project snapshots, including the current **Draft** state.
-- **Compare Snapshots**: the comparison of two snapshots you select.
+- **Snapshots**: View the timeline of all project snapshots, including the current **Draft** state.
+- **Compare Snapshots**: Compare two snapshots.
 
 See [manage file versions](/components/hub/workspace/modeler/modeling/versions.md) to learn about more features like comparing and restoring individual file versions.
 
@@ -39,19 +42,19 @@ See [manage file versions](/components/hub/workspace/modeler/modeling/versions.m
 To manage a project snapshot:
 
 1. In your workspace, open a project.
-2. On the right side of the project view, under **Snapshots**, open the vertical ellipsis menu.
+2. On the right side of the project view, under **Project snapshots**, next to a snapshot, open the vertical ellipsis menu.
 
 From here, you can perform the following actions on a project snapshot:
 
-| Action                | Description                                                                                     |
-| :-------------------- | :---------------------------------------------------------------------------------------------- |
-| **View details**      | Open the snapshot details page to review the contents of all files in the snapshot.             |
-| **Restore as latest** | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
-| **Edit details**      | Edit the snapshot tag and description.                                                          |
-| **Download**          | Download the project as a zip file.                                                             |
-| **Copy**              | Create a new project with the files from the snapshot.                                          |
-| **Edit review**       | Update the [review](#request-a-review) status of the snapshot.                                  |
-| **Delete**            | Delete the project snapshot.                                                                    |
+| Action                | Description                                                                                                        |
+| :-------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| **View details**      | Open the snapshot details page to review the contents of all files in the snapshot.                                |
+| **Restore as latest** | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project.                    |
+| **Edit details**      | Edit the snapshot tag and description.                                                                             |
+| **Download**          | Download the project as a zip file.                                                                                |
+| **Edit review**       | Update the [review](#request-a-review) status of the snapshot. (Only available if the snapshot has been reviewed.) |
+| **Copy to...**        | Create a new project with the files from the snapshot.                                                             |
+| **Delete**            | Delete the project snapshot.                                                                                       |
 
 On the snapshot details page (opened via **View details**), the actions menu also includes **Deploy**, which deploys the project snapshot, especially after it has been [reviewed](#request-a-review).
 
@@ -59,8 +62,9 @@ On the snapshot details page (opened via **View details**), the actions menu als
 
 You can compare any two project snapshots, including snapshots that are not next to each other in the timeline.
 
-1. In the **Compare Snapshots** tab, select the checkbox of the first snapshot you want to compare.
-1. Select the checkbox of the second snapshot you want to compare.
+1. In your workspace, open a project.
+2. On the right side of the project view, under **Project snapshots**, click **Show full list**.
+3. On the right side of the **Snapshots** view, in the **Compare Snapshots** tab, select two snapshots you want to compare.
 
 The comparison shows the older snapshot against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL, so you can share or bookmark a specific comparison.
 
@@ -79,8 +83,8 @@ A file gets only one status badge, in this order of priority: **New**, then **Re
 For each file in the list, you can:
 
 - Expand the row to view an inline diff of the file.
-- Select **Open file editor** to open the file.
-- Select **Open file history** to open the [version history](/components/hub/workspace/modeler/modeling/versions.md) of the file.
+- Select the **Open file editor** icon to open the file.
+- Select **Open version history** to open the [version history](/components/hub/workspace/modeler/modeling/versions.md) of the file.
 
 ## Restore a snapshot
 
@@ -93,8 +97,9 @@ Restoring a snapshot reverts the entire project to its state at the time the sna
 
 To restore a snapshot:
 
-1. In the **Snapshots** tab, open the actions menu of the snapshot you want to restore.
-1. Select **Restore as latest**.
+1. In your workspace, open a project.
+2. On the right side of the project view, under **Project snapshots**, next to a snapshot, open the vertical ellipsis menu.
+3. Select **Restore as latest**.
 
 The project state changes to match the snapshot, and the snapshots timeline is refreshed.
 

--- a/docs/components/hub/workspace/manage-projects/project-versioning.md
+++ b/docs/components/hub/workspace/manage-projects/project-versioning.md
@@ -23,16 +23,14 @@ To create a project snapshot:
 
 ## View all snapshots
 
-To view all snapshots:
+To view all snapshots, select **Snapshots** in the breadcrumb path at the top of a project or file within it.
 
-1. In your workspace, open a project.
-2. On the right side of the project view, under **Snapshots**, click **Show full list**.
-3. At the top of the modeling view, use the file navigation header buttons to switch between files and view their content.
+The page lists every file in the project with its status, file version, last changed date, and creator, so you can review changes at a glance without opening the comparison view.
 
-The side panel has two sub-tabs:
+The side panel has two tabs:
 
-- **Versions**: the timeline of all project snapshots.
-- **Compare**: the comparison of the two snapshots you selected.
+- **Snapshots**: the timeline of all project snapshots, including the current **Draft** state.
+- **Compare Snapshots**: the comparison of two snapshots you select.
 
 See [manage file versions](/components/hub/workspace/modeler/modeling/versions.md) to learn about more features like comparing and restoring individual file versions.
 
@@ -45,26 +43,26 @@ To manage a project snapshot:
 
 From here, you can perform the following actions on a project snapshot:
 
-| Action           | Description                                                                                     |
-| :--------------- | :---------------------------------------------------------------------------------------------- |
-| **View details** | Open the snapshot details page to review the contents of all files in the snapshot.             |
-| **Restore**      | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
-| **Edit details** | Edit the snapshot tag and description.                                                          |
-| **Download**     | Download the project as a zip file.                                                             |
-| **Copy to**      | Create a new project with the files from the snapshot.                                          |
-| **Edit review**  | Update the [review](#request-a-review) status of the snapshot.                                  |
-| **Delete**       | Delete the project snapshot.                                                                    |
+| Action                | Description                                                                                     |
+| :-------------------- | :---------------------------------------------------------------------------------------------- |
+| **View details**      | Open the snapshot details page to review the contents of all files in the snapshot.             |
+| **Restore as latest** | Revert changes, make further edits, or [sync](git-sync.md), download, or validate your project. |
+| **Edit details**      | Edit the snapshot tag and description.                                                          |
+| **Download**          | Download the project as a zip file.                                                             |
+| **Copy to**           | Create a new project with the files from the snapshot.                                          |
+| **Edit review**       | Update the [review](#request-a-review) status of the snapshot.                                  |
+| **Delete**            | Delete the project snapshot.                                                                    |
 
-You can also deploy a project snapshot from the project's main deployment flow after it has been [reviewed](#request-a-review). A dedicated **Deploy** action in this menu is planned as a follow-up.
+On the snapshot details page (opened via **View details**), the actions menu also includes **Deploy**, which deploys the project snapshot, especially after it has been [reviewed](#request-a-review).
 
 ## Compare snapshots
 
 You can compare any two project snapshots, including snapshots that are not next to each other in the timeline.
 
-1. In the **Versions** sub-tab, select the checkbox of the first snapshot you want to compare.
+1. In the **Compare Snapshots** tab, select the checkbox of the first snapshot you want to compare.
 1. Select the checkbox of the second snapshot you want to compare.
 
-The side panel switches to the **Compare** sub-tab and shows the older snapshot against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL, so you can share or bookmark a specific comparison.
+The comparison shows the older snapshot against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL, so you can share or bookmark a specific comparison.
 
 The comparison lists every file present in either snapshot, with a status badge per file:
 
@@ -95,8 +93,8 @@ Restoring a snapshot reverts the entire project to its state at the time the sna
 
 To restore a snapshot:
 
-1. In the **Versions** sub-tab, open the actions menu of the snapshot you want to restore.
-1. Select **Restore**.
+1. In the **Snapshots** tab, open the actions menu of the snapshot you want to restore.
+1. Select **Restore as latest**.
 
 The project state changes to match the snapshot, and the snapshots timeline is refreshed.
 
@@ -108,7 +106,11 @@ A project snapshot restore is a single bulk operation, not a series of individua
 - **Files that still exist in the project**: for each file that is still present (in its original location or elsewhere in the project), Web Modeler moves and renames it back into place, then restores its content the same way as an individual file restore — a safety autosave entry captures the file's state just before the restore (only if it differs from the file's last saved entry), followed by a new "(restored)" entry with the snapshot's content.
 - **Files that were moved out of the project or permanently deleted**: since there's no existing file to restore into, Web Modeler creates a new file from the snapshot's content directly. This new file has no autosave step and no prior version history, since none of its own history exists yet.
 - **Files that exist now but weren't part of the snapshot**: these are soft-deleted so the project matches the snapshot's file set.
-- **Element templates**: an element template that's still present in the project has its content reset in place, but this does **not** publish a new numbered template version the way [restoring an element template directly](/components/hub/workspace/modeler/element-templates/manage-element-templates.md#versioning-element-templates) does. If the element template that was part of the snapshot can no longer be found in the project, it's skipped — Web Modeler doesn't recreate deleted element templates as part of a project snapshot restore.
+- **Element templates**: element templates are handled differently depending on their state at the time of restore:
+  - If a template is still in the project, its content is reset in place, and it's moved back to its recorded location. This does **not** publish a new numbered template version the way [restoring an element template directly](/components/hub/workspace/modeler/element-templates/manage-element-templates.md#versioning-element-templates) does.
+  - If a template was soft- or permanently deleted since the snapshot was created, the entire restore fails rather than recreating the template.
+  - If a template is still live but was moved out of the project, it's skipped — restoring it in place would conflict with whoever now manages it in its new location. Any BPMN element still referencing the template keeps a broken reference; this is an accepted trade-off.
+  - If a template was added to the project after the snapshot was created, it's left in place rather than removed. Unlike other new files, it can't be safely reverted or removed, since it has its own independent versioning.
 
 ## Request a review
 

--- a/docs/components/hub/workspace/manage-projects/recently-deleted.md
+++ b/docs/components/hub/workspace/manage-projects/recently-deleted.md
@@ -38,7 +38,7 @@ DELETE /api/v2/files/{fileKey}/permanent
 
 ## Purge a file from versions
 
-If you delete a file within a project, its data is preserved in [older versions](../modeler/modeling/versions.md), if applicable. To permanently delete the file and its data from all file version history, a client with `delete` permissions can call the public purge endpoint:
+If you delete a file within a project, its data is preserved in [older versions](../modeler/modeling/versions.md), if applicable. To permanently delete the file and its data from the file's entire history, a client with `delete` permissions can call the public purge endpoint:
 
 ```bash
 DELETE /api/v2/files/{fileKey}/purge

--- a/docs/components/hub/workspace/manage-projects/recently-deleted.md
+++ b/docs/components/hub/workspace/manage-projects/recently-deleted.md
@@ -38,7 +38,7 @@ DELETE /api/v2/files/{fileKey}/permanent
 
 ## Purge a file from versions
 
-If you delete a file within a project, its data is preserved in [older versions](../modeler/modeling/versions.md), if applicable. To permanently delete the file and its data from all project version history, a client with `delete` permissions can call the public purge endpoint:
+If you delete a file within a project, its data is preserved in [older versions](../modeler/modeling/versions.md), if applicable. To permanently delete the file and its data from all file version history, a client with `delete` permissions can call the public purge endpoint:
 
 ```bash
 DELETE /api/v2/files/{fileKey}/purge

--- a/docs/components/hub/workspace/modeler/element-templates/manage-element-templates.md
+++ b/docs/components/hub/workspace/modeler/element-templates/manage-element-templates.md
@@ -103,7 +103,7 @@ Organization members without special organization permissions can:
 
 Element templates use their own numbered versioning, distinct from the [file version history](/components/hub/workspace/modeler/modeling/versions.md) used by diagrams, forms, RPA scripts, README files, and test files. Each publish creates a new numbered version in the template's versions list.
 
-To restore an earlier template version, select it in the versions list and select **Restore**. Restoring publishes the earlier content as a new numbered version — it doesn't create an autosave first, since the version you're restoring from remains available in the versions list.
+To restore an earlier template version, select it in the versions list and select **Restore**. Restoring publishes the earlier content as a new numbered version. It doesn't create an autosave first, since the version you're restoring from remains available in the versions list.
 
 If you publish a new version of an element template and an older version is already being used in diagrams, the user can either:
 

--- a/docs/components/hub/workspace/modeler/element-templates/manage-element-templates.md
+++ b/docs/components/hub/workspace/modeler/element-templates/manage-element-templates.md
@@ -101,7 +101,9 @@ Organization members without special organization permissions can:
 
 ### Versioning element templates
 
-You can version your element templates [similar to diagrams](/components/hub/workspace/modeler/modeling/versions.md).
+Element templates use their own numbered versioning, distinct from the [file version history](/components/hub/workspace/modeler/modeling/versions.md) used by diagrams, forms, RPA scripts, README files, and test files. Each publish creates a new numbered version in the template's versions list.
+
+To restore an earlier template version, select it in the versions list and select **Restore**. Restoring publishes the earlier content as a new numbered version — it doesn't create an autosave first, since the version you're restoring from remains available in the versions list.
 
 If you publish a new version of an element template and an older version is already being used in diagrams, the user can either:
 

--- a/docs/components/hub/workspace/modeler/modeler-settings.md
+++ b/docs/components/hub/workspace/modeler/modeler-settings.md
@@ -35,8 +35,8 @@ By default, only [organization administrators](/components/hub/organization/mana
 
 You can change this in the **Project deployment** settings. To get there, select the top right **Open Settings** user icon in Web Modeler and click **Settings**. Then, select **Project deployment**.
 
-Here, you can permit non-admin users with deployment permissions to deploy project versions to production stage clusters
-after a collaborator has reviewed and approved the project version using the
+Here, you can permit non-admin users with deployment permissions to deploy project snapshots to production stage clusters
+after a collaborator has reviewed and approved the project snapshot using the
 [project review](/components/hub/workspace/manage-projects/project-versioning.md#request-a-review) feature.
 This setting can only be configured by organization admins and applies to all projects in the organization.
 
@@ -49,8 +49,8 @@ clusters marked as [production stages](/components/hub/workspace/manage-projects
 
 You can change this in the **Project deployment** settings. To get there, select the top right **Open Settings** user icon in Web Modeler and click **Settings**. Then, select **Project deployment**.
 
-Here, you can permit non-admin users with deployment permissions to deploy project versions to production stage clusters
-after a collaborator has reviewed and approved the project version using the
+Here, you can permit non-admin users with deployment permissions to deploy project snapshots to production stage clusters
+after a collaborator has reviewed and approved the project snapshot using the
 [project review](/components/hub/workspace/manage-projects/project-versioning.md#request-a-review) feature.
 This setting can only be configured by users with the **Web Modeler Admin** role and applies to all projects.
 

--- a/docs/components/hub/workspace/modeler/modeling/versions.md
+++ b/docs/components/hub/workspace/modeler/modeling/versions.md
@@ -75,11 +75,19 @@ Select an entry to view it in the viewer next to the timeline.
 
 You can compare any two entries in the timeline, including entries that are not next to each other in the history.
 
+The version history page has two tabs:
+
+- **Versions**: the timeline of every entry for the file.
+- **Compare versions**: the comparison of two entries you select.
+
+To compare two entries:
+
 1. Open the version history for your file.
+1. Select the **Compare versions** tab.
 1. Select the first entry you want to compare.
 1. Select the second entry you want to compare.
 
-The page switches to the comparison view and shows the older entry against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL as `/<file-type>/<id>/versions/<entryId>...<entryId>`, so you can share or bookmark a specific comparison.
+The comparison shows the older entry against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL as `/<file-type>/<id>/versions/<entryId>...<entryId>`, so you can share or bookmark a specific comparison.
 
 ### Compare versions in visual view
 

--- a/docs/components/hub/workspace/modeler/modeling/versions.md
+++ b/docs/components/hub/workspace/modeler/modeling/versions.md
@@ -87,7 +87,7 @@ To compare two entries:
 1. Select the first entry you want to compare.
 1. Select the second entry you want to compare.
 
-The comparison shows the older entry against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL as `/<file-type>/<id>/versions/<entryId>...<entryId>`, so you can share or bookmark a specific comparison.
+The comparison shows the older entry against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL as `/<file-type>/<id>/versions/<olderEntryId>...<newerEntryId>`, so you can share or bookmark a specific comparison.
 
 ### Compare versions in visual view
 

--- a/docs/components/hub/workspace/modeler/modeling/versions.md
+++ b/docs/components/hub/workspace/modeler/modeling/versions.md
@@ -1,7 +1,7 @@
 ---
 id: versions
 title: Manage file versions
-description: Work with versions in Web Modeler.
+description: View, compare, and restore the version history of a file in Web Modeler.
 ---
 
 <span class="badge badge--cloud">Camunda 8 only</span>
@@ -10,43 +10,76 @@ description: Work with versions in Web Modeler.
 With 8.7, "milestone" has been renamed to "version". To learn more about this change, see [the related release note](/reference/announcements-release-notes/870/870-release-notes.md#web-modeler-milestones-renamed-to-versions).
 :::
 
-You can create a version at any time to save a snapshot of your BPMN or DMN diagram. This version is a Web Modeler snapshot version, not a deployed process definition version. See [version](/reference/glossary.md#version).
+Every file keeps a version history, a single timeline of the autosaves and named versions created as you work. You can open that history to view an earlier state of the file, compare any two entries, restore an entry, or copy one to another project.
 
-You can restore a version to revert to a previous snapshot of your diagram, for example if you make a mistake while modeling. You can also compare two versions to see the differences between them.
+A version is a Web Modeler snapshot of a file, not a deployed process definition version. See [version (file)](/reference/glossary.md#version-file).
 
-## Versions list
+## Files with a version history
 
-You can use the versions list to view, compare, and manage your diagram versions.
+The version history page is the same for every file type that uses it:
 
-To view the versions list, select **Versions > Show versions**.
+| File type           | Version history URL          |
+| ------------------- | ---------------------------- |
+| BPMN or DMN diagram | `/diagrams/<id>/versions`    |
+| Form                | `/forms/<id>/versions`       |
+| RPA script          | `/rpa-scripts/<id>/versions` |
+| README file         | `/readmes/<id>/versions`     |
+| Test file           | `/tests/<id>/versions`       |
 
-![Versions list showing the show versions button](../img/versions/web-modeler-version-action-show-versions.png)
+Element templates and connector templates do not use this page or timeline. They use numbered template versions that you publish to your project or organization. Restoring an element template version publishes its content as a new numbered version; there's no autosave step, since the previous published version remains available in the versions list. See [versioning element templates](/components/hub/workspace/modeler/element-templates/manage-element-templates.md#versioning-element-templates).
+
+:::note
+Links that use the older `/milestones/<slug>` path redirect to the equivalent `/versions/<slug>` path, so existing bookmarks and shared links keep working.
+:::
+
+## Open the version history of a file
+
+You can open the version history in the following ways:
+
+- From the file editor, select **Versions > Show versions**.
+
+  ![Versions list showing the show versions button](../img/versions/web-modeler-version-action-show-versions.png)
+
+- From a deep link to a single entry, such as a **See version** link from Copilot. The link opens the history with that entry selected.
 
 ## Create a version
 
-You can create a new version either from your diagram or the versions list.
+You can create a new version either from your file or from the version history.
 
-- From your diagram, select **Versions > Create version**.
+- From your file, select **Versions > Create version**.
 
   ![versions create via the breadcrumb menu](../img/versions/web-modeler-version-create-via-versions-menu.png)
 
-- From the versions list, hover over the draft in the **Versions** panel and select **Create a new version**.
+- From the version history, hover over the draft in the **Versions** panel and select **Create a new version**.
 
   ![versions create via icon](../img/versions/web-modeler-version-create-via-icon-highlight.png)
 
+## Read the version timeline
+
+The timeline lists every entry for the file, newest first. Autosaves and named versions appear in the same list.
+
+Each entry shows the following information:
+
+| Element           | Description                                                                                                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name              | The name of the version, or the autosave label.                                                                                                                        |
+| Description       | The optional description entered when the version was created or edited.                                                                                               |
+| Date and time     | The exact time the entry was captured.                                                                                                                                 |
+| Created by        | The author of the entry.                                                                                                                                               |
+| **Current state** | Shown at the top of the timeline as a draft when the file has unsaved changes.                                                                                         |
+| **In a snapshot** | Shown when the entry is captured in a [project snapshot](/components/hub/workspace/manage-projects/project-versioning.md). You cannot delete an entry with this badge. |
+
+Select an entry to view it in the viewer next to the timeline.
+
 ## Compare versions
 
-You can compare the change history between two versions, either visually as a diagram or as code in an XML diff layout.
+You can compare any two entries in the timeline, including entries that are not next to each other in the history.
 
-1. Open the versions list for your diagram.
-1. Ensure that the sidebar **Show changes** toggle is turned on.
-1. Select the version that you want to compare. The previous version is automatically selected for comparison.
+1. Open the version history for your file.
+1. Select the first entry you want to compare.
+1. Select the second entry you want to compare.
 
-:::note
-
-Turn off the sidebar **Show changes** toggle to view individual versions without comparison to the previous version.
-
-:::
+The page switches to the comparison view and shows the older entry against the newer one, ordered by time regardless of the order you selected them. The selected pair is written to the URL as `/<file-type>/<id>/versions/<entryId>...<entryId>`, so you can share or bookmark a specific comparison.
 
 ### Compare versions in visual view
 
@@ -60,7 +93,7 @@ To view BPMN diagram changes visually, select the **Visual view** tab.
 
 :::note
 
-You can only use the **Code view** to compare changes in a DMN diagram. The **Visual view** only shows a view of the version.
+DMN comparisons are available in the **Code view** only. The **Visual view** tab is disabled with the hint "Visual view is not supported for DMN comparisons".
 
 :::
 
@@ -70,53 +103,71 @@ To view BPMN and DMN diagram changes as code in an XML diff layout, select the *
 
 ![versions diffing in code view](../img/versions/web-modeler-version-code-diffing.png)
 
-- The XML for the previous version is shown on the left, with the currently selected version shown on the right.
+- The XML for the older entry is shown on the left, with the newer entry shown on the right.
 - Differences between the versions are highlighted in the XML. For example, if an element was added, this change is highlighted in green.
+
+## Version actions
+
+To act on an entry, hover over it in the timeline and select the three vertical dots to open the actions menu.
+
+| Action              | Description                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Restore**         | Reverts the file to the content of this entry. Disabled when the entry already matches the current file. |
+| **Edit**            | Updates the name and description of the entry.                                                           |
+| **Copy to project** | Creates a new file from this entry in a project and folder you choose.                                   |
+| **Delete**          | Permanently deletes the entry. Disabled for an entry with the **In a snapshot** badge.                   |
 
 ## Restore a version
 
-You can restore a version to revert to a previous snapshot of your diagram.
+You can restore a version to revert to an earlier state of your file.
 
-1. In the sidebar **Versions** list, hover over the version you want to restore.
+1. In the timeline, hover over the version you want to restore.
 1. Select the three vertical dots to open the actions menu.
-1. Select **Restore as latest**.
+1. Select **Restore**.
 
 ![versions restore](../img/versions/web-modeler-version-restore-highlight.png)
 
-The diagram reverts to the restored version. A new version is created with "(restored)" appended to the name.
+The file content changes to the content of the restored version, and the timeline is refreshed with up to two new entries:
+
+- A safety autosave that captures the state of the file before the restore. This entry is only added if that state differs from the most recent saved entry.
+- The restored entry, with `(restored)` appended to its name. This entry is selected in the viewer after the restore completes.
 
 ![version restored](../img/versions/web-modeler-version-restore-complete-highlight.png)
 
-## Copy a diagram version
+**Restore** is disabled when the content of the entry already matches the current file. The tooltip reads "This version matches the current file, so there is nothing to restore."
 
-You can create a new diagram by copying a specific version.
+## Copy a version to another project
 
-1. In the sidebar **Versions** list, hover over the diagram version you want to copy.
+You can create a new file by copying a specific entry.
+
+1. In the timeline, hover over the entry you want to copy.
 1. Select the three vertical dots to open the actions menu.
-1. Select **Copy to...**.
-1. Choose a project/folder and select **Copy here** to create the new diagram in the chosen folder.
+1. Select **Copy to project**.
+1. Choose a project or folder and select **Copy here** to create the new file in the chosen folder.
 
 ## Update a version
 
 You can update a version name and description at any time.
 
-1. In the sidebar **Versions** list, hover over the version you want to rename.
+1. In the timeline, hover over the version you want to rename.
 1. Select the three vertical dots to open the actions menu.
-1. Select **Edit** and enter a new name and/or description for the version.
+1. Select **Edit** and enter a new name, description, or both.
 
 ## Delete a version
 
 You can _permanently_ delete a version.
 
-1. In the sidebar **Versions** list, hover over the version you want to rename.
+1. In the timeline, hover over the version you want to delete.
 1. Select the three vertical dots to open the actions menu.
 1. Select **Delete**.
 1. You are prompted to confirm the deletion.
    - Select **Delete version** to permanently delete the version.
-   - Select **Cancel** to cancel the deletion and return to the versions list.
+   - Select **Cancel** to cancel the deletion and return to the timeline.
+
+An entry captured in a project snapshot cannot be deleted. **Delete** is disabled for these entries, and the tooltip reads "Captured in a snapshot, so it can't be deleted."
 
 :::caution
 
-Deleting a version is permanent. You cannot access a deleted version, and it is removed from the versions list.
+Deleting a version is permanent. You cannot access a deleted version, and it is removed from the version history.
 
 :::

--- a/docs/components/hub/workspace/modeler/modeling/versions.md
+++ b/docs/components/hub/workspace/modeler/modeling/versions.md
@@ -10,7 +10,7 @@ description: View, compare, and restore the version history of a file in Web Mod
 With 8.7, "milestone" has been renamed to "version". To learn more about this change, see [the related release note](/reference/announcements-release-notes/870/870-release-notes.md#web-modeler-milestones-renamed-to-versions).
 :::
 
-Every file keeps a version history, a single timeline of the autosaves and named versions created as you work. You can open that history to view an earlier state of the file, compare any two entries, restore an entry, or copy one to another project.
+Every BPMN diagram, DMN diagram, form, RPA script, README file, and test file keeps a version history, a single timeline of the autosaves and named versions created as you work. You can open that history to view an earlier state of the file, compare any two entries, restore an entry, or copy one to another project.
 
 A version is a Web Modeler snapshot of a file, not a deployed process definition version. See [version (file)](/reference/glossary.md#version-file).
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -776,7 +776,7 @@ The state of all active [process instances](#process-instance), (these are also 
 
 ### Snapshot (project)
 
-A project snapshot is a saved capture of all files in a project at a specific point in time. You can compare, restore, and review project snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
+A project snapshot is a saved capture of all files in a project at a specific point in time. You can compare, restore, review, and deploy project snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
 
 - [Project snapshots](/components/hub/workspace/manage-projects/project-versioning.md)
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -310,7 +310,7 @@ An event represents a state change associated with an aspect of an executing [pr
 
 In Desktop Modeler and Web Modeler, the execution platform version is the Camunda runtime version that a diagram targets. It determines which execution semantics and validation rules are applied during modeling.
 
-The execution platform version is not a deployed process definition version, a Web Modeler version, or a SaaS cluster generation.
+The execution platform version is not a deployed process definition version, a [file version](#version-file) or [project snapshot](#snapshot-project), or a SaaS cluster generation.
 
 - [Desktop Modeler flags](/components/modeler/desktop-modeler/flags/flags.md#default-execution-platform-version)
 
@@ -374,7 +374,7 @@ Any AI system that can produce new content, such as text, images, or audio, in r
 
 In Camunda 8 SaaS, a generation is the release identifier for the version set running in a cluster. Console uses generations instead of a single engine version because the underlying component versions can change independently.
 
-A generation is not a process definition version, a version tag, or a Web Modeler version.
+A generation is not a process definition version, a version tag, or a [file version](#version-file) or [project snapshot](#snapshot-project).
 
 - [Generation names](/reference/announcements-release-notes/release-policy.md#generation-names)
 
@@ -597,7 +597,7 @@ The engine uses process definitions to start [process instances](#process-instan
 
 A process definition version is the numeric version assigned by the Orchestration Cluster each time you deploy a process definition with the same process ID.
 
-Operate, Optimize, and APIs often shorten this to version. A process definition version is different from a version tag, which is a user-defined label, and from a Web Modeler version, which is a saved file or project snapshot.
+Operate, Optimize, and APIs often shorten this to version. A process definition version is different from a version tag, which is a user-defined label, and from a [file version](#version-file) or [project snapshot](#snapshot-project), which are saved Web Modeler captures.
 
 - [Process definition](#process-definition)
 - [Migrate process instances](/components/operate/userguide/process-instance-migration.md)
@@ -776,7 +776,7 @@ The state of all active [process instances](#process-instance), (these are also 
 
 ### Snapshot (project)
 
-A project snapshot is a saved capture of all files in a project at a specific point in time. You can compare, restore, review, and deploy project snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
+A project snapshot is a saved capture of all files in a project at a specific point in time. You can compare, restore, and review project snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
 
 - [Project snapshots](/components/hub/workspace/manage-projects/project-versioning.md)
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -774,6 +774,12 @@ The state of all active [process instances](#process-instance), (these are also 
 
 - [Resource planning](/components/best-practices/architecture/sizing-self-managed.md#snapshots)
 
+### Snapshot (project)
+
+A project snapshot is a saved capture of all files in a project at a specific point in time. You can compare, restore, review, and deploy project snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
+
+- [Project snapshots](/components/hub/workspace/manage-projects/project-versioning.md)
+
 ### Soft pause exporting
 
 Soft pause exporting is a feature that allows you to continue exporting records from [Zeebe](#zeebe), but without deleting those [records](#record) ([log](#log) compaction) from Zeebe. This is particularly useful during hot backups.
@@ -847,27 +853,24 @@ A variable stores data for a [process instance](#process-instance) or a local sc
 
 ### Version
 
-In Camunda 8, version is an overloaded term. Depending on context, it can refer to a [process definition version](#process-definition-version), a [version tag](#version-tag), a [Web Modeler version](#web-modeler-version), an [execution platform version](#execution-platform-version), or a SaaS [generation](#generation).
+In Camunda 8, version is an overloaded term. Depending on context, it can refer to a [process definition version](#process-definition-version), a [version tag](#version-tag), a [file version](#version-file) or [project snapshot](#snapshot-project), an [execution platform version](#execution-platform-version), or a SaaS [generation](#generation).
 
 ### Version tag
 
 A version tag is a user-defined string label for a specific resource or snapshot.
 
-For deployed BPMN, DMN, and form resources, a version tag can be used to identify a resource version and to resolve dependencies with `versionTag` binding. In Web Modeler project versioning, a version tag labels a saved project snapshot.
+For deployed BPMN, DMN, and form resources, a version tag can be used to identify a resource version and to resolve dependencies with `versionTag` binding. In Camunda Hub project snapshots, a version tag labels a saved project snapshot.
 
 A version tag is not generated automatically and does not replace the numeric process definition version.
 
 - [Resource binding types](/components/best-practices/modeling/choosing-the-resource-binding-type.md#versiontag)
 - [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
 
-### Web Modeler version
+### Version (file)
 
-A Web Modeler version is a saved snapshot of a BPMN or DMN file, or of an entire project. Diagram versions were previously called milestones.
-
-Web Modeler versions help you compare, restore, review, and deploy snapshots. They are distinct from deployed process definition versions in the Orchestration Cluster.
+A file version is a saved snapshot of a single file, such as a BPMN or DMN diagram, form, RPA script, README file, or test file. File versions were previously called milestones. You can compare, restore, and copy file versions. They are distinct from deployed process definition versions in the Orchestration Cluster.
 
 - [Versions](/components/hub/workspace/modeler/modeling/versions.md)
-- [Project versioning](/components/hub/workspace/manage-projects/project-versioning.md)
 
 ## W
 


### PR DESCRIPTION
## Description

Documents the Process Application Versioning and File Versioning redesign shipped in [camunda-hub#27824](https://github.com/camunda/camunda-hub/pull/27824).

- **File version history** ([versions.md](docs/components/hub/workspace/modeler/modeling/versions.md)): the five previously-separate "milestones" pages (diagrams, forms, RPA scripts, README files, test files) are now one unified page. Documents the single newest-first timeline mixing autosaves and named versions, the **Current state** draft entry, the **In a snapshot** badge and its delete restriction, non-sequential (any-two) comparison with the new shareable URL shape, entry actions, and the restore outcome (safety autosave + `(restored)` entry). Notes the `/milestones` → `/versions` redirect and excludes element/connector templates, which keep their existing numbered-version flow.
- **Project snapshots** ([project-versioning.md](docs/components/hub/workspace/manage-projects/project-versioning.md)): "process application version" is renamed to "process application snapshot" in the UI. Documents opening the snapshots page, the Versions/Compare side panel, the union file comparison table (New/Modified/Moved/Removed/Unchanged), snapshot actions, and what a full project restore does (moves/renames files and folders, soft-deletes files added after the snapshot, restores deleted file instances, updates all file content).
- Updated cross-references in [project-pipeline.md](docs/components/hub/workspace/manage-projects/project-pipeline.md) and [manage-projects.md](docs/components/hub/workspace/manage-projects/manage-projects.md) to use the new terminology.
- Split the glossary's single "Web Modeler version" entry into separate **Version (file)** and **Snapshot (project)** entries in [glossary.md](docs/reference/glossary.md), alphabetized under **S** and **V**.

Closes https://github.com/camunda/camunda-hub/issues/27893
Closes https://github.com/camunda/camunda-docs/issues/9715

### Notes for reviewers

- The **Deploy** action on the PA snapshot menu is intentionally not documented yet — it ships separately in [camunda-hub#27875](https://github.com/camunda/camunda-hub/issues/27875).
- These features are unreleased, so changes are in `/docs` only.

## When should this change go live?

- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
