### PR TITLE
docs(api): document secret references in the expression evaluation endpoint

### DIFF
--- a/api/camunda/v2/expression.yaml
+++ b/api/camunda/v2/expression.yaml
@@ -11,9 +11,9 @@ paths:
       description: |-
 
 
-        [[REQUIRED_PERMISSIONS:eyJwZXJtaXNzaW9ucyI6W3sicmVzb3VyY2VUeXBlIjoiRVhQUkVTU0lPTiIsInBlcm1pc3Npb25UeXBlIjoiRVZBTFVBVEUifSx7ImR5bmFtaWMiOnRydWUsIm5vdGUiOiJXaGVuIHRoZSBleHByZXNzaW9uIGlzIGV2YWx1YXRlZCBpbiB0aGUgc2NvcGUgb2YgYSBwcm9jZXNzIGluc3RhbmNlIChzY29wZUtleSByZXNvbHZlcyB0byBhbiBpbnN0YW5jZSksIGFkZGl0aW9uYWxseSByZXF1aXJlcyBSRUFEX1BST0NFU1NfSU5TVEFOQ0Ugb24gUFJPQ0VTU19ERUZJTklUSU9OIGZvciB0aGF0IHByb2Nlc3MuIFNraXBwZWQgd2hlbiB1bnNjb3BlZC4ifV19]]
-
         [[ADDED_IN_VERSION:8.9]]
+
+        [[REQUIRED_PERMISSIONS:eyJwZXJtaXNzaW9ucyI6W3sicmVzb3VyY2VUeXBlIjoiRVhQUkVTU0lPTiIsInBlcm1pc3Npb25UeXBlIjoiRVZBTFVBVEUifSx7ImR5bmFtaWMiOnRydWUsIm5vdGUiOiJXaGVuIHRoZSBleHByZXNzaW9uIGlzIGV2YWx1YXRlZCBpbiB0aGUgc2NvcGUgb2YgYSBwcm9jZXNzIGluc3RhbmNlIChzY29wZUtleSByZXNvbHZlcyB0byBhbiBpbnN0YW5jZSksIGFkZGl0aW9uYWxseSByZXF1aXJlcyBSRUFEX1BST0NFU1NfSU5TVEFOQ0Ugb24gUFJPQ0VTU19ERUZJTklUSU9OIGZvciB0aGF0IHByb2Nlc3MuIFNraXBwZWQgd2hlbiB1bnNjb3BlZC4ifV19]]
 
         [[CONSISTENCY:STRONG]]
 
@@ -21,6 +21,20 @@ paths:
         cluster variables when a tenant ID is provided. Optionally, provide a `scopeKey` to make the
         variables of a specific process instance or element instance visible while evaluating the
         expression.
+
+        When the expression references a secret (`camunda.secrets.<name>`), the endpoint never
+        returns the resolved secret value. Instead, each reference resolves to its own literal
+        placeholder text `camunda.secrets.<name>`, which composes like any other string. This
+        changed in 8.10; previously such references evaluated to `null` and logged a warning:
+
+        - `=camunda.secrets.TEST` now returns `"camunda.secrets.TEST"`.
+        - `="Bearer " + camunda.secrets.TEST` now returns `"Bearer camunda.secrets.TEST"`.
+
+        Every secret reference the evaluation encountered from a trusted source is listed in the
+        `referencedSecrets` array of the response. To obtain the actual secret values, resolve those
+        references yourself with [`POST /v2/secrets/resolve`](/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets.api.mdx).
+        For how the cluster resolves secret references in general, see
+        [Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
       requestBody:
         required: true
         content:
@@ -84,6 +98,7 @@ components:
         - expression
         - result
         - warnings
+        - referencedSecrets
       properties:
         expression:
           type: string
@@ -99,6 +114,35 @@ components:
           items:
             $ref: "#/components/schemas/ExpressionEvaluationWarningItem"
           example: []
+        referencedSecrets:
+          type: array
+          description: |
+            The secret references resolved from trusted sources while evaluating the expression: a
+            `camunda.secrets.<name>` reference used directly in the expression, or a reference
+            carried by a `SECRET_REFERENCE`-kind cluster variable the expression read. References
+            appearing only in request-body variables or plain cluster variables are excluded.
+            Callers use this to know which `camunda.secrets.<name>` occurrences in the result they
+            may safely resolve.
+          items:
+            $ref: "#/components/schemas/ExpressionSecretReferenceItem"
+          example: []
+      x-properties-added-in-version:
+        - propertyName: referencedSecrets
+          addedInVersion: "8.10"
+    ExpressionSecretReferenceItem:
+      type: object
+      required:
+        - storeId
+        - secretName
+      properties:
+        storeId:
+          type: string
+          description: The identifier of the secret store that holds the referenced secret
+          example: default
+        secretName:
+          type: string
+          description: The secret name, e.g. "token" for "camunda.secrets.token"
+          example: token
     ExpressionEvaluationWarningItem:
       type: object
       required:

--- a/api/camunda/v2/expression.yaml
+++ b/api/camunda/v2/expression.yaml
@@ -30,11 +30,23 @@ paths:
         - `=camunda.secrets.TEST` now returns `"camunda.secrets.TEST"`.
         - `="Bearer " + camunda.secrets.TEST` now returns `"Bearer camunda.secrets.TEST"`.
 
+        This placeholder mechanism is bypassed if the request-body `variables` include a variable
+        literally named `camunda`. In that case the request-body variable takes precedence, so
+        `camunda.secrets.<name>` resolves against it instead of producing a placeholder (typically
+        evaluating to `null`).
+
         Every secret reference the evaluation encountered from a trusted source is listed in the
-        `referencedSecrets` array of the response. To obtain the actual secret values, resolve those
-        references yourself with [`POST /v2/secrets/resolve`](/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets.api.mdx).
-        For how the cluster resolves secret references in general, see
+        `referencedSecrets` array of the response. That array reports every `camunda.secrets.<name>`
+        name that was referenced, whether or not a matching secret is configured: a misspelled or
+        unconfigured name is still listed here and only surfaces as an error later, in the `errors`
+        array of the follow-up `POST /v2/secrets/resolve` call. To obtain the actual secret values,
+        resolve those references yourself with that endpoint
+        ([`POST /v2/secrets/resolve`](/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets.api.mdx)).
+
+        For background on how the cluster resolves secret references in other contexts, such as
+        during job activation, see
         [Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+        That page describes a different mechanism than this endpoint uses.
       requestBody:
         required: true
         content:

--- a/docs/apis-tools/orchestration-cluster-api-rest/specifications/evaluate-expression.api.mdx
+++ b/docs/apis-tools/orchestration-cluster-api-rest/specifications/evaluate-expression.api.mdx
@@ -4,7 +4,7 @@ title: "Evaluate an expression"
 sidebar_label: "Evaluate an expression"
 hide_title: true
 hide_table_of_contents: true
-api: eJztWuty2ziyfhUsZk9FzkjUxbmZu55zLEd2lElkjy52YtPlgCQkISYBDgBKZlSqOg+xT7hPcqoBUqIsOZlU7Y/zw6lKWSRxaXR//XUDjQUWCZVEM8G7IXYxnZEoJZp27hNJlWKC4ypWNEgl0xl2rxfYp0RSeZTqKXavb5bVBfaJYsHqxU0VazJR2L3GpUFuqjikKpAsgamwiz3u8evro7dvO29vu73bi05/0D3ruW+cg5sb+63f+WPU7Xfe3p53+h+7A/g8cGn2fn716b0mn3rfyOVBGmTdV5f7igXxxTd//yL73LoY0U/tqPtVsP7F9I/R3cVw1IjOh6yrurwdBXEzCfZ7id96WWp31R6eXLQvOiM2Hty/7sb9l358osnlR3bG+1l4OVLd+OUsPB2xM/b+Ezm9SLvv+uJq0I7ou3Z2lcvSPY2+dU8vWp8v75ufP/Wjq+N24rN2g5yOJkGrNwtORxO/9XnyedCeB/HBV+jXPY3SYL8/9eNe1D2efvvcOphfjXREB2bcmf/uKgqydsPP2lOftROf9xqfL19+vRrcqe7pyd3VadSAuT9f3ivb56RJPr2HPoP+6KTzqdkeDBu9k1GzNx6MXg4vOidnfzRAjheT0cn78z8aF8NR86DTH129H95Fo8Ho4Kx7ejULjNwnje67dua3elGw/zHtnvQk+dSeX13+MQlb08hn7abPe1/9/XZ0dfyCjS+aK+Mdn/UG3cGw0zv+7A6G/bPeqf3SyfGlEEEnnc4HRFcYQYSHSFKdSq6QnlIkqUoj7aBBmiRCaoUkHVNJeUAV0gJpygnXSAUioaHHgyhVmko0I5IRP6IKzaeUI1K0675FTKFEihkLaeigM4NEEkVZtXiLCPpihvudZl9gipjcURDF4+tRxRgRpBIasDELoGdAlUKMK014QJGQiEY0plyv382YYn5E0XzKIopyF2N8Yodea8DBVSzpnylVui3CDLsL88gkDbGrZUqrOBBcU67hE0mSiAXGdetfFTjVAqtgSmMCv3SWUOxi4X+lgc7HtQNdY7rhl4kECtCMKuhX+rYeRWnJ+AQ/9OHhlJbtp0WxNooq1Jk4VeThw3v0K8o8vIermN6TOIlgQPsWL6vYWge450ez9fMVWLvqzbnL0DAj1iwu0BYsNuSwbW+brX2QpbC90W4UnY0N4W1KMciUpnFtQjnQJg3RHc3QWEgABXR30JH9gQLC0VREYQmRFuEgNOVaIcr0lEpEuMe3MMMAuu3zj70VxIQ0i95CHNOKRmPHA6Z+qMGxkDHRIHaxtCoWnP7syh7O6ZSHPrcfu/k3O8laxa3Wy+brg4M3zf1XB43XL17tkPIxXV9R6lPU4RPGDRuIVAbUiFV5T2YERYJPkKKSkYh9oyEiCtkx93ZMopk28nwQfAIymkCVv9uxBAhsf1k/D623oZ+O/fgX9PPm1es3B/8f9bNjCeXPK3Att8L87zQDxtwJ3F1UOZ8KRUseo6YijULkUxSTcMWkHgf+32AAB40U3QFVo44yM5EJgW87RfK4cd0qiEb4tnSPj0X0duucD7pjj4uYaU3D6kPaYmo1WIhSO3tYRamC6CB4lG3zl8cti5gwUfNFmK2/WRK4r5EwpGGN8dqMSkvl+I3TbADHrXlwR5DYtF0RIUvmALiXxC9CGah/OKUbliOS2hWkioamI6w9SKUEJa17GlIMBeJCowTEVRr5NBM8REw7ZVdZ4HvsNhtVnGG31VhWMQlDZkU8L8UwGyh5GkUgiH1eLktgXsnfWQnRt+rEyyW0lFQlgiuro1ajAX82VdPZ0gENkUoDQNM4jSJw8f90qDZypRG0mBPJGZ+o/0D4Xkm/MdOuSJ3PvqWL4SpVQzAYIF4rBFObEDgjMtsw435jyzqlFa2lJlKSbEvoD4APMUZFB7Tm4zCFZe7GJ65ipmm8E/VlfcdUKTKh24otPvwlrebCoaJTWaE9gcYpDwz0xyLlIZozPUWcxBQ9k4SHIn5mfKKJEiJJTDWVCv8IwJd2xq6mMdhqNd31zY+hb8xqkf9iF9iHlilN3oxCognQFrjrjEQsdB6HeiKFH9H4123Ib05whM5tSxRSTViErGkgXtmGPg0hIbrunxyjgxcvX99Uplonyq3X5/O5I8dBjYZMC+kIOanLcQD/od2eoSUJwSODGLImDLS27jqZz4NKLraB8EZatRMx5luh4ipWmuhUGVTAUgB3eTzYxpQddhtQq9QhlWwLX0do1O8iFlKu2TjLdxGbMps+Y2K8FRNfpNr1I8LvNnBYaDAUgXICEqc8JA4TdZKw+qzlNArr1WBIVfdJWJMFS64Q9SNnOEIqjWMiy0nAhpxredokRP31BLke1zMwrumEyrJ6GNf7rZ0O+G44PEd2CBSIkObxx24AQYCNuV80GlUcM87iNC6eyL19etWASJMb88fr5UA/EeE2tD1YNOMoFpLmKN9cfr70ApcZuo7J/Xvhq6E4CjSbwZ75BggVHM+nwA2KhqCpFb5+gKTaao/0CKYSoqdbwBKSTdjDlWyKXp+16l+Fr+rECgpjllknd+63VocF0TQfiyRWDxEJ7pRlGERSPQWpLK2gQFIjJIkUCDKlJASKdBf48vKydrRuTHfG2Vw5Rown4noirifieiKunyGu/W0eOBHSZ2FI7TZoxWF5mkSiSMzpU6L0xDdPfPPENz/JNy937ciOOAIrS/BPKqWQSATmZCXMawz5wVYhW47HJwZ6YqAnBnpioJ9hoOWj58kHZmRNObxRpjxxB7WzXe3h3DlKad4PygQx1VMBNw4SocBPYUUg4Pr0rr5xeqeonJld3vUCpzLCLl5Yjlq69fpiKpReugsoEy/rsxZ+cM4Nny2XFa4WiYBEUzv1NibhgzmQy3V5JoMpVdrek0DH+ZF8vzMYolOi6ZxkDpgXpt+c5k3jTWPnDND0L4x+dN5FduWOLVCuWbmYAshh5xS28c9OsgTjFBc+BjCEVWH52scKvPncZiZ4to1wNf9xUkD6/eUQxC9dFHl8CGhjMAmhqL+uhnfWZYDyIXdxQF2uJJfLuuWq7q5a5AZONuoLxl/Hwsiau8duJR6dd2GglWs0nGYeaElg8ABQwi4+tsydF+xo7vcWzAXFT5iepr4TiLieE/3qL1MqpQovtxjhvGs4MxBxnHIT0PnEHioTVMz5pigkOXAL45df0LHgM6APwZV98wvq8DS2R/goIJA7wIeBAUZNsZBWEeWpDTKrAhQaMxqFCpEgoIlGhGd5X3NPwuOhCFKoitEwH7liS0jGlujL0fGwe9H5UkVfDCHRL1Vz9P3lyD5BEcmDOxr5+DREUDTjSar3HNQvyjSIRHOSKag02SIT4QIUEa3WoaZiDh1tYCmyCFu5glUOTbyhMmZKsdl6B+fTKZkxIWErR3InMbpAgdEfA44GkT3OFHr+nAv9/DkQ/tq5E8rBQqA66KQlCTT69//+Cw3e/l6uXoyliD2+LR/yM1O1DXTRWEhlsiRJTerFBa+tVuzxQv32ikQQMSi3gcgOOhHSEA/xWcR0hkgghVJGkGquQ48rysOdWkSbSiwsa9OuiAWUK7oD7R/sF3Rh/QM1ncbPoN6PhF+PCeP1fApVPz76OOq9Pap96B53eoNOrek0HH2vDWlANIkJL8nRWRVr+WaNa8OLFuvE+Olq2tPVtKeraTuupuURW9N7XU8iwjjEIuPIizx9e1CvLiVwN9U8CbvGi4VPFB3JaLmE13+mVMLN0pt1LLYXS/OD/VJieWxdtDa0+7gipdyqrsPdHdvjyISN77Yt56LnZ4MhZC/55btYhNBHkjlsJMkcuxjuTxnrmHzBvFvgiPBJaorD2I4JTEQ285wHqZFZVVHo5llJwsXCthiKO8qXS1zNl6LhGS9vbEYOO6WBCaI2JQYRIO/LEjowrAacTHwKLDt4+zukQeZ2EGzFYpN8LqCOQjTNefrYBoqliUPo2f/k/PumLso5Ty2Hco0k7Nk/wGuIyniwrmhv3x/O87bKHlp4HEEIVBrlo6PDXUJU9szIRdv8bsEhInPCVl2d7ZkqZgJU8lsXPTtEJj98VrXfVs7iogW6d1GzUUWZi1oNtDQtluW5RUSdSEwqX2yN3EV/X+SOb/8sv0DrpcFbboDzTE8N9h9RvtFuvoTbDdXeqvAO5bbZUEcVfefGCggb0vFK77frxd/SleZrv6Ge4NS1OshzgkP0QOt24WitcNvQ2TF2xbaEf3Ah4PA7Epaabhrn0MOHqIl+RS0PV9eN9vLfK3ESybiujD1cWOGBEeBuackCx788rn17rypftrORzTuD8M6YPkn9iAXmRIIFyMJ7SNQd6jwObY/n0LMTzIh8RMnOsYH7CuEGkFsIt0235zsCYUr65HT+fWwUDRebNijdXjpEu62wXEt4nHvCpWSafmCcVv6+bYv+yhYPPaKfqu+QEaTsj7qD65KEKdctYZokzHW3NXMON2XUPzz+g/GA0SPlut/R2o8H2bBomQT5Lje07mf188/KXhW1xf0/w4wjpUPXNae3rtuBP7/9VhgqovoRALkuMMgt5bPK3n+vTATtH3jt2pQ7/fcxFT6ESplOVpq6zbdH7vfQ93Ckh8zs4TirrV942NHi1p6GVfaq230d560983Dd/PAD/K7cYrmB35ICjFuBtlZ0EvG/VTy8WHq4WuRya1HW0D+7q1T29h4A+lT8MLZWPO5pD49j7ZndhKdFQjlJGPLwjr3OoyG2NhH13JzY44YR63W03tFs56n5hVTYq5otaPlqqKR/IvcQ5aI4PTr/Lm1jgn5Fvof3TE9nQPVFMVglJsm1tdUN4dnCw8TDLmrBhX8ffu0vjbBWtVWoUcDMjxJbJdD3VfRc0j/3PM7Gpv3fDhFnEaDI0zb1htceX3p8HGvnHMw4rnj5tUQX/dfM83jJnqdUW6er7O1B2vR/T3tlNg==
+api: eJztW/1u27iyfxVCe4Cmu7bsJP2Kz8nBjV0ndbd1Un8kbeKgpqSxzUYidUjKjmoYuA9xn/A+ycWQkizHzrYFzh8HuFlgkUT8Gg5/85sZcrp0RAySaiZ4J3AaDsxpmFAN7ftYglJMcKfiKPATyXTqNG6WjgdUgjxJ9Mxp3NyuKkvHo4r5xYfbiqPpVDmNG6c0yW3FCUD5ksW4lNNwRnzEb25O3r5tv/3a6X69bPf6nfNu4417dHtr23rtT8NOr/3260W797HTx+Z+A9L3i+vP7zX93P1Or44SP+28ujpUzI8uv3uHl+mXg8shfG6GnW+C9S5nn4Z3l4NhPbwYsI7q8GboR/uxf9iNvYOXpX7XzcHpZfOyPWST/v3rTtR76UWnml59ZOe8lwZXQ9WJXs6DsyE7Z+8/07PLpPOuJ677zRDeNdPrTJbOWfi9c3Z58OXqfv/L51543WrGHmvW6dlw6h905/7ZcOodfJl+6TcXfnT0Dcd1zsLEP+zNvKgbdlqz718OjhbXQx1C38w7995dh37arHtpc+axZuzxbv3L1ctv1/071Tk7vbs+C+u49pere2XHnO7Tz+9xTL83PG1/3m/2B/Xu6XC/O+kPXw4u26fnn+oox4vp8PT9xaf65WC4f9TuDa/fD+7CYX94dN45u577Ru7TeuddM/UOuqF/+DHpnHYl/dxcXF99mgYHs9BjzX2Pd795h83wuvWCTS73i8NrnXf7nf6g3W19afQHvfPumW1pZ/hShJLTdvsDgQIjhPKASNCJ5IroGRAJKgm1S/pJHAupFZEwAQncB0W0IBo45ZooX8QQjLgfJkqDJHMqGfVCUGQxA05o3q/zljBFYinmLIDAJecGiTQM00r+lVAyNtP9CekYl4joHaAoI76eVUwIJSoGn02YjyN9UIowrjTlPhAhCYQQAdfrb3OmmBcCWcxYCCQzMcanduq1BlzU0BVKjdsvaaa0cUoU+BI02Rv7NEp4QF37Qbn/4DSCf46fV+xwHsSCcU04zEGO+APNinAOQT4XSgQu6XClgQYVAtSfrRfNuxutM62IWHASMg2ShiMeh9SHmQgDkETDvSaPyVXB/fsz4osoFgoUCdkdEMpTIvQMJFFaMj51yWDG1Ij7M8qnEBDGyRt3v/53EkuYM5GoMCUqKYunco1CgAKOeRKGYwOmUExxCkoWVHLGpw3Ub5WMjx9KOGj3B2PCxaLA33jk7Oo0csaunWLkNA0RkpFD/iA/NWE24PF50TxApvmprA/AnGcGG8EJcF8kXIOEgEykiBDkEtEfECUS6QMiPWTmA+MWZeNitqBvFx4TKiVNEdAZJmLBFbhkIIjwNLUjCfV1QsMNpKhKDgmiZ0IBgqs4jFQkUkE4IQumZ+RmfHHeH5Da/KCW7beWDR3f7tVozFRVCxGqmpD+DJS2rqiaGXOVxqwqQelabnCmuZijmuuQxsyNgvvn7oifCklmYmFkzzmhAPBDzaLhkilwhHKFKIARv+nnfZQIE50T0zfhoSrY3Ehwu1czMObAtar5gvsQa5VtsboeWqU8qH4TXnU91I2C565TcST8KwGlmyJIncbS/MkkBE5DywQqji+4Bq6xicZxmO289k2h91w6yp9BRPE3ncbgNBzhfQNfZ/PaiW4c2HDAsURfrxkoHFdqW89ibdB56KwHm3SkRWFyZA/cqVshI+f4nvxB0pHz3Kk4cE+jOMQJ7VdnVXEsDWOQ8aPVetkOLIE/ToV2xqp1AGSL/zfksH2/7h8coiw5yRvthuH5xEQ2m1L0U6UhqlpwoCXdQUomQiID43CXnNhfiE85QQIsuR7rylBoBAgBZhiO8hHfcg4MfVTz4mO38CVCmk1vuRam0a7cEYZkDzU4ETKiGsXOt1ZxBIdf3dnDNd3y1Be2sZO12UXWKj44eLn/+ujozf7hq6P66xevdkj5mK6vATwgbT5l3HobQ2Io1t57OqckFHxKFEhGQ/YdGV1l3uL5jkU000aeD4JPUUYTkWbfdmwBI9if1s/D09vQT9s2/oR+3rx6/eboP1E/O7ZQbi7AtdqK5/+EwpP8VEy0QMdRshg1E0kYEA9IRIMiZBpxDPQ2GMAlQwU7oGrUUWYmOqXYtlOkETemW0HRKN+W7vG5qN7unfFBZzLiImJaQ1B5SFusHKUkdvWgQhKFYaDgYbrNXyNuWcS4iaongnTdZkngvkqDAIIq49U5SEvlDkZLyHFrHtzhJDbPLg+FS8eBcC+Jvw4+MD6DjZOjEuwOEoXxSMZefiIlKqkUtuB2AkG40CRGcZUmHqSCB4Rpt2wqS+feaezXK07qNA7qq4pDg4BZES9KPsw6Sgz3UBD792pVAnMhf7sQomfV6axW2DOPeYyODup1/LGpmvaWDjDISnxE0yQJQzTxf7erNnIlIfbIAldlvj2I3/4NLr3Y0cbqu7x3JtGWfgZFnlYkEVoRXNq4xTmV6cbRHta3Tqy0y7XUJjTdEvoDYkZM8nhekTVHBwluczdmnYrDNEQ7LaF8BhEoRaewrdi84ae0mglH8kFlhXYFmSTcN+YwEQkPbJSMCRJ5JikPRPTM2Mk+iamkEWiQyvkRqK/sih0NEZ5VsRxez+zAzY+0jJvYDpSLnNFkHJv5htqZ2pYOo0HoiD+WGJYSHUMhAZPg6zDNcpfSNJav1/1H3KdSMgiIl2Ly3m+3eu3B1177tN1rd1vtcfWO8e3QcDumpIFLesVeR5zGMVBZcDPjj/AwyhOHmCptXz8gL8K9HyZ43TDiLRqGIBVukegZM8n0HWaINit+VDnCt1SaJSvrixH8NR3xiKZE0QmEaX5E1jn8FOKVFhI6gb3jk6C7NNoB/7zXT8GfBcA1mzCQeTyQYcnMYj0oRsv5TUSOzqzbhrkEMKFIO6sN+X5KjGxRVGKFYI5CRo4Wd8BHjvFR2/l91rqZNuC3R+zPmlOBmh3W95ce+oeOyhCu9VMvdrmmgY1rzHUWCaimGGSgc53TkAXu444plsILIfpj20FtLnBCLmxPEoCmLCQWQhhd2o6evV+46Z22yNGLl69v92Zax6pRqy0WC1dO/CoETAvpCjmtyYmP/2O/5yaIkBjqpRjxrd07WQNvfceWhYCZ2Ma5bCRBO5Ft2nIVVxylqU6UQQpuBe0ji9624W6n3QZZEegnkm1h7oQMe50c/GnOgBsymzEW0A2HeiLRDS+k/G4DcbkGA+ErN4coE3hVUpsfuPX89Ko4pap5NKjKPKYpEPUjAzkhKokiKssh+4aca3maNCC99QKZHtcrMK5hCrKsHsb14cFOo3w3GFwQOwXxRQBZtGjvZVGAjbVf1OsVJ2KcRUmU/0Xv7V+v6hgXZof54/1ypPuQchuIPtg04yRCarKzbW4/23qOy5TcRPT+vfDUQJzYKx1QtxjqoOF5gF5bQYCaKvD1AyRVCwp8BFMx1bMtYAnJpuzhTjZFxzu3b8JTtfXd0wbrZMb91uowJ5r9x2I8q4eQ+nfKMgyhiZ6hVJZWiC/BCElDhYLMgAYYvDSWztXVVfVk3Rl2RsWZcowYT8T1RFxPxPVEXL9CXIfbPHAqpMeCAOylRcFhWZhEw1As4ClQeuKbJ7554ptf5JuXuzKyE07wlCXaJ0gpZJ68B9n9SHYNncuW4fGJgZ4Y6ImBnhjoVxho9ejd0pGZWQPHL8o8Jt7hS/eu/vhKFCaQjcNHvQj0TGAhYCwU2inuCAVc35bWNu7VFci5yfJulk4iQ6fhLC1HrRq12nImlF41lli9tarND5wHr1LYbLksN7VQ+DSc2aW3MYkN5qo80+V5uWaEtLIb2F67PyBnVMOCpi4eLy6/ucyb+pv6zhWw60/MfnLRIXbnri0nWLNyvgSSw+6LSdP5VxdZ4eHkdZh9nMKqsFyNWYA3W9ushH/bTk4l++U0h/T7qwGKX6rffHwK7GMwia6ot65daa8f7crPT/nTUbnuo1yEUa7B2FU5sIGTjddAY68TYWTNzGO3Ek8uOjhRYRp1dz9ztNQ3eODmMtlpWebOntchs3sL5pzip0zPEs/1RVTLiL74yZRKQDmrLUa46BjO9EUUJdw4dD61zz2U5Gu+yd8NTPXXb7+RluBzpA/Blf3yG2nzJLKPa8SnGDtgQ98Ao6pYgNfbPLFOpnguJhMGeMVOfSxMMkV2dqwpXxzxQPgJvmFDkM28Zx98zVmS8Ulr0LlsjytkbAgJxhXzKDU+sX/h08YISyez+SEg+MTN40Q/x3eU7FGV0HBB0/zFwzwIClREWOxDzbCU0LxqsHUUYd+ZcZcD429ARkwpNl9ncB7M6JwJiakczYzE6IL4Rn/MPCZRHow4U+T337nQv/+OhL827hg4nhCqDgdpSX1N/ve//4f03/5ZflfE164R35YPX5zQSfg67yykMlGSBBN6cSxjy3eMD1XZU39WmMbwcRxFdglWrCHxUI+FTKeE+lIoZQSpZDoccQU82KlFsqnE/GRt2BUyH7iCHWj/YFvIpbUPsu/WfwX1Xii8WkQZr2VLqFrr5OOw+/ak+qHTanf77eq+W3f1vTakgd4korwkR7soreCbr88bVrRcB8ZPFeNPFeNPFeNPFeNPFeNPFeP/PyvGs9AcTaZmik4w6DQee5nlaQ/KyEqZ2m0ly7ZunOXSowqGMlyt8PO/EpCprVbIKSurHLIveKUMsmV9cXVgL2zy3HGr6A1Lau2IExMf/mXfctKJJ49pSlYTH4kAx0i6wBsjunAaWJ0hDA2bxMB8Wzoh5dPE1Gc5dk4MOehmQvMgBzK7yqugeFqScLm0PQZY+rFaOZVsK1kpyK1NvfFKpG+iZZv7ogiY4KUx9E34gsEX9QDDqf7bPzHfMXaGdy6RyTKX+GBKNWQBWctGhCtrns/+K7P5N4/D/Nnf0f6pSrm/Lirb/vd7WYK295wsR5xgrKt0zijkeJcQe8/NzHnfrNromNAFZcVQd3ulPbMA2Sj7enZMTCL4rGLbCq/YIEty3yD79QpJG+SgTlamx6q8tgjBDcV0b2yLYRrkb8vMw9sfqzH2Xhm8ZQdwkeqZwf4jyjfazbbwdUO1X1VwR7Kz2VBHhfxFISkKG8Ck0PvX9ea/QqH56j9JV3BoWB1kwf8xeaB1u3GyVrjt6O6Ye8/2xP+w8uf4LyQsdd08nOORc0z2yR/kYORU1p2eZ78X4sSScb03GTn5KTw4BPwnH6UTaP32uPZtuXO2bXcjbXf7wZ05+jjxQuabq0fmEwvvAVV3pP04tEc8g55dYE7lI0p2WwbuBcINILcQbrtur3eCwpT0yWHx19jIOy43z6BUVHxMdp/Cai1hK7OEK8k0fGAc9v62fRa94iysRdyu/g8BOglV
 sidebar_class_name: "post api-method"
 info_path: docs/apis-tools/orchestration-cluster-api-rest/specifications/orchestration-cluster-api
 custom_edit_url: null
@@ -42,6 +42,20 @@ Evaluates a FEEL expression and returns the result. Supports references to tenan
 cluster variables when a tenant ID is provided. Optionally, provide a `scopeKey` to make the
 variables of a specific process instance or element instance visible while evaluating the
 expression.
+
+When the expression references a secret (`camunda.secrets.<name>`), the endpoint never
+returns the resolved secret value. Instead, each reference resolves to its own literal
+placeholder text `camunda.secrets.<name>`, which composes like any other string. This
+changed in 8.10; previously such references evaluated to `null` and logged a warning:
+
+- `=camunda.secrets.TEST` now returns `"camunda.secrets.TEST"`.
+- `="Bearer " + camunda.secrets.TEST` now returns `"Bearer camunda.secrets.TEST"`.
+
+Every secret reference the evaluation encountered from a trusted source is listed in the
+`referencedSecrets` array of the response. To obtain the actual secret values, resolve those
+references yourself with [`POST /v2/secrets/resolve`](/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets.api.mdx).
+For how the cluster resolves secret references in general, see
+[Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
 
 <MarkerRequiredPermissions
   permissions={[
@@ -154,7 +168,7 @@ expression.
         "application/json": {
           schema: {
             type: "object",
-            required: ["expression", "result", "warnings"],
+            required: ["expression", "result", "warnings", "referencedSecrets"],
             properties: {
               expression: {
                 type: "string",
@@ -184,6 +198,32 @@ expression.
                   title: "ExpressionEvaluationWarningItem",
                 },
                 example: [],
+              },
+              referencedSecrets: {
+                type: "array",
+                description:
+                  "The secret references resolved from trusted sources while evaluating the expression: a\n`camunda.secrets.<name>` reference used directly in the expression, or a reference\ncarried by a `SECRET_REFERENCE`-kind cluster variable the expression read. References\nappearing only in request-body variables or plain cluster variables are excluded.\nCallers use this to know which `camunda.secrets.<name>` occurrences in the result they\nmay safely resolve.\n",
+                items: {
+                  type: "object",
+                  required: ["storeId", "secretName"],
+                  properties: {
+                    storeId: {
+                      type: "string",
+                      description:
+                        "The identifier of the secret store that holds the referenced secret",
+                      example: "default",
+                    },
+                    secretName: {
+                      type: "string",
+                      description:
+                        'The secret name, e.g. "token" for "camunda.secrets.token"',
+                      example: "token",
+                    },
+                  },
+                  title: "ExpressionSecretReferenceItem",
+                },
+                example: [],
+                "x-added-in-version": "8.10",
               },
             },
             title: "ExpressionEvaluationResult",

--- a/docs/apis-tools/orchestration-cluster-api-rest/specifications/evaluate-expression.api.mdx
+++ b/docs/apis-tools/orchestration-cluster-api-rest/specifications/evaluate-expression.api.mdx
@@ -51,11 +51,23 @@ changed in 8.10; previously such references evaluated to `null` and logged a war
 - `=camunda.secrets.TEST` now returns `"camunda.secrets.TEST"`.
 - `="Bearer " + camunda.secrets.TEST` now returns `"Bearer camunda.secrets.TEST"`.
 
+This placeholder mechanism is bypassed if the request-body `variables` include a variable
+literally named `camunda`. In that case the request-body variable takes precedence, so
+`camunda.secrets.<name>` resolves against it instead of producing a placeholder (typically
+evaluating to `null`).
+
 Every secret reference the evaluation encountered from a trusted source is listed in the
-`referencedSecrets` array of the response. To obtain the actual secret values, resolve those
-references yourself with [`POST /v2/secrets/resolve`](/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets.api.mdx).
-For how the cluster resolves secret references in general, see
+`referencedSecrets` array of the response. That array reports every `camunda.secrets.<name>`
+name that was referenced, whether or not a matching secret is configured: a misspelled or
+unconfigured name is still listed here and only surfaces as an error later, in the `errors`
+array of the follow-up `POST /v2/secrets/resolve` call. To obtain the actual secret values,
+resolve those references yourself with that endpoint
+([`POST /v2/secrets/resolve`](/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets.api.mdx)).
+
+For background on how the cluster resolves secret references in other contexts, such as
+during job activation, see
 [Secret resolution and job activation](/components/concepts/secret-resolution-and-job-activation.md).
+That page describes a different mechanism than this endpoint uses.
 
 <MarkerRequiredPermissions
   permissions={[


### PR DESCRIPTION
## Description

Documents the secret-related behavior of `POST /v2/expression/evaluation` and its response, for camunda/camunda#60962.

- Adds the `referencedSecrets` array (`storeId`, `secretName`) to `ExpressionEvaluationResult`, with an **8.10 version marker**, plus the `ExpressionSecretReferenceItem` schema, and regenerates the v2 API reference.
- Documents that the endpoint returns only placeholder text, **never a resolved secret value**, and that callers resolve the reported references themselves via `POST /v2/secrets/resolve`.
- Documents the observable 8.10 behavior change from `null` + warning to placeholder text. Each `camunda.secrets.<name>` reference resolves to its own literal placeholder string, which composes like any other string:
  - `=camunda.secrets.TEST` → `"camunda.secrets.TEST"`
  - `="Bearer " + camunda.secrets.TEST` → `"Bearer camunda.secrets.TEST"`
- Cross-links the endpoint to the **D7 API content** ([`POST /v2/secrets/resolve`](https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/specifications/resolve-secrets)) and the **D1 concept page** (Secret resolution and job activation).

Implementation verified against `ExpressionProcessor.withSecretReferenceContext()` and `SecretReferenceExpressionEvaluationTest` in camunda/camunda#60240 (also camunda/camunda#60384).

### Acceptance criteria

- [x] `referencedSecrets` documented on the endpoint page — shape (`storeId`, `secretName`), that it lists the references the evaluation encountered, added in 8.10.
- [x] Endpoint returns placeholder text, never a resolved value; caller resolves via `POST /v2/secrets/resolve`.
- [x] `null` → placeholder change documented as an observable 8.10 change, with the two examples.
- [ ] **Java client `EvaluateExpressionResponse.getReferencedSecrets()`** — not covered here; belongs alongside the other secret client content, tracked by [camunda/camunda#60334](https://github.com/camunda/camunda/issues/60334) (D8, no docs PR yet). AC4 is blocked until that client page exists; flagged in a [comment there](https://github.com/camunda/camunda/issues/60334#issuecomment-5515183867).
- [x] Generated v2 API reference renders `referencedSecrets` with its 8.10 marker (`x-added-in-version: "8.10"`, rendered by the theme's `SchemaItem` as "Added in 8.10", same mechanism as `scopeKey`).
- [x] Cross-linked to the D1 concept page and the D7 API content.

### Notes

- No release-notes entry: camunda/camunda#60240 merged after the `8.10.0-alpha4` tag, so the change ships in a tag that has no section in `8100-release-notes.md` yet. The behavior change (with both examples) is documented on the endpoint reference instead.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [ ] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

