### PR TITLE
docs(self-managed): document Helm values migration and validation with Camunda Helm Toolkit

### DIFF
--- a/docs/self-managed/deployment/helm/chart-parameters.md
+++ b/docs/self-managed/deployment/helm/chart-parameters.md
@@ -93,6 +93,8 @@ You can use these files individually or combine them with your own overrides.
 To customize parameters, create an override file (for example, `my-overrides.yaml`) with custom settings.  
 This approach is recommended over editing `values.yaml` directly.
 
+You can [validate the keys in your overrides with the Camunda Helm Toolkit](operational-tasks/camunda-helm-toolkit.md#validate-override-files). This checks the supplied configuration, not the completeness or deployment readiness of all merged Helm values.
+
 ### Combining multiple values files
 
 Helm lets you specify multiple values files. You can layer them to build the configuration you need:

--- a/docs/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md
+++ b/docs/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md
@@ -1,0 +1,154 @@
+---
+id: camunda-helm-toolkit
+title: "Use the Camunda Helm Toolkit"
+sidebar_label: "Helm values toolkit"
+description: "Migrate and validate Camunda Helm override files with the local Web UI or Docker CLI, then review findings before upgrading."
+---
+
+Use the Camunda Helm Toolkit to migrate Helm override files between Camunda versions and check their configuration.
+
+The toolkit rewrites supported configuration keys and reports changes that need your attention. It doesn't upgrade your deployment, migrate stored data, or replace the [Helm upgrade procedure](/self-managed/upgrade/helm/890-to-8100.md).
+
+## Check version compatibility
+
+Migrate one adjacent Camunda minor version at a time, then review the output before continuing.
+
+| Source version | Migration target | Post-migration validation |
+| -------------- | ---------------- | ------------------------- |
+| 8.7            | 8.8              | 8.8                       |
+| 8.8            | 8.9              | 8.9                       |
+| 8.9            | 8.10             | 8.10                      |
+
+Standalone validation supports 8.8, 8.9, and 8.10. You can't validate an 8.7 file directly; migrate it to 8.8 first. Support for 8.10 is preliminary, and some changes require manual configuration.
+
+The source and target arguments are Camunda versions, such as `8.9`, not Helm chart versions, such as `14.x`. Use the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) to identify your deployment's Camunda version.
+
+## Prepare your files
+
+Provide your own override files, such as the files you pass to Helm with `-f`, rather than the chart's default `values.yaml`.
+
+- Install Docker and use a local Docker daemon with Linux containers.
+- Keep a copy of your original overrides. For layered configurations, keep the files separate and record their Helm `-f` order.
+- Identify the source and target Camunda versions. The examples on this page migrate 8.9 overrides to 8.10.
+
+The examples use the [public Docker image](https://hub.docker.com/r/camunda/camunda-helm-toolkit/tags). Its `SNAPSHOT` tag is a rolling build, not a versioned release, and can change between pulls. The CLI examples use a POSIX-compatible shell on macOS or Linux. The Web UI avoids host-path mount commands.
+
+## Use the local Web UI
+
+Start the toolkit in Docker to migrate and validate files through your browser.
+
+```bash
+docker run --rm --pull always \
+  -p 127.0.0.1:8080:8080 \
+  camunda/camunda-helm-toolkit:SNAPSHOT
+```
+
+Open [the local toolkit](http://localhost:8080) in your browser. If port 8080 is occupied, change the first port in the mapping and use that port in the browser URL.
+
+1. Select **Migrate** and upload or paste your override files.
+2. Select source version **8.9**. The toolkit chooses the next minor version, **8.10**, as the target.
+3. Run the migration and review the findings alongside the YAML. Select a finding to locate the affected configuration.
+4. Select the target-version document to inspect the migrated output. To correct it, select **Edit migrated**, make your changes, and select **Validate again**.
+5. Download each migrated document. The download uses the document currently displayed, so confirm you're viewing the target version rather than the original input.
+
+For a configuration check without migration, select **Validate**, provide your overrides, and choose their Camunda version. Stop the container with `Ctrl+C` when you're finished.
+
+## Migrate from the CLI
+
+Run `migrate` to create an updated override file without modifying your source file.
+
+From the directory containing `values-8.9.yaml`, run:
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /work/values-8.9.yaml \
+  --source 8.9 --target 8.10 \
+  --output - > values-8.10.yaml
+```
+
+The container uses your user and group IDs and `/tmp` as its working directory. The input directory is mounted read-only. Docker writes the migrated YAML to standard output, and your shell saves it on the host. Choose a new output filename: shell redirection replaces an existing file, so never redirect to an input file.
+
+With `--output -`, the report and summary go to standard error, separate from the YAML. A completed migration can produce output and still exit with warnings or validation errors. Check the exit code and findings before using the output; a tool failure can leave an empty redirected file.
+
+Migration automatically validates each output against its target version. It changes keys present in your overrides, but doesn't add the target chart's defaults or automatically apply every recommended setting.
+
+### Migrate layered overrides
+
+Use repeated `--input` arguments and `--output-dir` to keep layered overrides separate.
+
+From the directory containing your 8.9 `base.yaml` and `production.yaml` overrides, create a separate output directory and run:
+
+```bash
+mkdir -p migrated
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  --env TMPDIR=/output \
+  -v "$PWD":/input:ro \
+  -v "$PWD/migrated":/output \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /input/base.yaml --input /input/production.yaml \
+  --source 8.9 --target 8.10 \
+  --output-dir /output \
+  --output-format markdown --report-file /output/migration-report.md
+```
+
+The container runs with your user and group IDs so it can write to the output mount. `TMPDIR=/output` keeps temporary files on the same filesystem as the output, which is required when the toolkit moves completed files into place. The toolkit writes `migrated/base.yaml` and `migrated/production.yaml`, without merging them. Input basenames must be unique. Use a separate output directory for each migration to avoid replacing earlier results.
+
+When you continue with the Helm upgrade guide, pass the migrated overrides in the same order: `-f migrated/base.yaml -f migrated/production.yaml`. Later files still take precedence on shared keys.
+
+### Continue across additional versions
+
+Review and correct each migrated output before using it as the next migration's input.
+
+For example, to prepare 8.7 overrides for 8.9, run 8.7 to 8.8 first, then 8.8 to 8.9. Preparing files for several versions doesn't let you skip deployment upgrades or intermediate data migrations. Follow each version's upgrade guide in order.
+
+## Validate override files
+
+Run `validate` to check an existing or edited override without migrating it.
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT validate \
+  --input /work/values-8.10.yaml --target 8.10 \
+  --output-format markdown
+```
+
+Validation checks the keys your file contains for types, unsupported or deprecated settings, and configuration rules. It doesn't require an override to contain every chart setting. Each file is checked separately, not as the merged result of all Helm layers.
+
+A clean report doesn't prove deployment readiness. Validation doesn't check live Kubernetes resources, stored data, all cross-file requirements, or whether the complete configuration renders and runs successfully. Review the findings, render or test the complete configuration, and follow the upgrade guide's required checks.
+
+## Interpret reports and exit codes
+
+Reports identify changes, warnings, and validation errors that need review before deployment.
+
+| Option            | Purpose                                                                   |
+| ----------------- | ------------------------------------------------------------------------- |
+| `--output-format` | Select `json` (default), `yaml`, or `markdown` for the report.            |
+| `--report-file`   | Save the report to a container path on a writable host-mounted directory. |
+| `--strict`        | Treat warnings as validation errors when choosing the exit code.          |
+
+Without `--report-file`, reports go to standard output, except when `migrate --output -` reserves it for YAML. The one-line summary goes to standard error.
+
+| Exit code | Meaning                                               |
+| --------- | ----------------------------------------------------- |
+| `0`       | No warnings or errors.                                |
+| `1`       | Tool or usage failure; don't rely on the output.      |
+| `2`       | Warnings or manual follow-up required.                |
+| `3`       | Validation errors, or warnings when using `--strict`. |
+
+Inspect both the migrated YAML and the report. Some findings recommend changes the toolkit can't safely automate. For all command options, run `docker run --rm camunda/camunda-helm-toolkit:SNAPSHOT migrate --help` or replace `migrate` with `validate`.
+
+## Keep configuration local
+
+With the local Docker setup above, your YAML is processed by the container on your machine.
+
+The Web UI has no authentication. Keep the `127.0.0.1` port binding and don't expose the service on a shared network. Downloading the image requires registry access; processing files doesn't require access to your Kubernetes cluster.
+
+Treat input files, migrated files, and reports as potentially sensitive. They can contain configuration values, including credentials. Review them before sharing or committing them.
+
+After reviewing the results, continue with [upgrading Camunda 8.9 to 8.10 using Helm](/self-managed/upgrade/helm/890-to-8100.md). The toolkit doesn't replace backups, non-production testing, or the required deployment and data-migration steps.

--- a/docs/self-managed/upgrade/helm/890-to-8100.md
+++ b/docs/self-managed/upgrade/helm/890-to-8100.md
@@ -38,7 +38,7 @@ Before upgrading, ensure you have met the following prerequisites:
 
 Use your existing 8.9 configuration as the starting point for the upgrade.
 
-1. Copy your current `values.yaml` and name the file `values-8.10.yaml`.
+1. Create `values-8.10.yaml` from your existing overrides. Copy the original file, or use the [Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md) with source `8.9` and target `8.10` to migrate supported settings. Review its findings and complete the required configuration changes below; toolkit support for 8.10 is preliminary.
 
 1. Download the default values for the Camunda 8.10 Helm chart:
 

--- a/docs/self-managed/upgrade/helm/index.md
+++ b/docs/self-managed/upgrade/helm/index.md
@@ -91,5 +91,6 @@ If you previously set `webModeler.persistence.enabled: true` without `existingCl
 
 ## Related resources
 
+- [Migrate and validate Helm overrides with the Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md)
 - [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)
 - [Component upgrade from 8.9 to 8.10](../components/890-to-8100.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -1944,6 +1944,7 @@ module.exports = {
                 "self-managed/deployment/helm/operational-tasks/dual-region-operational-procedure",
                 "self-managed/deployment/helm/operational-tasks/helm-v4",
                 "self-managed/deployment/helm/operational-tasks/moving-helm-v3-to-v4",
+                "self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit",
               ],
             },
             {

--- a/versioned_docs/version-8.7/self-managed/setup/guides/camunda-helm-toolkit.md
+++ b/versioned_docs/version-8.7/self-managed/setup/guides/camunda-helm-toolkit.md
@@ -1,0 +1,154 @@
+---
+id: camunda-helm-toolkit
+title: "Use the Camunda Helm Toolkit"
+sidebar_label: "Helm values toolkit"
+description: "Prepare Camunda 8.7 Helm overrides for 8.8 with the local Web UI or Docker CLI, and validate the migrated configuration."
+---
+
+Use the Camunda Helm Toolkit to prepare your Helm override files for an upgrade from Camunda 8.7 to 8.8.
+
+The toolkit rewrites supported configuration keys and reports changes that need your attention. It doesn't upgrade your deployment, migrate stored data, or replace the <a href="/docs/8.8/self-managed/upgrade/helm/870-to-880/" target="_blank" rel="noopener noreferrer">Helm upgrade procedure for 8.7 to 8.8</a>.
+
+## Check version compatibility
+
+Migrate one adjacent Camunda minor version at a time, then review the output before continuing.
+
+| Source version | Migration target | Post-migration validation |
+| -------------- | ---------------- | ------------------------- |
+| 8.7            | 8.8              | 8.8                       |
+| 8.8            | 8.9              | 8.9                       |
+| 8.9            | 8.10             | 8.10                      |
+
+Standalone validation supports 8.8, 8.9, and 8.10. You can't validate an 8.7 file directly; migrate it to 8.8 first. Support for 8.10 is preliminary, and some changes require manual configuration. The toolkit doesn't migrate from versions earlier than 8.7.
+
+The source and target arguments are Camunda versions, such as `8.7`, not Helm chart versions, such as `12.x`. Use the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) to identify your deployment's Camunda version.
+
+## Prepare your files
+
+Provide your own override files, such as the files you pass to Helm with `-f`, rather than the chart's default `values.yaml`.
+
+- Install Docker and use a local Docker daemon with Linux containers.
+- Keep a copy of your original overrides. For layered configurations, keep the files separate and record their Helm `-f` order.
+- Identify the source and target Camunda versions. The examples on this page migrate 8.7 overrides to 8.8.
+
+The examples use the [public Docker image](https://hub.docker.com/r/camunda/camunda-helm-toolkit/tags). Its `SNAPSHOT` tag is a rolling build, not a versioned release, and can change between pulls. The CLI examples use a POSIX-compatible shell on macOS or Linux. The Web UI avoids host-path mount commands.
+
+## Use the local Web UI
+
+Start the toolkit in Docker to migrate and validate files through your browser.
+
+```bash
+docker run --rm --pull always \
+  -p 127.0.0.1:8080:8080 \
+  camunda/camunda-helm-toolkit:SNAPSHOT
+```
+
+Open [the local toolkit](http://localhost:8080) in your browser. If port 8080 is occupied, change the first port in the mapping and use that port in the browser URL.
+
+1. Select **Migrate** and upload or paste your override files.
+2. Select source version **8.7**. The toolkit chooses the next minor version, **8.8**, as the target.
+3. Run the migration and review the findings alongside the YAML. Select a finding to locate the affected configuration.
+4. Select the target-version document to inspect the migrated output. To correct it, select **Edit migrated**, make your changes, and select **Validate again**.
+5. Download each migrated document. The download uses the document currently displayed, so confirm you're viewing the target version rather than the original input.
+
+To check the migrated or edited 8.8 configuration without migrating again, select **Validate**, provide the 8.8 overrides, and choose **8.8**. Don't select 8.8 for an unmigrated 8.7 file. Stop the container with `Ctrl+C` when you're finished.
+
+## Migrate from the CLI
+
+Run `migrate` to create an updated override file without modifying your source file.
+
+From the directory containing `values-8.7.yaml`, run:
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /work/values-8.7.yaml \
+  --source 8.7 --target 8.8 \
+  --output - > values-8.8.yaml
+```
+
+The container uses your user and group IDs and `/tmp` as its working directory. The input directory is mounted read-only. Docker writes the migrated YAML to standard output, and your shell saves it on the host. Choose a new output filename: shell redirection replaces an existing file, so never redirect to an input file.
+
+With `--output -`, the report and summary go to standard error, separate from the YAML. A completed migration can produce output and still exit with warnings or validation errors. Check the exit code and findings before using the output; a tool failure can leave an empty redirected file.
+
+Migration automatically validates each output against its target version. It changes keys present in your overrides, but doesn't add the target chart's defaults or automatically apply every recommended setting.
+
+### Migrate layered overrides
+
+Use repeated `--input` arguments and `--output-dir` to keep layered overrides separate.
+
+From the directory containing your 8.7 `base.yaml` and `production.yaml` overrides, create a separate output directory and run:
+
+```bash
+mkdir -p migrated
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  --env TMPDIR=/output \
+  -v "$PWD":/input:ro \
+  -v "$PWD/migrated":/output \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /input/base.yaml --input /input/production.yaml \
+  --source 8.7 --target 8.8 \
+  --output-dir /output \
+  --output-format markdown --report-file /output/migration-report.md
+```
+
+The container runs with your user and group IDs so it can write to the output mount. `TMPDIR=/output` keeps temporary files on the same filesystem as the output, which is required when the toolkit moves completed files into place. The toolkit writes `migrated/base.yaml` and `migrated/production.yaml`, without merging them. Input basenames must be unique. Use a separate output directory for each migration to avoid replacing earlier results.
+
+When you continue with the Helm upgrade guide, pass the migrated overrides in the same order: `-f migrated/base.yaml -f migrated/production.yaml`. Later files still take precedence on shared keys.
+
+### Continue across additional versions
+
+Review and correct each migrated output before using it as the next migration's input.
+
+For example, to prepare 8.7 overrides for 8.9, run 8.7 to 8.8 first, then 8.8 to 8.9. Preparing files for several versions doesn't let you skip deployment upgrades or intermediate data migrations. Follow each version's upgrade guide in order.
+
+## Validate override files
+
+Run `validate` to check the migrated or edited 8.8 override, not the original 8.7 file.
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT validate \
+  --input /work/values-8.8.yaml --target 8.8 \
+  --output-format markdown
+```
+
+Validation checks the keys your file contains for types, unsupported or deprecated settings, and configuration rules. It doesn't require an override to contain every chart setting. Each file is checked separately, not as the merged result of all Helm layers.
+
+A clean report doesn't prove deployment readiness. Validation doesn't check live Kubernetes resources, stored data, all cross-file requirements, or whether the complete configuration renders and runs successfully. Review the findings, render or test the complete configuration, and follow the upgrade guide's required checks.
+
+## Interpret reports and exit codes
+
+Reports identify changes, warnings, and validation errors that need review before deployment.
+
+| Option            | Purpose                                                                   |
+| ----------------- | ------------------------------------------------------------------------- |
+| `--output-format` | Select `json` (default), `yaml`, or `markdown` for the report.            |
+| `--report-file`   | Save the report to a container path on a writable host-mounted directory. |
+| `--strict`        | Treat warnings as validation errors when choosing the exit code.          |
+
+Without `--report-file`, reports go to standard output, except when `migrate --output -` reserves it for YAML. The one-line summary goes to standard error.
+
+| Exit code | Meaning                                               |
+| --------- | ----------------------------------------------------- |
+| `0`       | No warnings or errors.                                |
+| `1`       | Tool or usage failure; don't rely on the output.      |
+| `2`       | Warnings or manual follow-up required.                |
+| `3`       | Validation errors, or warnings when using `--strict`. |
+
+Inspect both the migrated YAML and the report. Some findings recommend changes the toolkit can't safely automate. For all command options, run `docker run --rm camunda/camunda-helm-toolkit:SNAPSHOT migrate --help` or replace `migrate` with `validate`.
+
+## Keep configuration local
+
+With the local Docker setup above, your YAML is processed by the container on your machine.
+
+The Web UI has no authentication. Keep the `127.0.0.1` port binding and don't expose the service on a shared network. Downloading the image requires registry access; processing files doesn't require access to your Kubernetes cluster.
+
+Treat input files, migrated files, and reports as potentially sensitive. They can contain configuration values, including credentials. Review them before sharing or committing them.
+
+After reviewing the results, continue with <a href="/docs/8.8/self-managed/upgrade/helm/870-to-880/" target="_blank" rel="noopener noreferrer">upgrading Camunda 8.7 to 8.8 using Helm</a>. The toolkit doesn't replace backups, non-production testing, or the required deployment and data-migration steps.

--- a/versioned_docs/version-8.7/self-managed/setup/upgrade.md
+++ b/versioned_docs/version-8.7/self-managed/setup/upgrade.md
@@ -52,6 +52,8 @@ If you are still using a Camunda Helm chart that references the old repository, 
 
 Configuration adjustments may be required when upgrading to a new version of the Helm chart. Before beginning your upgrade, ensure you have implemented any changes required by your new version.
 
+For an upgrade from 8.7 to 8.8, you can [prepare your overrides with the Camunda Helm Toolkit](guides/camunda-helm-toolkit.md#migrate-from-the-cli). Review its findings and follow the 8.8 upgrade procedure linked from that guide. The toolkit doesn't handle the earlier upgrade paths described below or validate an unmigrated 8.7 file.
+
 :::note
 With the 8.7 release, no special configuration is required to update Helm from 8.6 to 8.7. Review the full [8.6 to 8.7 update guide](/self-managed/operational-guides/update-guide/860-to-870.md) for additional details.
 :::

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/chart-parameters.md
@@ -78,6 +78,8 @@ You can use these files individually or combine them with your own overrides.
 To customize parameters, create an override file (for example, `my-overrides.yaml`) with custom settings.  
 This approach is recommended over editing `values.yaml` directly.
 
+You can [validate the keys in your overrides with the Camunda Helm Toolkit](operational-tasks/camunda-helm-toolkit.md#validate-override-files). This checks the supplied configuration, not the completeness or deployment readiness of all merged Helm values.
+
 ### Combining multiple values files
 
 Helm lets you specify multiple values files. You can layer them to build the configuration you need:

--- a/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md
+++ b/versioned_docs/version-8.8/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md
@@ -1,0 +1,154 @@
+---
+id: camunda-helm-toolkit
+title: "Use the Camunda Helm Toolkit"
+sidebar_label: "Helm values toolkit"
+description: "Migrate and validate Camunda Helm override files with the local Web UI or Docker CLI, then review findings before upgrading."
+---
+
+Use the Camunda Helm Toolkit to migrate Helm override files between Camunda versions and check their configuration.
+
+The toolkit rewrites supported configuration keys and reports changes that need your attention. It doesn't upgrade your deployment, migrate stored data, or replace the [Helm upgrade procedure](/self-managed/upgrade/helm/870-to-880.md).
+
+## Check version compatibility
+
+Migrate one adjacent Camunda minor version at a time, then review the output before continuing.
+
+| Source version | Migration target | Post-migration validation |
+| -------------- | ---------------- | ------------------------- |
+| 8.7            | 8.8              | 8.8                       |
+| 8.8            | 8.9              | 8.9                       |
+| 8.9            | 8.10             | 8.10                      |
+
+Standalone validation supports 8.8, 8.9, and 8.10. You can't validate an 8.7 file directly; migrate it to 8.8 first. Support for 8.10 is preliminary, and some changes require manual configuration.
+
+The source and target arguments are Camunda versions, such as `8.7`, not Helm chart versions, such as `12.x`. Use the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) to identify your deployment's Camunda version.
+
+## Prepare your files
+
+Provide your own override files, such as the files you pass to Helm with `-f`, rather than the chart's default `values.yaml`.
+
+- Install Docker and use a local Docker daemon with Linux containers.
+- Keep a copy of your original overrides. For layered configurations, keep the files separate and record their Helm `-f` order.
+- Identify the source and target Camunda versions. The examples on this page migrate 8.7 overrides to 8.8.
+
+The examples use the [public Docker image](https://hub.docker.com/r/camunda/camunda-helm-toolkit/tags). Its `SNAPSHOT` tag is a rolling build, not a versioned release, and can change between pulls. The CLI examples use a POSIX-compatible shell on macOS or Linux. The Web UI avoids host-path mount commands.
+
+## Use the local Web UI
+
+Start the toolkit in Docker to migrate and validate files through your browser.
+
+```bash
+docker run --rm --pull always \
+  -p 127.0.0.1:8080:8080 \
+  camunda/camunda-helm-toolkit:SNAPSHOT
+```
+
+Open [the local toolkit](http://localhost:8080) in your browser. If port 8080 is occupied, change the first port in the mapping and use that port in the browser URL.
+
+1. Select **Migrate** and upload or paste your override files.
+2. Select source version **8.7**. The toolkit chooses the next minor version, **8.8**, as the target.
+3. Run the migration and review the findings alongside the YAML. Select a finding to locate the affected configuration.
+4. Select the target-version document to inspect the migrated output. To correct it, select **Edit migrated**, make your changes, and select **Validate again**.
+5. Download each migrated document. The download uses the document currently displayed, so confirm you're viewing the target version rather than the original input.
+
+For a configuration check without migration, select **Validate**, provide your overrides, and choose their Camunda version. Stop the container with `Ctrl+C` when you're finished.
+
+## Migrate from the CLI
+
+Run `migrate` to create an updated override file without modifying your source file.
+
+From the directory containing `values-8.7.yaml`, run:
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /work/values-8.7.yaml \
+  --source 8.7 --target 8.8 \
+  --output - > values-8.8.yaml
+```
+
+The container uses your user and group IDs and `/tmp` as its working directory. The input directory is mounted read-only. Docker writes the migrated YAML to standard output, and your shell saves it on the host. Choose a new output filename: shell redirection replaces an existing file, so never redirect to an input file.
+
+With `--output -`, the report and summary go to standard error, separate from the YAML. A completed migration can produce output and still exit with warnings or validation errors. Check the exit code and findings before using the output; a tool failure can leave an empty redirected file.
+
+Migration automatically validates each output against its target version. It changes keys present in your overrides, but doesn't add the target chart's defaults or automatically apply every recommended setting.
+
+### Migrate layered overrides
+
+Use repeated `--input` arguments and `--output-dir` to keep layered overrides separate.
+
+From the directory containing your 8.7 `base.yaml` and `production.yaml` overrides, create a separate output directory and run:
+
+```bash
+mkdir -p migrated
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  --env TMPDIR=/output \
+  -v "$PWD":/input:ro \
+  -v "$PWD/migrated":/output \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /input/base.yaml --input /input/production.yaml \
+  --source 8.7 --target 8.8 \
+  --output-dir /output \
+  --output-format markdown --report-file /output/migration-report.md
+```
+
+The container runs with your user and group IDs so it can write to the output mount. `TMPDIR=/output` keeps temporary files on the same filesystem as the output, which is required when the toolkit moves completed files into place. The toolkit writes `migrated/base.yaml` and `migrated/production.yaml`, without merging them. Input basenames must be unique. Use a separate output directory for each migration to avoid replacing earlier results.
+
+When you continue with the Helm upgrade guide, pass the migrated overrides in the same order: `-f migrated/base.yaml -f migrated/production.yaml`. Later files still take precedence on shared keys.
+
+### Continue across additional versions
+
+Review and correct each migrated output before using it as the next migration's input.
+
+For example, to prepare 8.7 overrides for 8.9, run 8.7 to 8.8 first, then 8.8 to 8.9. Preparing files for several versions doesn't let you skip deployment upgrades or intermediate data migrations. Follow each version's upgrade guide in order.
+
+## Validate override files
+
+Run `validate` to check an existing or edited override without migrating it.
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT validate \
+  --input /work/values-8.8.yaml --target 8.8 \
+  --output-format markdown
+```
+
+Validation checks the keys your file contains for types, unsupported or deprecated settings, and configuration rules. It doesn't require an override to contain every chart setting. Each file is checked separately, not as the merged result of all Helm layers.
+
+A clean report doesn't prove deployment readiness. Validation doesn't check live Kubernetes resources, stored data, all cross-file requirements, or whether the complete configuration renders and runs successfully. Review the findings, render or test the complete configuration, and follow the upgrade guide's required checks.
+
+## Interpret reports and exit codes
+
+Reports identify changes, warnings, and validation errors that need review before deployment.
+
+| Option            | Purpose                                                                   |
+| ----------------- | ------------------------------------------------------------------------- |
+| `--output-format` | Select `json` (default), `yaml`, or `markdown` for the report.            |
+| `--report-file`   | Save the report to a container path on a writable host-mounted directory. |
+| `--strict`        | Treat warnings as validation errors when choosing the exit code.          |
+
+Without `--report-file`, reports go to standard output, except when `migrate --output -` reserves it for YAML. The one-line summary goes to standard error.
+
+| Exit code | Meaning                                               |
+| --------- | ----------------------------------------------------- |
+| `0`       | No warnings or errors.                                |
+| `1`       | Tool or usage failure; don't rely on the output.      |
+| `2`       | Warnings or manual follow-up required.                |
+| `3`       | Validation errors, or warnings when using `--strict`. |
+
+Inspect both the migrated YAML and the report. Some findings recommend changes the toolkit can't safely automate. For all command options, run `docker run --rm camunda/camunda-helm-toolkit:SNAPSHOT migrate --help` or replace `migrate` with `validate`.
+
+## Keep configuration local
+
+With the local Docker setup above, your YAML is processed by the container on your machine.
+
+The Web UI has no authentication. Keep the `127.0.0.1` port binding and don't expose the service on a shared network. Downloading the image requires registry access; processing files doesn't require access to your Kubernetes cluster.
+
+Treat input files, migrated files, and reports as potentially sensitive. They can contain configuration values, including credentials. Review them before sharing or committing them.
+
+After reviewing the results, continue with [upgrading Camunda 8.7 to 8.8 using Helm](/self-managed/upgrade/helm/870-to-880.md). The toolkit doesn't replace backups, non-production testing, or the required deployment and data-migration steps.

--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880-dual-region.md
@@ -16,6 +16,8 @@ Upgrading a Helm-based dual-region Camunda 8 Self-Managed deployment from 8.7 to
 
 1. If your deployment requires component-specific upgrade steps, also review the [component upgrade guide](../components/870-to-880.md).
 
+You can use the [Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md#migrate-layered-overrides) with source `8.7` and target `8.8` to prepare copies of your regional override files. Review the output and findings. The toolkit doesn't replace the manual exporter configuration, regional coordination, or data-migration steps in these guides.
+
 :::info
 Dual-region deployments, as described in [dual-region setup](/self-managed/deployment/helm/cloud-providers/amazon/amazon-eks/dual-region.md), require manual exporter configuration.
 :::

--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/870-to-880.md
@@ -38,7 +38,7 @@ Before upgrading, ensure you have met the following prerequisites:
 
 Use your existing 8.7 configuration as the starting point for the upgrade.
 
-1. Copy your current `values.yaml` and name the file `values-8.8.yaml`.
+1. Create `values-8.8.yaml` from your existing overrides. Copy the original file, or use the [Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md) with source `8.7` and target `8.8` to migrate supported settings. Review its findings and complete the required configuration changes below.
 
 1. Download the default values for the Camunda 8.8 Helm chart:
 

--- a/versioned_docs/version-8.8/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.8/self-managed/upgrade/helm/index.md
@@ -48,5 +48,6 @@ See the [Bitnami GitHub announcement](https://github.com/bitnami/containers/issu
 
 ## Related resources
 
+- [Migrate and validate Helm overrides with the Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md)
 - [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)
 - [Component upgrade from 8.7 to 8.8](/self-managed/upgrade/components/870-to-880.md)

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/chart-parameters.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/chart-parameters.md
@@ -90,6 +90,8 @@ You can use these files individually or combine them with your own overrides.
 To customize parameters, create an override file (for example, `my-overrides.yaml`) with custom settings.  
 This approach is recommended over editing `values.yaml` directly.
 
+You can [validate the keys in your overrides with the Camunda Helm Toolkit](operational-tasks/camunda-helm-toolkit.md#validate-override-files). This checks the supplied configuration, not the completeness or deployment readiness of all merged Helm values.
+
 ### Combining multiple values files
 
 Helm lets you specify multiple values files. You can layer them to build the configuration you need:

--- a/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md
+++ b/versioned_docs/version-8.9/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md
@@ -1,0 +1,154 @@
+---
+id: camunda-helm-toolkit
+title: "Use the Camunda Helm Toolkit"
+sidebar_label: "Helm values toolkit"
+description: "Migrate and validate Camunda Helm override files with the local Web UI or Docker CLI, then review findings before upgrading."
+---
+
+Use the Camunda Helm Toolkit to migrate Helm override files between Camunda versions and check their configuration.
+
+The toolkit rewrites supported configuration keys and reports changes that need your attention. It doesn't upgrade your deployment, migrate stored data, or replace the [Helm upgrade procedure](/self-managed/upgrade/helm/880-to-890.md).
+
+## Check version compatibility
+
+Migrate one adjacent Camunda minor version at a time, then review the output before continuing.
+
+| Source version | Migration target | Post-migration validation |
+| -------------- | ---------------- | ------------------------- |
+| 8.7            | 8.8              | 8.8                       |
+| 8.8            | 8.9              | 8.9                       |
+| 8.9            | 8.10             | 8.10                      |
+
+Standalone validation supports 8.8, 8.9, and 8.10. You can't validate an 8.7 file directly; migrate it to 8.8 first. Support for 8.10 is preliminary, and some changes require manual configuration.
+
+The source and target arguments are Camunda versions, such as `8.8`, not Helm chart versions, such as `13.x`. Use the [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) to identify your deployment's Camunda version.
+
+## Prepare your files
+
+Provide your own override files, such as the files you pass to Helm with `-f`, rather than the chart's default `values.yaml`.
+
+- Install Docker and use a local Docker daemon with Linux containers.
+- Keep a copy of your original overrides. For layered configurations, keep the files separate and record their Helm `-f` order.
+- Identify the source and target Camunda versions. The examples on this page migrate 8.8 overrides to 8.9.
+
+The examples use the [public Docker image](https://hub.docker.com/r/camunda/camunda-helm-toolkit/tags). Its `SNAPSHOT` tag is a rolling build, not a versioned release, and can change between pulls. The CLI examples use a POSIX-compatible shell on macOS or Linux. The Web UI avoids host-path mount commands.
+
+## Use the local Web UI
+
+Start the toolkit in Docker to migrate and validate files through your browser.
+
+```bash
+docker run --rm --pull always \
+  -p 127.0.0.1:8080:8080 \
+  camunda/camunda-helm-toolkit:SNAPSHOT
+```
+
+Open [the local toolkit](http://localhost:8080) in your browser. If port 8080 is occupied, change the first port in the mapping and use that port in the browser URL.
+
+1. Select **Migrate** and upload or paste your override files.
+2. Select source version **8.8**. The toolkit chooses the next minor version, **8.9**, as the target.
+3. Run the migration and review the findings alongside the YAML. Select a finding to locate the affected configuration.
+4. Select the target-version document to inspect the migrated output. To correct it, select **Edit migrated**, make your changes, and select **Validate again**.
+5. Download each migrated document. The download uses the document currently displayed, so confirm you're viewing the target version rather than the original input.
+
+For a configuration check without migration, select **Validate**, provide your overrides, and choose their Camunda version. Stop the container with `Ctrl+C` when you're finished.
+
+## Migrate from the CLI
+
+Run `migrate` to create an updated override file without modifying your source file.
+
+From the directory containing `values-8.8.yaml`, run:
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /work/values-8.8.yaml \
+  --source 8.8 --target 8.9 \
+  --output - > values-8.9.yaml
+```
+
+The container uses your user and group IDs and `/tmp` as its working directory. The input directory is mounted read-only. Docker writes the migrated YAML to standard output, and your shell saves it on the host. Choose a new output filename: shell redirection replaces an existing file, so never redirect to an input file.
+
+With `--output -`, the report and summary go to standard error, separate from the YAML. A completed migration can produce output and still exit with warnings or validation errors. Check the exit code and findings before using the output; a tool failure can leave an empty redirected file.
+
+Migration automatically validates each output against its target version. It changes keys present in your overrides, but doesn't add the target chart's defaults or automatically apply every recommended setting.
+
+### Migrate layered overrides
+
+Use repeated `--input` arguments and `--output-dir` to keep layered overrides separate.
+
+From the directory containing your 8.8 `base.yaml` and `production.yaml` overrides, create a separate output directory and run:
+
+```bash
+mkdir -p migrated
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  --env TMPDIR=/output \
+  -v "$PWD":/input:ro \
+  -v "$PWD/migrated":/output \
+  camunda/camunda-helm-toolkit:SNAPSHOT migrate \
+  --input /input/base.yaml --input /input/production.yaml \
+  --source 8.8 --target 8.9 \
+  --output-dir /output \
+  --output-format markdown --report-file /output/migration-report.md
+```
+
+The container runs with your user and group IDs so it can write to the output mount. `TMPDIR=/output` keeps temporary files on the same filesystem as the output, which is required when the toolkit moves completed files into place. The toolkit writes `migrated/base.yaml` and `migrated/production.yaml`, without merging them. Input basenames must be unique. Use a separate output directory for each migration to avoid replacing earlier results.
+
+When you continue with the Helm upgrade guide, pass the migrated overrides in the same order: `-f migrated/base.yaml -f migrated/production.yaml`. Later files still take precedence on shared keys.
+
+### Continue across additional versions
+
+Review and correct each migrated output before using it as the next migration's input.
+
+For example, to prepare 8.7 overrides for 8.9, run 8.7 to 8.8 first, then 8.8 to 8.9. Preparing files for several versions doesn't let you skip deployment upgrades or intermediate data migrations. Follow each version's upgrade guide in order.
+
+## Validate override files
+
+Run `validate` to check an existing or edited override without migrating it.
+
+```bash
+docker run --rm --pull always \
+  --user "$(id -u):$(id -g)" --workdir /tmp \
+  -v "$PWD":/work:ro \
+  camunda/camunda-helm-toolkit:SNAPSHOT validate \
+  --input /work/values-8.9.yaml --target 8.9 \
+  --output-format markdown
+```
+
+Validation checks the keys your file contains for types, unsupported or deprecated settings, and configuration rules. It doesn't require an override to contain every chart setting. Each file is checked separately, not as the merged result of all Helm layers.
+
+A clean report doesn't prove deployment readiness. Validation doesn't check live Kubernetes resources, stored data, all cross-file requirements, or whether the complete configuration renders and runs successfully. Review the findings, render or test the complete configuration, and follow the upgrade guide's required checks.
+
+## Interpret reports and exit codes
+
+Reports identify changes, warnings, and validation errors that need review before deployment.
+
+| Option            | Purpose                                                                   |
+| ----------------- | ------------------------------------------------------------------------- |
+| `--output-format` | Select `json` (default), `yaml`, or `markdown` for the report.            |
+| `--report-file`   | Save the report to a container path on a writable host-mounted directory. |
+| `--strict`        | Treat warnings as validation errors when choosing the exit code.          |
+
+Without `--report-file`, reports go to standard output, except when `migrate --output -` reserves it for YAML. The one-line summary goes to standard error.
+
+| Exit code | Meaning                                               |
+| --------- | ----------------------------------------------------- |
+| `0`       | No warnings or errors.                                |
+| `1`       | Tool or usage failure; don't rely on the output.      |
+| `2`       | Warnings or manual follow-up required.                |
+| `3`       | Validation errors, or warnings when using `--strict`. |
+
+Inspect both the migrated YAML and the report. Some findings recommend changes the toolkit can't safely automate. For all command options, run `docker run --rm camunda/camunda-helm-toolkit:SNAPSHOT migrate --help` or replace `migrate` with `validate`.
+
+## Keep configuration local
+
+With the local Docker setup above, your YAML is processed by the container on your machine.
+
+The Web UI has no authentication. Keep the `127.0.0.1` port binding and don't expose the service on a shared network. Downloading the image requires registry access; processing files doesn't require access to your Kubernetes cluster.
+
+Treat input files, migrated files, and reports as potentially sensitive. They can contain configuration values, including credentials. Review them before sharing or committing them.
+
+After reviewing the results, continue with [upgrading Camunda 8.8 to 8.9 using Helm](/self-managed/upgrade/helm/880-to-890.md). The toolkit doesn't replace backups, non-production testing, or the required deployment and data-migration steps.

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/880-to-890.md
@@ -41,7 +41,7 @@ Before upgrading, ensure you have met the following prerequisites:
 
 Use your existing 8.8 configuration as the starting point for the upgrade.
 
-1. Copy your current `values.yaml` and name the file `values-8.9.yaml`.
+1. Create `values-8.9.yaml` from your existing overrides. Copy the original file, or use the [Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md) with source `8.8` and target `8.9` to migrate supported settings. Review its findings and complete the required configuration changes below.
 
 1. Download the default values for the Camunda 8.9 Helm chart:
 

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/890-to-8100.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/890-to-8100.md
@@ -38,7 +38,7 @@ Before upgrading, ensure you have met the following prerequisites:
 
 Use your existing 8.9 configuration as the starting point for the upgrade.
 
-1. Copy your current `values.yaml` and name the file `values-8.10.yaml`.
+1. Create `values-8.10.yaml` from your existing overrides. Copy the original file, or use the [Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md) with source `8.9` and target `8.10` to migrate supported settings. Review its findings and complete the required configuration changes below; toolkit support for 8.10 is preliminary.
 
 1. Download the default values for the Camunda 8.10 Helm chart:
 

--- a/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
+++ b/versioned_docs/version-8.9/self-managed/upgrade/helm/index.md
@@ -91,5 +91,6 @@ If you previously set `webModeler.persistence.enabled: true` without `existingCl
 
 ## Related resources
 
+- [Migrate and validate Helm overrides with the Camunda Helm Toolkit](/self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit.md)
 - [Helm chart version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)
 - [Component upgrade from 8.8 to 8.9](/self-managed/upgrade/components/880-to-890.md)

--- a/versioned_sidebars/version-8.7-sidebars.json
+++ b/versioned_sidebars/version-8.7-sidebars.json
@@ -1943,6 +1943,7 @@
             "id": "self-managed/setup/guides/guides"
           },
           "items": [
+            "self-managed/setup/guides/camunda-helm-toolkit",
             "self-managed/setup/guides/accessing-components-without-ingress",
             "self-managed/setup/guides/ingress-setup",
             "self-managed/setup/guides/gateway-api-setup",

--- a/versioned_sidebars/version-8.8-sidebars.json
+++ b/versioned_sidebars/version-8.8-sidebars.json
@@ -3053,6 +3053,7 @@
                 "id": "self-managed/deployment/helm/operational-tasks/index"
               },
               "items": [
+                "self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit",
                 "self-managed/deployment/helm/operational-tasks/diagnostics",
                 "self-managed/deployment/helm/operational-tasks/dual-region-operational-procedure"
               ]

--- a/versioned_sidebars/version-8.9-sidebars.json
+++ b/versioned_sidebars/version-8.9-sidebars.json
@@ -3657,6 +3657,7 @@
                 "id": "self-managed/deployment/helm/operational-tasks/index"
               },
               "items": [
+                "self-managed/deployment/helm/operational-tasks/camunda-helm-toolkit",
                 {
                   "type": "category",
                   "label": "Migration from Bitnami",


### PR DESCRIPTION
## Description

Add a customer-facing guide for using the Camunda Helm Toolkit to migrate and validate Helm override files through its Docker-based local Web UI and CLI.

- Add the guide and sidebar navigation in Next (8.10), 8.9, 8.8, and 8.7. The 8.7 page covers migration to 8.8, not validation of 8.7 inputs; 8.10 support is explicitly preliminary.
- Link from the applicable Helm upgrade guides, including dual-region preparation, upgrade overviews, and override-file configuration pages. Keep the existing manual upgrade requirements authoritative.
- Cover adjacent-hop migration, layered overrides, automatic and standalone overlay validation, findings, exit codes, and safe file handling. Distinguish values preparation from deployment upgrades and data migration.
- Use the public Docker image, a localhost-only UI binding, read-only inputs, host user IDs, and output-local temporary files for bind-mounted directory output.

Verification covers all twelve CLI command examples from the four pages against the public image, unchanged owner-only input files, separate layered outputs and report order, saved Markdown reports, exit codes and strict mode, and command help. Browser checks cover migration, editing and revalidation, the generated download filename and YAML payload, standalone type-error reporting, and a 390-pixel viewport without horizontal overflow or browser errors.

All twenty changed files pass formatting checks. The four new pages compile as MDX, their shell blocks parse, their sidebar entries resolve, and all eighteen new same-version source links and anchors resolve. The explicit 8.7-to-8.8 cross-version link has a versioned source target. Full-site build and rendered-link validation are provided by the existing docs CI workflows.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [x] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [x] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Changes to **docs infra**, including updates to workflows and adding new npm packages, must be first discussed via issue or #ask-c8-documentation and linked for context.
- [ ] My changes require a [docs infrastructure review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process). (add `dx` label) -->
