### PR TITLE
fix: update stale Identity documentation links

### DIFF
--- a/product-links.txt
+++ b/product-links.txt
@@ -251,5 +251,5 @@ https://docs.camunda.io/docs/next/components/modeler/feel/cluster-variable/clust
 
 # Management Identity
 
-https://docs.camunda.io/docs/8.7/self-managed/identity/access-management/resource-authorizations
-https://docs.camunda.io/docs/next/components/whats-new-in-88/#identity-and-management-identity
+https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/access-management-overview/
+https://docs.camunda.io/docs/reference/announcements-release-notes/880/whats-new-in-88/#identity-and-management-identity

--- a/product-links.txt
+++ b/product-links.txt
@@ -252,11 +252,11 @@ https://docs.camunda.io/docs/next/components/modeler/feel/cluster-variable/clust
 # Management Identity
 
 https://docs.camunda.io/docs/next/self-managed/components/management-identity/overview/
-https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/access-management-overview/
-https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/manage-permissions/
-https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/manage-permissions/#assign-a-permission-to-a-role
-https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/applications/
-https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/manage-groups/
-https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/manage-roles/
-https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/identity-application-user-group-role-management-overview/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/access-management-overview/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/manage-permissions/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/manage-permissions/#assign-a-permission-to-a-role
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/applications/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-groups/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-roles/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/identity-application-user-group-role-management-overview/
 https://docs.camunda.io/docs/reference/announcements-release-notes/880/whats-new-in-88/#identity-and-management-identity

--- a/product-links.txt
+++ b/product-links.txt
@@ -252,11 +252,11 @@ https://docs.camunda.io/docs/next/components/modeler/feel/cluster-variable/clust
 # Management Identity
 
 https://docs.camunda.io/docs/next/self-managed/components/management-identity/overview/
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/access-management-overview/
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/manage-permissions/
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/manage-permissions/#assign-a-permission-to-a-role
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/applications/
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-groups/
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-roles/
-https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/identity-application-user-group-role-management-overview/
+https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/access-management-overview/
+https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/manage-permissions/
+https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/manage-permissions/#assign-a-permission-to-a-role
+https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/applications/
+https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/manage-groups/
+https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/manage-roles/
+https://docs.camunda.io/docs/self-managed/components/management-identity/application-user-group-role-management/identity-application-user-group-role-management-overview/
 https://docs.camunda.io/docs/reference/announcements-release-notes/880/whats-new-in-88/#identity-and-management-identity

--- a/product-links.txt
+++ b/product-links.txt
@@ -251,5 +251,12 @@ https://docs.camunda.io/docs/next/components/modeler/feel/cluster-variable/clust
 
 # Management Identity
 
-https://docs.camunda.io/docs/self-managed/components/management-identity/access-management/access-management-overview/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/overview/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/access-management-overview/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/manage-permissions/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/access-management/manage-permissions/#assign-a-permission-to-a-role
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/applications/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-groups/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-roles/
+https://docs.camunda.io/docs/next/self-managed/components/management-identity/application-user-group-role-management/identity-application-user-group-role-management-overview/
 https://docs.camunda.io/docs/reference/announcements-release-notes/880/whats-new-in-88/#identity-and-management-identity


### PR DESCRIPTION
## Summary
The `# Management Identity` section only tracked 2 links, and both were stale, matching camunda/identity#3365:
- `docs/8.7/self-managed/identity/access-management/resource-authorizations` (404)
- `docs/next/components/whats-new-in-88/#identity-and-management-identity` (404)

This PR expands the section to track every documentation link currently used by the Identity frontend (main branch), so future breakages are caught too.

All links verified to return 200:
- `docs/next/self-managed/components/management-identity/overview/` — hardcoded in the container's OCI `documentation` label, literally `next` in source
- `docs/next/self-managed/components/management-identity/access-management/access-management-overview/`
- `docs/next/self-managed/components/management-identity/access-management/manage-permissions/` (+ anchor variant)
- `docs/next/self-managed/components/management-identity/application-user-group-role-management/applications/`
- `docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-groups/`
- `docs/next/self-managed/components/management-identity/application-user-group-role-management/manage-roles/`
- `docs/next/self-managed/components/management-identity/application-user-group-role-management/identity-application-user-group-role-management-overview/`
- `docs/reference/announcements-release-notes/880/whats-new-in-88/#identity-and-management-identity`

These use `docs/next/...` because Identity's `main` branch pins its `DOCS_URL` to `docs/next/self-managed` (see companion PR camunda/identity#5139), matching the convention used elsewhere in this file for non-versioned entries.

Relates to camunda/identity#3365.