### PR TITLE
docs(self-managed): remove em dashes from how-identity-works.md

### DIFF
--- a/docs/self-managed/components/identity/how-identity-works.md
+++ b/docs/self-managed/components/identity/how-identity-works.md
@@ -42,7 +42,7 @@ In most deployments, both subsystems share the same IdP. You create a separate O
 
 Before Camunda 8.8, [Management Identity](/self-managed/components/management-identity/overview.md) (then called just Identity) managed access for every component, including Zeebe, Operate, and Tasklist. Camunda 8.8 split identity management into two subsystems. The [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) began managing its own authentication and authorization through [Admin](/self-managed/components/orchestration-cluster/admin/overview.md) (formerly called Orchestration Cluster Identity). See [Identity, authentication, and authorization](/reference/announcements-release-notes/880/whats-new-in-88.md#identity) for the full migration details.
 
-Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be re-created. From that point on, manage access to Operate and Tasklist in Admin. Role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
+Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be recreated. From that point on, manage access to Operate and Tasklist in Admin. Role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
 
 ## Configure the identity subsystems
 

--- a/docs/self-managed/components/identity/how-identity-works.md
+++ b/docs/self-managed/components/identity/how-identity-works.md
@@ -9,7 +9,7 @@ import DocCardList from '@theme/DocCardList';
 
 Camunda Self-Managed uses two separate identity subsystems.
 
-Understanding which subsystem controls what helps you avoid a common misconfiguration — connecting your identity provider (IdP) to one system but not the other, so some components authenticate while others don't.
+Understanding which subsystem controls what helps you avoid a common misconfiguration. If you connect your identity provider (IdP) to one system but not the other, some components authenticate while others don't.
 
 ## The two identity subsystems
 
@@ -36,20 +36,20 @@ graph LR
 
 For the full breakdown, see [Admin vs Management Identity](/self-managed/reference-architecture/reference-architecture.md#admin-vs-management-identity).
 
-In most deployments, both subsystems share the same IdP — you create a separate OIDC application registration for each subsystem but manage users in one place at the IdP level.
+In most deployments, both subsystems share the same IdP. You create a separate OIDC application registration for each subsystem but manage users in one place at the IdP level.
 
 ## How identity changed in Camunda 8.8
 
 Before Camunda 8.8, [Management Identity](/self-managed/components/management-identity/overview.md) (then called just Identity) managed access for every component, including Zeebe, Operate, and Tasklist. Camunda 8.8 split identity management into two subsystems. The [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) began managing its own authentication and authorization through [Admin](/self-managed/components/orchestration-cluster/admin/overview.md) (formerly called Orchestration Cluster Identity). See [Identity, authentication, and authorization](/reference/announcements-release-notes/880/whats-new-in-88.md#identity) for the full migration details.
 
-Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be re-created. From that point on, manage access to Operate and Tasklist in Admin — role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
+Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be re-created. From that point on, manage access to Operate and Tasklist in Admin. Role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
 
 ## Configure the identity subsystems
 
 If you are deploying the full Camunda Self-Managed stack, you configure both subsystems, in this order:
 
-1. **Management Identity first** — configure your IdP connection and verify users can log in to Camunda Hub.
-2. **Admin second** — configure a separate IdP application registration and verify users can log in to Operate and Tasklist.
+1. **Management Identity first**: configure your IdP connection and verify users can log in to Camunda Hub.
+2. **Admin second**: configure a separate IdP application registration and verify users can log in to Operate and Tasklist.
 
 If you are deploying only the Orchestration Cluster (Operate, Tasklist, Zeebe) without the management plane, you only need to configure Admin.
 

--- a/versioned_docs/version-8.9/self-managed/components/identity/how-identity-works.md
+++ b/versioned_docs/version-8.9/self-managed/components/identity/how-identity-works.md
@@ -44,7 +44,7 @@ In most deployments, both subsystems share the same IdP. You create a separate O
 
 Before Camunda 8.8, [Management Identity](/self-managed/components/management-identity/overview.md) (then called just Identity) managed access for every component, including Zeebe, Operate, and Tasklist. Camunda 8.8 split identity management into two subsystems. The [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) began managing its own authentication and authorization through [Admin](/self-managed/components/orchestration-cluster/admin/overview.md) (formerly called Orchestration Cluster Identity). See [Identity, authentication, and authorization](/reference/announcements-release-notes/880/whats-new-in-88.md#identity) for the full migration details.
 
-Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be re-created. From that point on, manage access to Operate and Tasklist in Admin. Role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
+Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be recreated. From that point on, manage access to Operate and Tasklist in Admin. Role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
 
 ## Configure the identity subsystems
 

--- a/versioned_docs/version-8.9/self-managed/components/identity/how-identity-works.md
+++ b/versioned_docs/version-8.9/self-managed/components/identity/how-identity-works.md
@@ -9,7 +9,7 @@ import DocCardList from '@theme/DocCardList';
 
 Camunda Self-Managed uses two separate identity subsystems.
 
-Understanding which subsystem controls what helps you avoid a common misconfiguration — connecting your identity provider (IdP) to one system but not the other, so some components authenticate while others don't.
+Understanding which subsystem controls what helps you avoid a common misconfiguration. If you connect your identity provider (IdP) to one system but not the other, some components authenticate while others don't.
 
 ## The two identity subsystems
 
@@ -38,20 +38,20 @@ graph LR
 
 For the full breakdown, see [Admin vs Management Identity](/self-managed/reference-architecture/reference-architecture.md#admin-vs-management-identity).
 
-In most deployments, both subsystems share the same IdP — you create a separate OIDC application registration for each subsystem but manage users in one place at the IdP level.
+In most deployments, both subsystems share the same IdP. You create a separate OIDC application registration for each subsystem but manage users in one place at the IdP level.
 
 ## How identity changed in Camunda 8.8
 
 Before Camunda 8.8, [Management Identity](/self-managed/components/management-identity/overview.md) (then called just Identity) managed access for every component, including Zeebe, Operate, and Tasklist. Camunda 8.8 split identity management into two subsystems. The [Orchestration Cluster](/self-managed/reference-architecture/reference-architecture.md#orchestration-cluster) began managing its own authentication and authorization through [Admin](/self-managed/components/orchestration-cluster/admin/overview.md) (formerly called Orchestration Cluster Identity). See [Identity, authentication, and authorization](/reference/announcements-release-notes/880/whats-new-in-88.md#identity) for the full migration details.
 
-Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be re-created. From that point on, manage access to Operate and Tasklist in Admin — role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
+Admin becomes the single source of truth for the migrated cluster's roles and authorizations after this change. Existing roles and authorizations carry over automatically during the upgrade, so nothing needs to be re-created. From that point on, manage access to Operate and Tasklist in Admin. Role or authorization changes made in Console or Management Identity no longer apply to the migrated cluster.
 
 ## Configure the identity subsystems
 
 If you are deploying the full Camunda Self-Managed stack, you configure both subsystems, in this order:
 
-1. **Management Identity first** — configure your IdP connection and verify users can log in to Console.
-2. **Admin second** — configure a separate IdP application registration and verify users can log in to Operate and Tasklist.
+1. **Management Identity first**: configure your IdP connection and verify users can log in to Console.
+2. **Admin second**: configure a separate IdP application registration and verify users can log in to Operate and Tasklist.
 
 If you are deploying only the Orchestration Cluster (Operate, Tasklist, Zeebe) without the management plane, you only need to configure Admin.
 


### PR DESCRIPTION
## Description

Removes em dashes from running text in "How identity works in Camunda", per the [style guide](https://github.com/camunda/camunda-docs/blob/main/.github/instructions/content.instructions.md), which discourages em dashes in favor of shorter sentences.

Split into its own PR after it was flagged by Copilot as unrelated scope creep on [#9717](https://github.com/camunda/camunda-docs/pull/9717) (a secret resolution docs PR). Fixes both the unreleased (`docs/`) and 8.9 (`versioned_docs/version-8.9/`) copies of the page, since both carried the same em dashes.

No content or meaning changes — five sentences reworded into shorter sentences, or a colon for two bold-lead-in list items.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
