### PR TITLE
feat: allow to filter the versions to build when developing locally

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,17 @@ const { currentVersion } = require("./src/versions");
 const [_currentMajor, _currentMinor] = currentVersion.split(".").map(Number);
 const nextVersion = `${_currentMajor}.${_currentMinor + 1}`;
 
+// Build only selected doc versions to cut build time and memory.
+//   DOCS_ONLY_VERSIONS=current           -> only the unreleased docs (the `docs/` folder)
+//   DOCS_ONLY_VERSIONS=8.9               -> only the 8.9 versioned docs
+//   DOCS_ONLY_VERSIONS=current,8.9       -> both
+// The first selected version becomes `lastVersion`, so it is served at the site
+// root instead of its usual path (for example, `current` is served at `/` rather
+// than `/next`).
+const onlyIncludeVersions = process.env.DOCS_ONLY_VERSIONS
+  ? process.env.DOCS_ONLY_VERSIONS.split(",").map((v) => v.trim())
+  : undefined;
+
 const docsSiteUrl = process.env.DOCS_SITE_URL || "https://docs.camunda.io";
 const docsSitebaseUrl = process.env.DOCS_SITE_BASE_URL || "/";
 const { themes } = require("prism-react-renderer");
@@ -29,8 +40,10 @@ module.exports = {
     currentVersion,
     nextVersion,
   },
-  onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  // Partial-version builds can't resolve links into the versions they skip,
+  // so downgrade link errors to warnings when DOCS_ONLY_VERSIONS is set.
+  onBrokenLinks: onlyIncludeVersions ? "warn" : "throw",
+  onBrokenMarkdownLinks: onlyIncludeVersions ? "warn" : "throw",
   favicon: "img/favicon.ico",
   organizationName: "camunda", // Usually your GitHub org/user name.
   projectName: "camunda-docs", // Usually your repo name.
@@ -759,19 +772,28 @@ module.exports = {
           remarkPlugins: [
             require("./static/plugins/terminology/remark-glossary-terms"),
           ],
-          lastVersion: currentVersion,
+          ...(onlyIncludeVersions ? { onlyIncludeVersions } : {}),
+          lastVersion:
+            onlyIncludeVersions && !onlyIncludeVersions.includes(currentVersion)
+              ? onlyIncludeVersions[0]
+              : currentVersion,
           // 👋 When cutting a new version, remove the banner for maintained versions by adding an entry. Remove the entry to versions >18 months old.
-          versions: {
-            current: {
-              label: "8.10 (unreleased)",
-            },
-            8.8: {
-              banner: "none",
-            },
-            8.7: {
-              banner: "none",
-            },
-          },
+          versions: Object.fromEntries(
+            Object.entries({
+              current: {
+                label: "8.10 (unreleased)",
+              },
+              8.8: {
+                banner: "none",
+              },
+              8.7: {
+                banner: "none",
+              },
+            }).filter(
+              ([version]) =>
+                !onlyIncludeVersions || onlyIncludeVersions.includes(version)
+            )
+          ),
           docItemComponent: "@theme/ApiItem",
         },
         blog: false,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "build:current": "DOCS_ONLY_VERSIONS=current docusaurus build",
+    "start:current": "DOCS_ONLY_VERSIONS=current docusaurus start",
     "build:docker": "docker build -f Dockerfile.build --output ./build --target=outputs . ",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION


## Description
Adds possibility to build docs just for one version via env var DOCS_ONLY_VERSIONS, which is most useful when building the unreleased version of the docs.
Adds a npm task "build:current" and "start:current" to build only the unreleased version of the docs.

Motivation is that building the site locally to modify the docs requires quite some time and large amount of memory, which sometimes fails if I'm doing other tasks. 
I haven't run tests, but it's noticeably faster than building all 4 version (3 supported + 1 unreleased)

<img width="422" height="182" alt="image" src="https://github.com/user-attachments/assets/1f2c4b75-f7a8-4036-b2d7-039b3ed90cdc" />


<!-- Provide an overview of what to expect in the PR. -->
<!-- Relate or link the associated epic or task. -->
<!-- Add `@camunda/tech-writers` as reviewer to pull in a tech writer, or add your embedded tech writer. -->

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [X] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
