### PR TITLE
docs: document secret resolution and cache metrics

### DIFF
--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -281,6 +281,100 @@ The `REPORT_NAME` and `REPORT_ID` labels identify the evaluated report or dashbo
 
 Report latency metrics are controlled by the `optimize.metrics.report-latency.enabled=true` configuration property. Set the property to `false` to disable report latency metrics.
 
+## Secret resolution and cache metrics
+
+Camunda emits meters for resolving secret references against a secret store, and for the in-memory
+cache that sits in front of each configured store. Together, they distinguish a secret store that
+is slow or unavailable from a cache that is simply cold, in a case that otherwise shows up only as
+jobs that fail to activate.
+
+No meter listed here is tagged by secret name: the cardinality is unbounded, and secret names are
+customer data.
+
+### Secret resolution metrics
+
+These meters cover resolving secret references against a secret store.
+
+| Metric name                             | Type    | Description                                                                                                                                                                                                                                                                                                                                                                  | Labels                        |
+| --------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `camunda.secret.resolution.duration`    | Timer   | Latency of one batch resolution call against a secret store, covering the call itself and not the follow-up commands the engine writes for its results. Split by how the call ended, so a store timing out does not distort the latency of the calls that came back.                                                                                                         | `store`, `result` (see below) |
+| `camunda.secret.resolution.outcome`     | Counter | Number of secret reference resolutions that produced an outcome, per store. Every result value is terminal for the reference it counts, so the values can be summed or divided by one another to derive rates. A reference whose store is unavailable but still has retry attempts left is not counted at all, since it has not reached a terminal outcome.                  | `store`, `result` (see below) |
+| `camunda.secret.resolution.cycle.error` | Counter | Number of resolution cycles in which a store failed in a way the engine does not model: an unexpected exception rather than a per-secret failure or an unreachable store. Counted per store. Always indicates a bug, either in the store implementation or in the engine. Counts cycles, not references, so it is a separate meter from `camunda.secret.resolution.outcome`. | `store`                       |
+
+The `store` label carries the ID of the secret store a reference belongs to.
+
+The `result` label carries different value domains depending on the meter, because
+`camunda.secret.resolution.duration` measures a whole batch call while
+`camunda.secret.resolution.outcome` measures one reference at a time:
+
+`result` values on `camunda.secret.resolution.duration`:
+
+| Value               | Description                                                                  |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `RETURNED`          | The store returned, whatever the per-reference results were.                 |
+| `STORE_UNAVAILABLE` | The store could not be reached for this call.                                |
+| `ERROR`             | The store threw something the engine does not model. Always indicates a bug. |
+
+`result` values on `camunda.secret.resolution.outcome`:
+
+| Value               | Description                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `RESOLVED`          | The store returned a value for the reference.                                                                                         |
+| `NOT_FOUND`         | The store does not hold the reference.                                                                                                |
+| `ACCESS_DENIED`     | The store refused to read the reference.                                                                                              |
+| `INVALID_REF`       | The reference is not valid for the store.                                                                                             |
+| `UNREADABLE`        | The store holds the reference but could not read a value from it.                                                                     |
+| `STORE_UNAVAILABLE` | The store could not serve the reference at all: either it is not configured, or it could not be reached and no retry attempt is left. |
+
+### Secret cache metrics
+
+Each configured secret store resolves through an in-memory cache. These meters say how well that
+cache is doing its job.
+
+| Metric name                      | Type    | Description                                                                                                                                                                                                                                                                                                                          | Labels                        |
+| -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| `camunda.secret.cache.result`    | Counter | Number of secret cache lookups, per store and per result, so the hit rate is `HIT / (HIT + MISS)`. Every lookup is counted exactly once. A name the store answers permanently (deleted, denied, or an invalid reference) is never cached, so it misses on every lookup for as long as it is referenced. That is not a cache to tune. | `store`, `result` (see below) |
+| `camunda.secret.cache.evictions` | Counter | Number of entries removed from a secret cache, per store and per cause.                                                                                                                                                                                                                                                              | `store`, `cause` (see below)  |
+| `camunda.secret.cache.size`      | Gauge   | Estimated number of entries a secret cache currently holds, per store. Estimated because eviction is asynchronous, so the value can briefly sit above the configured maximum: read it as a level to compare against that maximum, not as an exact count.                                                                             | `store`                       |
+
+The `store` label carries the ID of the secret store whose cache this is.
+
+`result` values on `camunda.secret.cache.result`:
+
+| Value  | Description                                                                            |
+| ------ | -------------------------------------------------------------------------------------- |
+| `HIT`  | The cache held a value for the name.                                                   |
+| `MISS` | The cache held no value for the name, so the caller had to reach the store or give up. |
+
+`cause` values on `camunda.secret.cache.evictions`:
+
+| Value       | Description                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SIZE`      | The cache was full, so it dropped an entry to make room for another.                                                                       |
+| `EXPIRED`   | The entry's time-to-live elapsed.                                                                                                          |
+| `EXPLICIT`  | Something removed the entry by name. In practice, this is a store answering a name permanently (deleted, denied, or an invalid reference). |
+| `COLLECTED` | The entry's key or value was garbage collected.                                                                                            |
+
+### Read cache and resolution metrics together
+
+`camunda.secret.cache.result` and `camunda.secret.resolution.outcome` answer different questions.
+Reading them in the wrong order can make a healthy cache look broken. A falling cache hit rate only
+means the cache is not holding what callers ask for. It does not mean the value was cacheable in the
+first place. A reference that a store answers permanently as not found, denied, or invalid is never
+cached, so it registers a `MISS` on every lookup for as long as it is referenced. Read a low hit rate
+against `camunda.secret.resolution.outcome` first: if the misses concentrate on references that never
+resolve, the fix is not in the cache.
+
+### Cache size and the configured maximum
+
+`camunda.secret.cache.size` is bounded per store by the
+[`camunda.secrets.cache.max-size`](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camunda-secrets-cache)
+property. The bound applies per store, not as a shared budget, so the worst-case memory footprint
+across a deployment is the number of configured stores multiplied by that maximum.
+
+For how the broker resolves secret references before job activation, see
+[Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+
 ## Grafana
 
 ### Zeebe

--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -285,8 +285,8 @@ Report latency metrics are controlled by the `optimize.metrics.report-latency.en
 
 Camunda emits meters for resolving secret references against a secret store, and for the in-memory
 cache that sits in front of each configured store. Together, they distinguish a secret store that
-is slow or unavailable from a cache that is simply cold, in a case that otherwise shows up only as
-jobs that fail to activate.
+is slow or unavailable from a cache that is simply cold, in cases that otherwise show up only as
+jobs that don't activate.
 
 No meter listed here is tagged by secret name: the cardinality is unbounded, and secret names are
 customer data.
@@ -368,7 +368,7 @@ resolve, the fix is not in the cache.
 ### Cache size and the configured maximum
 
 `camunda.secret.cache.size` is bounded per store by the
-[`camunda.secrets.cache.max-size`](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camunda-secrets-cache)
+[`camunda.secrets.cache.max-size`](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camundasecretscache)
 property. The bound applies per store, not as a shared budget, so the worst-case memory footprint
 across a deployment is the number of configured stores multiplied by that maximum.
 

--- a/docs/self-managed/operational-guides/monitoring/metrics.md
+++ b/docs/self-managed/operational-guides/monitoring/metrics.md
@@ -295,17 +295,16 @@ customer data.
 
 These meters cover resolving secret references against a secret store.
 
-| Metric name                             | Type    | Description                                                                                                                                                                                                                                                                                                                                                                  | Labels                        |
-| --------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `camunda.secret.resolution.duration`    | Timer   | Latency of one batch resolution call against a secret store, covering the call itself and not the follow-up commands the engine writes for its results. Split by how the call ended, so a store timing out does not distort the latency of the calls that came back.                                                                                                         | `store`, `result` (see below) |
-| `camunda.secret.resolution.outcome`     | Counter | Number of secret reference resolutions that produced an outcome, per store. Every result value is terminal for the reference it counts, so the values can be summed or divided by one another to derive rates. A reference whose store is unavailable but still has retry attempts left is not counted at all, since it has not reached a terminal outcome.                  | `store`, `result` (see below) |
-| `camunda.secret.resolution.cycle.error` | Counter | Number of resolution cycles in which a store failed in a way the engine does not model: an unexpected exception rather than a per-secret failure or an unreachable store. Counted per store. Always indicates a bug, either in the store implementation or in the engine. Counts cycles, not references, so it is a separate meter from `camunda.secret.resolution.outcome`. | `store`                       |
+| Metric name                             | Type    | Description                                                                                                                                                                                                                                                                                                                                                                  | Labels                                                       |
+| --------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `camunda.secret.resolution.duration`    | Timer   | Latency of one batch resolution call against a secret store, covering the call itself and not the follow-up commands the engine writes for its results. Split by how the call ended, so a store timing out does not distort the latency of the calls that came back.                                                                                                         | `store`, `result` (see below), `physicalTenant`, `partition` |
+| `camunda.secret.resolution.outcome`     | Counter | Number of secret reference resolutions that produced an outcome, per store. Every result value is terminal for the reference it counts, so the values can be summed or divided by one another to derive rates. A reference whose store is unavailable but still has retry attempts left is not counted at all, since it has not reached a terminal outcome.                  | `store`, `result` (see below), `physicalTenant`, `partition` |
+| `camunda.secret.resolution.cycle.error` | Counter | Number of resolution cycles in which a store failed in a way the engine does not model: an unexpected exception rather than a per-secret failure or an unreachable store. Counted per store. Always indicates a bug, either in the store implementation or in the engine. Counts cycles, not references, so it is a separate meter from `camunda.secret.resolution.outcome`. | `store`, `physicalTenant`, `partition`                       |
+| `camunda.secret.resolution.cycle.delay` | Timer   | The delay a resolution cycle chose for the next one, tagged by why. `IDLE_BACKOFF` is the one to watch: it grows geometrically on consecutive misses, so its distribution shows directly whether that backoff is behaving as intended, rather than needing to be inferred from the cycle rate alone.                                                                         | `result` (see below), `physicalTenant`, `partition`          |
 
-The `store` label carries the ID of the secret store a reference belongs to.
+The `store` label carries the ID of the secret store a reference belongs to. `camunda.secret.resolution.cycle.delay` carries no `store` label, since a resolution cycle isn't scoped to one store. Every resolution meter also carries the `physicalTenant` and `partition` labels applied to Zeebe metrics generally.
 
-The `result` label carries different value domains depending on the meter, because
-`camunda.secret.resolution.duration` measures a whole batch call while
-`camunda.secret.resolution.outcome` measures one reference at a time:
+The `result` label carries different value domains depending on the meter:
 
 `result` values on `camunda.secret.resolution.duration`:
 
@@ -326,18 +325,27 @@ The `result` label carries different value domains depending on the meter, becau
 | `UNREADABLE`        | The store holds the reference but could not read a value from it.                                                                     |
 | `STORE_UNAVAILABLE` | The store could not serve the reference at all: either it is not configured, or it could not be reached and no retry attempt is left. |
 
+`result` values on `camunda.secret.resolution.cycle.delay` (why the cycle chose its delay, not a per-reference outcome):
+
+| Value            | Description                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `DRAINING`       | More pending references remained than the batch cap allowed this cycle to take. The delay is always zero. |
+| `WAKE`           | This cycle resolved something, or a reference was requested since the last cycle ran.                     |
+| `IDLE_BACKOFF`   | Neither of the above, and no store is in retry cooldown.                                                  |
+| `RETRY_COOLDOWN` | Neither of the above, and a store's retry cooldown deadline set the delay instead.                        |
+
 ### Secret cache metrics
 
 Each configured secret store resolves through an in-memory cache. These meters say how well that
 cache is doing its job.
 
-| Metric name                      | Type    | Description                                                                                                                                                                                                                                                                                                                          | Labels                        |
-| -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
-| `camunda.secret.cache.result`    | Counter | Number of secret cache lookups, per store and per result, so the hit rate is `HIT / (HIT + MISS)`. Every lookup is counted exactly once. A name the store answers permanently (deleted, denied, or an invalid reference) is never cached, so it misses on every lookup for as long as it is referenced. That is not a cache to tune. | `store`, `result` (see below) |
-| `camunda.secret.cache.evictions` | Counter | Number of entries removed from a secret cache, per store and per cause.                                                                                                                                                                                                                                                              | `store`, `cause` (see below)  |
-| `camunda.secret.cache.size`      | Gauge   | Estimated number of entries a secret cache currently holds, per store. Estimated because eviction is asynchronous, so the value can briefly sit above the configured maximum: read it as a level to compare against that maximum, not as an exact count.                                                                             | `store`                       |
+| Metric name                      | Type    | Description                                                                                                                                                                                                                                                                                                                          | Labels                                          |
+| -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| `camunda.secret.cache.result`    | Counter | Number of secret cache lookups, per store and per result, so the hit rate is `HIT / (HIT + MISS)`. Every lookup is counted exactly once. A name the store answers permanently (deleted, denied, or an invalid reference) is never cached, so it misses on every lookup for as long as it is referenced. That is not a cache to tune. | `store`, `result` (see below), `physicalTenant` |
+| `camunda.secret.cache.evictions` | Counter | Number of entries removed from a secret cache, per store and per cause.                                                                                                                                                                                                                                                              | `store`, `cause` (see below), `physicalTenant`  |
+| `camunda.secret.cache.size`      | Gauge   | Estimated number of entries a secret cache currently holds, per store. Estimated because eviction is asynchronous, so the value can briefly sit above the configured maximum: read it as a level to compare against that maximum, not as an exact count.                                                                             | `store`, `physicalTenant`                       |
 
-The `store` label carries the ID of the secret store whose cache this is.
+The `store` label carries the ID of the secret store whose cache this is. Every cache meter also carries `physicalTenant`, since the registry that publishes them is wrapped per tenant. None carry `partition`: a secret cache lives outside any partition.
 
 `result` values on `camunda.secret.cache.result`:
 
@@ -348,12 +356,12 @@ The `store` label carries the ID of the secret store whose cache this is.
 
 `cause` values on `camunda.secret.cache.evictions`:
 
-| Value       | Description                                                                                                                                |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SIZE`      | The cache was full, so it dropped an entry to make room for another.                                                                       |
-| `EXPIRED`   | The entry's time-to-live elapsed.                                                                                                          |
-| `EXPLICIT`  | Something removed the entry by name. In practice, this is a store answering a name permanently (deleted, denied, or an invalid reference). |
-| `COLLECTED` | The entry's key or value was garbage collected.                                                                                            |
+| Value       | Description                                                                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SIZE`      | The cache was full, so it dropped an entry to make room for another.                                                                        |
+| `EXPIRED`   | The entry's time-to-live elapsed.                                                                                                           |
+| `EXPLICIT`  | Something removed the entry by name. In practice, this is a store answering a name permanently (deleted, denied, or an invalid reference).  |
+| `COLLECTED` | The entry's key or value was garbage collected. Not emitted in the current configuration: the cache uses neither weak keys nor soft values. |
 
 ### Read cache and resolution metrics together
 
@@ -371,6 +379,30 @@ resolve, the fix is not in the cache.
 [`camunda.secrets.cache.max-size`](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camundasecretscache)
 property. The bound applies per store, not as a shared budget, so the worst-case memory footprint
 across a deployment is the number of configured stores multiplied by that maximum.
+
+### Metric names in Prometheus
+
+The tables above name meters by their Micrometer meter ID. When Prometheus scrapes them, dots
+become underscores, and Micrometer appends a type suffix: `_total` for a counter, the base unit for
+a timer (plus `_count` and `_sum`; both timers here also declare fixed histogram buckets, so
+`_bucket` is always emitted for them too), and no suffix for a gauge:
+
+| Metric name                             | Prometheus metric name                          |
+| --------------------------------------- | ----------------------------------------------- |
+| `camunda.secret.resolution.duration`    | `camunda_secret_resolution_duration_seconds`    |
+| `camunda.secret.resolution.cycle.delay` | `camunda_secret_resolution_cycle_delay_seconds` |
+| `camunda.secret.resolution.outcome`     | `camunda_secret_resolution_outcome_total`       |
+| `camunda.secret.resolution.cycle.error` | `camunda_secret_resolution_cycle_error_total`   |
+| `camunda.secret.cache.result`           | `camunda_secret_cache_result_total`             |
+| `camunda.secret.cache.evictions`        | `camunda_secret_cache_evictions_total`          |
+| `camunda.secret.cache.size`             | `camunda_secret_cache_size`                     |
+
+`camunda.secret.cache.size` is the one exception with no unit suffix at all, so it stays exactly
+`camunda_secret_cache_size`. For example, the cache hit rate described above becomes:
+
+```promql
+camunda_secret_cache_result_total{result="HIT"} / ignoring(result) sum without (result) (camunda_secret_cache_result_total)
+```
 
 For how the broker resolves secret references before job activation, see
 [Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).


### PR DESCRIPTION


## Description

Add the six meters emitted for secret reference resolution and the per-store secret cache to the Self-Managed metrics reference, using the descriptions from SecretResolutionMetricsDoc and SecretCacheMetricsDoc as the source of truth.

closes camunda/camunda#60963
base off https://github.com/camunda/camunda-docs/pull/9770, so merge that one first and rebase this one

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
