### PR TITLE
docs(hub): describe the reusable assets tab in the modeling menus

### DIFF
--- a/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
+++ b/docs/components/hub/workspace/modeler/element-templates/use-catalog-assets.md
@@ -32,6 +32,23 @@ When the CoE publishes a newer version of a template you already use, Hub offers
 
 If the CoE unpublishes an asset you already use, the template is deprecated. Elements that reference it keep working but show a deprecation hint in the properties panel, signaling that you should migrate to a newer version or a different template.
 
+## Find reusable assets in the modeling menus
+
+When you create, append, or change an element, the menu separates what you can insert into two tabs:
+
+- **BPMN** — the standard BPMN elements, in their usual categories.
+- **Reusable assets** — catalog assets, connectors, and templates from your project, together with resources the project already contains: forms, called processes, decisions, and RPA scripts.
+
+To insert a catalog asset, open the **Reusable assets** tab and select it. This creates a new element with the template already applied. To apply a template to an element that already exists, use **Change element** from the context pad, or follow [Apply assets while modeling](#apply-assets-while-modeling).
+
+If your project has no templates and no linked resources, no tabs appear and the menu behaves as before.
+
+### Find an asset quickly
+
+Type in the search field to search both tabs at once. Search matches asset names and descriptions, and also template IDs. While you search, the tabs are hidden and matches appear as a single ranked list.
+
+Within **Reusable assets**, entries are grouped: resources already in your project first, then named categories, then remaining templates, with connectors last.
+
 ## Find outdated assets in a diagram
 
 When an element references a template version that isn't the latest one, Camunda Hub flags it in two places in the modeler:


### PR DESCRIPTION
## Description

The page explained how to apply a catalog asset but not how to find one — step 2 of *Apply assets while modeling* said "select an element and apply a published element template" without saying where templates appear.

The create, append, and change element menus split entries into a **BPMN** tab and a **Reusable assets** tab, and catalog assets live in the latter. This adds a short section covering the two tabs, search across them, and the grouping inside **Reusable assets**.

**Versioning:** this is 8.10 only and does not ship before, so the change is deliberately in `/docs` and is *not* backported to `versioned_docs/version-8.9/`. The versioning bot's suggestion above can be disregarded.

Related to https://github.com/camunda/product-hub/issues/3481

## When should this change go live?

- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
