### PR TITLE
docs(operate): fix content inaccuracies found during screenshot review

### DIFF
--- a/docs/components/operate/overview/batch-operation-details-overview.md
+++ b/docs/components/operate/overview/batch-operation-details-overview.md
@@ -35,7 +35,7 @@ In the table, you can review these details about each item in the batch operatio
 | Column               | Description                                                                             |
 | -------------------- | --------------------------------------------------------------------------------------- |
 | Process instance key | The key of the process instance. Clicking this opens the process instance details page. |
-| Operation state      | The state of the batch operation item.                                                  |
+| Batch state          | The state of the batch operation item.                                                  |
 | Date                 | The date and time when the operation was performed on this item.                        |
 
 ## Next steps

--- a/docs/components/operate/userguide/basic-operate-navigation.md
+++ b/docs/components/operate/userguide/basic-operate-navigation.md
@@ -22,11 +22,12 @@ To view a deployed process, take the following steps:
 
 Running process instances appear in the **Process Instances** table below the process model. To inspect a specific instance, click the **Process Instance Key**.
 
-The process instance page has three parts:
+The process instance page has four parts:
 
 - A header showing the process instance's key, version, and state.
 - A process diagram showing the instance's current progress.
-- A bottom panel with tabs, including **Details**, **Incidents** (shown only when the instance has an incident), and **Variables**.
+- An **Instance History** panel listing the instance's elements, with search and status filter controls.
+- A bottom panel with tabs: **Variables**, **Listeners**, and **Operations Log** are always available. **Incidents** appears when the instance has one. **Details**, **Input Mappings**, and **Output Mappings** appear once you select a specific element in the diagram.
 
 Click an element in the diagram to select it, then use the tabs in the bottom panel to inspect its details, incidents, and variables. In earlier versions, an element's details and incidents appeared in a metadata popover when you clicked it; the popover is now replaced by the **Details** and **Incidents** tabs. To visualize process instance performance, use [Optimize](/components/optimize/what-is-optimize.md).
 

--- a/docs/components/operate/userguide/manage-batch-operation.md
+++ b/docs/components/operate/userguide/manage-batch-operation.md
@@ -24,6 +24,6 @@ Before you begin, ensure you're [authorized to update batch operations](../overv
 
 To take an action on a batch operation:
 
-1. On the **Processes** page, above the process diagram, click **View batch operations**.
+1. In the left navigation, click **Operations > Batch operations**. For more details, see [monitor batch operations](./monitor-batch-operations.md).
 2. From the **Batch Operations** page, click the operation you want to manage.
 3. On the batch operation details page, on the right side of the page header, click an action, if available.


### PR DESCRIPTION
## Description

Split out of #9840 (Operate screenshot refresh for the new design system): fixes three content inaccuracies surfaced while comparing old and new screenshots. No screenshot changes here — those stay in #9840.

- `overview/batch-operation-details-overview.md`: the items table's state column is labeled **Batch state** in the live UI, not "Operation state".
- `userguide/basic-operate-navigation.md`: the process instance page's part/tab description was outdated — it was missing the **Instance History** panel, and the tab-visibility conditions were wrong (only **Incidents** is conditional on having one; **Details**, **Input Mappings**, and **Output Mappings** are conditional on selecting an element).
- `userguide/manage-batch-operation.md`: step 1 referenced a **View batch operations** button that no longer exists; replaced with the current left-nav **Operations > Batch operations** path.

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
