### PR TITLE
docs: update health check references for unified schema readiness check

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -523,6 +523,19 @@ Camunda no longer produces the following individual component Docker images in C
 </div>
 <div className="release-announcement-content">
 
+#### Operate and Tasklist health indicators replaced by a unified schema readiness check
+
+Camunda 8.10 removes the Operate- and Tasklist-specific Elasticsearch/OpenSearch health indicators (`indicesCheck` and `searchEngineCheck`). A single `schemaReadinessCheck` now backs the gateways readiness probe; it is set once at startup, after the schema is initialized and the cluster reports green or yellow. `searchEngineStatus` reflects the current health status of Elasticsearch/OpenSearch and can be fetched via `/actuator/health` (it is not part of the readiness probe group).
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
 #### Unused PVC in Optimize is unmounted
 
 An unused volume mounted at `/camunda` in Optimize has been removed from the Helm chart. Optimize did not use this volume.

--- a/docs/self-managed/concepts/databases/elasticsearch/elasticsearch-without-cluster-privileges.md
+++ b/docs/self-managed/concepts/databases/elasticsearch/elasticsearch-without-cluster-privileges.md
@@ -235,9 +235,7 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_CREATESCHEMA
       value: "false"
-    - name: CAMUNDA_TASKLIST_ELASTICSEARCH_HEALTHCHECKENABLED
-      value: "false"
-    - name: CAMUNDA_OPERATE_ELASTICSEARCH_HEALTHCHECKENABLED
+    - name: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_HEALTHCHECKENABLED
       value: "false"
     - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CREATESCHEMA
       value: "false"
@@ -262,12 +260,10 @@ orchestration:
     camunda.database:
       schema-manager:
         create-schema: false
-    camunda.tasklist:
-      elasticsearch:
-        health-check-enabled: false
-    camunda.operate:
-      elasticsearch:
-        health-check-enabled: false
+    camunda.data:
+      secondary-storage:
+        elasticsearch:
+          health-check-enabled: false
     zeebe.broker.exporters:
       camundaexporter:
         class-name: io.camunda.zeebe.exporter.CamundaExporter

--- a/docs/self-managed/concepts/databases/elasticsearch/opensearch-without-cluster-privileges.md
+++ b/docs/self-managed/concepts/databases/elasticsearch/opensearch-without-cluster-privileges.md
@@ -217,9 +217,7 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_CREATESCHEMA
       value: "false"
-    - name: CAMUNDA_TASKLIST_OPENSEARCH_HEALTHCHECKENABLED
-      value: "false"
-    - name: CAMUNDA_OPERATE_OPENSEARCH_HEALTHCHECKENABLED
+    - name: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_HEALTHCHECKENABLED
       value: "false"
     - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CREATESCHEMA
       value: "false"
@@ -238,9 +236,7 @@ orchestration:
     camunda.database:
       schema-manager:
         create-schema: false
-    camunda.tasklist.opensearch:
-      health-check-enabled: false
-    camunda.operate.opensearch:
+    camunda.data.secondary-storage.opensearch:
       health-check-enabled: false
     zeebe.broker.exporters:
       camundaexporter:

--- a/docs/self-managed/deployment/manual/install.md
+++ b/docs/self-managed/deployment/manual/install.md
@@ -425,16 +425,16 @@ curl localhost:9600/actuator/health
     "brokerStatus": {
       "status": "UP"
     },
-    "indicesCheck": {
-      "status": "UP"
-    },
     "livenessState": {
       "status": "UP"
     },
     "readinessState": {
       "status": "UP"
     },
-    "searchEngineCheck": {
+    "schemaReadinessCheck": {
+      "status": "UP"
+    },
+    "searchEngineStatus": {
       "status": "UP"
     }
   }


### PR DESCRIPTION
## Summary
- Updates docs that reference the removed Operate/Tasklist `indicesCheck`/`searchEngineCheck` health indicators, following camunda/camunda#55499 (closes camunda/camunda#51861).
- Replaces per-webapp health-check-enabled config examples with the unified `camunda.data.secondary-storage.<db>.health-check-enabled` property in the ES/OS "without cluster privileges" guides.
- Updates the sample `/actuator/health` response in the manual install guide to show `schemaReadinessCheck` and `searchEngineStatus` instead of `indicesCheck`/`searchEngineCheck`.
- Adds an 8.10 breaking-change announcement entry describing the change.