### PR TITLE
docs(agentic-orchestration): add real-world agent pattern examples

### DIFF
--- a/docs/components/agentic-orchestration/ai-agents.md
+++ b/docs/components/agentic-orchestration/ai-agents.md
@@ -64,6 +64,31 @@ Decision-making and execution are intentionally split:
 Learn more in the [example AI Agent Sub-process connector integration](/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md) and [Add tools to an AI agent](/components/agentic-orchestration/add-tool-to-ai-agent.md).
 :::
 
+#### Example: an order exception agent
+
+Consider an order fulfillment process that hands off exception handling to an AI agent. The agent's ad-hoc sub-process exposes tools built from existing BPMN elements and connectors:
+
+- **Check inventory**: a REST connector call to an inventory system.
+- **Apply discount rules**: a business rule task evaluating a DMN decision.
+- **Notify customer**: a REST connector call to an email or messaging service.
+- **Escalate to support**: a user task routed to a human.
+
+Given the order details, the LLM decides which tools to call, in what order, and with what parameters. Camunda executes each selected tool as a governed BPMN activity and returns the result to the LLM, until the agent reaches a final response.
+
+```mermaid
+flowchart LR
+    Start([Order exception]) --> Agent{{AI agent<br/>ad-hoc sub-process}}
+    Agent -->|checkInventory| Inventory[Check inventory]
+    Agent -->|applyDiscountRules| Discount[Apply discount rules]
+    Agent -->|notifyCustomer| Notify[Notify customer]
+    Agent -->|escalateToSupport| Escalate[Escalate to support]
+    Inventory --> Agent
+    Discount --> Agent
+    Notify --> Agent
+    Escalate --> Agent
+    Agent --> Done([Final response])
+```
+
 ## AI agent integration features
 
 Use the following Camunda 8 features to integrate AI agents into your processes:

--- a/docs/components/agentic-orchestration/design-architecture.md
+++ b/docs/components/agentic-orchestration/design-architecture.md
@@ -105,6 +105,27 @@ For a how-to guide on adding tools, see [add tools to an AI agent](./add-tool-to
 </tr>
 </table>
 
+#### Example: an agent that delegates to specialized agents
+
+Consider a support process where one agent receives an incoming request and delegates parts of it to other, more specialized agents rather than handling everything itself:
+
+- A **billing agent** with tools scoped to invoices, payments, and refunds.
+- A **technical agent** with tools scoped to diagnostics and troubleshooting.
+
+The receiving agent uses the [A2A Client connector](/components/early-access/alpha/a2a-client/a2a-client.md) as a tool to call each specialized agent over the Agent-to-Agent (A2A) protocol, then combines their responses into a single result.
+
+```mermaid
+flowchart TB
+    Request([Support request]) --> Coordinator{{Coordinating agent}}
+    Coordinator -->|A2A Client connector| Billing[Billing agent]
+    Coordinator -->|A2A Client connector| Technical[Technical agent]
+    Billing --> Coordinator
+    Technical --> Coordinator
+    Coordinator --> Response([Combined response])
+```
+
+Splitting agents this way keeps each agent's tool set small and scoped to one domain, and lets specialized agents be reused across multiple processes.
+
 ### Call processes as agent tools
 
 When an AI agent needs to invoke another BPMN process as a tool, you have two options:

--- a/versioned_docs/version-8.9/components/agentic-orchestration/ai-agents.md
+++ b/versioned_docs/version-8.9/components/agentic-orchestration/ai-agents.md
@@ -53,6 +53,31 @@ Decision-making and execution are intentionally split:
 Learn more in the [example AI Agent Sub-process connector integration](/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess-example.md) and [Add tools to an AI agent](/components/agentic-orchestration/add-tool-to-ai-agent.md).
 :::
 
+#### Example: an order exception agent
+
+Consider an order fulfillment process that hands off exception handling to an AI agent. The agent's ad-hoc sub-process exposes tools built from existing BPMN elements and connectors:
+
+- **Check inventory**: a REST connector call to an inventory system.
+- **Apply discount rules**: a business rule task evaluating a DMN decision.
+- **Notify customer**: a REST connector call to an email or messaging service.
+- **Escalate to support**: a user task routed to a human.
+
+Given the order details, the LLM decides which tools to call, in what order, and with what parameters. Camunda executes each selected tool as a governed BPMN activity and returns the result to the LLM, until the agent reaches a final response.
+
+```mermaid
+flowchart LR
+    Start([Order exception]) --> Agent{{AI agent<br/>ad-hoc sub-process}}
+    Agent -->|checkInventory| Inventory[Check inventory]
+    Agent -->|applyDiscountRules| Discount[Apply discount rules]
+    Agent -->|notifyCustomer| Notify[Notify customer]
+    Agent -->|escalateToSupport| Escalate[Escalate to support]
+    Inventory --> Agent
+    Discount --> Agent
+    Notify --> Agent
+    Escalate --> Agent
+    Agent --> Done([Final response])
+```
+
 ## AI agent integration features
 
 Use the following Camunda 8 features to integrate AI agents into your processes:

--- a/versioned_docs/version-8.9/components/agentic-orchestration/design-architecture.md
+++ b/versioned_docs/version-8.9/components/agentic-orchestration/design-architecture.md
@@ -108,3 +108,24 @@ For a how-to guide on adding tools, see [add tools to an AI agent](./add-tool-to
     <td>**Multi-agent orchestration**: Agents orchestrate other agents for streamlined, scalable solutions. This agent-to-agent pattern runs inside Camunda's [agentic orchestration](/components/agentic-orchestration/agentic-orchestration-overview.md), as one of the tools available to an agent. It is not the same as agentic orchestration itself, which is Camunda's overall model for orchestrating agents, people, and systems. With the [A2A Client connector](/components/early-access/alpha/a2a-client/a2a-client.md) implements this pattern, an agent can call a remote agent using the Agent-to-Agent (A2A) protocol.</td>
 </tr>
 </table>
+
+#### Example: an agent that delegates to specialized agents
+
+Consider a support process where one agent receives an incoming request and delegates parts of it to other, more specialized agents rather than handling everything itself:
+
+- A **billing agent** with tools scoped to invoices, payments, and refunds.
+- A **technical agent** with tools scoped to diagnostics and troubleshooting.
+
+The receiving agent uses the [A2A Client connector](/components/early-access/alpha/a2a-client/a2a-client.md) as a tool to call each specialized agent over the Agent-to-Agent (A2A) protocol, then combines their responses into a single result.
+
+```mermaid
+flowchart TB
+    Request([Support request]) --> Coordinator{{Coordinating agent}}
+    Coordinator -->|A2A Client connector| Billing[Billing agent]
+    Coordinator -->|A2A Client connector| Technical[Technical agent]
+    Billing --> Coordinator
+    Technical --> Coordinator
+    Coordinator --> Response([Combined response])
+```
+
+Splitting agents this way keeps each agent's tool set small and scoped to one domain, and lets specialized agents be reused across multiple processes.


### PR DESCRIPTION
## Description

Adds two real-world example scenarios to the agentic orchestration docs, illustrating patterns that were previously described only mechanically with no worked example:

- **`components/agentic-orchestration/ai-agents.md`**: a single-agent tool-calling example (an order exception agent choosing between inventory, discount, notification, and escalation tools), with a Mermaid diagram.
- **`components/agentic-orchestration/design-architecture.md`**: a multi-agent delegation example (a coordinating agent calling specialized billing/technical agents via the A2A Client connector), with a Mermaid diagram, expanding on the existing "Multi-agent orchestration" callout.

Mirrored to both `docs/` and `versioned_docs/version-8.9/` (both target sections are unaffected by 8.9/8.10 wording differences elsewhere in these files).

### Context

This follows feedback shared via Slack: [camunda.com/orchestrate/agents](https://camunda.com/orchestrate/agents/)'s "Build any enterprise agent on one platform" section and its diagrams were well received, and of its categories, only the Task Agent and Orchestrator Agent patterns were judged to have enough substance to warrant inclusion.

Per the [agentic orchestration docs audit epic](https://github.com/camunda/documentation-team/issues/515)'s caveat against parroting marketing language/taxonomy, this PR does **not** introduce "Task Agent"/"Orchestrator Agent" as new docs terms. Instead, it adds worked examples for the two underlying patterns Camunda docs already document (single-agent tool-calling, multi-agent delegation via A2A), in Camunda's own terminology, linking to existing connector/tool docs rather than duplicating them.

Closes camunda/documentation-team#550. Part of #515.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
