### PR TITLE
docs(self-managed): document adding a zone back by broker count [ready]

### DIFF
--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -394,7 +394,7 @@ POST actuator/cluster/zones/{zoneId}
 ```
 
 Name the zone's brokers either by count with `numberOfBrokers`, or one by one with
-`brokers`. Exactly one of the two must be set; setting both, or neither, is rejected with
+`brokers`. Exactly one of the two must be set; setting both, or neither, is rejected with HTTP
 `400`.
 
 `numberOfBrokers` is the number of brokers deployed in the zone, from which the broker IDs
@@ -402,8 +402,8 @@ Name the zone's brokers either by count with `numberOfBrokers`, or one by one wi
 brokers of a zone-aware cluster assign themselves, so a zone whose brokers are numbered
 from zero without gaps needs nothing else.
 
-Use `brokers` when they are not: a zone that comes back with a subset of its brokers has
-IDs that are not contiguous, and only the explicit list can express that.
+Use `brokers` when the IDs are not contiguous, which is what a zone coming back with only
+some of its brokers looks like: only the explicit list can express that.
 
 <details>
   <summary>Example requests</summary>

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -388,7 +388,8 @@ POST actuator/cluster/zones/{zoneId}
 {
   "numberOfReplicas": <integer>,
   "priority": <integer>,
-  "numberOfBrokers": <integer>
+  "numberOfBrokers": <integer>,
+  "brokers": [<brokerId1>, <brokerId2>, ...]
 }
 ```
 
@@ -405,7 +406,7 @@ Use `brokers` when they are not: a zone that comes back with a subset of its bro
 IDs that are not contiguous, and only the explicit list can express that.
 
 <details>
-  <summary>Example request</summary>
+  <summary>Example requests</summary>
 
 ```
 curl -X 'POST' \

--- a/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
+++ b/docs/self-managed/components/orchestration-cluster/zeebe/operations/management-api.md
@@ -379,7 +379,7 @@ The response is a JSON object with the same shape as the [partition distribution
 
 #### Add back a previously force-removed zone
 
-Re-adds the operator-supplied brokers and re-includes the given zone in the persisted partition distribution configuration, with the supplied replica count and priority, in one atomic change.
+Re-adds the zone's brokers and re-includes the given zone in the persisted partition distribution configuration, with the supplied replica count and priority, in one atomic change.
 
 ##### Request
 
@@ -388,12 +388,38 @@ POST actuator/cluster/zones/{zoneId}
 {
   "numberOfReplicas": <integer>,
   "priority": <integer>,
-  "brokers": [<brokerId1>, <brokerId2>, ...]
+  "numberOfBrokers": <integer>
 }
 ```
 
+Name the zone's brokers either by count with `numberOfBrokers`, or one by one with
+`brokers`. Exactly one of the two must be set; setting both, or neither, is rejected with
+`400`.
+
+`numberOfBrokers` is the number of brokers deployed in the zone, from which the broker IDs
+`<zoneId>_0` through `<zoneId>_<numberOfBrokers - 1>` are derived. These are the IDs the
+brokers of a zone-aware cluster assign themselves, so a zone whose brokers are numbered
+from zero without gaps needs nothing else.
+
+Use `brokers` when they are not: a zone that comes back with a subset of its brokers has
+IDs that are not contiguous, and only the explicit list can express that.
+
 <details>
   <summary>Example request</summary>
+
+```
+curl -X 'POST' \
+   'http://localhost:9600/actuator/cluster/zones/zone-b' \
+   -H 'accept: application/json' \
+   -H 'Content-Type: application/json' \
+   -d '{
+        "numberOfReplicas": 2,
+        "priority": 500,
+        "numberOfBrokers": 3
+      }'
+```
+
+The same request naming the brokers explicitly:
 
 ```
 curl -X 'POST' \


### PR DESCRIPTION
## Description

`POST actuator/cluster/zones/{zoneId}` gained `numberOfBrokers` as an alternative to `brokers` in [camunda/camunda#61627](https://github.com/camunda/camunda/pull/61627), backported to `stable/8.10` in [camunda/camunda#61775](https://github.com/camunda/camunda/pull/61775). The endpoint derives `<zoneId>_0` through `<zoneId>_<numberOfBrokers - 1>` itself, which are the same IDs a zone-aware broker assigns itself. Exactly one of `brokers` and `numberOfBrokers` must be set, otherwise the request is rejected with `400`.

The management API page documented only `brokers`, so the smaller form is undiscoverable, and an operator re-adding a zone of 10 to 20 brokers reproduces an engine-internal naming convention by hand, where one wrong ID fails the whole change.

This updates the [Zones API](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/zeebe/operations/management-api/#zones-api) section of the management API page:

- The request schema shows `numberOfBrokers`, with the exclusivity rule and how the IDs are derived.
- Both forms are shown as example requests.
- `brokers` stays documented and is not deprecated: it is the only way to express a zone that comes back with non-contiguous broker IDs, for example two of its three brokers.

`docs/` only. The endpoint is new in 8.10, so there is no versioned copy to update.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
