### PR TITLE
docs(hub): document supported Helm topology combinations

### DIFF
--- a/docs/self-managed/components/hub/configuration/properties.md
+++ b/docs/self-managed/components/hub/configuration/properties.md
@@ -75,6 +75,19 @@ server:
 
 To show your Orchestration Clusters in Camunda Hub, use the following configuration options available from Camunda 8.10. If you're migrating from an older version of Camunda Self-Managed, refer to the deprecated [legacy configurations](./legacy-cluster-config.md) and the [migration guide](../../../upgrade/components/890-to-8100.md#camunda-hub).
 
+The Camunda 8.10 Helm chart can deploy one Hub release with orchestration releases from supported chart versions:
+
+| Hub chart | Orchestration chart | Topology mode   |
+| :-------- | :------------------ | :-------------- |
+| 8.10      | 8.10                | `orchestration` |
+| 8.10      | 8.9                 | `orchestration` |
+| 8.10      | 8.8                 | `orchestration` |
+| 8.10      | 8.7                 | `orchestration` |
+
+Set `global.topology.mode: orchestration` in each orchestration release. The 8.7, 8.8, and 8.9 charts don't support Hub mode or `global.topology.clusters`; configure the Hub release and cluster inventory with the 8.10 chart.
+
+An orchestration release must disable its local Management Identity and set `global.identity.service.url` to the Management Identity service in the Hub release. Chart 8.7 uses separate Zeebe, Operate, and Tasklist components, so its Hub inventory must use the legacy component endpoints rather than the unified Orchestration Cluster endpoints.
+
 :::note
 Access to the cluster pages in Camunda Hub depends on the user's role: `Console` and `DevOps` role holders (users with the [`admin:clusters` permission](/self-managed/components/management-identity/access-management/access-management-overview.md#permissions)) get management access to the cluster pages, Hub admins (users with the [`admin:*` permission](/self-managed/components/management-identity/access-management/access-management-overview.md#permissions)) get full access, and other Hub members get read-only access.
 :::


### PR DESCRIPTION
## Description

Documents the supported Helm topology combinations for Camunda Hub 8.10. The page now states that 8.7, 8.8, and 8.9 charts support orchestration mode only, and records the legacy endpoint requirement for 8.7.

Companion to the [camunda-platform-helm topology backport stack](https://github.com/camunda/camunda-platform-helm/pull/7008), with the contract recorded in [ADR PR #7012](https://github.com/camunda/camunda-platform-helm/pull/7012).

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [ ] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)
- [ ] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.
- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
