### PR TITLE
docs(self-managed): announce the ingress-nginx annotation deprecation in the Helm chart [ready]

### DIFF
--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -553,6 +553,44 @@ Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Camunda 8.9 (chart 14.x
 </div>
 <div className="release-announcement-content">
 
+#### Ingress annotation defaults removed from the Helm chart {#ingress-annotation-defaults-removed}
+
+`global.ingress.annotations` and `orchestration.ingress.grpc.annotations` no longer ship ingress-nginx-specific defaults. Both now default to `{}`, so the chart renders no controller-specific configuration unless you ask for it.
+
+Previously these maps carried `nginx.ingress.kubernetes.io/*` values. Helm deep-merges maps, so setting a single annotation of your own still inherited all of them, and they were written onto the `Ingress` whatever `ingressClassName` you configured. Deployments on Contour, Traefik, or any other controller therefore carried dead nginx configuration, and there was no way to remove it short of setting each key to `null`.
+
+**Action:** If you run [ingress-nginx](https://github.com/kubernetes/ingress-nginx), set the annotations explicitly. Two of them carry behavior rather than cosmetics: `backend-protocol: GRPC` is what makes ingress-nginx proxy Zeebe gRPC at all, and `proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
+
+```yaml
+global:
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      # keep in sync with global.config.requestBodySize
+      nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+orchestration:
+  ingress:
+    grpc:
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+```
+
+If you run another Ingress controller, set that controller's equivalents instead. With [Contour](https://projectcontour.io/), the gRPC upstream is declared with `projectcontour.io/upstream-protocol.h2c` on the Orchestration Cluster **Service**, listing the gRPC port, rather than on the Ingress.
+
+<p className="link-arrow">[Ingress setup](/self-managed/deployment/helm/configure/ingress/ingress-setup.md)</p>
+
+</div>
+</div>
+
+<div className="release-announcement-row">
+<div className="release-announcement-badge">
+<span className="badge badge--breaking-change">Breaking change</span>
+</div>
+<div className="release-announcement-content">
+
 #### Individual component Docker images no longer produced
 
 Camunda no longer produces the following individual component Docker images in Camunda 8.10 and later, or in Camunda 8.9 from patch release 8.9.12:

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -591,7 +591,14 @@ orchestration:
 
 Two of those carry behavior rather than cosmetics: `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` is what makes ingress-nginx proxy Zeebe gRPC at all, and `nginx.ingress.kubernetes.io/proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
 
-With [Contour](https://projectcontour.io/), the gRPC upstream is declared with `projectcontour.io/upstream-protocol.h2c` on the Orchestration Cluster **Service**, listing the gRPC port, rather than on the Ingress.
+With [Contour](https://projectcontour.io/), the gRPC upstream is declared with `projectcontour.io/upstream-protocol.h2c` on the Orchestration Cluster **Service**, listing the gRPC port. Set it through `orchestration.service.annotations`, not `orchestration.ingress.grpc.annotations`, which renders on the Ingress:
+
+```yaml
+orchestration:
+  service:
+    annotations:
+      projectcontour.io/upstream-protocol.h2c: "26500"
+```
 
 While the shim is active the chart emits a deprecation warning naming the flag and the removal.
 

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -557,16 +557,18 @@ Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Camunda 8.9 (chart 14.x
 
 The Helm chart used to ship ingress-nginx-specific defaults in `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Helm deep-merges maps, so setting a single annotation of your own still inherited all of them, and they were written onto the `Ingress` whatever `ingressClassName` you configured. On Contour, Traefik, or any other controller they are dead configuration, and removing them meant setting each key to `null`.
 
-From Camunda 8.10 (chart 15.x) those annotations come from a compatibility shim controlled by `global.ingress.nginxCompatAnnotations`, which defaults to `true`. **Nothing changes on upgrade:** the same annotations render, so ingress-nginx deployments are unaffected. The shim is removed in the next major, after which the annotations are opt-in.
+From Camunda 8.10 (chart 15.x) those annotations come from a compatibility shim controlled by `global.compatibility.nginx.renderAnnotations`, which defaults to `true`. **Nothing changes on upgrade:** the same annotations render, so ingress-nginx deployments are unaffected. The shim is removed in the next major, after which the annotations are opt-in.
 
-**Action:** If you run an Ingress controller other than ingress-nginx, set `global.ingress.nginxCompatAnnotations: false` and configure whatever your controller needs through `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Keys you set there always win over the shim.
+**Action:** If you run an Ingress controller other than ingress-nginx, set `global.compatibility.nginx.renderAnnotations: false` and configure whatever your controller needs through `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Keys you set there always win over the shim.
 
 That removes the shim's annotations only. The chart still adds `nginx.ingress.kubernetes.io/backend-protocol` to the dedicated Ingress objects it renders when an upstream TLS mode is enabled through `global.tls.orchestration`, `global.tls.connectors` or `global.tls.optimize`, and only ingress-nginx reads that annotation.
 
 ```yaml
 global:
+  compatibility:
+    nginx:
+      renderAnnotations: false
   ingress:
-    nginxCompatAnnotations: false
     annotations:
       # for example, with Contour
       kubernetes.io/tls-acme: "true"

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -549,17 +549,28 @@ Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Camunda 8.9 (chart 14.x
 
 <div className="release-announcement-row">
 <div className="release-announcement-badge">
-<span className="badge badge--breaking-change">Breaking change</span>
+<span className="badge badge--deprecated">Deprecated</span>
 </div>
 <div className="release-announcement-content">
 
-#### Ingress annotation defaults removed from the Helm chart {#ingress-annotation-defaults-removed}
+#### Ingress-nginx annotation defaults deprecated in the Helm chart {#ingress-annotation-defaults-deprecated}
 
-`global.ingress.annotations` and `orchestration.ingress.grpc.annotations` no longer ship ingress-nginx-specific defaults. Both now default to `{}`, so the chart renders no controller-specific configuration unless you ask for it.
+The Helm chart used to ship ingress-nginx-specific defaults in `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Helm deep-merges maps, so setting a single annotation of your own still inherited all of them, and they were written onto the `Ingress` whatever `ingressClassName` you configured. On Contour, Traefik, or any other controller they are dead configuration, and removing them meant setting each key to `null`.
 
-Previously these maps carried `nginx.ingress.kubernetes.io/*` values. Helm deep-merges maps, so setting a single annotation of your own still inherited all of them, and they were written onto the `Ingress` whatever `ingressClassName` you configured. Deployments on Contour, Traefik, or any other controller therefore carried dead nginx configuration, and there was no way to remove it short of setting each key to `null`.
+From Camunda 8.10 (chart 15.x) those annotations come from a compatibility shim controlled by `global.ingress.nginxCompatAnnotations`, which defaults to `true`. **Nothing changes on upgrade:** the same annotations render, so ingress-nginx deployments are unaffected. The shim is removed in the next major, after which the annotations are opt-in.
 
-**Action:** If you run [ingress-nginx](https://github.com/kubernetes/ingress-nginx), set the annotations explicitly. Two of them carry behavior rather than cosmetics: `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` is what makes ingress-nginx proxy Zeebe gRPC at all, and `nginx.ingress.kubernetes.io/proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
+**Action:** If you run an Ingress controller other than ingress-nginx, set `global.ingress.nginxCompatAnnotations: false` to render controller-neutral `Ingress` objects, and configure whatever your controller needs through `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Keys you set there always win over the shim.
+
+```yaml
+global:
+  ingress:
+    nginxCompatAnnotations: false
+    annotations:
+      # for example, with Contour
+      kubernetes.io/tls-acme: "true"
+```
+
+If you stay on ingress-nginx, no action is required before the next major. When the shim is removed you will need to set the annotations yourself:
 
 ```yaml
 global:
@@ -578,7 +589,11 @@ orchestration:
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 ```
 
-If you run another Ingress controller, set that controller's equivalents instead. With [Contour](https://projectcontour.io/), the gRPC upstream is declared with `projectcontour.io/upstream-protocol.h2c` on the Orchestration Cluster **Service**, listing the gRPC port, rather than on the Ingress.
+Two of those carry behavior rather than cosmetics: `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` is what makes ingress-nginx proxy Zeebe gRPC at all, and `nginx.ingress.kubernetes.io/proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
+
+With [Contour](https://projectcontour.io/), the gRPC upstream is declared with `projectcontour.io/upstream-protocol.h2c` on the Orchestration Cluster **Service**, listing the gRPC port, rather than on the Ingress.
+
+While the shim is active the chart emits a deprecation warning naming the flag and the removal.
 
 <p className="link-arrow">[Ingress setup](/self-managed/deployment/helm/configure/ingress/ingress-setup.md)</p>
 

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -559,7 +559,9 @@ The Helm chart used to ship ingress-nginx-specific defaults in `global.ingress.a
 
 From Camunda 8.10 (chart 15.x) those annotations come from a compatibility shim controlled by `global.ingress.nginxCompatAnnotations`, which defaults to `true`. **Nothing changes on upgrade:** the same annotations render, so ingress-nginx deployments are unaffected. The shim is removed in the next major, after which the annotations are opt-in.
 
-**Action:** If you run an Ingress controller other than ingress-nginx, set `global.ingress.nginxCompatAnnotations: false` to render controller-neutral `Ingress` objects, and configure whatever your controller needs through `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Keys you set there always win over the shim.
+**Action:** If you run an Ingress controller other than ingress-nginx, set `global.ingress.nginxCompatAnnotations: false` and configure whatever your controller needs through `global.ingress.annotations` and `orchestration.ingress.grpc.annotations`. Keys you set there always win over the shim.
+
+That removes the shim's annotations only. The chart still adds `nginx.ingress.kubernetes.io/backend-protocol` to the dedicated Ingress objects it renders when an upstream TLS mode is enabled through `global.tls.orchestration`, `global.tls.connectors` or `global.tls.optimize`, and only ingress-nginx reads that annotation.
 
 ```yaml
 global:
@@ -586,8 +588,12 @@ orchestration:
   ingress:
     grpc:
       annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "false"
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
 ```
+
+The gRPC Ingress reads `orchestration.ingress.grpc.annotations` only; it inherits nothing from `global.ingress.annotations`, so set all three keys there.
 
 Two of those carry behavior rather than cosmetics: `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` is what makes ingress-nginx proxy Zeebe gRPC at all, and `nginx.ingress.kubernetes.io/proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
 

--- a/docs/reference/announcements-release-notes/8100/8100-announcements.md
+++ b/docs/reference/announcements-release-notes/8100/8100-announcements.md
@@ -559,7 +559,7 @@ Camunda 8.10 (chart 15.x) supports the Helm CLI v4 only. Camunda 8.9 (chart 14.x
 
 Previously these maps carried `nginx.ingress.kubernetes.io/*` values. Helm deep-merges maps, so setting a single annotation of your own still inherited all of them, and they were written onto the `Ingress` whatever `ingressClassName` you configured. Deployments on Contour, Traefik, or any other controller therefore carried dead nginx configuration, and there was no way to remove it short of setting each key to `null`.
 
-**Action:** If you run [ingress-nginx](https://github.com/kubernetes/ingress-nginx), set the annotations explicitly. Two of them carry behavior rather than cosmetics: `backend-protocol: GRPC` is what makes ingress-nginx proxy Zeebe gRPC at all, and `proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
+**Action:** If you run [ingress-nginx](https://github.com/kubernetes/ingress-nginx), set the annotations explicitly. Two of them carry behavior rather than cosmetics: `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` is what makes ingress-nginx proxy Zeebe gRPC at all, and `nginx.ingress.kubernetes.io/proxy-buffer-size` is the documented fix for gateway timeouts caused by large JWT `Set-Cookie` headers.
 
 ```yaml
 global:

--- a/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
@@ -17,6 +17,13 @@ Camunda 8 Self-Managed has multiple web applications and gRPC services. You can 
 ## Prerequisites
 
 - An Ingress controller deployed in advance. The examples below use the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), but you can use any Ingress controller by setting `ingress.className`.
+
+:::note Controller annotations are not set for you
+From Camunda 8.10 (chart 15.x), `global.ingress.annotations` and `orchestration.ingress.grpc.annotations` default to `{}`. Earlier chart versions shipped `nginx.ingress.kubernetes.io/*` defaults and rendered them onto every `Ingress`, whatever the configured `ingressClassName`.
+
+Set the annotations your own controller needs. For ingress-nginx that includes `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` on the gRPC Ingress, without which Zeebe gRPC is not proxied at all. See [Ingress annotation defaults removed from the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-removed) for the full set and the equivalents on other controllers.
+:::
+
 - TLS configuration is not included in the examples because it varies between different workflows. Configure TLS in one of these ways:
   - Use `ingress.tls` options directly.
   - Use an external tool such as [Cert-Manager](https://github.com/cert-manager/cert-manager) with `ingress.annotations`.  

--- a/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Self-Managed has multiple web applications and gRPC services. You can 
 ## Prerequisites
 
 - An Ingress controller deployed in advance. The examples below use the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), but you can use any Ingress controller by setting `ingress.className`.
-- The annotations your controller needs. From Camunda 8.10 (chart 15.x), the chart no longer sets any, so see [Ingress annotation defaults removed from the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-removed) for what to set and why.
+- The annotations your controller needs. From Camunda 8.10 (chart 15.x), the ingress-nginx ones come from a compatibility shim that you can turn off with `global.ingress.nginxCompatAnnotations: false`; see [Ingress-nginx annotation defaults deprecated in the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-deprecated).
 - TLS configuration is not included in the examples because it varies between different workflows. Configure TLS in one of these ways:
   - Use `ingress.tls` options directly.
   - Use an external tool such as [Cert-Manager](https://github.com/cert-manager/cert-manager) with `ingress.annotations`.  

--- a/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Self-Managed has multiple web applications and gRPC services. You can 
 ## Prerequisites
 
 - An Ingress controller deployed in advance. The examples below use the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), but you can use any Ingress controller by setting `ingress.className`.
-- The annotations your controller needs. From Camunda 8.10 (chart 15.x), `global.ingress.annotations` and `orchestration.ingress.grpc.annotations` default to `{}`; earlier chart versions shipped `nginx.ingress.kubernetes.io/*` defaults and rendered them onto every `Ingress`, whatever the configured `ingressClassName`. For ingress-nginx this includes `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` on the gRPC Ingress, without which Zeebe gRPC is not proxied at all. See [Ingress annotation defaults removed from the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-removed) for the full set and the equivalents on other controllers.
+- The annotations your controller needs. From Camunda 8.10 (chart 15.x), the chart no longer sets any, so see [Ingress annotation defaults removed from the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-removed) for what to set and why.
 - TLS configuration is not included in the examples because it varies between different workflows. Configure TLS in one of these ways:
   - Use `ingress.tls` options directly.
   - Use an external tool such as [Cert-Manager](https://github.com/cert-manager/cert-manager) with `ingress.annotations`.  

--- a/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
@@ -17,13 +17,7 @@ Camunda 8 Self-Managed has multiple web applications and gRPC services. You can 
 ## Prerequisites
 
 - An Ingress controller deployed in advance. The examples below use the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), but you can use any Ingress controller by setting `ingress.className`.
-
-:::note Controller annotations are not set for you
-From Camunda 8.10 (chart 15.x), `global.ingress.annotations` and `orchestration.ingress.grpc.annotations` default to `{}`. Earlier chart versions shipped `nginx.ingress.kubernetes.io/*` defaults and rendered them onto every `Ingress`, whatever the configured `ingressClassName`.
-
-Set the annotations your own controller needs. For ingress-nginx that includes `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` on the gRPC Ingress, without which Zeebe gRPC is not proxied at all. See [Ingress annotation defaults removed from the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-removed) for the full set and the equivalents on other controllers.
-:::
-
+- The annotations your controller needs. From Camunda 8.10 (chart 15.x), `global.ingress.annotations` and `orchestration.ingress.grpc.annotations` default to `{}`; earlier chart versions shipped `nginx.ingress.kubernetes.io/*` defaults and rendered them onto every `Ingress`, whatever the configured `ingressClassName`. For ingress-nginx this includes `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` on the gRPC Ingress, without which Zeebe gRPC is not proxied at all. See [Ingress annotation defaults removed from the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-removed) for the full set and the equivalents on other controllers.
 - TLS configuration is not included in the examples because it varies between different workflows. Configure TLS in one of these ways:
   - Use `ingress.tls` options directly.
   - Use an external tool such as [Cert-Manager](https://github.com/cert-manager/cert-manager) with `ingress.annotations`.  

--- a/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
+++ b/docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md
@@ -17,7 +17,7 @@ Camunda 8 Self-Managed has multiple web applications and gRPC services. You can 
 ## Prerequisites
 
 - An Ingress controller deployed in advance. The examples below use the [ingress-nginx controller](https://github.com/kubernetes/ingress-nginx), but you can use any Ingress controller by setting `ingress.className`.
-- The annotations your controller needs. From Camunda 8.10 (chart 15.x), the ingress-nginx ones come from a compatibility shim that you can turn off with `global.ingress.nginxCompatAnnotations: false`; see [Ingress-nginx annotation defaults deprecated in the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-deprecated).
+- The annotations your controller needs. From Camunda 8.10 (chart 15.x), the ingress-nginx ones come from a compatibility shim that you can turn off with `global.compatibility.nginx.renderAnnotations: false`; see [Ingress-nginx annotation defaults deprecated in the Helm chart](/reference/announcements-release-notes/8100/8100-announcements.md#ingress-annotation-defaults-deprecated).
 - TLS configuration is not included in the examples because it varies between different workflows. Configure TLS in one of these ways:
   - Use `ingress.tls` options directly.
   - Use an external tool such as [Cert-Manager](https://github.com/cert-manager/cert-manager) with `ingress.annotations`.  


### PR DESCRIPTION
## Description

Documents the Helm chart change in camunda/camunda-platform-helm#7145, which moves the ingress-nginx defaults on `global.ingress.annotations` and `orchestration.ingress.grpc.annotations` behind a compatibility flag in chart 15.x (Camunda 8.10).

This is the documentation twin of that PR. It is `docs/` only: the change lands in an unreleased chart, so no `versioned_docs` folder is affected.

### Why it needs an announcement

The chart previously shipped `nginx.ingress.kubernetes.io/*` defaults on both maps. Helm deep-merges maps, so a user who set a single annotation of their own still inherited all of them, and they rendered onto the `Ingress` whatever `ingressClassName` was configured. Deployments on Contour, Traefik or anything else carried dead nginx configuration with no way to remove it short of setting each key to `null` (camunda/camunda-platform-helm#6410).

The annotations now come from a shim gated on `global.compatibility.nginx.renderAnnotations`, which defaults to `true`, so **rendered output is unchanged on upgrade** and this is a deprecation rather than a breaking change. Operators on another controller set it to `false` and get controller-neutral manifests immediately instead of waiting for the next major. Two of the keys carry behaviour rather than cosmetics, and the announcement calls both out:

- `nginx.ingress.kubernetes.io/backend-protocol: GRPC` is what makes ingress-nginx proxy Zeebe gRPC at all.
- `nginx.ingress.kubernetes.io/proxy-buffer-size` is the documented fix for the gateway timeouts covered in the troubleshooting guide, caused by large JWT `Set-Cookie` headers.

### Changes

| File | Change |
| --- | --- |
| `docs/reference/announcements-release-notes/8100/8100-announcements.md` | New **Deprecated** entry under **Deployment**, covering the opt-out, the values to set when the shim is removed, and the Contour equivalent. |
| `docs/self-managed/deployment/helm/configure/ingress/ingress-setup.md` | Prerequisite bullet naming the shim and its opt-out, linking to the announcement. |

## Related

- Chart change: camunda/camunda-platform-helm#7145
- Chart issue: camunda/camunda-platform-helm#6410
- Reference-architecture side of the same migration, documenting Contour as the tested default and the Ingress-vs-Gateway-API choice: #9892

#9892 also touches `ingress-setup.md`, but a different region (it adds an ingress-nginx retirement note). Whichever merges second may need a trivial rebase.

## When should this change go live?

<!-- PRs merged go to stage.docs.camunda.io first and must be manually released to docs.camunda.io. -->

- [ ] This is a bug fix, security concern, or something that needs **urgent release support**. (add `bug` or `support` label)
- [ ] This is already available but undocumented and should be released within a week. (add `available & undocumented` label)
- [ ] This is on a **specific schedule** and the assignee will coordinate a release with the Documentation team. (create draft PR and/or add `hold` label)
- [x] This is part of a scheduled **alpha or minor**. (add alpha or minor label)
- [ ] There is **no urgency** with this change (add `low prio` label)

## PR Checklist

- [x] The commit history of this PR is cleaned up, using [`{type}(scope): {description}` commit message(s)](https://github.com/camunda/camunda-docs/blob/main/CONTRIBUTING.MD#commit-message-header-formatting)

<!-- Camunda maintains 18 months of minor versions. Backporting your change to multiple versions is common. -->

- [x] My changes are for **an upcoming minor release** and are in the `/docs` directory.
- [ ] My changes are for an **already released minor** and are in a `/versioned_docs` directory.

<!-- UNCOMMENT THIS SECTION IF APPLICABLE. Adding or removing pages requires extra steps.
- [ ] I included my new page in the sidebar file(s).
- [ ] I added a redirect for a renamed or deleted page to the .htaccess file.
-->

- [x] I added a DRI, team, or delegate as a reviewer for technical accuracy and grammar/style:
  - [x] [Engineering team review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process)
  - [x] [Technical writer review](https://github.com/camunda/camunda-docs/blob/main/howtos/documentation-guidelines.md#review-process) via `@camunda/tech-writers` unless working with an embedded writer.


