### PR TITLE
docs(hub): document outdated catalog asset visibility and usage tracking

### DIFF
--- a/docs/components/hub/organization/manage-catalog/index.md
+++ b/docs/components/hub/organization/manage-catalog/index.md
@@ -12,6 +12,7 @@ In this section, you learn how to:
 
 - [Set up a Git repository](/components/hub/organization/manage-catalog/getting-started.md) for storing, approving, and publishing catalog assets.
 - [Manage the asset lifecycle](/components/hub/organization/manage-catalog/manage-asset-lifecycle.md), including unpublishing and deleting assets.
+- [Track catalog asset usage](/components/hub/organization/manage-catalog/track-asset-usage.md) to find outdated assets and the projects that still use them.
 - [Consolidate templates](/components/hub/organization/manage-catalog/sync-multiple-repositories.md) from multiple repositories before syncing.
 
 Delivery teams [discover published assets and apply them](/components/hub/workspace/modeler/element-templates/use-catalog-assets.md) when modeling business processes.

--- a/docs/components/hub/organization/manage-catalog/manage-asset-lifecycle.md
+++ b/docs/components/hub/organization/manage-catalog/manage-asset-lifecycle.md
@@ -39,6 +39,8 @@ For the center of excellence, responsible for managing the catalog, the asset re
 - Track which diagrams still reference the template.
 - Encourage the migration of those diagrams to a newer version or a different template before the asset is removed entirely.
 
+Unpublished assets that are still in use are reported as **Deprecated** in the [asset usage overview](/components/hub/organization/manage-catalog/track-asset-usage.md), where you can see the workspaces and projects that still reference them.
+
 :::note
 Unpublishing is a catalog-level state that indicates the asset is no longer part of the current submission. Use it when an asset should no longer be offered to delivery teams—for example, when you replace a connector with a successor and want to drive migration off the old one.
 
@@ -78,5 +80,6 @@ Deletion is irreversible. Use it to correct mistakes or remove assets that shoul
 ## Next steps
 
 - [Get started with the catalog](/components/hub/organization/manage-catalog/getting-started.md) — set up the repository and CI/CD pipeline.
+- [Track catalog asset usage](/components/hub/organization/manage-catalog/track-asset-usage.md) — find outdated assets and the projects that still use them.
 - [Sync assets from multiple repositories](/components/hub/organization/manage-catalog/sync-multiple-repositories.md) — consolidate templates before syncing.
 - [Use catalog assets in Hub](/components/hub/workspace/modeler/element-templates/use-catalog-assets.md) — learn how delivery teams apply published assets.

--- a/docs/components/hub/organization/manage-catalog/track-asset-usage.md
+++ b/docs/components/hub/organization/manage-catalog/track-asset-usage.md
@@ -21,8 +21,6 @@ To review adoption across your organization:
 
 The **Browse assets** tab shows the same catalog your delivery teams see. The **Asset usage** tab is visible to organization administrators and owners only, and adds the governance view described here.
 
-<!--- TODO: screenshot — the Organization catalog page with the "Asset usage" tab selected, showing the tab list, the toolbar (search, Status filter, Sort by), and several rows of the table with a mix of statuses. Suggested alt text: "Asset usage tab of the organization catalog, listing assets with their status, workspace and project counts". Save to `img/` alongside this file. --->
-
 ## Asset status values
 
 Camunda Hub derives a status for every catalog asset from the versions currently referenced in diagrams. The same four values are used in the usage table, the usage drawer, and the project tile.
@@ -65,9 +63,7 @@ No sort is selected on first load, and the table falls back to ordering by name 
 
 ## Find where an asset is used
 
-Select any row in the **Asset usage** table to open a drawer showing where that asset is used.
-
-<!--- TODO: screenshot — the usage drawer open next to the table, showing the asset name, status badge, the "Used in X projects across Y workspaces." summary, and at least two version groups so both the "Latest" marker and an "Update available" badge are visible. Suggested alt text: "Usage drawer showing an asset's usage grouped by version, with project and workspace entries". Save to `img/` alongside this file. --->
+Select any row in the **Asset usage** table to open a drawer on the right showing where that asset is used.
 
 The drawer header repeats the asset name as a link to its catalog detail page, shows the asset status, and summarizes the reach of the asset, for example `Used in 7 projects across 3 workspaces.`
 
@@ -83,12 +79,20 @@ If an asset has no usage, the drawer shows **Not used yet**.
 
 ### How permissions affect the results
 
-The drawer is permission-aware, so what you see depends on your access:
+Because the **Asset usage** tab is limited to organization administrators and owners, the drawer shows every project in your organization that uses the asset, across all workspaces — including workspaces you aren't a member of.
 
-- As an organization owner or administrator, you see every project in the organization that uses the asset.
-- Without elevated organization access, you see only projects in workspaces where you're a member. Projects outside your workspaces are excluded from the list rather than shown with hidden details.
+Seeing a project in this list doesn't grant you access to it. Catalog administration and workspace membership are separate, so opening a linked project or workspace still requires access to that workspace. To reach the team responsible for a usage you can't open, contact the owner of the workspace shown in the drawer.
 
-Catalog access alone does not grant you access to the workspaces and projects that appear in the results. To reach the team responsible for an outdated usage you can't open, contact the owner of the workspace shown in the drawer.
+## Drive a migration off an outdated asset
+
+To turn the overview into a prioritized list of work:
+
+1. Open the **Asset usage** tab and set the **Status** filter to **Update available** and **Deprecated** to hide assets that need no action.
+2. Select **Status** in **Sort by** to bring the most urgent assets to the top.
+3. Compare the **On latest** ratio of each asset to judge how much of the migration is left, and the **Workspaces** and **Projects** counts to judge how many teams a change affects.
+4. Select an asset to open the usage drawer, and note the projects grouped under any version other than the latest. Those are the projects that still need to migrate.
+
+You can't update a diagram from the catalog. The migration itself happens in each project, where teams [resolve outdated assets](/components/hub/workspace/modeler/element-templates/use-catalog-assets.md#review-catalog-updates-for-a-project) from the project page or directly in the diagram.
 
 ## Next steps
 

--- a/docs/components/hub/organization/manage-catalog/track-asset-usage.md
+++ b/docs/components/hub/organization/manage-catalog/track-asset-usage.md
@@ -81,8 +81,6 @@ If an asset has no usage, the drawer shows **Not used yet**.
 
 Because the **Asset usage** tab is limited to organization administrators and owners, the drawer shows every project in your organization that uses the asset, across all workspaces — including workspaces you aren't a member of.
 
-Elevated organization access also applies to the projects and workspaces themselves, so you can open any entry in the drawer to inspect a usage directly.
-
 ## Drive a migration off an outdated asset
 
 To turn the overview into a prioritized list of work:

--- a/docs/components/hub/organization/manage-catalog/track-asset-usage.md
+++ b/docs/components/hub/organization/manage-catalog/track-asset-usage.md
@@ -1,0 +1,92 @@
+---
+id: track-asset-usage
+title: Track catalog asset usage
+description: "See which catalog assets are outdated and which workspaces and projects still use an older version, so you can prioritize migrations."
+keywords:
+  [catalog, element templates, hub, usage, adoption, outdated, governance]
+---
+
+See which catalog assets are outdated and which workspaces and projects still use an older version, so you can prioritize migrations.
+
+## Prerequisites
+
+To open the **Asset usage** tab, you must have an **Admin** or **Owner** role in your organization, and your organization must have at least one [published catalog asset](/components/hub/organization/manage-catalog/getting-started.md). Without a published asset, the catalog shows only the setup instructions and no tabs.
+
+## Open the asset usage overview
+
+To review adoption across your organization:
+
+1. From the Camunda Hub home page, select **Catalog**.
+2. On the **Organization catalog** page, select the **Asset usage** tab.
+
+The **Browse assets** tab shows the same catalog your delivery teams see. The **Asset usage** tab is visible to organization administrators and owners only, and adds the governance view described here.
+
+## Asset status values
+
+Camunda Hub derives a status for every catalog asset from the versions currently referenced in diagrams. The same four values are used in the usage table, the usage drawer, and the project tile.
+
+| Status               | Meaning                                                                                                                                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Up to date**       | The asset is active, and every diagram that references it uses the latest version.                                                                                                                      |
+| **Update available** | The asset is active, and at least one diagram references a version older than the latest version.                                                                                                       |
+| **Deprecated**       | The asset is [unpublished](/components/hub/organization/manage-catalog/manage-asset-lifecycle.md#unpublish-an-asset) or its latest version is deprecated, and at least one diagram still references it. |
+| **Unused**           | No diagram references the asset.                                                                                                                                                                        |
+
+**Deprecated** takes priority over the version comparison. An unpublished asset that is still in use is reported as **Deprecated**, even when some diagrams already use its latest version.
+
+Unpublished assets remain in the usage table even though delivery teams can no longer discover them while browsing, so you keep visibility into the remaining usage you need to migrate away.
+
+## Read the asset usage table
+
+Each row in the **Asset usage** table represents one catalog asset.
+
+| Column           | Description                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Asset name**   | The name of the catalog asset.                                                                                 |
+| **Status**       | The asset status described in [Asset status values](#asset-status-values).                                     |
+| **Workspaces**   | The number of distinct workspaces that use the asset.                                                          |
+| **Projects**     | The number of distinct projects that use the asset.                                                            |
+| **On latest**    | The number of projects on the latest version, as a ratio of the projects using the asset, for example `3 / 7`. |
+| **Last updated** | When the asset was last updated in the catalog.                                                                |
+
+A project counts toward **On latest** only when _every_ usage of the asset within that project is on the latest version. A project with one outdated diagram is not counted, even if its other diagrams are current.
+
+### Filter, search, and sort the table
+
+Use the toolbar above the table to narrow the list:
+
+- **Search catalog assets** matches against the asset name only.
+- **Status** opens a checkbox list. Select any combination of **Up to date**, **Update available**, **Deprecated**, and **Unused**. Matching assets for any selected status are shown, and the trigger displays a count badge while a filter is active.
+- **Sort by** offers **Name (A–Z)**, **Name (Z–A)**, **Newest**, and **Status**. Sorting by **Status** orders assets by urgency: **Deprecated**, then **Update available**, then **Up to date**, then **Unused**.
+
+No sort is selected on first load, and the table falls back to ordering by name ascending. Changing the search, status filter, sort, or page size returns you to page 1. Table headers aren't sortable, and you can page through results with a page size of 20, 50, or 100.
+
+## Find where an asset is used
+
+Select any row in the **Asset usage** table to open a drawer showing where that asset is used.
+
+The drawer header repeats the asset name as a link to its catalog detail page, shows the asset status, and summarizes the reach of the asset, for example `Used in 7 projects across 3 workspaces.`
+
+Below the header, usage is grouped by the asset version in use. Each version group shows:
+
+- The version number, for example `v3`.
+- Either a **Latest** marker or an **Update available** badge. A group for any version other than the latest always means those projects have an update available.
+- The number of projects using that version.
+
+Each entry in a group lists the **Project** and the **Workspace** it belongs to, both linking to the corresponding page in Camunda Hub. Select **Load more** to fetch additional entries.
+
+If an asset has no usage, the drawer shows **Not used yet**.
+
+### How permissions affect the results
+
+The drawer is permission-aware, so what you see depends on your access:
+
+- As an organization owner or administrator, you see every project in the organization that uses the asset.
+- Without elevated organization access, you see only projects in workspaces where you're a member. Projects outside your workspaces are excluded from the list rather than shown with hidden details.
+
+Catalog access alone does not grant you access to the workspaces and projects that appear in the results. To reach the team responsible for an outdated usage you can't open, contact the owner of the workspace shown in the drawer.
+
+## Next steps
+
+- [Manage the asset lifecycle](/components/hub/organization/manage-catalog/manage-asset-lifecycle.md) — unpublish and delete assets to drive migrations.
+- [Use catalog assets in Hub](/components/hub/workspace/modeler/element-templates/use-catalog-assets.md) — see how delivery teams find and resolve outdated assets in their own projects and diagrams.

--- a/docs/components/hub/organization/manage-catalog/track-asset-usage.md
+++ b/docs/components/hub/organization/manage-catalog/track-asset-usage.md
@@ -10,29 +10,33 @@ See which catalog assets are outdated and which workspaces and projects still us
 
 ## Prerequisites
 
-To open the **Asset usage** tab, you must have an **Admin** or **Owner** role in your organization, and your organization must have at least one [published catalog asset](/components/hub/organization/manage-catalog/getting-started.md). Without a published asset, the catalog shows only the setup instructions and no tabs.
+To open the **Asset usage** tab, you must have an **Org Admin** or **Org Owner** role in your organization, and your organization must have at least one [published catalog asset](/components/hub/organization/manage-catalog/getting-started.md). Without a published asset, the catalog shows only the setup instructions and no tabs.
 
 ## Open the asset usage overview
 
 To review adoption across your organization:
 
-1. From the Camunda Hub home page, select **Catalog**.
+1. In Camunda Hub, in the left navigation, select **Catalog**.
 2. On the **Organization catalog** page, select the **Asset usage** tab.
 
-The **Browse assets** tab shows the same catalog your delivery teams see. The **Asset usage** tab is visible to organization administrators and owners only, and adds the governance view described here.
+The **Browse assets** tab shows the same catalog your delivery teams see. The **Asset usage** tab is visible to organization administrators and owners only and adds the governance view described here.
 
 ## Asset status values
 
-Camunda Hub derives a status for every catalog asset from the versions currently referenced in diagrams. The same four values are used in the usage table, the usage drawer, and the project tile.
+Camunda Hub derives a status for every catalog asset from the versions currently referenced in diagrams:
 
-| Status               | Meaning                                                                                                                                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Up to date**       | The asset is active, and every diagram that references it uses the latest version.                                                                                                                      |
-| **Update available** | The asset is active, and at least one diagram references a version older than the latest version.                                                                                                       |
-| **Deprecated**       | The asset is [unpublished](/components/hub/organization/manage-catalog/manage-asset-lifecycle.md#unpublish-an-asset) or its latest version is deprecated, and at least one diagram still references it. |
-| **Unused**           | No diagram references the asset.                                                                                                                                                                        |
+| Status               | Meaning                                                                                                                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Unused**           | The asset is not used in any diagram.                                                                                                                                                            |
+| **Deprecated**       | The asset is used in at least one diagram, and it's [unpublished](/components/hub/organization/manage-catalog/manage-asset-lifecycle.md#unpublish-an-asset) or its latest version is deprecated. |
+| **Update available** | The asset is used in at least one diagram, and at least one diagram references a version older than the latest version.                                                                          |
+| **Up to date**       | The asset is used in at least one diagram, and every diagram that references it uses the latest version.                                                                                         |
 
-**Deprecated** takes priority over the version comparison. An unpublished asset that is still in use is reported as **Deprecated**, even when some diagrams already use its latest version.
+The same four values are used in the usage table, the usage drawer, and the project tile.
+
+:::note
+**Deprecated** takes priority over the version comparison. An unpublished asset that is still in use is reported as **Deprecated**, even if some diagrams already use its latest version.
+:::
 
 Unpublished assets remain in the usage table even though delivery teams can no longer discover them while browsing, so you keep visibility into the remaining usage you need to migrate away.
 
@@ -40,14 +44,14 @@ Unpublished assets remain in the usage table even though delivery teams can no l
 
 Each row in the **Asset usage** table represents one catalog asset.
 
-| Column           | Description                                                                                                    |
-| ---------------- | -------------------------------------------------------------------------------------------------------------- |
-| **Asset name**   | The name of the catalog asset.                                                                                 |
-| **Status**       | The asset status described in [Asset status values](#asset-status-values).                                     |
-| **Workspaces**   | The number of distinct workspaces that use the asset.                                                          |
-| **Projects**     | The number of distinct projects that use the asset.                                                            |
-| **On latest**    | The number of projects on the latest version, as a ratio of the projects using the asset, for example `3 / 7`. |
-| **Last updated** | When the asset was last updated in the catalog.                                                                |
+| Column           | Description                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Asset name**   | The name of the catalog asset.                                                                               |
+| **Status**       | The asset status described in [Asset status values](#asset-status-values).                                   |
+| **Workspaces**   | The number of distinct workspaces that use the asset.                                                        |
+| **Projects**     | The number of distinct projects that use the asset.                                                          |
+| **On latest**    | The ratio of projects using the latest version compared to projects using any version. For example, `3 / 7`. |
+| **Last updated** | When the asset was last updated in the catalog.                                                              |
 
 A project counts toward **On latest** only when _every_ usage of the asset within that project is on the latest version. A project with one outdated diagram is not counted, even if its other diagrams are current.
 
@@ -57,9 +61,16 @@ Use the toolbar above the table to narrow the list:
 
 - **Search catalog assets** matches against the asset name only.
 - **Status** opens a checkbox list. Select any combination of **Up to date**, **Update available**, **Deprecated**, and **Unused**. Matching assets for any selected status are shown, and the trigger displays a count badge while a filter is active.
-- **Sort by** offers **Name (A–Z)**, **Name (Z–A)**, **Newest**, and **Status**. Sorting by **Status** orders assets by urgency: **Deprecated**, then **Update available**, then **Up to date**, then **Unused**.
+- **Sort by** offers sorting options:
 
-No sort is selected on first load, and the table falls back to ordering by name ascending. Changing the search, status filter, sort, or page size returns you to page 1. Table headers aren't sortable, and you can page through results with a page size of 20, 50, or 100.
+| Sort option | Description                                                                                               |
+| :---------- | :-------------------------------------------------------------------------------------------------------- |
+| Name (A-Z)  | **(Default)** Order assets by name in ascending order (A-Z)                                               |
+| Name (Z-A)  | Order assets by name in descending order (Z-A)                                                            |
+| Newest      | Order assets by last updated date, newest first                                                           |
+| Status      | Order assets by urgency: **Deprecated**, then **Update available**, then **Up to date**, then **Unused**. |
+
+Changing the search, status filter, sort, or page size returns you to page 1. Table headers aren't sortable, and you can page through results with a page size of 20, 50, or 100.
 
 ## Find where an asset is used
 
@@ -75,11 +86,11 @@ Below the header, usage is grouped by the asset version in use. Each version gro
 
 Each entry in a group lists the **Project** and the **Workspace** it belongs to, both linking to the corresponding page in Camunda Hub. Select **Load more** to fetch additional entries.
 
-If an asset has no usage, the drawer shows **Not used yet**.
+If an asset has no usage, the drawer shows **Unused**.
 
 ### How permissions affect the results
 
-Because the **Asset usage** tab is limited to organization administrators and owners, the drawer shows every project in your organization that uses the asset, across all workspaces — including workspaces you aren't a member of.
+Because the **Asset usage** tab is limited to organization administrators and owners, the drawer shows every project in your organization that uses the asset, across all workspaces, including workspaces you aren't a member of.
 
 ## Drive a migration off an outdated asset
 

--- a/docs/components/hub/organization/manage-catalog/track-asset-usage.md
+++ b/docs/components/hub/organization/manage-catalog/track-asset-usage.md
@@ -81,7 +81,7 @@ If an asset has no usage, the drawer shows **Not used yet**.
 
 Because the **Asset usage** tab is limited to organization administrators and owners, the drawer shows every project in your organization that uses the asset, across all workspaces — including workspaces you aren't a member of.
 
-Seeing a project in this list doesn't grant you access to it. Catalog administration and workspace membership are separate, so opening a linked project or workspace still requires access to that workspace. To reach the team responsible for a usage you can't open, contact the owner of the workspace shown in the drawer.
+Elevated organization access also applies to the projects and workspaces themselves, so you can open any entry in the drawer to inspect a usage directly.
 
 ## Drive a migration off an outdated asset
 

--- a/docs/components/hub/organization/manage-catalog/track-asset-usage.md
+++ b/docs/components/hub/organization/manage-catalog/track-asset-usage.md
@@ -21,6 +21,8 @@ To review adoption across your organization:
 
 The **Browse assets** tab shows the same catalog your delivery teams see. The **Asset usage** tab is visible to organization administrators and owners only, and adds the governance view described here.
 
+<!--- TODO: screenshot — the Organization catalog page with the "Asset usage" tab selected, showing the tab list, the toolbar (search, Status filter, Sort by), and several rows of the table with a mix of statuses. Suggested alt text: "Asset usage tab of the organization catalog, listing assets with their status, workspace and project counts". Save to `img/` alongside this file. --->
+
 ## Asset status values
 
 Camunda Hub derives a status for every catalog asset from the versions currently referenced in diagrams. The same four values are used in the usage table, the usage drawer, and the project tile.
@@ -64,6 +66,8 @@ No sort is selected on first load, and the table falls back to ordering by name 
 ## Find where an asset is used
 
 Select any row in the **Asset usage** table to open a drawer showing where that asset is used.
+
+<!--- TODO: screenshot — the usage drawer open next to the table, showing the asset name, status badge, the "Used in X projects across Y workspaces." summary, and at least two version groups so both the "Latest" marker and an "Update available" badge are visible. Suggested alt text: "Usage drawer showing an asset's usage grouped by version, with project and workspace entries". Save to `img/` alongside this file. --->
 
 The drawer header repeats the asset name as a link to its catalog detail page, shows the asset status, and summarizes the reach of the asset, for example `Used in 7 projects across 3 workspaces.`
 

--- a/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
+++ b/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
@@ -41,6 +41,8 @@ When an element references a template version that isn't the latest one, Camunda
 
 Select **Update** to apply the latest version of the template to the element. The hint is reported once per affected element, and an element that already uses the latest version produces no hint.
 
+<!--- TODO: screenshot — a BPMN element selected on the canvas with the properties panel showing the expanded "Update available" dropdown, including the "A new version of the template is available: N" text and the Update and Unlink actions. Include the problems panel hint in the same capture if it fits. Suggested alt text: "Properties panel showing the Update available dropdown for an element using an outdated template". Save to `img/` alongside this file. --->
+
 This signal covers every element template available to your diagram, whether it comes from the catalog or from your project.
 
 ## Review catalog updates for a project
@@ -53,6 +55,8 @@ To review the catalog assets a project uses:
 2. In the right sidebar of the project page, find the **Catalog updates** tile.
 
 The tile lists only the catalog assets that need attention — assets whose status is **Update available** or **Deprecated**. Assets that are up to date aren't listed. For each asset you see its name and status, followed by links to the diagrams in the project that use it. An asset used in more than two diagrams shows a **+N more files** control that expands the full list.
+
+<!--- TODO: screenshot — the "Catalog updates" tile in the project page sidebar, showing the status filter in the header and at least two assets with different status badges and their diagram links. Suggested alt text: "Catalog updates tile on the project page, listing assets with an update available and the diagrams using them". Save to `img/` alongside this file. --->
 
 Use the filter in the tile header to narrow the list to **All**, **Update available**, or **Deprecated**. Assets load five at a time, a **Showing X of Y** counter tracks how many are listed against the total, and **Load N more assets** appends the next batch.
 

--- a/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
+++ b/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
@@ -32,7 +32,35 @@ When the CoE publishes a newer version of a template you already use, Hub offers
 
 If the CoE unpublishes an asset you already use, the template is deprecated. Elements that reference it keep working but show a deprecation hint in the properties panel, signaling that you should migrate to a newer version or a different template.
 
+## Find outdated assets in a diagram
+
+When an element references a template version that isn't the latest one, Camunda Hub flags it in two places while you model:
+
+- The problems panel reports `Element has updated template available.` as an information-level hint. Select the hint to focus the affected element on the canvas.
+- The properties panel of the focused element shows an **Update available** dropdown. It reports the version you can move to, for example `A new version of the template is available: 3`, and offers the **Update** and **Unlink** actions.
+
+Select **Update** to apply the latest version of the template to the element. The hint is reported once per affected element, and an element that already uses the latest version produces no hint.
+
+This signal covers every element template available to your diagram, whether it comes from the catalog or from your project.
+
+## Review catalog updates for a project
+
+The project page collects the same information for a whole project, so you don't have to open each diagram to find outdated assets.
+
+To review the catalog assets a project uses:
+
+1. Open the project in your workspace.
+2. In the right sidebar of the project page, find the **Catalog updates** tile.
+
+The tile lists only the catalog assets that need attention — assets whose status is **Update available** or **Deprecated**. Assets that are up to date aren't listed. For each asset you see its name and status, followed by links to the diagrams in the project that use it. An asset used in more than two diagrams shows a **+N more files** control that expands the full list.
+
+Use the filter in the tile header to narrow the list to **All**, **Update available**, or **Deprecated**. Assets load five at a time, a **Showing X of Y** counter tracks how many are listed against the total, and **Load N more assets** appends the next batch.
+
+When the project has nothing to act on, including when it uses no catalog assets at all, the tile shows `All catalog assets in this project are up to date.`
+
+The tile is visible to any project member with read access, so you don't need catalog administrator permissions to see it. Updating a template still happens in the diagram — the tile points you to the diagrams that need the change.
+
 ## Next steps
 
 - Learn more about [element templates](/components/hub/workspace/modeler/element-templates/using-templates.md).
-- For CoE members: Learn how to [manage the catalog](/components/hub/organization/manage-catalog/index.md).
+- For CoE members: Learn how to [manage the catalog](/components/hub/organization/manage-catalog/index.md) and [track catalog asset usage](/components/hub/organization/manage-catalog/track-asset-usage.md) across your organization.

--- a/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
+++ b/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
@@ -41,8 +41,6 @@ When an element references a template version that isn't the latest one, Camunda
 
 Select **Update** to apply the latest version of the template to the element. The hint is reported once per affected element, and an element that already uses the latest version produces no hint.
 
-<!--- TODO: screenshot — a BPMN element selected on the canvas with the properties panel showing the expanded "Update available" dropdown, including the "A new version of the template is available: N" text and the Update and Unlink actions. Include the problems panel hint in the same capture if it fits. Suggested alt text: "Properties panel showing the Update available dropdown for an element using an outdated template". Save to `img/` alongside this file. --->
-
 This signal covers every element template available to your diagram, whether it comes from the catalog or from your project.
 
 ## Review catalog updates for a project
@@ -55,8 +53,6 @@ To review the catalog assets a project uses:
 2. In the right sidebar of the project page, find the **Catalog updates** tile.
 
 The tile lists only the catalog assets that need attention — assets whose status is **Update available** or **Deprecated**. Assets that are up to date aren't listed. For each asset you see its name and status, followed by links to the diagrams in the project that use it. An asset used in more than two diagrams shows a **+N more files** control that expands the full list.
-
-<!--- TODO: screenshot — the "Catalog updates" tile in the project page sidebar, showing the status filter in the header and at least two assets with different status badges and their diagram links. Suggested alt text: "Catalog updates tile on the project page, listing assets with an update available and the diagrams using them". Save to `img/` alongside this file. --->
 
 Use the filter in the tile header to narrow the list to **All**, **Update available**, or **Deprecated**. Assets load five at a time, a **Showing X of Y** counter tracks how many are listed against the total, and **Load N more assets** appends the next batch.
 

--- a/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
+++ b/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
@@ -34,7 +34,7 @@ If the CoE unpublishes an asset you already use, the template is deprecated. Ele
 
 ## Find outdated assets in a diagram
 
-When an element references a template version that isn't the latest one, Camunda Hub flags it in two places while you model:
+When an element references a template version that isn't the latest one, Camunda Hub flags it in two places in the modeler:
 
 - The problems panel reports `Element has updated template available.` as an information-level hint. Select the hint to focus the affected element on the canvas.
 - The properties panel of the focused element shows an **Update available** dropdown. It reports the version you can move to, for example `A new version of the template is available: 3`, and offers the **Update** and **Unlink** actions.

--- a/sidebars.js
+++ b/sidebars.js
@@ -746,6 +746,7 @@ module.exports = {
               items: [
                 "components/hub/organization/manage-catalog/getting-started-catalog",
                 "components/hub/organization/manage-catalog/manage-asset-lifecycle",
+                "components/hub/organization/manage-catalog/track-asset-usage",
                 "components/hub/organization/manage-catalog/sync-multiple-repositories",
               ],
             },


### PR DESCRIPTION
## Description

Documents the **outdated catalog asset visibility** work from [camunda/product-hub#3490](https://github.com/camunda/product-hub/issues/3490) (implementation epic [camunda/camunda-hub#23598](https://github.com/camunda/camunda-hub/issues/23598)), targeting 8.10-alpha5.

### What's included

**New page — [Track catalog asset usage](https://github.com/camunda/camunda-docs/blob/docs/catalog-outdated-asset-visibility/docs/components/hub/organization/manage-catalog/track-asset-usage.md)** (`manage-catalog/track-asset-usage.md`), covering the admin-facing governance surface:

- Reaching the **Asset usage** tab on the **Organization catalog** page, and the two conditions that gate it (org Admin/Owner, plus at least one published asset).
- The four asset statuses — **Up to date**, **Update available**, **Deprecated**, **Unused** — including that **Deprecated** takes priority over the version comparison, and that unpublished assets stay visible here.
- The table columns, and the rule that a project counts toward **On latest** only when *every* usage in it is on the latest version.
- The toolbar: name-only search, the OR-combined status filter, and the **Sort by** options (including the urgency ordering for **Status**).
- The usage drawer: the reach summary, grouping by version, and the **Project**/**Workspace** entries.
- A short migration walkthrough tying the filter, sort, ratio, and drawer together.

**Updated — `element-templates/use-catalog-assets.md`**, covering the delivery-team surfaces:

- The in-diagram signal: the info-level problems-panel hint and the properties-panel **Update available** dropdown with its **Update** and **Unlink** actions.
- The project page **Catalog updates** tile: actionable-only listing, per-asset diagram links, filter, batched loading, and the all-clear state.

Also adds the sidebar entry and cross-links from the catalog section index and `manage-asset-lifecycle.md`.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
