### PR TITLE
docs(concepts): document secret references in input mappings and connector coexistence

### DIFF
--- a/docs/components/concepts/variables.md
+++ b/docs/components/concepts/variables.md
@@ -206,6 +206,63 @@ Examples:
 | -                                      | **source:** `"Peter"`<br/>**target:** `sender`                                                               | `sender: "Peter"`                           |
 | `customer:{"name": "John"}`            | **source:** (not provided)<br/>**target:** `customer`                                                        | `customer: null`                            |
 
+### Secret references in input mappings
+
+An input mapping's `source` can reference a secret directly, without first storing it in a process variable. Write the reference as `camunda.secrets.<name>` in a FEEL expression.
+
+This is part of an [alpha feature](/components/early-access/alpha/alpha-features.md) and may be subject to change in future releases.
+
+| Process variables | Input mappings                                                                       | New variables                                                    |
+| ----------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| -                 | **source:** `=camunda.secrets.API_TOKEN`<br/>**target:** `token`                     | `token` holds the secret's value when the job reaches the worker |
+| -                 | **source:** `="Bearer " + camunda.secrets.API_TOKEN`<br/>**target:** `authorization` | `authorization` holds `"Bearer "` followed by the secret's value |
+
+Secret references are only resolved in input mappings defined on elements that create a job for a job worker (for example, service tasks, business rule tasks, and ad hoc sub-processes). See [secret resolution and job activation](secret-resolution-and-job-activation.md) for how a reference is resolved and what the worker receives once the job is handed out; until then, the variable holds the placeholder text `camunda.secrets.<name>`.
+
+A reference must be an expression, and it must be exactly `camunda.secrets.<name>` with nothing else attached:
+
+- Writing the reference as a plain string, or quoting it inside an expression, is rejected at deployment rather than passed through as literal text:
+
+  ```feel
+  ="camunda.secrets.API_TOKEN"
+  ```
+
+  ```
+  Secret reference(s) 'camunda.secrets.API_TOKEN' must be used as an expression (e.g. '=camunda.secrets.<name>'), not as a string literal, in input mapping source '="camunda.secrets.API_TOKEN"'.
+  ```
+
+- A trailing path after the name, such as `camunda.secrets.API_TOKEN.length`, is not treated as a reference. It's evaluated as an ordinary FEEL path access instead.
+
+- A reference placed inside a list, or inside a context built by an `if` branch, is rejected at deployment, because the reference is no longer a value the mapping assigns directly:
+
+  ```feel
+  =[camunda.secrets.API_TOKEN]
+  ```
+
+  ```
+  Input mapping source '=[camunda.secrets.API_TOKEN]' puts a secret reference inside a list, or inside a context built by an 'if' branch. Camunda can only replace a secret where the mapping assigns it directly to a value, so this secret would never be filled in. Assign each secret reference to its own input mapping instead.
+  ```
+
+Give each secret its own input mapping. A later mapping that reads the _variable_ created by an earlier one, rather than writing `camunda.secrets.<name>` itself, does not get the secret resolved:
+
+| Input mappings                                                                                        | New variables                                                                                     |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **source:** `=camunda.secrets.API_TOKEN`<br/>**target:** `x`<br/>**source:** `=x`<br/>**target:** `y` | `x` holds the resolved secret value; `y` holds the literal placeholder text, not the secret value |
+
+#### Names with special characters
+
+A secret name containing a character FEEL doesn't allow in a bare identifier — most commonly a dash — must be backtick-escaped, the same way any other FEEL name with special characters is:
+
+```feel
+=camunda.secrets.`db-password`
+```
+
+Without the backticks, `camunda.secrets.db-password` parses as subtraction (`db` minus `password`), not as a reference.
+
+:::note
+Backtick escaping accepts any name, including a name your secret store accepts but the [`/v2/secrets`](/apis-tools/orchestration-cluster-api-rest/specifications/list-secrets.api.mdx) endpoints do not. Those endpoints list and resolve only names matching `[\p{Alnum}_-]+`. A name outside that set, such as `tls.crt`, can be backtick-escaped and resolved from a process model (``=camunda.secrets.`tls.crt` ``) if your secret store holds it under that name, but the same secret cannot be listed or resolved through `/v2/secrets`.
+:::
+
 ### Output mappings
 
 Output mappings can be used for several purposes:

--- a/docs/components/concepts/variables.md
+++ b/docs/components/concepts/variables.md
@@ -212,12 +212,14 @@ An input mapping's `source` can reference a secret directly, without first stori
 
 This is part of an [alpha feature](/components/early-access/alpha/alpha-features.md) and may be subject to change in future releases.
 
+Using secret references requires a configured [secret store](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#secrets) that holds the secret. Without a configured store, the reference cannot be resolved.
+
 | Process variables | Input mappings                                                                       | New variables                                                    |
 | ----------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | -                 | **source:** `=camunda.secrets.API_TOKEN`<br/>**target:** `token`                     | `token` holds the secret's value when the job reaches the worker |
 | -                 | **source:** `="Bearer " + camunda.secrets.API_TOKEN`<br/>**target:** `authorization` | `authorization` holds `"Bearer "` followed by the secret's value |
 
-Secret references are only resolved in input mappings defined on elements that create a job for a job worker (for example, service tasks, business rule tasks, and ad hoc sub-processes). See [secret resolution and job activation](secret-resolution-and-job-activation.md) for how a reference is resolved and what the worker receives once the job is handed out; until then, the variable holds the placeholder text `camunda.secrets.<name>`.
+Secret references are only resolved in input mappings defined on elements that create a job for a job worker (for example, service tasks, business rule tasks, and ad hoc sub-processes). See [secret resolution and job activation](secret-resolution-and-job-activation.md) for how a reference is resolved and what the worker receives once the job is handed out. The stored process variable always holds the placeholder text `camunda.secrets.<name>`; resolution replaces it only in the payload handed to the worker, not in the variable kept in the process instance's state. Any other consumer of that variable sees the placeholder.
 
 A reference must be an expression, and the reference itself must be exactly the three-segment path `camunda.secrets.<name>`. It can still take part in a supported expression, such as the concatenation shown above, but the following rejections apply:
 
@@ -249,6 +251,14 @@ Give each secret its own input mapping. A later mapping that reads the _variable
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | **source:** `=camunda.secrets.API_TOKEN`<br/>**target:** `x`<br/>**source:** `=x`<br/>**target:** `y` | `x` exposes the resolved secret value to the worker; `y` holds the literal placeholder text, not the secret value |
 
+:::note
+A secret reference can also come from a [cluster variable](/components/modeler/feel/cluster-variable/data-types.md) of kind `SECRET_REFERENCE`. An input mapping that selects such a variable, for example `=camunda.vars.env.MY_CONFIG`, resolves the `camunda.secrets.<name>` references embedded in its value the same way. See [resolve secret references in a cluster variable](/components/modeler/feel/cluster-variable/usage-guide.md#resolve-secret-references-in-a-cluster-variable).
+:::
+
+:::note
+Avoid using `camunda` as a process variable name. A process variable literally named `camunda` takes precedence over the secret namespace, so `camunda.secrets.<name>` resolves against that variable and no secret is injected.
+:::
+
 #### Escape secret names with special characters
 
 A secret name containing a character FEEL doesn't allow in a bare identifier (most commonly a dash) must be backtick-escaped, the same way any other FEEL name with special characters is:
@@ -257,10 +267,10 @@ A secret name containing a character FEEL doesn't allow in a bare identifier (mo
 =camunda.secrets.`db-password`
 ```
 
-Without the backticks, `camunda.secrets.db-password` parses as subtraction (`db` minus `password`), not as a reference.
+Without the backticks, `camunda.secrets.db-password` parses as a subtraction (`db` minus `password`). FEEL reads the left operand as a reference named `db`, which is not a valid secret reference, so the deployment fails at evaluation.
 
 :::note
-Backtick escaping accepts any name, including a name your secret store accepts but the [`/v2/secrets`](/apis-tools/orchestration-cluster-api-rest/specifications/list-secrets.api.mdx) endpoints do not. Those endpoints list and resolve only names matching `[\p{Alnum}_-]+`. A name outside that set, such as `tls.crt`, can be backtick-escaped and resolved from a process model (``=camunda.secrets.`tls.crt` ``) if your secret store holds it under that name, but the same secret cannot be listed or resolved through `/v2/secrets`.
+When a reference is written directly in an input mapping source, backtick escaping accepts any name, including a name your secret store accepts but the [`/v2/secrets`](/apis-tools/orchestration-cluster-api-rest/specifications/list-secrets.api.mdx) endpoints do not. Those endpoints list and resolve only names matching `[\p{Alnum}_-]+`. A name outside that set, such as `tls.crt`, can be backtick-escaped and resolved from a process model (``=camunda.secrets.`tls.crt` ``) if your secret store holds it under that name, but the same secret cannot be listed or resolved through `/v2/secrets`. This applies to references written directly in an input mapping source, not to references embedded in a [`SECRET_REFERENCE`-kind cluster variable value](/components/modeler/feel/cluster-variable/data-types.md#where-references-can-appear-in-a-value), whose names follow the restricted cluster-variable character set.
 :::
 
 ### Output mappings

--- a/docs/components/concepts/variables.md
+++ b/docs/components/concepts/variables.md
@@ -219,7 +219,7 @@ This is part of an [alpha feature](/components/early-access/alpha/alpha-features
 
 Secret references are only resolved in input mappings defined on elements that create a job for a job worker (for example, service tasks, business rule tasks, and ad hoc sub-processes). See [secret resolution and job activation](secret-resolution-and-job-activation.md) for how a reference is resolved and what the worker receives once the job is handed out; until then, the variable holds the placeholder text `camunda.secrets.<name>`.
 
-A reference must be an expression, and it must be exactly `camunda.secrets.<name>` with nothing else attached:
+A reference must be an expression, and the reference itself must be exactly the three-segment path `camunda.secrets.<name>`. It can still take part in a supported expression, such as the concatenation shown above, but the following rejections apply:
 
 - Writing the reference as a plain string, or quoting it inside an expression, is rejected at deployment rather than passed through as literal text:
 
@@ -227,7 +227,7 @@ A reference must be an expression, and it must be exactly `camunda.secrets.<name
   ="camunda.secrets.API_TOKEN"
   ```
 
-  ```
+  ```text
   Secret reference(s) 'camunda.secrets.API_TOKEN' must be used as an expression (e.g. '=camunda.secrets.<name>'), not as a string literal, in input mapping source '="camunda.secrets.API_TOKEN"'.
   ```
 
@@ -239,19 +239,19 @@ A reference must be an expression, and it must be exactly `camunda.secrets.<name
   =[camunda.secrets.API_TOKEN]
   ```
 
-  ```
+  ```text
   Input mapping source '=[camunda.secrets.API_TOKEN]' puts a secret reference inside a list, or inside a context built by an 'if' branch. Camunda can only replace a secret where the mapping assigns it directly to a value, so this secret would never be filled in. Assign each secret reference to its own input mapping instead.
   ```
 
 Give each secret its own input mapping. A later mapping that reads the _variable_ created by an earlier one, rather than writing `camunda.secrets.<name>` itself, does not get the secret resolved:
 
-| Input mappings                                                                                        | New variables                                                                                     |
-| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **source:** `=camunda.secrets.API_TOKEN`<br/>**target:** `x`<br/>**source:** `=x`<br/>**target:** `y` | `x` holds the resolved secret value; `y` holds the literal placeholder text, not the secret value |
+| Input mappings                                                                                        | New variables                                                                                                     |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **source:** `=camunda.secrets.API_TOKEN`<br/>**target:** `x`<br/>**source:** `=x`<br/>**target:** `y` | `x` exposes the resolved secret value to the worker; `y` holds the literal placeholder text, not the secret value |
 
-#### Names with special characters
+#### Escape secret names with special characters
 
-A secret name containing a character FEEL doesn't allow in a bare identifier — most commonly a dash — must be backtick-escaped, the same way any other FEEL name with special characters is:
+A secret name containing a character FEEL doesn't allow in a bare identifier (most commonly a dash) must be backtick-escaped, the same way any other FEEL name with special characters is:
 
 ```feel
 =camunda.secrets.`db-password`

--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -57,6 +57,19 @@ our [Connector SDK documentation](/components/connectors/custom-built-connectors
 Using this in other areas can lead to unexpected results and incidents.
 :::
 
+### Using `camunda.secrets.*` references
+
+You can also reference a secret from a [secret store](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#secrets) directly in a connector's input mapping, using `camunda.secrets.<name>` in a FEEL expression. This is part of an [alpha feature](/components/early-access/alpha/alpha-features.md). See [secret references in input mappings](/components/concepts/variables.md#secret-references-in-input-mappings) for the syntax and its rules.
+
+The two forms coexist and are handled differently:
+
+- `{{secrets.*}}` remains fully supported for existing process models. It's still resolved by the connector runtime itself, at execution time, exactly as described above; the runtime keeps receiving it as plain placeholder text in the job's input.
+- `camunda.secrets.<name>` is resolved before the job reaches any worker, including a connector runtime. The connector receives the value already in place, the same way whether the connector runtime is co-located with the cluster or run separately (for example, a self-managed runtime connecting to a SaaS cluster).
+
+`{{secrets.*}}` values are not scoped per [physical tenant](/self-managed/concepts/physical-tenants/connectors-runtime.md#per-tenant-secret-access) unless you opt in to `physicaltenantaware` in the connector runtime's own configuration. Physical tenant scoping of `camunda.secrets.<name>` is separate from that setting: each physical tenant resolves its own configured secret store.
+
+To migrate a field from `{{secrets.NAME}}` to `camunda.secrets.NAME` without moving the value out of its current provider first, set `camunda.connector.secret-resolver.legacy.mode` to `FALLBACK` on the connector runtime: a legacy-style reference whose name isn't found in a configured secret provider is then looked up in the same store `camunda.secrets.<name>` uses. The default, `ON`, only resolves legacy references from the configured providers.
+
 ## Variable and response mapping
 
 When a connector is expected to return a result, connectors feature a dedicated section known as

--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -68,7 +68,7 @@ The two forms coexist and are handled differently:
 
 `{{secrets.*}}` values are not scoped per [physical tenant](/self-managed/concepts/physical-tenants/connectors-runtime.md#per-tenant-secret-access) unless you opt in to `physicaltenantaware` in the connector runtime's own configuration. Physical tenant scoping of `camunda.secrets.<name>` is separate from that setting: each physical tenant resolves its own configured secret store.
 
-To migrate a field from `{{secrets.NAME}}` to `camunda.secrets.NAME` without moving the value out of its current provider first, set `camunda.connector.secret-resolver.legacy.mode` to `FALLBACK` on the connector runtime: a legacy-style reference whose name isn't found in a configured secret provider is then looked up in the same store `camunda.secrets.<name>` uses. The default, `ON`, only resolves legacy references from the configured providers.
+`{{secrets.*}}` and `camunda.secrets.<name>` can be migrated independently of where the value is stored. If you move a secret value into the store that `camunda.secrets.<name>` uses but keep existing process models on the legacy `{{secrets.NAME}}` syntax, set `camunda.connector.secret-resolver.legacy.mode` to `FALLBACK` on the connector runtime: a legacy-style reference whose name isn't found in a configured secret provider is then looked up in that same store. The default, `ON`, only resolves legacy references from the configured providers.
 
 ## Variable and response mapping
 

--- a/docs/components/connectors/use-connectors/index.md
+++ b/docs/components/connectors/use-connectors/index.md
@@ -61,10 +61,11 @@ Using this in other areas can lead to unexpected results and incidents.
 
 You can also reference a secret from a [secret store](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#secrets) directly in a connector's input mapping, using `camunda.secrets.<name>` in a FEEL expression. This is part of an [alpha feature](/components/early-access/alpha/alpha-features.md). See [secret references in input mappings](/components/concepts/variables.md#secret-references-in-input-mappings) for the syntax and its rules.
 
-The two forms coexist and are handled differently:
+These forms coexist and are handled differently:
 
 - `{{secrets.*}}` remains fully supported for existing process models. It's still resolved by the connector runtime itself, at execution time, exactly as described above; the runtime keeps receiving it as plain placeholder text in the job's input.
 - `camunda.secrets.<name>` is resolved before the job reaches any worker, including a connector runtime. The connector receives the value already in place, the same way whether the connector runtime is co-located with the cluster or run separately (for example, a self-managed runtime connecting to a SaaS cluster).
+- A [cluster variable](/components/modeler/feel/cluster-variable/data-types.md) of kind `SECRET_REFERENCE` can hold `camunda.secrets.<name>` references in its value. A connector field that reads such a variable, for example `=camunda.vars.env.MY_CONFIG`, receives the resolved value the same way, because the references are recorded on the job and resolved before activation. See [resolve secret references in a cluster variable](/components/modeler/feel/cluster-variable/usage-guide.md#resolve-secret-references-in-a-cluster-variable).
 
 `{{secrets.*}}` values are not scoped per [physical tenant](/self-managed/concepts/physical-tenants/connectors-runtime.md#per-tenant-secret-access) unless you opt in to `physicaltenantaware` in the connector runtime's own configuration. Physical tenant scoping of `camunda.secrets.<name>` is separate from that setting: each physical tenant resolves its own configured secret store.
 

--- a/docs/components/modeler/feel/cluster-variable/data-types.md
+++ b/docs/components/modeler/feel/cluster-variable/data-types.md
@@ -37,7 +37,7 @@ Only a `SECRET_REFERENCE`-kind variable has its references resolved. A `JSON`-ki
 
 ### Where references can appear in a value
 
-Camunda scans every string in a `SECRET_REFERENCE`-kind variable's value, including strings nested inside objects and arrays. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes, up to 240 characters. A name that fails either limit is never resolved; see [secrets](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#secrets).
+Camunda scans every string in a `SECRET_REFERENCE`-kind variable's value, including strings nested inside objects and arrays. Object keys are not scanned. A reference has the form `camunda.secrets.<name>`, where `<name>` can contain ASCII letters, digits, underscores, and dashes, up to 240 characters. A name that fails either limit is never resolved; see [secrets](/self-managed/components/orchestration-cluster/core-settings/configuration/properties.md#secrets). This character set applies to references embedded in a cluster-variable value; a reference [written directly in an input mapping source](/components/concepts/variables.md#escape-secret-names-with-special-characters) can use other characters through backtick escaping.
 
 For example, the following value carries two references, one at the top level and one nested:
 


### PR DESCRIPTION
## Description

Documents the new `camunda.secrets.<name>` input-mapping secret references (alpha) and how they coexist with the legacy `{{secrets.*}}` connector syntax. This complements the already-merged broker-side resolution page (`secret-resolution-and-job-activation.md`) by covering the modelling and connector-authoring side.

**`docs/components/concepts/variables.md`** — new "Secret references in input mappings" section on the modelling/variables page:

- References live in input mappings on job-worker elements (service tasks, business rule tasks, ad hoc sub-processes); links to the resolution page for what the worker receives.
- A reference must be exactly `=camunda.secrets.<name>`. Documents deployment-time rejections with the real validator errors: string literal (`="camunda.secrets.API_TOKEN"`) and reference inside a list/`if`-context (`=[camunda.secrets.API_TOKEN]`).
- Concatenation works (`="Bearer " + camunda.secrets.API_TOKEN`).
- A trailing path (`camunda.secrets.API_TOKEN.length`) is treated as ordinary FEEL path access, not a reference.
- Cross-mapping references are not resolved (`x <- camunda.secrets.X`, then `y <- x` leaves `y` as the placeholder).
- "Names with special characters": a dash-containing name is valid but must be backtick-escaped (`` =camunda.secrets.`db-password` ``) because a bare dash is FEEL's minus operator. Documents the limitation that backtick escaping admits names the `/v2/secrets` endpoints reject (they accept only `[\p{Alnum}_-]+`).

**`docs/components/connectors/use-connectors/index.md`** — new "Using `camunda.secrets.*` references" subsection under "Using secrets" with the coexistence rule:

- `{{secrets.*}}` remains fully supported and is still resolved by the connector runtime at execution time as plain placeholder text.
- `camunda.secrets.<name>` is resolved by the orchestration cluster before the job reaches any worker; the connector receives the value already in place, whether co-located or run separately.
- Physical-tenant scoping difference between the two forms.
- Migration via `camunda.connector.secret-resolver.legacy.mode=FALLBACK`.

Technical claims (hybrid resolution, legacy `ON`/`FALLBACK` behavior, physical-tenant scoping) were verified against the `camunda/camunda` engine (`ClusterVariableJobSecretResolver`, `BpmnJobBehavior`) and `camunda/connectors` (`LegacySecretMode`, `CentralStoreSecretProvider`, `ConnectorsAutoConfiguration`) source.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [ ] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

Closes https://github.com/camunda/camunda/issues/60329