### PR TITLE
chore(ci): pin all GitHub Actions to commit SHA

### DIFF
--- a/.github/actions/docusaurus-cache/action.yaml
+++ b/.github/actions/docusaurus-cache/action.yaml
@@ -4,7 +4,7 @@ description: "Cache Docusaurus for faster application rebuilds."
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: |
           ${{ github.workspace }}/.docusaurus

--- a/.github/actions/docusaurus-cache/action.yaml
+++ b/.github/actions/docusaurus-cache/action.yaml
@@ -4,7 +4,7 @@ description: "Cache Docusaurus for faster application rebuilds."
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v6
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |
           ${{ github.workspace }}/.docusaurus

--- a/.github/actions/docusaurus-cache/action.yaml
+++ b/.github/actions/docusaurus-cache/action.yaml
@@ -4,7 +4,7 @@ description: "Cache Docusaurus for faster application rebuilds."
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ${{ github.workspace }}/.docusaurus

--- a/.github/actions/muffet/action.yaml
+++ b/.github/actions/muffet/action.yaml
@@ -32,7 +32,7 @@ runs:
         echo "Muffet version  : ${{ inputs.muffet_version }}"
         echo "URL to validate : ${{ inputs.url_to_validate }}"
     - name: Restore cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       id: tool-cache-muffet
       with:
         path: ${{ runner.temp }}/muffet/${{ inputs.muffet_version }}/muffet

--- a/.github/actions/muffet/action.yaml
+++ b/.github/actions/muffet/action.yaml
@@ -32,7 +32,7 @@ runs:
         echo "Muffet version  : ${{ inputs.muffet_version }}"
         echo "URL to validate : ${{ inputs.url_to_validate }}"
     - name: Restore cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: tool-cache-muffet
       with:
         path: ${{ runner.temp }}/muffet/${{ inputs.muffet_version }}/muffet

--- a/.github/actions/muffet/action.yaml
+++ b/.github/actions/muffet/action.yaml
@@ -32,7 +32,7 @@ runs:
         echo "Muffet version  : ${{ inputs.muffet_version }}"
         echo "URL to validate : ${{ inputs.url_to_validate }}"
     - name: Restore cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       id: tool-cache-muffet
       with:
         path: ${{ runner.temp }}/muffet/${{ inputs.muffet_version }}/muffet

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -36,7 +36,7 @@ runs:
       # Composite actions cannot access the secrets context directly; callers must
       # pass vault config as inputs so they resolve correctly here via inputs.*.
       continue-on-error: true
-      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4.0.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
       if: |
         inputs.secret_vault_address != ''
         && inputs.secret_vault_jwt_path != ''
@@ -80,7 +80,7 @@ runs:
         fi
 
     ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@67d00e9260887361a31f6446252fffbecae4a02e  # submit-build-status-1.3.1
+    - uses: camunda/infra-global-github-actions/submit-build-status@67d00e9260887361a31f6446252fffbecae4a02e # submit-build-status-1.3.1
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name || github.job }}"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -36,7 +36,7 @@ runs:
       # Composite actions cannot access the secrets context directly; callers must
       # pass vault config as inputs so they resolve correctly here via inputs.*.
       continue-on-error: true
-      uses: hashicorp/vault-action@v4.0.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc
       if: |
         inputs.secret_vault_address != ''
         && inputs.secret_vault_jwt_path != ''
@@ -80,7 +80,7 @@ runs:
         fi
 
     ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@main
+    - uses: camunda/infra-global-github-actions/submit-build-status@ee746fa695a43480b4294e944a6bf6e01b4f8459
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name || github.job }}"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -36,7 +36,7 @@ runs:
       # Composite actions cannot access the secrets context directly; callers must
       # pass vault config as inputs so they resolve correctly here via inputs.*.
       continue-on-error: true
-      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4.0.0
       if: |
         inputs.secret_vault_address != ''
         && inputs.secret_vault_jwt_path != ''
@@ -80,7 +80,7 @@ runs:
         fi
 
     ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@ee746fa695a43480b4294e944a6bf6e01b4f8459
+    - uses: camunda/infra-global-github-actions/submit-build-status@67d00e9260887361a31f6446252fffbecae4a02e  # submit-build-status-1.3.1
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name || github.job }}"

--- a/.github/workflows/add-bugs-to-quality-board.yaml
+++ b/.github/workflows/add-bugs-to-quality-board.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: add-bug-to-quality-board
         name: Add issue to Quality Board
-        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@67d00e9260887361a31f6446252fffbecae4a02e  # add-bug-to-quality-board-1.0.4
+        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@67d00e9260887361a31f6446252fffbecae4a02e # add-bug-to-quality-board-1.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           project-number: "187"

--- a/.github/workflows/add-bugs-to-quality-board.yaml
+++ b/.github/workflows/add-bugs-to-quality-board.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: add-bug-to-quality-board
         name: Add issue to Quality Board
-        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@ee746fa695a43480b4294e944a6bf6e01b4f8459
+        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@67d00e9260887361a31f6446252fffbecae4a02e  # add-bug-to-quality-board-1.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           project-number: "187"

--- a/.github/workflows/add-bugs-to-quality-board.yaml
+++ b/.github/workflows/add-bugs-to-quality-board.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: add-bug-to-quality-board
         name: Add issue to Quality Board
-        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@main
+        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@ee746fa695a43480b4294e944a6bf6e01b4f8459
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           project-number: "187"

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -22,7 +22,7 @@ jobs:
             secret/data/products/camunda-docs/github/apps/camunda-docs-pr-automation APP_ID;
             secret/data/products/camunda-docs/github/apps/camunda-docs-pr-automation APP_PRIVATE_KEY;
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -22,7 +22,7 @@ jobs:
             secret/data/products/camunda-docs/github/apps/camunda-docs-pr-automation APP_ID;
             secret/data/products/camunda-docs/github/apps/camunda-docs-pr-automation APP_PRIVATE_KEY;
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}

--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/slack DOCS_RELEASE_BOT_WEBHOOK;
       - id: slack
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
         with:
           webhook: ${{ steps.secrets.outputs.DOCS_RELEASE_BOT_WEBHOOK }}
           webhook-type: webhook-trigger

--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/slack DOCS_RELEASE_BOT_WEBHOOK;
       - id: slack
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ steps.secrets.outputs.DOCS_RELEASE_BOT_WEBHOOK }}
           webhook-type: webhook-trigger

--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/slack DOCS_RELEASE_BOT_WEBHOOK;
       - id: slack
-        uses: slackapi/slack-github-action@v4.0.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d
         with:
           webhook: ${{ steps.secrets.outputs.DOCS_RELEASE_BOT_WEBHOOK }}
           webhook-type: webhook-trigger

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -10,7 +10,7 @@ jobs:
     if: startsWith(github.actor, 'renovate') == false && startsWith(github.actor, 'camunda-docs-pr-automation') == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747  # v1.0.0
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           assignees: ${{ github.actor }}

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -10,7 +10,7 @@ jobs:
     if: startsWith(github.actor, 'renovate') == false && startsWith(github.actor, 'camunda-docs-pr-automation') == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-assignees@v1
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           assignees: ${{ github.actor }}

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -10,7 +10,7 @@ jobs:
     if: startsWith(github.actor, 'renovate') == false && startsWith(github.actor, 'camunda-docs-pr-automation') == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747  # v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           assignees: ${{ github.actor }}

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # SHA ref is main
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Dependencies
         run: npm ci
       # Removed because it's causing build issues
@@ -37,7 +37,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=30720
       - name: Upload build
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-build
           path: build
@@ -65,19 +65,19 @@ jobs:
     steps:
       # SHA ref is main
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Download build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-build
           path: build
       - name: Install hyperlink
         run: npm install -g @untitaker/hyperlink
       - name: Check internal links
-        uses: untitaker/hyperlink@9375bc4063712ad490d5eb3d54df0b6aade15e54  # 0.3.2
+        uses: untitaker/hyperlink@9375bc4063712ad490d5eb3d54df0b6aade15e54 # 0.3.2
         with:
           args: build/
       - name: Remove https redirect
@@ -90,7 +90,7 @@ jobs:
           echo "container_ip=${container_ip}" >> $GITHUB_ENV
           echo "domain_to_test=http://${container_ip}:8080" >> $GITHUB_ENV
       - name: Wait for running docs web server
-        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1  # v1.0.1
+        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1 # v1.0.1
         with:
           url: ${{ env.domain_to_test }}
       - name: Download sitemap from production
@@ -113,7 +113,7 @@ jobs:
             > ${temporary_link_path}/connectors-element-template-links.html
       - name: Serve link collections
         ## Run another web server because Muffet only works against web pages, not source files.
-        uses: Eun/http-server-action@dadebd209d4a902eeefceb524c24c38b364c46a7  # v1.0.13
+        uses: Eun/http-server-action@dadebd209d4a902eeefceb524c24c38b364c46a7 # v1.0.13
         with:
           directory: ${{ env.temporary_link_path }}
           port: 8081
@@ -151,7 +151,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c  # rerun-failed-run-1.1.2
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # SHA ref is main
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Dependencies
         run: npm ci
       # Removed because it's causing build issues
@@ -37,7 +37,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=30720
       - name: Upload build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: docs-build
           path: build
@@ -65,19 +65,19 @@ jobs:
     steps:
       # SHA ref is main
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: docs-build
           path: build
       - name: Install hyperlink
         run: npm install -g @untitaker/hyperlink
       - name: Check internal links
-        uses: untitaker/hyperlink@0.3.2
+        uses: untitaker/hyperlink@9375bc4063712ad490d5eb3d54df0b6aade15e54
         with:
           args: build/
       - name: Remove https redirect
@@ -90,7 +90,7 @@ jobs:
           echo "container_ip=${container_ip}" >> $GITHUB_ENV
           echo "domain_to_test=http://${container_ip}:8080" >> $GITHUB_ENV
       - name: Wait for running docs web server
-        uses: nev7n/wait_for_response@v1
+        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
         with:
           url: ${{ env.domain_to_test }}
       - name: Download sitemap from production
@@ -113,7 +113,7 @@ jobs:
             > ${temporary_link_path}/connectors-element-template-links.html
       - name: Serve link collections
         ## Run another web server because Muffet only works against web pages, not source files.
-        uses: Eun/http-server-action@v1
+        uses: Eun/http-server-action@dadebd209d4a902eeefceb524c24c38b364c46a7
         with:
           directory: ${{ env.temporary_link_path }}
           port: 8081
@@ -151,7 +151,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        uses: camunda/infra-global-github-actions/rerun-failed-run@ee746fa695a43480b4294e944a6bf6e01b4f8459
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # SHA ref is main
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install Dependencies
         run: npm ci
       # Removed because it's causing build issues
@@ -37,7 +37,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=30720
       - name: Upload build
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: docs-build
           path: build
@@ -65,19 +65,19 @@ jobs:
     steps:
       # SHA ref is main
       - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
       - name: Download build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: docs-build
           path: build
       - name: Install hyperlink
         run: npm install -g @untitaker/hyperlink
       - name: Check internal links
-        uses: untitaker/hyperlink@9375bc4063712ad490d5eb3d54df0b6aade15e54
+        uses: untitaker/hyperlink@9375bc4063712ad490d5eb3d54df0b6aade15e54  # 0.3.2
         with:
           args: build/
       - name: Remove https redirect
@@ -90,7 +90,7 @@ jobs:
           echo "container_ip=${container_ip}" >> $GITHUB_ENV
           echo "domain_to_test=http://${container_ip}:8080" >> $GITHUB_ENV
       - name: Wait for running docs web server
-        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
+        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1  # v1.0.1
         with:
           url: ${{ env.domain_to_test }}
       - name: Download sitemap from production
@@ -113,7 +113,7 @@ jobs:
             > ${temporary_link_path}/connectors-element-template-links.html
       - name: Serve link collections
         ## Run another web server because Muffet only works against web pages, not source files.
-        uses: Eun/http-server-action@dadebd209d4a902eeefceb524c24c38b364c46a7
+        uses: Eun/http-server-action@dadebd209d4a902eeefceb524c24c38b364c46a7  # v1.0.13
         with:
           directory: ${{ env.temporary_link_path }}
           port: 8081
@@ -151,7 +151,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@ee746fa695a43480b4294e944a6bf6e01b4f8459
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c  # rerun-failed-run-1.1.2
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -5,20 +5,20 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install Dependencies
         run: npm ci
       - name: Verify format with Vale
-        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff  # v3.0.0
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # v3.0.0
         with:
           filter_mode: added
           reporter: github-pr-review
           version: 3.9.6
       - name: Verify format with Prettier
-        uses: EPMatt/reviewdog-action-prettier@f691104cbeb4b0299df971275444c64be93c03ae  # v1.3.0
+        uses: EPMatt/reviewdog-action-prettier@f691104cbeb4b0299df971275444c64be93c03ae # v1.3.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -5,20 +5,20 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
       - name: Install Dependencies
         run: npm ci
       - name: Verify format with Vale
-        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff  # v3.0.0
         with:
           filter_mode: added
           reporter: github-pr-review
           version: 3.9.6
       - name: Verify format with Prettier
-        uses: EPMatt/reviewdog-action-prettier@f691104cbeb4b0299df971275444c64be93c03ae
+        uses: EPMatt/reviewdog-action-prettier@f691104cbeb4b0299df971275444c64be93c03ae  # v1.3.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -5,20 +5,20 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
       - name: Install Dependencies
         run: npm ci
       - name: Verify format with Vale
-        uses: errata-ai/vale-action@v3.0.0
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff
         with:
           filter_mode: added
           reporter: github-pr-review
           version: 3.9.6
       - name: Verify format with Prettier
-        uses: EPMatt/reviewdog-action-prettier@v1.3.0
+        uses: EPMatt/reviewdog-action-prettier@f691104cbeb4b0299df971275444c64be93c03ae
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout last two commits of the PR
         # The last *two* commits are (1) everything in this branch, and (2) the parent of this branch.
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
 
@@ -31,7 +31,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Comment on PR if version updates are potentially missing
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ env.MESSAGES != '' }}
         with:
           message: |
@@ -43,7 +43,7 @@ jobs:
           comment-tag: check-versions
 
       - name: Comment 'LGTM' on PR once potential version issues are resolved
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ env.MESSAGES == '' }}
         with:
           message: |

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout last two commits of the PR
         # The last *two* commits are (1) everything in this branch, and (2) the parent of this branch.
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 2
 
@@ -31,7 +31,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Comment on PR if version updates are potentially missing
-        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
         if: ${{ env.MESSAGES != '' }}
         with:
           message: |
@@ -43,7 +43,7 @@ jobs:
           comment-tag: check-versions
 
       - name: Comment 'LGTM' on PR once potential version issues are resolved
-        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
         if: ${{ env.MESSAGES == '' }}
         with:
           message: |

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout last two commits of the PR
         # The last *two* commits are (1) everything in this branch, and (2) the parent of this branch.
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 2
 
@@ -31,7 +31,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Comment on PR if version updates are potentially missing
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74
         if: ${{ env.MESSAGES != '' }}
         with:
           message: |
@@ -43,7 +43,7 @@ jobs:
           comment-tag: check-versions
 
       - name: Comment 'LGTM' on PR once potential version issues are resolved
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74
         if: ${{ env.MESSAGES == '' }}
         with:
           message: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Import secrets from Vault
         id: secrets
@@ -35,7 +35,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/claude-reviewer ANTHROPIC_API_KEY;
 
-      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10
+      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10  # v1.0.210
         with:
           anthropic_api_key: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Import secrets from Vault
         id: secrets
@@ -35,7 +35,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/claude-reviewer ANTHROPIC_API_KEY;
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10
         with:
           anthropic_api_key: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import secrets from Vault
         id: secrets
@@ -35,7 +35,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/claude-reviewer ANTHROPIC_API_KEY;
 
-      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10  # v1.0.210
+      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -7,6 +7,6 @@ jobs:
   enforce-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024  # 2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: "hold"

--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -7,6 +7,6 @@ jobs:
   enforce-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024  # 2.2.2
         with:
           BANNED_LABELS: "hold"

--- a/.github/workflows/enforce-labels.yaml
+++ b/.github/workflows/enforce-labels.yaml
@@ -7,6 +7,6 @@ jobs:
   enforce-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024
         with:
           BANNED_LABELS: "hold"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Get Current Date
         id: dateofday
@@ -27,7 +27,7 @@ jobs:
 
       - name: Restore lychee cache
         id: cache-restore
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .lycheecache
           key: cache-lychee-${{ env.DATEOFDAY }}
@@ -35,7 +35,7 @@ jobs:
             cache-lychee-
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.9.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         id: link-checker
         with:
           fail: false
@@ -45,7 +45,7 @@ jobs:
 
       - name: Save lychee cache
         if: always()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .lycheecache
           key: cache-lychee-${{ env.DATEOFDAY }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create Issue From File
         if: ${{ failure() && github.event_name == 'schedule' && steps.link-checker.outputs.exit_code != 0 }}
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get Current Date
         id: dateofday
@@ -27,7 +27,7 @@ jobs:
 
       - name: Restore lychee cache
         id: cache-restore
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .lycheecache
           key: cache-lychee-${{ env.DATEOFDAY }}
@@ -35,7 +35,7 @@ jobs:
             cache-lychee-
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         id: link-checker
         with:
           fail: false
@@ -45,7 +45,7 @@ jobs:
 
       - name: Save lychee cache
         if: always()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .lycheecache
           key: cache-lychee-${{ env.DATEOFDAY }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create Issue From File
         if: ${{ failure() && github.event_name == 'schedule' && steps.link-checker.outputs.exit_code != 0 }}
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # v6.0.0
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Get Current Date
         id: dateofday
@@ -27,7 +27,7 @@ jobs:
 
       - name: Restore lychee cache
         id: cache-restore
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .lycheecache
           key: cache-lychee-${{ env.DATEOFDAY }}
@@ -35,7 +35,7 @@ jobs:
             cache-lychee-
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         id: link-checker
         with:
           fail: false
@@ -45,7 +45,7 @@ jobs:
 
       - name: Save lychee cache
         if: always()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .lycheecache
           key: cache-lychee-${{ env.DATEOFDAY }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create Issue From File
         if: ${{ failure() && github.event_name == 'schedule' && steps.link-checker.outputs.exit_code != 0 }}
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # v6.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@67d00e9260887361a31f6446252fffbecae4a02e  # generate-github-app-token-from-vault-secrets-1.1.1
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@67d00e9260887361a31f6446252fffbecae4a02e # generate-github-app-token-from-vault-secrets-1.1.1
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/infra/ci/team-infrastructure
@@ -41,7 +41,7 @@ jobs:
             secret/data/products/infra/ci/infra-core SLACK_WEBHOOK_INFRA_ALERTS;
 
       - name: Apply maintenance parameters to the Pull Request if applicable
-        uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@67d00e9260887361a31f6446252fffbecae4a02e  # configure-maintenance-pull-request-1.0.1
+        uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@67d00e9260887361a31f6446252fffbecae4a02e # configure-maintenance-pull-request-1.0.1
         with:
           github-token: ${{ steps.github-token.outputs.token }}
           slack-webhook-url: ${{ steps.secrets.outputs.SLACK_WEBHOOK_INFRA_ALERTS }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@ee746fa695a43480b4294e944a6bf6e01b4f8459
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/infra/ci/team-infrastructure
@@ -41,7 +41,7 @@ jobs:
             secret/data/products/infra/ci/infra-core SLACK_WEBHOOK_INFRA_ALERTS;
 
       - name: Apply maintenance parameters to the Pull Request if applicable
-        uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@main
+        uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@ee746fa695a43480b4294e944a6bf6e01b4f8459
         with:
           github-token: ${{ steps.github-token.outputs.token }}
           slack-webhook-url: ${{ steps.secrets.outputs.SLACK_WEBHOOK_INFRA_ALERTS }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@ee746fa695a43480b4294e944a6bf6e01b4f8459
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@67d00e9260887361a31f6446252fffbecae4a02e  # generate-github-app-token-from-vault-secrets-1.1.1
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/infra/ci/team-infrastructure
@@ -41,7 +41,7 @@ jobs:
             secret/data/products/infra/ci/infra-core SLACK_WEBHOOK_INFRA_ALERTS;
 
       - name: Apply maintenance parameters to the Pull Request if applicable
-        uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@ee746fa695a43480b4294e944a6bf6e01b4f8459
+        uses: camunda/infra-global-github-actions/teams/infra/configure-maintenance-pull-request@67d00e9260887361a31f6446252fffbecae4a02e  # configure-maintenance-pull-request-1.0.1
         with:
           github-token: ${{ steps.github-token.outputs.token }}
           slack-webhook-url: ${{ steps.secrets.outputs.SLACK_WEBHOOK_INFRA_ALERTS }}

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -31,7 +31,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/slack DOCS_NOTIFICATION_WEBHOOK_URL;
       - id: slack
-        uses: slackapi/slack-github-action@e090a7a7c0b2d9b7ae32bd34f086e680ce260b06  # v3.0.0
+        uses: slackapi/slack-github-action@e090a7a7c0b2d9b7ae32bd34f086e680ce260b06 # v3.0.0
         with:
           webhook: ${{ steps.secrets.outputs.DOCS_NOTIFICATION_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -31,7 +31,7 @@ jobs:
           secrets: |
             secret/data/products/camunda-docs/ci/slack DOCS_NOTIFICATION_WEBHOOK_URL;
       - id: slack
-        uses: slackapi/slack-github-action@e090a7a7c0b2d9b7ae32bd34f086e680ce260b06
+        uses: slackapi/slack-github-action@e090a7a7c0b2d9b7ae32bd34f086e680ce260b06  # v3.0.0
         with:
           webhook: ${{ steps.secrets.outputs.DOCS_NOTIFICATION_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
     name: build-docs
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Import secrets from Vault
         id: secrets
@@ -40,7 +40,7 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Upsert comment with build status
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
         with:
           refresh-message-position: true
           message: |
@@ -60,7 +60,7 @@ jobs:
         run: npm run build
 
       - name: Upload build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: docs-build
           path: build
@@ -85,21 +85,21 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: docs-build
           path: build
 
       - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Start Deployment
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         id: deployment
         with:
           step: start
@@ -108,7 +108,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with upload status
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
         with:
           refresh-message-position: true
           message: |
@@ -120,7 +120,7 @@ jobs:
         run: |
           gcloud storage rsync --gzip-in-flight-all --delete-unmatched-destination-objects --recursive build gs://$BUCKET_NAME/pr-${{ github.event.number }}
 
-      - uses: bobheadxi/deployments@v1
+      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         with:
           step: finish
           token: ${{ github.token }}
@@ -130,7 +130,7 @@ jobs:
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
       - name: Update comment with deployment status
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
@@ -149,7 +149,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        uses: camunda/infra-global-github-actions/rerun-failed-run@ee746fa695a43480b4294e944a6bf6e01b4f8459
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
     name: build-docs
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import secrets from Vault
         id: secrets
@@ -40,7 +40,7 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Upsert comment with build status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           refresh-message-position: true
           message: |
@@ -60,7 +60,7 @@ jobs:
         run: npm run build
 
       - name: Upload build
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-build
           path: build
@@ -85,21 +85,21 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Download build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-build
           path: build
 
       - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Start Deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8  # v1.5.0
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
         id: deployment
         with:
           step: start
@@ -108,7 +108,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with upload status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           refresh-message-position: true
           message: |
@@ -120,7 +120,7 @@ jobs:
         run: |
           gcloud storage rsync --gzip-in-flight-all --delete-unmatched-destination-objects --recursive build gs://$BUCKET_NAME/pr-${{ github.event.number }}
 
-      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8  # v1.5.0
+      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
         with:
           step: finish
           token: ${{ github.token }}
@@ -130,7 +130,7 @@ jobs:
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
       - name: Update comment with deployment status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
@@ -149,7 +149,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c  # rerun-failed-run-1.1.2
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
     name: build-docs
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Import secrets from Vault
         id: secrets
@@ -40,7 +40,7 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Upsert comment with build status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
         with:
           refresh-message-position: true
           message: |
@@ -60,7 +60,7 @@ jobs:
         run: npm run build
 
       - name: Upload build
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: docs-build
           path: build
@@ -85,21 +85,21 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Download build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: docs-build
           path: build
 
       - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
       - name: Start Deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8  # v1.5.0
         id: deployment
         with:
           step: start
@@ -108,7 +108,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with upload status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
         with:
           refresh-message-position: true
           message: |
@@ -120,7 +120,7 @@ jobs:
         run: |
           gcloud storage rsync --gzip-in-flight-all --delete-unmatched-destination-objects --recursive build gs://$BUCKET_NAME/pr-${{ github.event.number }}
 
-      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
+      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8  # v1.5.0
         with:
           step: finish
           token: ${{ github.token }}
@@ -130,7 +130,7 @@ jobs:
           env_url: https://${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}/pr-${{ github.event.number }}/index.html
 
       - name: Update comment with deployment status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
         env:
           BUCKET_NAME: ${{ steps.secrets.outputs.PREVIEW_ENV_BUCKET_NAME }}
         with:
@@ -149,7 +149,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@ee746fa695a43480b4294e944a6bf6e01b4f8459
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c  # rerun-failed-run-1.1.2
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
     name: teardown-preview-env
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Import secrets
         id: secrets
@@ -25,19 +25,19 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
       - name: Update comment with tear-down warning
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
         with:
           refresh-message-position: true
           message: |
             :warning: Preview environment for commit ${{ github.sha }} is being deleted. This usually takes 2-3 minutes.
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
       - name: Remove files from Google bucket
         env:
@@ -45,7 +45,7 @@ jobs:
         run: |
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
-      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
+      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8  # v1.5.0
         if: always()
         name: Deactivate GitHub Deployment environment
         with:
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with tear-down status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
         with:
           refresh-message-position: true
           message: |

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
     name: teardown-preview-env
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Import secrets
         id: secrets
@@ -25,19 +25,19 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
       - name: Update comment with tear-down warning
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           refresh-message-position: true
           message: |
             :warning: Preview environment for commit ${{ github.sha }} is being deleted. This usually takes 2-3 minutes.
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Remove files from Google bucket
         env:
@@ -45,7 +45,7 @@ jobs:
         run: |
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
-      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8  # v1.5.0
+      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
         if: always()
         name: Deactivate GitHub Deployment environment
         with:
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with tear-down status
-        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # v3.12.0
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           refresh-message-position: true
           message: |

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
     name: teardown-preview-env
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Import secrets
         id: secrets
@@ -25,19 +25,19 @@ jobs:
             secret/data/products/camunda-docs/ci/preview-environment PREVIEW_ENV_GCLOUD_SA_KEY;
 
       - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
           credentials_json: ${{ steps.secrets.outputs.PREVIEW_ENV_GCLOUD_SA_KEY }}
 
       - name: Update comment with tear-down warning
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
         with:
           refresh-message-position: true
           message: |
             :warning: Preview environment for commit ${{ github.sha }} is being deleted. This usually takes 2-3 minutes.
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Remove files from Google bucket
         env:
@@ -45,7 +45,7 @@ jobs:
         run: |
           gsutil -m rm -r gs://$BUCKET_NAME/pr-${{ github.event.number }}/
 
-      - uses: bobheadxi/deployments@v1
+      - uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         if: always()
         name: Deactivate GitHub Deployment environment
         with:
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update comment with tear-down status
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59
         with:
           refresh-message-position: true
           message: |

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -26,8 +26,8 @@ jobs:
     runs-on: gcp-core-16-release
     container: node:24
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
       - name: Install Dependencies
@@ -55,7 +55,7 @@ jobs:
             secret/data/products/camunda-docs/ci/publish USER;
             secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
-        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5  # 9.0.0
         with:
           switches: -avzr --delete
           path: build/
@@ -83,7 +83,7 @@ jobs:
             secret/data/products/camunda-docs/ci/algolia-crawl CRAWLER_API_KEY;
             secret/data/products/camunda-docs/ci/algolia-crawl CRAWLER_USER_ID;
       - name: Trigger Algolia crawl
-        uses: algolia/algoliasearch-crawler-github-actions@3ae4def15d82c60aa02b0e528b50167593cbaaf6
+        uses: algolia/algoliasearch-crawler-github-actions@3ae4def15d82c60aa02b0e528b50167593cbaaf6  # v1.1.13
         id: algolia_crawler
         with:
           crawler-user-id: ${{ steps.secrets.outputs.CRAWLER_USER_ID }}

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -26,8 +26,8 @@ jobs:
     runs-on: gcp-core-16-release
     container: node:24
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
       - name: Install Dependencies
@@ -55,7 +55,7 @@ jobs:
             secret/data/products/camunda-docs/ci/publish USER;
             secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
-        uses: burnett01/rsync-deployments@v9
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5
         with:
           switches: -avzr --delete
           path: build/
@@ -83,7 +83,7 @@ jobs:
             secret/data/products/camunda-docs/ci/algolia-crawl CRAWLER_API_KEY;
             secret/data/products/camunda-docs/ci/algolia-crawl CRAWLER_USER_ID;
       - name: Trigger Algolia crawl
-        uses: algolia/algoliasearch-crawler-github-actions@v1.1.13
+        uses: algolia/algoliasearch-crawler-github-actions@3ae4def15d82c60aa02b0e528b50167593cbaaf6
         id: algolia_crawler
         with:
           crawler-user-id: ${{ steps.secrets.outputs.CRAWLER_USER_ID }}

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -26,8 +26,8 @@ jobs:
     runs-on: gcp-core-16-release
     container: node:24
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install Dependencies
@@ -55,7 +55,7 @@ jobs:
             secret/data/products/camunda-docs/ci/publish USER;
             secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
-        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5  # 9.0.0
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5 # 9.0.0
         with:
           switches: -avzr --delete
           path: build/
@@ -83,7 +83,7 @@ jobs:
             secret/data/products/camunda-docs/ci/algolia-crawl CRAWLER_API_KEY;
             secret/data/products/camunda-docs/ci/algolia-crawl CRAWLER_USER_ID;
       - name: Trigger Algolia crawl
-        uses: algolia/algoliasearch-crawler-github-actions@3ae4def15d82c60aa02b0e528b50167593cbaaf6  # v1.1.13
+        uses: algolia/algoliasearch-crawler-github-actions@3ae4def15d82c60aa02b0e528b50167593cbaaf6 # v1.1.13
         id: algolia_crawler
         with:
           crawler-user-id: ${{ steps.secrets.outputs.CRAWLER_USER_ID }}

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: gcp-core-8-default
     container: node:24
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
       - name: Install Dependencies
@@ -46,7 +46,7 @@ jobs:
             secret/data/products/camunda-docs/ci/publish USER;
             secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
-        uses: burnett01/rsync-deployments@v9
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5
         with:
           switches: -avzr --delete
           path: build/
@@ -64,7 +64,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        uses: camunda/infra-global-github-actions/rerun-failed-run@ee746fa695a43480b4294e944a6bf6e01b4f8459
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: gcp-core-8-default
     container: node:24
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
       - name: Install Dependencies
@@ -46,7 +46,7 @@ jobs:
             secret/data/products/camunda-docs/ci/publish USER;
             secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
-        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5  # 9.0.0
         with:
           switches: -avzr --delete
           path: build/
@@ -64,7 +64,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@ee746fa695a43480b4294e944a6bf6e01b4f8459
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c  # rerun-failed-run-1.1.2
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: gcp-core-8-default
     container: node:24
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install Dependencies
@@ -46,7 +46,7 @@ jobs:
             secret/data/products/camunda-docs/ci/publish USER;
             secret/data/products/camunda-docs/ci/publish PRIVATE_KEY;
       - name: Publish
-        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5  # 9.0.0
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5 # 9.0.0
         with:
           switches: -avzr --delete
           path: build/
@@ -64,7 +64,7 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     steps:
       - name: Retry job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c  # rerun-failed-run-1.1.2
+        uses: camunda/infra-global-github-actions/rerun-failed-run@475528365f4010480dccff71ccac554cc3352e7c # rerun-failed-run-1.1.2
         with:
           error-messages: |
             The runner has received a shutdown signal.

--- a/.github/workflows/sync-c8ctl-docs.yaml
+++ b/.github/workflows/sync-c8ctl-docs.yaml
@@ -44,20 +44,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout c8ctl
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/c8ctl
           ref: ${{ steps.resolve.outputs.c8ctl_ref }}
           path: c8ctl
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "24"
 
@@ -124,14 +124,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-c8ctl-docs.yaml
+++ b/.github/workflows/sync-c8ctl-docs.yaml
@@ -44,20 +44,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout c8ctl
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/c8ctl
           ref: ${{ steps.resolve.outputs.c8ctl_ref }}
           path: c8ctl
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "24"
 
@@ -131,7 +131,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-c8ctl-docs.yaml
+++ b/.github/workflows/sync-c8ctl-docs.yaml
@@ -44,20 +44,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout c8ctl
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/c8ctl
           ref: ${{ steps.resolve.outputs.c8ctl_ref }}
           path: c8ctl
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 
@@ -124,14 +124,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-csharp-sdk-docs.yaml
+++ b/.github/workflows/sync-csharp-sdk-docs.yaml
@@ -46,25 +46,25 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout C# SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-csharp
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: csharp-sdk
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "9.0.x"
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -123,7 +123,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -186,14 +186,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-csharp-sdk-docs.yaml
+++ b/.github/workflows/sync-csharp-sdk-docs.yaml
@@ -46,25 +46,25 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout C# SDK
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/orchestration-cluster-api-csharp
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: csharp-sdk
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68
         with:
           dotnet-version: "9.0.x"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: "3.14"
 
@@ -123,7 +123,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
 
@@ -193,7 +193,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-csharp-sdk-docs.yaml
+++ b/.github/workflows/sync-csharp-sdk-docs.yaml
@@ -46,25 +46,25 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout C# SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-csharp
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: csharp-sdk
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
         with:
           dotnet-version: "9.0.x"
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
@@ -123,7 +123,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
 
@@ -186,14 +186,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-go-sdk-docs.yaml
+++ b/.github/workflows/sync-go-sdk-docs.yaml
@@ -46,27 +46,27 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Go SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-go
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: go-sdk
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
       # The API snapshot is produced by `cmd/docgen`, a stdlib-only program, so
       # the toolchain pinned in the SDK's go.mod is all that is needed.
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go-sdk/go.mod
 
@@ -111,7 +111,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
 
@@ -174,14 +174,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-go-sdk-docs.yaml
+++ b/.github/workflows/sync-go-sdk-docs.yaml
@@ -46,27 +46,27 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Go SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-go
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: go-sdk
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
       # The API snapshot is produced by `cmd/docgen`, a stdlib-only program, so
       # the toolchain pinned in the SDK's go.mod is all that is needed.
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go-sdk/go.mod
 
@@ -111,7 +111,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -174,14 +174,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-go-sdk-docs.yaml
+++ b/.github/workflows/sync-go-sdk-docs.yaml
@@ -46,27 +46,27 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Go SDK
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/orchestration-cluster-api-go
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: go-sdk
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: "3.14"
 
       # The API snapshot is produced by `cmd/docgen`, a stdlib-only program, so
       # the toolchain pinned in the SDK's go.mod is all that is needed.
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go-sdk/go.mod
 
@@ -111,7 +111,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Checkout Camunda Hub (Self-Managed)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-hub
           token: ${{ steps.generate_token.outputs.token }}
@@ -101,7 +101,7 @@ jobs:
           npm run api:generate:hubsm
 
       - name: Upload Self-Managed changes
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: sm-changes
           path: |
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -140,7 +140,7 @@ jobs:
           repositories: camunda-hub
 
       - name: Checkout Camunda Hub (SaaS)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-hub
           token: ${{ steps.generate_token.outputs.token }}
@@ -163,7 +163,7 @@ jobs:
           npm run api:generate:hubsaas
 
       - name: Upload SaaS changes
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: saas-changes
           path: |
@@ -176,19 +176,19 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Download Self-Managed changes
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: sm-changes
           path: docs/
 
       - name: Download SaaS changes
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: saas-changes
           path: docs/
@@ -241,7 +241,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -31,7 +31,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Checkout Camunda Hub (Self-Managed)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-hub
           token: ${{ steps.generate_token.outputs.token }}
@@ -101,7 +101,7 @@ jobs:
           npm run api:generate:hubsm
 
       - name: Upload Self-Managed changes
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sm-changes
           path: |
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -133,14 +133,14 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
           repositories: camunda-hub
 
       - name: Checkout Camunda Hub (SaaS)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-hub
           token: ${{ steps.generate_token.outputs.token }}
@@ -163,7 +163,7 @@ jobs:
           npm run api:generate:hubsaas
 
       - name: Upload SaaS changes
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: saas-changes
           path: |
@@ -176,19 +176,19 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Download Self-Managed changes
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sm-changes
           path: docs/
 
       - name: Download SaaS changes
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: saas-changes
           path: docs/
@@ -208,7 +208,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
@@ -241,7 +241,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-hub-rest-api-docs.yaml
+++ b/.github/workflows/sync-hub-rest-api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -31,7 +31,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Checkout Camunda Hub (Self-Managed)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-hub
           token: ${{ steps.generate_token.outputs.token }}
@@ -101,7 +101,7 @@ jobs:
           npm run api:generate:hubsm
 
       - name: Upload Self-Managed changes
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sm-changes
           path: |
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -133,14 +133,14 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
           repositories: camunda-hub
 
       - name: Checkout Camunda Hub (SaaS)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-hub
           token: ${{ steps.generate_token.outputs.token }}
@@ -163,7 +163,7 @@ jobs:
           npm run api:generate:hubsaas
 
       - name: Upload SaaS changes
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: saas-changes
           path: |
@@ -176,19 +176,19 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Download Self-Managed changes
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: sm-changes
           path: docs/
 
       - name: Download SaaS changes
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: saas-changes
           path: docs/
@@ -208,7 +208,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
@@ -241,7 +241,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-python-sdk-docs.yaml
+++ b/.github/workflows/sync-python-sdk-docs.yaml
@@ -46,25 +46,25 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Python SDK
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/orchestration-cluster-api-python
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: python-sdk
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: "3.14"
 
@@ -112,7 +112,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
 
@@ -182,7 +182,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-python-sdk-docs.yaml
+++ b/.github/workflows/sync-python-sdk-docs.yaml
@@ -46,25 +46,25 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Python SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-python
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: python-sdk
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -112,7 +112,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -175,14 +175,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-python-sdk-docs.yaml
+++ b/.github/workflows/sync-python-sdk-docs.yaml
@@ -46,25 +46,25 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Python SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-python
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: python-sdk
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
@@ -112,7 +112,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
 
@@ -175,14 +175,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Checkout Camunda
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda
           path: rest-spec
@@ -170,14 +170,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Checkout Camunda
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda
           path: rest-spec
@@ -170,14 +170,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-rest-api-docs.yaml
+++ b/.github/workflows/sync-rest-api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Camunda docs repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Checkout Camunda
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda
           path: rest-spec
@@ -177,7 +177,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-rust-sdk-docs.yaml
+++ b/.github/workflows/sync-rust-sdk-docs.yaml
@@ -46,20 +46,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Rust SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-rust
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: rust-sdk
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -109,7 +109,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -172,14 +172,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-rust-sdk-docs.yaml
+++ b/.github/workflows/sync-rust-sdk-docs.yaml
@@ -46,20 +46,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Rust SDK
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/orchestration-cluster-api-rust
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: rust-sdk
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: "3.14"
 
@@ -109,7 +109,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
 
@@ -179,7 +179,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-rust-sdk-docs.yaml
+++ b/.github/workflows/sync-rust-sdk-docs.yaml
@@ -46,20 +46,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout Rust SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-rust
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: rust-sdk
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
@@ -109,7 +109,7 @@ jobs:
           echo "Copied landing page + ${SECTION_COUNT} section pages + ${API_COUNT} API reference files → ${{ steps.resolve.outputs.docs_root }}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
 
@@ -172,14 +172,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-spring-boot-docs.yaml
+++ b/.github/workflows/sync-spring-boot-docs.yaml
@@ -33,15 +33,15 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version-file: ".nvmrc"
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: "temurin"
           java-version: "21"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create pull request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           title: "docs: update Spring Boot properties (${{ steps.resolve.outputs.version_label }})"

--- a/.github/workflows/sync-spring-boot-docs.yaml
+++ b/.github/workflows/sync-spring-boot-docs.yaml
@@ -33,15 +33,15 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Set up Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
         with:
           distribution: "temurin"
           java-version: "21"
@@ -83,14 +83,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create pull request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           title: "docs: update Spring Boot properties (${{ steps.resolve.outputs.version_label }})"

--- a/.github/workflows/sync-spring-boot-docs.yaml
+++ b/.github/workflows/sync-spring-boot-docs.yaml
@@ -33,15 +33,15 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Set up Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: "temurin"
           java-version: "21"
@@ -83,14 +83,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create pull request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           title: "docs: update Spring Boot properties (${{ steps.resolve.outputs.version_label }})"

--- a/.github/workflows/sync-ts-sdk-docs.yaml
+++ b/.github/workflows/sync-ts-sdk-docs.yaml
@@ -46,20 +46,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout TypeScript SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-js
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: ts-sdk
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 
@@ -155,14 +155,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-ts-sdk-docs.yaml
+++ b/.github/workflows/sync-ts-sdk-docs.yaml
@@ -46,20 +46,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout TypeScript SDK
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: camunda/orchestration-cluster-api-js
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: ts-sdk
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "24"
 
@@ -155,14 +155,14 @@ jobs:
       - name: Generate token
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/sync-ts-sdk-docs.yaml
+++ b/.github/workflows/sync-ts-sdk-docs.yaml
@@ -46,20 +46,20 @@ jobs:
           fi
 
       - name: Checkout camunda-docs
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/camunda-docs
           path: docs
 
       - name: Checkout TypeScript SDK
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: camunda/orchestration-cluster-api-js
           ref: ${{ steps.resolve.outputs.sdk_ref }}
           path: ts-sdk
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "24"
 
@@ -162,7 +162,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true' && github.event.inputs.dry_run != 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           path: docs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/update-postman.yaml
+++ b/.github/workflows/update-postman.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
       - name: Import Secrets

--- a/.github/workflows/update-postman.yaml
+++ b/.github/workflows/update-postman.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
       - name: Import Secrets

--- a/.github/workflows/update-postman.yaml
+++ b/.github/workflows/update-postman.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Import Secrets

--- a/.github/workflows/update-release-links.yml
+++ b/.github/workflows/update-release-links.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "24"
           cache: "npm"
@@ -62,14 +62,14 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.update-links.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ steps.generate_token.outputs.token }}
           commit-message: "docs: update release links in release notes"

--- a/.github/workflows/update-release-links.yml
+++ b/.github/workflows/update-release-links.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "24"
           cache: "npm"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update-links.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ steps.generate_token.outputs.token }}
           commit-message: "docs: update release links in release notes"

--- a/.github/workflows/update-release-links.yml
+++ b/.github/workflows/update-release-links.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: "npm"
@@ -62,14 +62,14 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         if: steps.update-links.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate_token.outputs.token }}
           commit-message: "docs: update release links in release notes"


### PR DESCRIPTION
## Description

Pins every remaining GitHub Actions reference (third-party and `camunda/infra-global-github-actions/*`) to its resolved commit SHA. 113 refs across 29 workflow/composite-action files were tag-pinned (e.g. `@v4`) or pinned to the mutable `@main` branch; this repo already SHA-pins a subset of actions (`hashicorp/vault-action`, `actions/create-github-app-token`, `slackapi/slack-github-action`), so this brings the rest in line with that existing convention and with infra-core's action-pinning policy.

Each SHA was resolved from the GitHub API against the exact tag/branch it replaces and independently re-verified against the API afterward; no manual/typed SHAs.

Follow-up: the maintenance DRI will need to retry/rebase open Renovate PRs against `.github/workflows` and `.github/actions` after this merges, since their diffs are now against SHA-pinned lines.

## When should this change go live?

- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using `{type}(scope): {description}` commit message(s)
- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] Engineering team review
  - [ ] Technical writer review

This is CI/docs-infra tooling, not documentation content, so the doc-release and content-review checklist items above don't apply.