### PR TITLE
docs(marketplace): Note that Marketplace serves only the latest connector template version

### DIFF
--- a/docs/components/hub/workspace/modeler/modeling/camunda-marketplace.md
+++ b/docs/components/hub/workspace/modeler/modeling/camunda-marketplace.md
@@ -51,6 +51,12 @@ For the out-of-the-box connectors provided by Camunda, the connectors Bundle pro
 This means a developer created a template and reused one of the built-in connectors. Only for these templates is direct **Download to project** available.
 :::
 
+## Connector template versions
+
+The Camunda Marketplace always serves the **latest** version of a connector template. If that version's [`engines.camunda`](/components/modeler/element-templates/template-metadata.md#engine-compatibility-engines) range doesn't cover your cluster version, the connector is listed under **Requires newer Camunda version** and can't be applied to your diagram.
+
+To use an older version, obtain the template file from the connector's source and [upload it as an element template](/components/hub/workspace/modeler/element-templates/manage-element-templates.md#importing-an-existing-element-template) yourself. Camunda's out-of-the-box connectors publish previous versions in the `element-templates/versioned` directory of the [`camunda/connectors`](https://github.com/camunda/connectors) repository. For partner and community connectors, availability of previous versions depends on the provider.
+
 ## Browse Marketplace blueprints
 
 1. Log in to your Camunda account and navigate to Web Modeler by clicking the Camunda components icon in the top left corner of your console, and then select Modeler.

--- a/versioned_docs/version-8.8/components/modeler/web-modeler/camunda-marketplace.md
+++ b/versioned_docs/version-8.8/components/modeler/web-modeler/camunda-marketplace.md
@@ -55,6 +55,12 @@ For the out-of-the-box connectors provided by Camunda, the connectors Bundle pro
 This means a developer created a template and reused one of the built-in connectors. Only for these templates is direct **Download to project** available.
 :::
 
+## Connector template versions
+
+The Camunda Marketplace always serves the **latest** version of a connector template. If that version's [`engines.camunda`](/components/modeler/element-templates/template-metadata.md#engine-compatibility-engines) range doesn't cover your cluster version, the connector is listed under **Requires newer Camunda version** and can't be applied to your diagram.
+
+To use an older version, obtain the template file from the connector's source and [upload it as an element template](/components/modeler/web-modeler/element-templates/manage-element-templates.md#importing-an-existing-element-template) yourself. Camunda's out-of-the-box connectors publish previous versions in the `element-templates/versioned` directory of the [`camunda/connectors`](https://github.com/camunda/connectors) repository. For partner and community connectors, availability of previous versions depends on the provider.
+
 ## Browse Marketplace blueprints
 
 1. Log in to your Camunda account and navigate to Web Modeler by clicking the Camunda components icon in the top left corner of your console, and then select Modeler.

--- a/versioned_docs/version-8.9/components/modeler/web-modeler/modeling/camunda-marketplace.md
+++ b/versioned_docs/version-8.9/components/modeler/web-modeler/modeling/camunda-marketplace.md
@@ -51,6 +51,12 @@ For the out-of-the-box connectors provided by Camunda, the connectors Bundle pro
 This means a developer created a template and reused one of the built-in connectors. Only for these templates is direct **Download to project** available.
 :::
 
+## Connector template versions
+
+The Camunda Marketplace always serves the **latest** version of a connector template. If that version's [`engines.camunda`](/components/modeler/element-templates/template-metadata.md#engine-compatibility-engines) range doesn't cover your cluster version, the connector is listed under **Requires newer Camunda version** and can't be applied to your diagram.
+
+To use an older version, obtain the template file from the connector's source and [upload it as an element template](/components/modeler/web-modeler/element-templates/manage-element-templates.md#importing-an-existing-element-template) yourself. Camunda's out-of-the-box connectors publish previous versions in the `element-templates/versioned` directory of the [`camunda/connectors`](https://github.com/camunda/connectors) repository. For partner and community connectors, availability of previous versions depends on the provider.
+
 ## Browse Marketplace blueprints
 
 1. Log in to your Camunda account and navigate to Web Modeler by clicking the Camunda components icon in the top left corner of your console, and then select Modeler.


### PR DESCRIPTION
## Description

The Camunda Marketplace always serves the **latest** version of a connector template, with no way to browse or download previous versions. When the latest template's `engines.camunda` range doesn't cover the cluster version, the connector shows up as **Requires newer Camunda version** and can't be applied. This mainly hits Self-Managed users on older clusters, and today the behavior is undocumented.

This PR adds a short **Connector template versions** section to the Camunda Marketplace page describing the behavior and the manual workaround (obtain the template from the connector's source and upload it as an element template).
 
Added in `/docs` (Next), `versioned_docs/version-8.9`, and `versioned_docs/version-8.8`.

Related: https://github.com/camunda/marketplace-api/issues/320#issuecomment-5328328192

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
