### PR TITLE
docs(hub): Note element template ID uniqueness constraint when publishing

### DIFF
--- a/docs/components/hub/workspace/modeler/element-templates/manage-element-templates.md
+++ b/docs/components/hub/workspace/modeler/element-templates/manage-element-templates.md
@@ -68,6 +68,10 @@ You cannot publish a new version if:
 Web Modeler also shows a warning if the template ID has changed since the last published version.
 You can still publish the new version in this case.
 
+:::note
+Template IDs must be unique across the organization, including for templates that are only published to a project. If a conflicting template ID is already published in another project, publish a new template with a different ID.
+:::
+
 As a [user with elevated access](/components/hub/workspace/modeler/collaboration/collaboration.md#elevated-access), you can publish an element template version within the organization context, enabling all organization members to use it in their diagrams.
 To do so, click **Publish > Publish to organization** on the editor screen or promote a template version via the [versions list](#versioning-connector-templates).
 

--- a/versioned_docs/version-8.8/components/modeler/web-modeler/element-templates/manage-element-templates.md
+++ b/versioned_docs/version-8.8/components/modeler/web-modeler/element-templates/manage-element-templates.md
@@ -68,6 +68,10 @@ You cannot publish a new version if:
 Web Modeler also shows a warning if the template ID has changed since the last published version.
 You can still publish the new version in this case.
 
+:::note
+Template IDs must be unique across the organization, including for templates that are only published to a project. If a conflicting template ID is already published in another project, publish a new template with a different ID.
+:::
+
 As a [user with elevated access](/components/modeler/web-modeler/collaboration/collaboration.md#elevated-access), you can publish an element template version within the organization context, enabling all organization members to use it in their diagrams.
 To do so, click **Publish > Publish to organization** on the editor screen or promote a template version via the [versions list](#versioning-connector-templates).
 

--- a/versioned_docs/version-8.9/components/modeler/web-modeler/element-templates/manage-element-templates.md
+++ b/versioned_docs/version-8.9/components/modeler/web-modeler/element-templates/manage-element-templates.md
@@ -68,6 +68,10 @@ You cannot publish a new version if:
 Web Modeler also shows a warning if the template ID has changed since the last published version.
 You can still publish the new version in this case.
 
+:::note
+Template IDs must be unique across the organization, including for templates that are only published to a project. If a conflicting template ID is already published in another project, publish a new template with a different ID.
+:::
+
 As a [user with elevated access](/components/modeler/web-modeler/collaboration/collaboration.md#elevated-access), you can publish an element template version within the organization context, enabling all organization members to use it in their diagrams.
 To do so, click **Publish > Publish to organization** on the editor screen or promote a template version via the [versions list](#versioning-connector-templates).
 


### PR DESCRIPTION
## Description

Adds a short note to **Publish an element template** in the Camunda Hub Web Modeler docs clarifying that element template IDs must be unique across the organization, including templates that are only published to a project.

This came up during an incident where the customer-facing path was unclear: a template published to a project can't be promoted to organization scope while the same template ID exists in another project. The behavior is intended, so the note also states the supported workaround — publish a new template with a different ID.

Docs-only change. Applied to `/docs` (Next) and backported to 8.9 and 8.8.

8.7 is intentionally skipped: on the equivalent 8.7 page (`components/connectors/manage-connector-templates.md`) the template ID is managed by Web Modeler and shown read-only, so the note and its workaround don't apply.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->

