### PR TITLE
docs(management-identity): document required database for OIDC provider connections

### DIFF
--- a/docs/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
@@ -33,6 +33,7 @@ If you deploy Camunda 8 Self-Managed with Helm, use the [Helm chart authenticati
   - Audience
 - A [claim name and value](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#oidc-configuration) to use for initial access.
 - Your OIDC provider must issue access tokens that contain an `aud` (audience) claim matching the configured audience, as Camunda validates this claim for auth flows. Providers that are not configured to emit, or do not emit, the `aud` claim in their access tokens are not supported. Configure your identity provider to emit this claim if supported. See [known limitations](#oidc-provider-known-limitations) for details.
+- A relational database for Identity to connect to. Connecting to an OIDC provider requires a database, regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
 
 :::note
 The steps below are a general approach for the Camunda components; it is important you reference the [component-specific

--- a/docs/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
+++ b/docs/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
@@ -33,7 +33,7 @@ If you deploy Camunda 8 Self-Managed with Helm, use the [Helm chart authenticati
   - Audience
 - A [claim name and value](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#oidc-configuration) to use for initial access.
 - Your OIDC provider must issue access tokens that contain an `aud` (audience) claim matching the configured audience, as Camunda validates this claim for auth flows. Providers that are not configured to emit, or do not emit, the `aud` claim in their access tokens are not supported. Configure your identity provider to emit this claim if supported. See [known limitations](#oidc-provider-known-limitations) for details.
-- A relational database for Identity to connect to. Connecting to an OIDC provider requires a database, regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
+- A relational database that Identity can connect to. The database is required regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
 
 :::note
 The steps below are a general approach for the Camunda components; it is important you reference the [component-specific

--- a/docs/self-managed/components/management-identity/miscellaneous/configuration-variables.md
+++ b/docs/self-managed/components/management-identity/miscellaneous/configuration-variables.md
@@ -94,8 +94,8 @@ for `WEBMODELER`, which is`web-modeler`.
 
 Identity requires a database in the following cases:
 
-- Connecting to an OIDC provider (Generic or Microsoft Entra ID) requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against it on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
-- Using the default Keycloak-based setup and enabling the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags) requires a database.
+- Connecting to either a generic OIDC provider or Microsoft Entra ID requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against the database on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
+- With the default Keycloak-based setup, Identity requires a database when you enable the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags).
 
 With the default Keycloak-based setup and no feature flags enabled, Identity does not require a database, as Keycloak stores this data separately.
 

--- a/docs/self-managed/components/management-identity/miscellaneous/configuration-variables.md
+++ b/docs/self-managed/components/management-identity/miscellaneous/configuration-variables.md
@@ -92,7 +92,12 @@ for `WEBMODELER`, which is`web-modeler`.
 
 ## Database configuration
 
-Identity requires a database to store information about resource authorization and [multi-tenancy](/components/concepts/multi-tenancy.md) or if you are [using an external IdP](/self-managed/components/management-identity/configuration/configure-external-identity-provider.md).
+Identity requires a database in the following cases:
+
+- Connecting to an OIDC provider (Generic or Microsoft Entra ID) requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against it on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
+- Using the default Keycloak-based setup and enabling the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags) requires a database.
+
+With the default Keycloak-based setup and no feature flags enabled, Identity does not require a database, as Keycloak stores this data separately.
 
 | Environment variable         | Description                                         |
 | :--------------------------- | :-------------------------------------------------- |

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -23,6 +23,7 @@ Before you begin, ensure you have:
 - Access to your provider's discovery document to obtain endpoint URLs.
 - A Kubernetes cluster with the Helm CLI v4 installed.
 - kubectl configured to access your cluster.
+- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 :::note
 This guide assumes your OIDC provider is already operational. It does not cover provider installation or basic OIDC configuration.

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have:
 - Access to your provider's discovery document to obtain endpoint URLs.
 - A Kubernetes cluster with the Helm CLI v4 installed.
 - kubectl configured to access your cluster.
-- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
+- When you connect Management Identity to an OIDC provider, you need a database regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so you don't need a separate database. To use an external database, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 :::note
 This guide assumes your OIDC provider is already operational. It does not cover provider installation or basic OIDC configuration.

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -14,6 +14,7 @@ Before you begin, ensure you have:
 - Access to a Microsoft Entra tenant with permission to create applications and app registrations
 - The ID of your tenant
 - An understanding of the structure and claims of access tokens in Entra
+- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 ## Configuration
 

--- a/docs/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/docs/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have:
 - Access to a Microsoft Entra tenant with permission to create applications and app registrations
 - The ID of your tenant
 - An understanding of the structure and claims of access tokens in Entra
-- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
+- When you connect Management Identity to an OIDC provider, you need a database regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so you don't need a separate database. To use an external database, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 ## Configuration
 

--- a/versioned_docs/version-8.8/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.8/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
@@ -33,6 +33,7 @@ If you deploy Camunda 8 Self-Managed with Helm, use the [Helm chart authenticati
   - Audience
 - A [claim name and value](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#oidc-configuration) to use for initial access.
 - Your OIDC provider must issue access tokens that contain an `aud` (audience) claim matching the configured audience, as Camunda validates this claim for auth flows. Providers that are not configured to emit, or do not emit, the `aud` claim in their access tokens are not supported. Configure your identity provider to emit this claim if supported. See [known limitations](#oidc-provider-known-limitations) for details.
+- A relational database for Identity to connect to. Connecting to an OIDC provider requires a database, regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
 
 :::note
 The steps below are a general approach for the Camunda components; it is important you reference the [component-specific

--- a/versioned_docs/version-8.8/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.8/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
@@ -33,7 +33,7 @@ If you deploy Camunda 8 Self-Managed with Helm, use the [Helm chart authenticati
   - Audience
 - A [claim name and value](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#oidc-configuration) to use for initial access.
 - Your OIDC provider must issue access tokens that contain an `aud` (audience) claim matching the configured audience, as Camunda validates this claim for auth flows. Providers that are not configured to emit, or do not emit, the `aud` claim in their access tokens are not supported. Configure your identity provider to emit this claim if supported. See [known limitations](#oidc-provider-known-limitations) for details.
-- A relational database for Identity to connect to. Connecting to an OIDC provider requires a database, regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
+- A relational database that Identity can connect to. The database is required regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
 
 :::note
 The steps below are a general approach for the Camunda components; it is important you reference the [component-specific

--- a/versioned_docs/version-8.8/self-managed/components/management-identity/miscellaneous/configuration-variables.md
+++ b/versioned_docs/version-8.8/self-managed/components/management-identity/miscellaneous/configuration-variables.md
@@ -93,8 +93,8 @@ for `WEBMODELER`, which is`web-modeler`.
 
 Identity requires a database in the following cases:
 
-- Connecting to an OIDC provider (Generic or Microsoft Entra ID) requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against it on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
-- Using the default Keycloak-based setup and enabling the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags) requires a database.
+- Connecting to either a generic OIDC provider or Microsoft Entra ID requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against the database on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
+- With the default Keycloak-based setup, Identity requires a database when you enable the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags).
 
 With the default Keycloak-based setup and no feature flags enabled, Identity does not require a database, as Keycloak stores this data separately.
 

--- a/versioned_docs/version-8.8/self-managed/components/management-identity/miscellaneous/configuration-variables.md
+++ b/versioned_docs/version-8.8/self-managed/components/management-identity/miscellaneous/configuration-variables.md
@@ -91,7 +91,12 @@ for `WEBMODELER`, which is`web-modeler`.
 
 ## Database configuration
 
-Identity requires a database to store information about resource authorization and [multi-tenancy](/components/concepts/multi-tenancy.md) or if you are [using an external IdP](/self-managed/components/management-identity/configuration/configure-external-identity-provider.md).
+Identity requires a database in the following cases:
+
+- Connecting to an OIDC provider (Generic or Microsoft Entra ID) requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against it on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
+- Using the default Keycloak-based setup and enabling the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags) requires a database.
+
+With the default Keycloak-based setup and no feature flags enabled, Identity does not require a database, as Keycloak stores this data separately.
 
 | Environment variable         | Description                                         |
 | :--------------------------- | :-------------------------------------------------- |

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have:
 - Access to your provider's discovery document to obtain endpoint URLs.
 - A Kubernetes cluster with Helm 3.x installed.
 - kubectl configured to access your cluster.
-- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
+- When you connect Management Identity to an OIDC provider, you need a database regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so you don't need a separate database. To use an external database, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 :::note
 This guide assumes your OIDC provider is already operational. It does not cover provider installation or basic OIDC configuration.
@@ -124,10 +124,10 @@ Camunda components request OIDC scopes when authenticating users. The default sc
 
 | Scope            | Description                         | Management Identity, Optimize, Web Modeler, Console | Orchestration Cluster (Operate, Tasklist) |
 | ---------------- | ----------------------------------- | --------------------------------------------------- | ----------------------------------------- |
-| `openid`         | Required for OIDC authentication.   | ✔                                                  | ✔                                        |
-| `profile`        | Access to user profile information. | ✔                                                  | ✔                                        |
-| `email`          | Access to user email address.       | ✔                                                  |                                           |
-| `offline_access` | Enables refresh token issuance.     | ✔                                                  |                                           |
+| `openid`         | Required for OIDC authentication.   | ✔                                                   | ✔                                         |
+| `profile`        | Access to user profile information. | ✔                                                   | ✔                                         |
+| `email`          | Access to user email address.       | ✔                                                   |                                           |
+| `offline_access` | Enables refresh token issuance.     | ✔                                                   |                                           |
 
 :::info
 If your provider supports the `offline_access` scope, components will receive refresh tokens. This allows sessions to remain active longer without requiring users to re-authenticate.

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -23,6 +23,7 @@ Before you begin, ensure you have:
 - Access to your provider's discovery document to obtain endpoint URLs.
 - A Kubernetes cluster with Helm 3.x installed.
 - kubectl configured to access your cluster.
+- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 :::note
 This guide assumes your OIDC provider is already operational. It does not cover provider installation or basic OIDC configuration.

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -14,6 +14,7 @@ Before you begin, ensure you have:
 - Access to a Microsoft Entra tenant with permission to create applications and app registrations
 - The ID of your tenant
 - An understanding of the structure and claims of access tokens in Entra
+- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 ## Configuration
 

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have:
 - Access to a Microsoft Entra tenant with permission to create applications and app registrations
 - The ID of your tenant
 - An understanding of the structure and claims of access tokens in Entra
-- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
+- When you connect Management Identity to an OIDC provider, you need a database regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so you don't need a separate database. To use an external database, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 ## Configuration
 

--- a/versioned_docs/version-8.9/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.9/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
@@ -33,6 +33,7 @@ If you deploy Camunda 8 Self-Managed with Helm, use the [Helm chart authenticati
   - Audience
 - A [claim name and value](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#oidc-configuration) to use for initial access.
 - Your OIDC provider must issue access tokens that contain an `aud` (audience) claim matching the configured audience, as Camunda validates this claim for auth flows. Providers that are not configured to emit, or do not emit, the `aud` claim in their access tokens are not supported. Configure your identity provider to emit this claim if supported. See [known limitations](#oidc-provider-known-limitations) for details.
+- A relational database for Identity to connect to. Connecting to an OIDC provider requires a database, regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
 
 :::note
 The steps below are a general approach for the Camunda components; it is important you reference the [component-specific

--- a/versioned_docs/version-8.9/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
+++ b/versioned_docs/version-8.9/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md
@@ -33,7 +33,7 @@ If you deploy Camunda 8 Self-Managed with Helm, use the [Helm chart authenticati
   - Audience
 - A [claim name and value](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#oidc-configuration) to use for initial access.
 - Your OIDC provider must issue access tokens that contain an `aud` (audience) claim matching the configured audience, as Camunda validates this claim for auth flows. Providers that are not configured to emit, or do not emit, the `aud` claim in their access tokens are not supported. Configure your identity provider to emit this claim if supported. See [known limitations](#oidc-provider-known-limitations) for details.
-- A relational database for Identity to connect to. Connecting to an OIDC provider requires a database, regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
+- A relational database that Identity can connect to. The database is required regardless of feature flags. See [database configuration](/self-managed/components/management-identity/miscellaneous/configuration-variables.md#database-configuration) for connection details and supported databases.
 
 :::note
 The steps below are a general approach for the Camunda components; it is important you reference the [component-specific

--- a/versioned_docs/version-8.9/self-managed/components/management-identity/miscellaneous/configuration-variables.md
+++ b/versioned_docs/version-8.9/self-managed/components/management-identity/miscellaneous/configuration-variables.md
@@ -94,8 +94,8 @@ for `WEBMODELER`, which is`web-modeler`.
 
 Identity requires a database in the following cases:
 
-- Connecting to an OIDC provider (Generic or Microsoft Entra ID) requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against it on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
-- Using the default Keycloak-based setup and enabling the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags) requires a database.
+- Connecting to either a generic OIDC provider or Microsoft Entra ID requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against the database on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
+- With the default Keycloak-based setup, Identity requires a database when you enable the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags).
 
 With the default Keycloak-based setup and no feature flags enabled, Identity does not require a database, as Keycloak stores this data separately.
 

--- a/versioned_docs/version-8.9/self-managed/components/management-identity/miscellaneous/configuration-variables.md
+++ b/versioned_docs/version-8.9/self-managed/components/management-identity/miscellaneous/configuration-variables.md
@@ -92,7 +92,12 @@ for `WEBMODELER`, which is`web-modeler`.
 
 ## Database configuration
 
-Identity requires a database to store information about resource authorization and [multi-tenancy](/components/concepts/multi-tenancy.md) or if you are [using an external IdP](/self-managed/components/management-identity/configuration/configure-external-identity-provider.md).
+Identity requires a database in the following cases:
+
+- Connecting to an OIDC provider (Generic or Microsoft Entra ID) requires a database, regardless of feature flags. Identity stores roles, permissions, mapping rules, and groups in the database, and resolves authorization against it on every request. See [connect Management Identity to an identity provider](/self-managed/components/management-identity/configuration/connect-to-an-oidc-provider.md).
+- Using the default Keycloak-based setup and enabling the `resource-permissions` or `multi-tenancy` [feature flags](#feature-flags) requires a database.
+
+With the default Keycloak-based setup and no feature flags enabled, Identity does not require a database, as Keycloak stores this data separately.
 
 | Environment variable         | Description                                         |
 | :--------------------------- | :-------------------------------------------------- |

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have:
 - Access to your provider's discovery document to obtain endpoint URLs.
 - A Kubernetes cluster with Helm 3.x installed.
 - kubectl configured to access your cluster.
-- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
+- When you connect Management Identity to an OIDC provider, you need a database regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so you don't need a separate database. To use an external database, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 :::note
 This guide assumes your OIDC provider is already operational. It does not cover provider installation or basic OIDC configuration.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md
@@ -23,6 +23,7 @@ Before you begin, ensure you have:
 - Access to your provider's discovery document to obtain endpoint URLs.
 - A Kubernetes cluster with Helm 3.x installed.
 - kubectl configured to access your cluster.
+- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 :::note
 This guide assumes your OIDC provider is already operational. It does not cover provider installation or basic OIDC configuration.

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -14,6 +14,7 @@ Before you begin, ensure you have:
 - Access to a Microsoft Entra tenant with permission to create applications and app registrations
 - The ID of your tenant
 - An understanding of the structure and claims of access tokens in Entra
+- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 ## Configuration
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/authentication-and-authorization/microsoft-entra.md
@@ -14,7 +14,7 @@ Before you begin, ensure you have:
 - Access to a Microsoft Entra tenant with permission to create applications and app registrations
 - The ID of your tenant
 - An understanding of the structure and claims of access tokens in Entra
-- A database is required for Management Identity when connecting to an OIDC provider, regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so no separate database is needed; to use an external database instead, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
+- When you connect Management Identity to an OIDC provider, you need a database regardless of feature flags. This guide uses the chart's bundled PostgreSQL instance (`identityPostgresql`), so you don't need a separate database. To use an external database, see [use external PostgreSQL](/self-managed/deployment/helm/configure/database/using-existing-postgres.md).
 
 ## Configuration
 


### PR DESCRIPTION
## Description

Documents that Management Identity requires a relational database when connecting to an OIDC provider (Generic or Microsoft Entra ID), regardless of feature flags — distinct from the default Keycloak-based setup, where a database is only needed if the `resource-permissions` or `multi-tenancy` feature flags are enabled.

Addresses camunda/identity#4939, which reported this requirement was missing from the OIDC setup guides, and that the "Database configuration" reference was ambiguous and linked to the wrong page (Keycloak's external-IdP brokering guide instead of the actual OIDC connection guide).

Applied identically to `docs/`, `versioned_docs/version-8.9/`, and `versioned_docs/version-8.8/`:

- `components/management-identity/miscellaneous/configuration-variables.md`: rewrote the **Database configuration** intro and fixed the broken link.
- `components/management-identity/configuration/connect-to-an-oidc-provider.md`: added the requirement to **Prerequisites**.
- `deployment/helm/configure/authentication-and-authorization/generic-oidc-provider.md` and `microsoft-entra.md`: added the requirement to **Prerequisites**, noting the bundled `identityPostgresql` instance these guides already configure.

Verified against `DatabaseRequired`/`JpaConfig` and the profile-gated service implementations in `camunda/identity` on `v8.8`, `v8.9`, and `main` — behavior is identical across all three.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
