### PR TITLE
docs(reference): add credential and credential type to the glossary

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -261,6 +261,18 @@ A correlation is an attribute within a [message](#message) that is used to match
 
 - [Message correlation](/components/concepts/messages.md)
 
+### Credential
+
+A reusable set of authentication and connection settings for a job worker, connector, or other element template, so you don't repeat the same settings on every task that asks for them. A credential is selected as a whole on an element template field; the engine resolves the reference at runtime and passes the credential's values, including any secrets, to the job worker or connector.
+
+- [Manage credentials](/components/hub/organization/credentials/index.md)
+
+### Credential type
+
+The shape of a [credential](#credential), such as AWS Credential, REST Authentication, or JDBC Connection. A credential type defines which fields a credential of that type has, and is defined alongside an element template.
+
+- [Credential types](/components/hub/organization/credentials/index.md#credential-types)
+
 ### CSAP CLI
 
 CSAP CLI stands for Camunda SAP Integration Command-Line Interface. It's a standalone tool (`csap`) that simplifies configuring and building Camunda’s SAP integration modules (like the RFC connector, OData connector, and BTP plugin) for deployment.


### PR DESCRIPTION
## Description

Adds **Credential** and **Credential type** entries to the [glossary](https://docs.camunda.io/docs/next/reference/glossary/) for 8.10, since credentials were newly introduced in that release (see [Manage credentials](https://docs.camunda.io/docs/next/components/hub/organization/credentials/)). Both entries link to the credentials page and are placed alphabetically between "Correlation key" and "CSAP CLI".

## When should this change go live?

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [x] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [ ] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [ ] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.
