### PR TITLE
docs(agentic-orchestration): weave into governance/security pages

### DIFF
--- a/docs/components/audit-log/overview.md
+++ b/docs/components/audit-log/overview.md
@@ -14,7 +14,7 @@ View and audit a comprehensive record of operations across process, identity, an
 
 ## About
 
-The audit log provides a record of operations, including who performed an operation, when it was performed, and on which entities the operation was performed.
+The audit log provides a record of operations, including who performed an operation (a user, client, or [AI agent](/reference/glossary.md#ai-agent)), when it was performed, and on which entities the operation was performed.
 
 Use the audit log to:
 

--- a/versioned_docs/version-8.9/components/audit-log/overview.md
+++ b/versioned_docs/version-8.9/components/audit-log/overview.md
@@ -14,7 +14,7 @@ View and audit a comprehensive record of operations across process, identity, an
 
 ## About
 
-The audit log provides a record of operations, including who performed an operation, when it was performed, and on which entities the operation was performed.
+The audit log provides a record of operations, including who performed an operation (a user, client, or [AI agent](/reference/glossary.md#ai-agent)), when it was performed, and on which entities the operation was performed.
 
 Use the audit log to:
 


### PR DESCRIPTION
## Description

Part of the agentic orchestration docs audit epic ([documentation-team#515](https://github.com/camunda/documentation-team/issues/515)), closing the governance/security sub-issue ([documentation-team#541](https://github.com/camunda/documentation-team/issues/541)).

Audited the governance/security-adjacent surface of `components/`: the **Audit log** section (`audit-log/overview.md` + subpages), the **Admin** category (access-control, user, group, role, authorization, client, mapping-rules, tenant, cluster-variables, global-user-task-listeners, audit-operations), and **Identity and access management** (`concepts/access-control/*`).

Most of this surface was already covered by earlier PRs in the epic:
- `concepts/access-control/authorizations.md` was woven in PR #9567; the rest of that category (`connect-to-identity-provider.md`, `mapping-rules.md`, `multi-tenancy.md`) was confirmed as actor-agnostic IAM and correctly left as-is.
- `admin/client.md` was woven in PR #9694; the rest of the Admin category is mechanical how-to content that already links out to the woven concept pages (for example, `admin/authorization.md` links to `concepts/access-control/authorizations.md`), so adding a mention there would duplicate rather than link.
- `guides/build-with-ai/ai-usage-guidelines.md` already has a full "Governance" section for AI agents (ownership, incident handling, change approval) — this is the actual governance/security content for agentic orchestration, and needed no changes.

**Pages edited (1 WEAVE):**
- `components/audit-log/overview.md` — the audit log's own "About" framing didn't yet acknowledge that a recorded operation's actor can be an [AI agent](/reference/glossary.md#ai-agent), even though `overview/operation-structure.md` already documents this (actor type, and the MCP inbound channel for agent-invoked tool calls). Added a one-clause mention linking to the glossary, matching this section's existing "governance and regulatory requirements" framing.

**Left as-is (confirmed genuine SKIPs):** `audit-log/overview/access-control.md`, `audit-log/overview/recorded-operations.md` (reference tables, actor-agnostic), `admin/access-control.md`, `admin/user.md`, `admin/group.md`, `admin/role.md`, `admin/authorization.md`, `admin/mapping-rules.md`, `admin/tenant.md`, `admin/cluster-variables.md`, `admin/global-user-task-listeners.md`, `admin/audit-operations.md`, `operate/userguide/audit-operations.md`, `tasklist/userguide/audit-task-history.md`.

Applied to both `docs/` and `versioned_docs/version-8.9/` — the edited line is byte-identical between versions, and the glossary anchor (`#ai-agent`) exists in both.

Closes camunda/documentation-team#541.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
