### PR TITLE
docs(concepts): link secret resolution monitoring to the metrics reference

### DIFF
--- a/docs/components/concepts/secret-resolution-and-job-activation.md
+++ b/docs/components/concepts/secret-resolution-and-job-activation.md
@@ -131,10 +131,7 @@ See the [property reference](/self-managed/components/orchestration-cluster/core
 
 ## Monitor secret resolution
 
-A store that is slow or failing shows up as jobs that do not activate, If a store is slow or unavailable, affected jobs may not activate, and the job worker does not indicate the cause. The cluster emits meters for secret resolution and secret caches. Use these meters to distinguish a cold cache from a store that is not responding. To scrape and interpret cluster meters, see the [metrics reference](/self-managed/operational-guides/monitoring/metrics.md).
-
-<!-- The six secret resolution and secret cache meters, their tags, and how to read them are
-owned by camunda/camunda#60963. Name and link them here once they are in the metrics reference. -->
+A store that is slow or unavailable shows up as jobs that do not activate, and the job worker does not indicate the cause. The cluster emits meters for secret resolution and secret caches. Use these meters to distinguish a cold cache from a store that is not responding. To scrape and interpret cluster meters, see the [metrics reference](/self-managed/operational-guides/monitoring/metrics.md#secret-resolution-and-cache-metrics).
 
 ## Related resources
 


### PR DESCRIPTION
## Description

Follow-up to camunda/camunda#61695.

The "Monitor secret resolution" section of `docs/components/concepts/secret-resolution-and-job-activation.md` carried a TODO comment deferring its link until the metrics reference gained a section for these meters. That section now exists on `main` (`## Secret resolution and cache metrics`, added in #9781), so this PR:

- Points the section at the `#secret-resolution-and-cache-metrics` anchor instead of the metrics reference as a whole.
- Removes the TODO comment.
- Rewrites the section's first sentence, which had two drafts merged into one during review.

One file, one section. No other content changes.

Closes camunda/camunda#61695

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [x] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
