### PR TITLE
fix(self-managed): remove unsupported RDBMS Helm value tables from the Helm RDBMS page

### DIFF
--- a/docs/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/docs/self-managed/deployment/helm/configure/database/rdbms.md
@@ -54,53 +54,6 @@ Store the database password in a Kubernetes secret and reference it. For testing
 | `orchestration.data.secondaryStorage.rdbms.secret.existingSecretKey` | string | `""`    | Key within the secret storing the password.         |
 | `orchestration.data.secondaryStorage.rdbms.secret.inlineSecret`      | string | `""`    | Password value (testing only, not production-safe). |
 
-### Connection pool and performance tuning
-
-Most tuning options are configured as application properties via [extraConfiguration](/self-managed/deployment/helm/configure/application-configs.md) (embedded `application.yml`).
-
-| Parameter                                                                 | Type              | Default | Description                                   |
-| ------------------------------------------------------------------------- | ----------------- | ------- | --------------------------------------------- |
-| `orchestration.data.secondaryStorage.rdbms.flushInterval`                 | ISO-8601 duration | `""`    | How frequently the exporter flushes events.   |
-| `orchestration.data.secondaryStorage.rdbms.queueSize`                     | integer           | `1000`  | Exporter queue size. Larger = more buffering. |
-| `camunda.data.secondary-storage.rdbms.queue-memory-limit`                 | integer           | `20`    | Memory limit (MB) for the exporter queue.     |
-| `camunda.data.secondary-storage.rdbms.connection-pool.maximum-pool-size`  | integer           | `10`    | Maximum JDBC connections.                     |
-| `camunda.data.secondary-storage.rdbms.connection-pool.minimum-idle`       | integer           | `10`    | Minimum idle connections.                     |
-| `camunda.data.secondary-storage.rdbms.connection-pool.connection-timeout` | integer           | `30000` | Timeout (ms) for acquiring a connection.      |
-
-### Search APIs and result limits
-
-| Parameter                                                      | Type    | Default | Description                                                                                                                                                                                                                                                  |
-| -------------------------------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.query.maxTotalHits` | integer | `10000` | Maximum result count cap for search APIs. Limits COUNT(\*) queries to improve performance. See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for details and performance implications. |
-
-### Schema and table management
-
-| Parameter                                           | Type    | Default | Description                                |
-| --------------------------------------------------- | ------- | ------- | ------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.autoDDL` | boolean | `true`  | Enable Liquibase auto-schema creation.     |
-| `orchestration.data.secondaryStorage.rdbms.prefix`  | string  | `""`    | Optional table name prefix for all tables. |
-
-### History and data retention
-
-| Parameter                                                                                          | Type              | Default | Description                               |
-| -------------------------------------------------------------------------------------------------- | ----------------- | ------- | ----------------------------------------- |
-| `orchestration.data.secondaryStorage.rdbms.history.defaultHistoryTTL`                              | ISO-8601 duration | `""`    | Default TTL for historic process data.    |
-| `orchestration.data.secondaryStorage.rdbms.history.minHistoryCleanupInterval`                      | ISO-8601 duration | `""`    | Minimum interval for history cleanup.     |
-| `orchestration.data.secondaryStorage.rdbms.history.maxHistoryCleanupInterval`                      | ISO-8601 duration | `""`    | Maximum interval for history cleanup.     |
-| `orchestration.data.secondaryStorage.rdbms.history.historyCleanupBatchSize`                        | integer           | `1000`  | Batch size when deleting historic data.   |
-| `orchestration.data.secondaryStorage.rdbms.history.defaultBatchOperationHistoryTTL`                | ISO-8601 duration | `""`    | TTL for batch operation history.          |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationCancelProcessInstanceHistoryTTL`  | ISO-8601 duration | `""`    | TTL for cancel-process-instance history.  |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationMigrateProcessInstanceHistoryTTL` | ISO-8601 duration | `""`    | TTL for migrate-process-instance history. |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationModifyProcessInstanceHistoryTTL`  | ISO-8601 duration | `""`    | TTL for modify-process-instance history.  |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationResolveIncidentHistoryTTL`        | ISO-8601 duration | `""`    | TTL for resolve-incident history.         |
-
-### Connection pool lifecycle
-
-| Parameter                                                                      | Type              | Default | Description                                |
-| ------------------------------------------------------------------------------ | ----------------- | ------- | ------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.history.connectionPool.idleTimeout` | ISO-8601 duration | `""`    | Maximum time a connection can remain idle. |
-| `orchestration.data.secondaryStorage.rdbms.history.connectionPool.maxLifetime` | ISO-8601 duration | `""`    | Maximum lifetime of a JDBC connection.     |
-
 ### Other parameters
 
 RDBMS supports other configuration options that can be configured in the helm chart `values.yaml` via [extraConfiguration](/self-managed/deployment/helm/configure/application-configs.md). See [RDBMS options](/self-managed/concepts/databases/relational-db/configuration.md).
@@ -143,7 +96,7 @@ Camunda bundles JDBC drivers for some databases. For others, you must supply a c
 
 ## Search APIs and result limits
 
-RDBMS search APIs return a `totalResults` field capped at **10,000** by default (configurable via `maxTotalHits`). Actual query performance depends on filter selectivity and database optimization.
+RDBMS search APIs return a `totalResults` field capped at **10,000** by default (configurable via `camunda.data.secondary-storage.rdbms.query.max-total-hits`). Actual query performance depends on filter selectivity and database optimization.
 
 See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for configuration options, performance trade-offs, optimization best practices, and database-specific tuning.
 

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/configure/database/rdbms.md
@@ -54,53 +54,6 @@ Store the database password in a Kubernetes secret and reference it. For testing
 | `orchestration.data.secondaryStorage.rdbms.secret.existingSecretKey` | string | `""`    | Key within the secret storing the password.         |
 | `orchestration.data.secondaryStorage.rdbms.secret.inlineSecret`      | string | `""`    | Password value (testing only, not production-safe). |
 
-### Connection pool and performance tuning
-
-Most tuning options are configured as application properties via [extraConfiguration](/self-managed/deployment/helm/configure/application-configs.md) (embedded `application.yml`).
-
-| Parameter                                                                 | Type              | Default | Description                                   |
-| ------------------------------------------------------------------------- | ----------------- | ------- | --------------------------------------------- |
-| `orchestration.data.secondaryStorage.rdbms.flushInterval`                 | ISO-8601 duration | `""`    | How frequently the exporter flushes events.   |
-| `orchestration.data.secondaryStorage.rdbms.queueSize`                     | integer           | `1000`  | Exporter queue size. Larger = more buffering. |
-| `camunda.data.secondary-storage.rdbms.queue-memory-limit`                 | integer           | `20`    | Memory limit (MB) for the exporter queue.     |
-| `camunda.data.secondary-storage.rdbms.connection-pool.maximum-pool-size`  | integer           | `10`    | Maximum JDBC connections.                     |
-| `camunda.data.secondary-storage.rdbms.connection-pool.minimum-idle`       | integer           | `10`    | Minimum idle connections.                     |
-| `camunda.data.secondary-storage.rdbms.connection-pool.connection-timeout` | integer           | `30000` | Timeout (ms) for acquiring a connection.      |
-
-### Search APIs and result limits
-
-| Parameter                                                      | Type    | Default | Description                                                                                                                                                                                                                                                  |
-| -------------------------------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.query.maxTotalHits` | integer | `10000` | Maximum result count cap for search APIs. Limits COUNT(\*) queries to improve performance. See [search APIs and result limits](/self-managed/deployment/helm/configure/database/rdbms-search-and-result-limits.md) for details and performance implications. |
-
-### Schema and table management
-
-| Parameter                                           | Type    | Default | Description                                |
-| --------------------------------------------------- | ------- | ------- | ------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.autoDDL` | boolean | `true`  | Enable Liquibase auto-schema creation.     |
-| `orchestration.data.secondaryStorage.rdbms.prefix`  | string  | `""`    | Optional table name prefix for all tables. |
-
-### History and data retention
-
-| Parameter                                                                                          | Type              | Default | Description                               |
-| -------------------------------------------------------------------------------------------------- | ----------------- | ------- | ----------------------------------------- |
-| `orchestration.data.secondaryStorage.rdbms.history.defaultHistoryTTL`                              | ISO-8601 duration | `""`    | Default TTL for historic process data.    |
-| `orchestration.data.secondaryStorage.rdbms.history.minHistoryCleanupInterval`                      | ISO-8601 duration | `""`    | Minimum interval for history cleanup.     |
-| `orchestration.data.secondaryStorage.rdbms.history.maxHistoryCleanupInterval`                      | ISO-8601 duration | `""`    | Maximum interval for history cleanup.     |
-| `orchestration.data.secondaryStorage.rdbms.history.historyCleanupBatchSize`                        | integer           | `1000`  | Batch size when deleting historic data.   |
-| `orchestration.data.secondaryStorage.rdbms.history.defaultBatchOperationHistoryTTL`                | ISO-8601 duration | `""`    | TTL for batch operation history.          |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationCancelProcessInstanceHistoryTTL`  | ISO-8601 duration | `""`    | TTL for cancel-process-instance history.  |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationMigrateProcessInstanceHistoryTTL` | ISO-8601 duration | `""`    | TTL for migrate-process-instance history. |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationModifyProcessInstanceHistoryTTL`  | ISO-8601 duration | `""`    | TTL for modify-process-instance history.  |
-| `orchestration.data.secondaryStorage.rdbms.history.batchOperationResolveIncidentHistoryTTL`        | ISO-8601 duration | `""`    | TTL for resolve-incident history.         |
-
-### Connection pool lifecycle
-
-| Parameter                                                                      | Type              | Default | Description                                |
-| ------------------------------------------------------------------------------ | ----------------- | ------- | ------------------------------------------ |
-| `orchestration.data.secondaryStorage.rdbms.history.connectionPool.idleTimeout` | ISO-8601 duration | `""`    | Maximum time a connection can remain idle. |
-| `orchestration.data.secondaryStorage.rdbms.history.connectionPool.maxLifetime` | ISO-8601 duration | `""`    | Maximum lifetime of a JDBC connection.     |
-
 ### Other parameters
 
 RDBMS supports other configuration options that can be configured in the helm chart `values.yaml` via [extraConfiguration](/self-managed/deployment/helm/configure/application-configs.md). See [RDBMS options](/self-managed/concepts/databases/relational-db/configuration.md).


### PR DESCRIPTION
## Description

Closes #9801.

The Helm RDBMS configuration page documents five parameter tables (`Connection pool and performance tuning`, `Search APIs and result limits`, `Schema and table management`, `History and data retention`, `Connection pool lifecycle`) built on keys such as `orchestration.data.secondaryStorage.rdbms.queueSize` and `orchestration.data.secondaryStorage.rdbms.history.defaultHistoryTTL`. These keys have no effect in the Helm chart — setting them changes nothing in the rendered manifests, with no error.

This is a regression. [#8170](https://github.com/camunda/camunda-docs/pull/8170) removed these tables in favour of an "Other parameters" section pointing at `extraConfiguration`. [#8069](https://github.com/camunda/camunda-docs/pull/8069) was branched before #8170 and reintroduced them verbatim on merge, right next to the still-present "Other parameters" section. No conflict was raised because the added and removed hunks did not overlap textually.

### Verification

In `camunda-platform-helm`, `templates/orchestration/files/_application.yaml` is the only consumer of `orchestration.data.secondaryStorage.rdbms`, in both the 8.9 and 8.10 charts:

```yaml
{{- with .Values.orchestration.data.secondaryStorage.rdbms }}
aws-enabled: {{ .aws.enabled }}
url: {{ .url | quote }}
username: {{ .username | quote }}
password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
{{- end }}
```

Only `aws.enabled`, `url`, `username`, and the password secret are mapped. Every other documented key is inert.

### Changes

- Removed the five reintroduced tables from `docs/` and `versioned_docs/version-8.9/`, restoring the state from #8170. `### Other parameters` now follows the credentials table and points at [RDBMS options](https://docs.camunda.io/docs/self-managed/concepts/databases/relational-db/configuration/), which documents every removed property as an application property.
- Corrected a dangling reference in `docs/` from `maxTotalHits` to the real property `camunda.data.secondary-storage.rdbms.query.max-total-hits`, matching the dedicated search-and-result-limits page.

The `## Search APIs and result limits` prose section added by #8069 is kept — it was new content, not part of the regression.

No inbound links reference the removed headings.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [x] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
