### PR TITLE
docs(agentic-orchestration): document usage metrics loss for external agents

### DIFF
--- a/docs/components/agentic-orchestration/connect-external-agent.md
+++ b/docs/components/agentic-orchestration/connect-external-agent.md
@@ -333,3 +333,16 @@ If your agent can't finish, [fail the job](/apis-tools/orchestration-cluster-api
 Start a process instance and open it in Operate. Select the agent element on the diagram to see the agent instance data you reported: its state, usage metrics, model, system prompt, tools, and conversation history grouped by loop iteration.
 
 See [monitor your AI agents](/components/agentic-orchestration/evaluate-agents/monitor-ai-agents.md) to learn how to inspect and debug AI agents in Operate.
+
+## Limitations
+
+### Usage metrics can be lost if your runtime doesn't report them before a competing activation completes the job
+
+Camunda only commits the usage metrics on history items reported under the lease of the activation that completes the job. If your runtime racks up token usage or tool calls but doesn't report them before a competing job activation completes the job first, those metrics are lost, since the superseded activation's history items are discarded rather than committed.
+
+This can happen with the external worker pattern in the following cases:
+
+- Your runtime crashes after a model call but before it reports that call's `metrics` through [step 5](#step-5-report-the-conversation-history).
+- Your runtime loses its connection, and by the time it reconnects, the job has already been re-activated and completed by a competing worker.
+
+If your runtime reconnects after the job was re-activated but before a competing worker completes it, it can still report metrics on the new activation's lease. Losing metrics in a crash or an extended disconnect is expected behavior. There's no way to recover usage that was never reported under a lease Camunda ends up committing.

--- a/docs/components/agentic-orchestration/connect-external-agent.md
+++ b/docs/components/agentic-orchestration/connect-external-agent.md
@@ -308,6 +308,15 @@ curl -L -X PATCH 'http://localhost:8080/v2/agent-instances/4503599627370496' \
 
 Whenever you send `history`, also send the `jobKey` and `jobLease` from the job activation. Camunda records each item with a `PENDING` commit status and promotes it to `COMMITTED` when the job completes successfully. If the job fails and a later activation supersedes the lease, the items are marked `DISCARDED` instead.
 
+:::caution Unreported usage metrics can be lost
+If a competing activation completes the job before your runtime reports a call's `metrics`, those metrics are discarded with the rest of that activation's history and can't be recovered. This can happen when:
+
+- Your runtime crashes after a model call but before reporting its `metrics`.
+- Your runtime loses its connection, and the job is reactivated and completed by a competing worker before the runtime reconnects.
+
+You can still report those metrics under the new activation’s lease if you reconnect before the job is completed.
+:::
+
 The response echoes one entry per submitted item, in request order, with the `historyItemKey` Camunda assigned and an `isDuplicate` flag showing whether the item had already been recorded.
 
 ## Step 6: Complete the job
@@ -333,16 +342,3 @@ If your agent can't finish, [fail the job](/apis-tools/orchestration-cluster-api
 Start a process instance and open it in Operate. Select the agent element on the diagram to see the agent instance data you reported: its state, usage metrics, model, system prompt, tools, and conversation history grouped by loop iteration.
 
 See [monitor your AI agents](/components/agentic-orchestration/evaluate-agents/monitor-ai-agents.md) to learn how to inspect and debug AI agents in Operate.
-
-## Limitations
-
-### Usage metrics can be lost if your runtime doesn't report them before a competing activation completes the job
-
-Camunda only commits the usage metrics on history items reported under the lease of the activation that completes the job. If your runtime racks up token usage or tool calls but doesn't report them before a competing job activation completes the job first, those metrics are lost, since the superseded activation's history items are discarded rather than committed.
-
-This can happen with the external worker pattern in the following cases:
-
-- Your runtime crashes after a model call but before it reports that call's `metrics` through [step 5](#step-5-report-the-conversation-history).
-- Your runtime loses its connection, and by the time it reconnects, the job has already been re-activated and completed by a competing worker.
-
-If your runtime reconnects after the job was re-activated but before a competing worker completes it, it can still report metrics on the new activation's lease. Losing metrics in a crash or an extended disconnect is expected behavior. There's no way to recover usage that was never reported under a lease Camunda ends up committing.


### PR DESCRIPTION
## Description

Documents a limitation of the external agent job worker pattern: usage metrics (token counts, tool call duration) reported via the [Agent Instance API](/apis-tools/orchestration-cluster-api-rest/specifications/update-agent-instance.api.mdx) can be lost if the job worker crashes or loses its connection before reporting them, and a competing job activation completes the job first.

Requested in [camunda/camunda#61913 (comment)](https://github.com/camunda/camunda/pull/61913#issuecomment-5538921430).

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
