### PR TITLE
docs(cluster-variables): document the SECRET_REFERENCE cluster variable kind

### DIFF
--- a/docs/components/admin/cluster-variables.md
+++ b/docs/components/admin/cluster-variables.md
@@ -92,7 +92,7 @@ If a global variable with the same name exists, the tenant-level variable takes 
 
 ## Manage cluster variables of kind `SECRET_REFERENCE`
 
-A cluster variable of kind `SECRET_REFERENCE` can contain `camunda.secrets.<name>` references in its value. Camunda resolves them at job activation for a process that reads the variable in an input mapping. A `JSON`-kind variable whose value contains the same text is treated as ordinary text.
+A cluster variable of kind `SECRET_REFERENCE` can contain `camunda.secrets.<name>` references in its value. When a process reads the variable in an input mapping, Camunda resolves these references in the background ahead of activation, and injects the resolved values into the job only once it's handed to a worker. A `JSON`-kind variable whose value contains the same text is treated as ordinary text.
 
 The Admin UI create form has no kind field, so every variable you create there is a `JSON`-kind variable. To create a `SECRET_REFERENCE`-kind variable, use the Orchestration Cluster API with `"kind": "SECRET_REFERENCE"` in the request body, either [globally](/apis-tools/orchestration-cluster-api-rest/specifications/create-global-cluster-variable.api.mdx) or [for a tenant](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant-cluster-variable.api.mdx).
 

--- a/docs/components/admin/cluster-variables.md
+++ b/docs/components/admin/cluster-variables.md
@@ -11,6 +11,8 @@ Use Admin to manage cluster variables, which store configuration values centrall
 
 Cluster variables allow you to maintain environment-specific configurations, API endpoints, feature flags, and other shared values without hardcoding them into individual process definitions. Variables can be defined at the global (cluster-wide) or tenant level.
 
+Each variable also has a kind, either `JSON` or `SECRET_REFERENCE`, which determines how Camunda reads its value. `JSON` is the default. See [variable kinds](/components/modeler/feel/cluster-variable/data-types.md#variable-kinds).
+
 :::tip
 To learn more about cluster variables, including scope resolution, data types, and FEEL expression usage, see the [cluster variables overview](/components/modeler/feel/cluster-variable/overview.md).
 :::
@@ -88,8 +90,36 @@ If a global variable with the same name exists, the tenant-level variable takes 
 3. Click **Delete** next to the variable you want to delete.
 4. Confirm the deletion by clicking **Delete** in the confirmation dialog.
 
+## Manage cluster variables of kind `SECRET_REFERENCE`
+
+A cluster variable of kind `SECRET_REFERENCE` can contain `camunda.secrets.<name>` references in its value. Camunda resolves them at job activation for a process that reads the variable in an input mapping. A `JSON`-kind variable whose value contains the same text is treated as ordinary text.
+
+The Admin UI create form has no kind field, so every variable you create there is a `JSON`-kind variable. To create a `SECRET_REFERENCE`-kind variable, use the Orchestration Cluster API with `"kind": "SECRET_REFERENCE"` in the request body, either [globally](/apis-tools/orchestration-cluster-api-rest/specifications/create-global-cluster-variable.api.mdx) or [for a tenant](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant-cluster-variable.api.mdx).
+
+You can manage an existing `SECRET_REFERENCE`-kind variable in the Admin UI:
+
+- Updating its value keeps its kind, and Camunda scans the new value for references. A variable's kind is fixed at creation and cannot be changed.
+- The value shown in the variable list and in the variable details is the stored value, so you see the reference text rather than a resolved value.
+- Deleting it works the same as deleting any other cluster variable.
+
+For where resolved values appear and where they do not, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+
+## Required permissions
+
+Managing cluster variables requires permissions on the `CLUSTER_VARIABLE` resource type. These permissions are the same for every kind, and there is no additional permission for a `SECRET_REFERENCE`-kind variable.
+
+| Action                    | Required permission |
+| ------------------------- | ------------------- |
+| Create a cluster variable | `CREATE`            |
+| View a cluster variable   | `READ`              |
+| Update a cluster variable | `UPDATE`            |
+| Delete a cluster variable | `DELETE`            |
+
+The resource identifier is the variable name, or `*` for all cluster variables. See [authorizations](/components/concepts/access-control/authorizations.md#available-resources) for how to grant these permissions.
+
 ## See also
 
 - [Cluster variables overview](/components/modeler/feel/cluster-variable/overview.md) — learn about scopes, data types, and FEEL expression usage.
 - [Get started with cluster variables](/components/modeler/feel/cluster-variable/get-started.md) — tutorial for creating and using your first cluster variable.
+- [Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md) — understand when a job that references secrets reaches a worker.
 - [Orchestration Cluster API: Create global cluster variable](/apis-tools/orchestration-cluster-api-rest/specifications/create-global-cluster-variable.api.mdx) — manage cluster variables via API.

--- a/docs/components/admin/cluster-variables.md
+++ b/docs/components/admin/cluster-variables.md
@@ -94,6 +94,8 @@ If a global variable with the same name exists, the tenant-level variable takes 
 
 A cluster variable of kind `SECRET_REFERENCE` can contain `camunda.secrets.<name>` references in its value. When a process reads the variable in an input mapping, Camunda resolves these references in the background ahead of activation, and injects the resolved values into the job only once it's handed to a worker. A `JSON`-kind variable whose value contains the same text is treated as ordinary text.
 
+Resolving these references requires a secret store to be configured. Without one, references are never resolved, and any job that depends on them stays unactivated with no error pointing at the cause. See [`camunda.secrets.stores.file`](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#camundasecretsstoresfile).
+
 The Admin UI create form has no kind field, so every variable you create there is a `JSON`-kind variable. To create a `SECRET_REFERENCE`-kind variable, use the Orchestration Cluster API with `"kind": "SECRET_REFERENCE"` in the request body, either [globally](/apis-tools/orchestration-cluster-api-rest/specifications/create-global-cluster-variable.api.mdx) or [for a tenant](/apis-tools/orchestration-cluster-api-rest/specifications/create-tenant-cluster-variable.api.mdx).
 
 You can manage an existing `SECRET_REFERENCE`-kind variable in the Admin UI:

--- a/docs/components/modeler/feel/cluster-variable/data-types.md
+++ b/docs/components/modeler/feel/cluster-variable/data-types.md
@@ -21,3 +21,71 @@ Understand the data types supported by cluster variables for different configura
 :::note
 Access patterns may vary depending on how the array is used.
 :::
+
+## Variable kinds
+
+Every cluster variable has a kind, which determines how Camunda reads its value.
+
+| Kind               | Description                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| `JSON`             | The default. The value is data, and Camunda reads it exactly as stored.            |
+| `SECRET_REFERENCE` | The value can contain `camunda.secrets.<name>` references, which Camunda resolves. |
+
+Only a `SECRET_REFERENCE`-kind variable has its references resolved. A `JSON`-kind variable whose value contains the same text is treated as ordinary text, and that text reaches your process unchanged.
+
+### Where references can appear in a value
+
+Camunda scans every string value in a `SECRET_REFERENCE`-kind value, including strings nested inside objects. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes.
+
+For example, the following value carries two references, one at the top level and one nested:
+
+```json
+{
+  "apiKey": "camunda.secrets.PAYMENT_API_KEY",
+  "database": {
+    "user": "reporting",
+    "password": "camunda.secrets.REPORTING_DB_PASSWORD"
+  }
+}
+```
+
+Do not place a reference inside an array. Camunda detects such a reference when you create the variable, but it cannot be resolved when a process reads the variable: the job is not activated and raises an incident instead. See [when a job is not activated](/components/concepts/secret-resolution-and-job-activation.md#when-a-job-is-not-activated).
+
+### Create a variable of kind `SECRET_REFERENCE`
+
+Set `kind` when you create the variable. If you omit `kind`, the variable is created as `JSON`.
+
+```bash
+POST /v2/cluster-variables/global
+Content-Type: application/json
+
+{
+  "name": "PAYMENT_API_CONFIG",
+  "kind": "SECRET_REFERENCE",
+  "value": {
+    "endpoint": "https://api.payment.prod.example.com",
+    "apiKey": "camunda.secrets.PAYMENT_API_KEY"
+  }
+}
+```
+
+A variable's kind is fixed at creation. Update requests carry no `kind` field, so updating a `SECRET_REFERENCE`-kind variable keeps its kind and scans the new value for references. To change a variable's kind, delete it and create it again with the kind you want.
+
+### Read a variable of kind `SECRET_REFERENCE`
+
+Get and search responses return the stored value, so you see the reference text rather than a resolved value. References are resolved only when a process reads the variable in an input mapping, as described in [resolve secret references in a cluster variable](./usage-guide.md#resolve-secret-references-in-a-cluster-variable). For where resolved values appear and where they do not, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+
+To find variables of a given kind, use the `kind` filter in [search cluster variables](/apis-tools/orchestration-cluster-api-rest/specifications/search-cluster-variables.api.mdx).
+
+### Required permissions
+
+A `SECRET_REFERENCE`-kind variable needs the same permissions as any other cluster variable. There is no additional permission for this kind.
+
+| Action            | Required permission                              |
+| ----------------- | ------------------------------------------------ |
+| Create a variable | `CREATE` on the `CLUSTER_VARIABLE` resource type |
+| Get or search     | `READ` on the `CLUSTER_VARIABLE` resource type   |
+| Update a variable | `UPDATE` on the `CLUSTER_VARIABLE` resource type |
+| Delete a variable | `DELETE` on the `CLUSTER_VARIABLE` resource type |
+
+The resource identifier is the variable name, or `*` for all cluster variables. See [authorizations](/components/concepts/access-control/authorizations.md#available-resources) for how to grant these permissions.

--- a/docs/components/modeler/feel/cluster-variable/data-types.md
+++ b/docs/components/modeler/feel/cluster-variable/data-types.md
@@ -31,11 +31,13 @@ Every cluster variable has a kind, which determines how Camunda reads its value.
 | `JSON`             | The default. Your value is data, and Camunda reads it exactly as you stored it.    |
 | `SECRET_REFERENCE` | The value can contain `camunda.secrets.<name>` references, which Camunda resolves. |
 
+Resolving `SECRET_REFERENCE` references is part of an [alpha feature](/components/early-access/alpha/alpha-features.md) and may be subject to change in future releases.
+
 Only a `SECRET_REFERENCE`-kind variable has its references resolved. A `JSON`-kind variable whose value contains the same text is treated as ordinary text, and that text reaches your process unchanged.
 
 ### Where references can appear in a value
 
-Camunda scans every string in a `SECRET_REFERENCE`-kind variable's value, including strings nested inside objects. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes.
+Camunda scans every string in a `SECRET_REFERENCE`-kind variable's value, including strings nested inside objects and arrays. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes, up to 240 characters. A name that fails either limit is never resolved; see [secrets](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#secrets).
 
 For example, the following value carries two references, one at the top level and one nested:
 
@@ -49,7 +51,7 @@ For example, the following value carries two references, one at the top level an
 }
 ```
 
-Do not place a reference inside an array. Camunda detects such a reference when you create the variable, but it cannot be resolved when a process reads the variable: the job is not activated and raises an incident instead. See [when a job is not activated](/components/concepts/secret-resolution-and-job-activation.md#when-a-job-is-not-activated).
+Do not place a reference inside an array. Camunda detects such a reference when you create the variable, but it cannot be resolved when a process reads the variable: the job is not activated and raises an incident instead. See [when a job is not activated](/components/concepts/secret-resolution-and-job-activation.md#understand-why-a-job-is-not-activated).
 
 ### Create a variable of kind `SECRET_REFERENCE`
 

--- a/docs/components/modeler/feel/cluster-variable/data-types.md
+++ b/docs/components/modeler/feel/cluster-variable/data-types.md
@@ -28,14 +28,14 @@ Every cluster variable has a kind, which determines how Camunda reads its value.
 
 | Kind               | Description                                                                        |
 | ------------------ | ---------------------------------------------------------------------------------- |
-| `JSON`             | The default. The value is data, and Camunda reads it exactly as stored.            |
+| `JSON`             | The default. Your value is data, and Camunda reads it exactly as you stored it.    |
 | `SECRET_REFERENCE` | The value can contain `camunda.secrets.<name>` references, which Camunda resolves. |
 
 Only a `SECRET_REFERENCE`-kind variable has its references resolved. A `JSON`-kind variable whose value contains the same text is treated as ordinary text, and that text reaches your process unchanged.
 
 ### Where references can appear in a value
 
-Camunda scans every string value in a `SECRET_REFERENCE`-kind value, including strings nested inside objects. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes.
+Camunda scans every string in a `SECRET_REFERENCE`-kind variable's value, including strings nested inside objects. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes.
 
 For example, the following value carries two references, one at the top level and one nested:
 

--- a/docs/components/modeler/feel/cluster-variable/namespace-collisions.md
+++ b/docs/components/modeler/feel/cluster-variable/namespace-collisions.md
@@ -99,6 +99,8 @@ camunda.vars.cluster.API_CREDENTIALS
 
 Tenant scope has higher priority, so `camunda.vars.env` selects the tenant variable, and only that variable's kind is considered. A `JSON`-kind value is ordinary text, so its references are not resolved. The global variable's references are reachable only through `camunda.vars.cluster`, which bypasses tenant scope.
 
+This assumes the tenant variable has a non-empty value. If it's empty, `camunda.vars.env` skips it and falls through to global instead, so the global `SECRET_REFERENCE` variable wins — the opposite of the outcome above.
+
 To avoid this, give a key the same kind at every scope where you define it.
 
 ### Detailed collision example

--- a/docs/components/modeler/feel/cluster-variable/namespace-collisions.md
+++ b/docs/components/modeler/feel/cluster-variable/namespace-collisions.md
@@ -74,7 +74,7 @@ Tenant scope has higher priority and returns a string, so the global object is n
 
 ### Kind collisions across scopes
 
-It happens when the same key is defined at both scopes with a different [variable kind](./data-types.md#variable-kinds).
+A kind collision happens when the same key is defined at both scopes with a different [variable kind](./data-types.md#variable-kinds).
 
 #### Scenario
 

--- a/docs/components/modeler/feel/cluster-variable/namespace-collisions.md
+++ b/docs/components/modeler/feel/cluster-variable/namespace-collisions.md
@@ -72,6 +72,35 @@ camunda.vars.env.CONFIG_KEY.nested → null (trying to access property on string
 
 Tenant scope has higher priority and returns a string, so the global object is never evaluated. Accessing properties on a string yields null.
 
+### Kind collisions across scopes
+
+It happens when the same key is defined at both scopes with a different [variable kind](./data-types.md#variable-kinds).
+
+#### Scenario
+
+```
+GLOBAL: { API_CREDENTIALS: "camunda.secrets.PAYMENT_API_KEY" }  (kind SECRET_REFERENCE)
+TENANT: { API_CREDENTIALS: "camunda.secrets.PAYMENT_API_KEY" }  (kind JSON)
+```
+
+#### Result
+
+When an input mapping on a service task reads the key:
+
+```
+camunda.vars.env.API_CREDENTIALS
+→ the literal text "camunda.secrets.PAYMENT_API_KEY" (TENANT wins, kind JSON)
+
+camunda.vars.cluster.API_CREDENTIALS
+→ the resolved secret value (GLOBAL, kind SECRET_REFERENCE)
+```
+
+#### Why this happens
+
+Tenant scope has higher priority, so `camunda.vars.env` selects the tenant variable, and only that variable's kind is considered. A `JSON`-kind value is ordinary text, so its references are not resolved. The global variable's references are reachable only through `camunda.vars.cluster`, which bypasses tenant scope.
+
+To avoid this, give a key the same kind at every scope where you define it.
+
 ### Detailed collision example
 
 #### Scenario

--- a/docs/components/modeler/feel/cluster-variable/scope-and-priority.md
+++ b/docs/components/modeler/feel/cluster-variable/scope-and-priority.md
@@ -49,6 +49,8 @@ From highest to lowest priority, the cluster variable resolution order is:
 2. Tenant-scope cluster variables.
 3. Global-scope cluster variables.
 
+Resolution priority is the same for every [variable kind](./data-types.md#variable-kinds). The `camunda.vars.env`, `camunda.vars.tenant`, and `camunda.vars.cluster` namespaces select a `SECRET_REFERENCE`-kind variable exactly as they select a `JSON`-kind one. The kind of the variable that wins is what decides whether its `camunda.secrets.<name>` references are resolved.
+
 ### Process variables
 
 Variables defined on the process instance always take precedence over cluster variables. This includes:

--- a/docs/components/modeler/feel/cluster-variable/usage-guide.md
+++ b/docs/components/modeler/feel/cluster-variable/usage-guide.md
@@ -80,7 +80,7 @@ camunda.vars.env.API_BASE_URL + "/api/v" + camunda.vars.env.API_VERSION + "/reso
 
 ### Resolve secret references in a cluster variable
 
-References in a [`SECRET_REFERENCE`-kind](./data-types.md#variable-kinds) cluster variable are resolved only when the variable is read by an input mapping on an element that creates a job for a job worker, such as a service task. In the other contexts on this page, including gateway conditions, script tasks, output mappings, and call activity input, the variable resolves to its stored value, so the reference text reaches your process unchanged.
+References in a [`SECRET_REFERENCE`-kind](./data-types.md#variable-kinds) cluster variable are resolved only when the variable is read by an input mapping on an element that creates a job for a job worker, such as a service task or an ad hoc sub-process. In the other contexts on this page, including gateway conditions, script tasks, output mappings, and call activity input, the variable resolves to its stored value, so the reference text reaches your process unchanged.
 
 The following rules apply to an input mapping that reads a `SECRET_REFERENCE`-kind variable:
 

--- a/docs/components/modeler/feel/cluster-variable/usage-guide.md
+++ b/docs/components/modeler/feel/cluster-variable/usage-guide.md
@@ -89,7 +89,7 @@ The following rules apply to an input mapping that reads a `SECRET_REFERENCE`-ki
 - If the variable does not exist, or if its kind is `JSON`, nothing is resolved and no incident is raised.
 - Execution listener and task listener jobs never carry resolved values, even when the element they run on has such an input mapping.
 
-The reference is recorded on the job at creation, the same path as a reference written directly into an input mapping, and resolved in the background ahead of activation. The resolved value reaches the worker only once the job is handed out. For what this means for when a job reaches a worker, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+The reference is recorded on the job at creation, in the same way as a reference written directly into an input mapping, and resolved in the background ahead of activation. The resolved value reaches the worker only once the job is handed out. For what this means for when a job reaches a worker, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
 
 ## Access using FEEL expressions
 

--- a/docs/components/modeler/feel/cluster-variable/usage-guide.md
+++ b/docs/components/modeler/feel/cluster-variable/usage-guide.md
@@ -78,6 +78,19 @@ For example:
 camunda.vars.env.API_BASE_URL + "/api/v" + camunda.vars.env.API_VERSION + "/resource"
 ```
 
+### Resolve secret references in a cluster variable
+
+References in a [`SECRET_REFERENCE`-kind](./data-types.md#variable-kinds) cluster variable are resolved only when the variable is read by an input mapping on an element that creates a job for a job worker, such as a service task. In the other contexts on this page, including gateway conditions, script tasks, output mappings, and call activity input, the variable resolves to its stored value, so the reference text reaches your process unchanged.
+
+The following rules apply to an input mapping that reads a `SECRET_REFERENCE`-kind variable:
+
+- The mapping source must be a FEEL expression. A static value, written without a leading `=`, is a plain string and holds no reference.
+- A trailing field path narrows what is resolved. `= camunda.vars.env.MY_VAR.a.b` resolves only the references stored inside the `a.b` part of the value.
+- If the variable does not exist, or if its kind is `JSON`, nothing is resolved and no incident is raised.
+- Execution listener and task listener jobs never carry resolved values, even when the element they run on has such an input mapping.
+
+Resolution happens at job activation, on the same path as a reference written directly into an input mapping. For what this means for when a job reaches a worker, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+
 ## Access using FEEL expressions
 
 You can reference cluster variables anywhere Camunda Modeler supports FEEL expressions.

--- a/docs/components/modeler/feel/cluster-variable/usage-guide.md
+++ b/docs/components/modeler/feel/cluster-variable/usage-guide.md
@@ -89,7 +89,7 @@ The following rules apply to an input mapping that reads a `SECRET_REFERENCE`-ki
 - If the variable does not exist, or if its kind is `JSON`, nothing is resolved and no incident is raised.
 - Execution listener and task listener jobs never carry resolved values, even when the element they run on has such an input mapping.
 
-Resolution happens at job activation, on the same path as a reference written directly into an input mapping. For what this means for when a job reaches a worker, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+The reference is recorded on the job at creation, the same path as a reference written directly into an input mapping, and resolved in the background ahead of activation. The resolved value reaches the worker only once the job is handed out. For what this means for when a job reaches a worker, see [secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
 
 ## Access using FEEL expressions
 

--- a/docs/components/modeler/feel/cluster-variable/usage-guide.md
+++ b/docs/components/modeler/feel/cluster-variable/usage-guide.md
@@ -84,7 +84,7 @@ References in a [`SECRET_REFERENCE`-kind](./data-types.md#variable-kinds) cluste
 
 The following rules apply to an input mapping that reads a `SECRET_REFERENCE`-kind variable:
 
-- The mapping source must be a FEEL expression. A static value, written without a leading `=`, is a plain string and holds no reference.
+- The mapping source must be a FEEL expression. A static value, written without a leading `=`, is a plain string and holds no references.
 - A trailing field path narrows what is resolved. `= camunda.vars.env.MY_VAR.a.b` resolves only the references stored inside the `a.b` part of the value.
 - If the variable does not exist, or if its kind is `JSON`, nothing is resolved and no incident is raised.
 - Execution listener and task listener jobs never carry resolved values, even when the element they run on has such an input mapping.


### PR DESCRIPTION
## Description
Add the variable kinds section to the cluster variable data types page as the home for this content: JSON is the default kind, SECRET_REFERENCE marks a variable whose value may contain camunda.secrets.<name> references, and only a SECRET_REFERENCE-kind variable has its references resolved.

Also state where resolution happens on the usage page, note in the scope resolution page that priority is unchanged for every kind, add the kind collision case to the namespace collisions page, and cover creating, editing, and reading these variables plus the required permissions in Admin.

Relates to camunda/camunda#60330

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
